### PR TITLE
[REVIEW] Fix invalid reference to local stack variable in `rmm::exec_policy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ situations:
 
 RMM includes a custom Thrust allocator in the file `thrust_rmm_allocator.h`. This defines the template class `rmm_allocator`, and 
 a custom Thrust CUDA device execution policy called `rmm::exec_policy(stream)`.
-This instructs Thrust to use RMM for temporary memory allocation and execute on 
-the specified `stream`.
+```
 
 #### Thrust Device Vectors
 
@@ -144,13 +143,20 @@ For convenience, you can use the alias `rmm::device_vector<T>` defined in
 #### Thrust Algorithms
 
 To instruct Thrust to use RMM to allocate temporary storage, you can use the custom
-Thrust CUDA device execution policy: `rmm::exec_policy(stream)`. This instructs 
-Thrust to use RMM for temporary memory allocation and execute on the specified `stream`.
+Thrust CUDA device execution policy: `rmm::exec_policy(stream)`. 
+This instructs Thrust to use the `rmm_allocator` on the specified stream for temporary memory allocation. 
 
-Example usage:
+`rmm::exec_policy(stream)` returns a `std::unique_ptr` to a Thrust execution policy that uses `rmm_allocator` for temporary allocations.
+In order to specify that the Thrust algorithm be executed on a specific stream, the usage is:
+
 ```
-thrust::sort(rmm::exec_policy(stream), ...);
+thrust::sort(rmm::exec_policy(stream)->on(stream), ...);
 ```
+
+The first `stream` argument is the `stream` to use for `rmm_allocator`. 
+The second `stream` argument is what should be used to execute the Thrust algorithm.
+These two arguments must be identical.
+
 
 ## Using RMM in Python Code
 

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -99,7 +99,12 @@ inline auto exec_policy(cudaStream_t stream = 0) {
   using T = decltype(thrust::cuda::par(*alloc));
 
   auto deleter = [&alloc](T* pointer) {
+
+// FIXME: Compiler warning for `alloc` being potentially uninitialized
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
     free(alloc);
+#pragma GCC diagnostic pop
     free(pointer);
   };
 

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -91,12 +91,16 @@ using device_vector = thrust::device_vector<T, rmm_allocator<T>>;
  */
 /* ----------------------------------------------------------------------------*/
 inline auto exec_policy(cudaStream_t stream = 0) {
-  rmm_allocator<char>* alloc = new rmm_allocator<char>(stream);
+
+  rmm_allocator<char> * alloc{nullptr};
+
+  alloc = new rmm_allocator<char>(stream);
+
   using T = decltype(thrust::cuda::par(*alloc));
 
   auto deleter = [&alloc](T* pointer) {
-    free(pointer);
     free(alloc);
+    free(pointer);
   };
 
   std::unique_ptr<T, decltype(deleter)> policy{new T(*alloc), deleter};


### PR DESCRIPTION

fixes https://github.com/rapidsai/rmm/issues/26

RMM provides the `rmm::exec_policy` to simplify executing a Thrust algorithm using RMM as the temporary memory allocator.

Previously, the implementation of `rmm::exec_policy` would create a function local instance of an `rmm_allocator` and pass it into `thrust::cuda::par::operator()`. E.g.,
```
  rmm_allocator<char> allocator(stream);
  return thrust::cuda::par(allocator).on(stream);
```

However, `thrust::cuda::par::operator()` accepts the allocator by _reference_. This means it gets a reference to a function local variable that becomes invalid as soon as the function returns. This led to segmentation faults in Thrust algorithms that attempted to use RMM for temporary allocations (see https://github.com/rapidsai/rmm/issues/26)

In attempt to provide the least intrusive fix, `rmm::exec_policy` will instead allocate an instance of `rmm_allocator` on the _heap_ and return a `std::unique_ptr` with a custom deleter that will free both the Thrust execution policy in addition to the heap allocated `rmm_allocator`.

This requires updating existing uses of `rmm::exec_policy(stream)` to `rmm::exec_policy(stream)->on(stream)`. (see https://github.com/rapidsai/cudf/pull/794)


