### PR TITLE
[WIP] Fix realloc to preserve data in the realloced memory

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -169,4 +169,3 @@ rmmError_t rmmGetLog(char *buffer, size_t buffer_size)
     }
     return RMM_SUCCESS;
 }
-


### PR DESCRIPTION
Fixes #5 . This PR adds logic to copy the old data from an allocation into the new allocation in `rmm::realloc`, along with tests of this behavior.

This fix is currently incomplete. Specifically, in pool allocation mode, it does not copy the data because cnmem does not provide a way to get the size of an allocation, and cnmem does not provide `realloc`.

There is also currently a segfault in rmmInitialize when running all tests that is not there when only the new tests are run. Will need to debug.