### PR TITLE
[gpuCI] Auto-merge branch-0.5 to branch-0.6 [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to RMM
+
+If you are interested in contributing to cuDF, your contributions will fall
+into three categories:
+1. You want to report a bug, feature request, or documentation issue
+    - File an [issue](https://github.com/rapidsai/rmm/issues/new/choose)
+    describing what you encountered or what you want to see changed.
+    - The RAPIDS team will evaluate the issues and triage them, scheduling
+    them for a release. If you believe the issue needs priority attention
+    comment on the issue to notify the team.
+2. You want to propose a new Feature and implement it
+    - Post about your intended feature, and we shall discuss the design and
+    implementation.
+    - Once we agree that the plan looks good, go ahead and implement it, using
+    the [code contributions](#code-contributions) guide below.
+3. You want to implement a feature or bug-fix for an outstanding issue
+    - Follow the [code contributions](#code-contributions) guide below.
+    - If you need more context on a particular issue, please ask and we shall
+    provide.
+
+## Code contributions
+
+### Your first issue
+
+1. Read the project's [README.md](https://github.com/rapidsai/rmm/blob/master/README.md)
+    to learn how to setup the development environment
+2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/rmm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+    or [help wanted](https://github.com/rapidsai/rmm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels
+3. Comment on the issue saying you are going to work on it
+4. Code! Make sure to update unit tests!
+5. When done, [create your pull request](https://github.com/rapidsai/rmm/compare)
+6. Verify that CI passes all [status checks](https://help.github.com/articles/about-status-checks/). Fix if needed
+7. Wait for other developers to review your code and update code as needed
+8. Once reviewed and approved, a RAPIDS developer will merge your pull request
+
+Remember, if you are unsure about anything, don't hesitate to comment on issues
+and ask for clarifications!
+
+### Seasoned developers
+
+Once you have gotten your feet wet and are more comfortable with the code, you
+can look at the prioritized issues of our next release in our [project boards](https://github.com/rapidsai/rmm/projects).
+
+> **Pro Tip:** Always look at the release board with the highest number for
+issues to work on. This is where RAPIDS developers also focus their efforts.
+
+Look at the unassigned issues, and find an issue you are comfortable with
+contributing to. Start with _Step 3_ from above, commenting on the issue to let
+others know you are working on it. If you have any questions related to the
+implementation of the issue, ask them in the issue instead of the PR.
+
+## Attribution
+Portions adopted from https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.5` that creates a PR to keep `branch-0.6` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.