### PR TITLE
[REVIEW] Update RMM to throw exceptions 

### DIFF
--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -15,7 +15,7 @@
  */
 
 #ifndef EXCEPTIONS_HPP
-#define EXCEPTION_HPP
+#define EXCEPTIONS_HPP
 
 #include <cuda_runtime_api.h>
 #include <exception>
@@ -89,6 +89,8 @@ struct cuda_error : public std::exception {
            cudaGetErrorName(error) + " " + cudaGetErrorString(error);
   }
 
+  cuda_error() = delete;
+
   /**---------------------------------------------------------------------------*
    * @brief Returns explanatory string for this exception
    *
@@ -110,6 +112,7 @@ struct cuda_error : public std::exception {
 struct cnmem_error : public std::exception {
   /**---------------------------------------------------------------------------*
    * @brief Construct a new cnmem_error exception.
+   *
    * @param[in] err_ The CNMEM error code that resulted from the unsuccesfull
    * CNMEM function.
    * @param[in] file_ Optional filename where error occured (should be populated
@@ -126,6 +129,8 @@ struct cnmem_error : public std::exception {
 
     msg += " error code: " + std::to_string(error);
   }
+
+  cnmem_error() = delete;
 
   /**---------------------------------------------------------------------------*
    * @brief Returns explanatory string for this exception

--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -108,7 +108,7 @@ struct bad_alloc : public std::bad_alloc {
   const char* what() const noexcept { return msg.c_str(); }
 
  private:
-  std::string msg{"RMM out of memory excpetion."};  ///< Explanatory string
+  std::string msg{"RMM out of memory exception."};  ///< Explanatory string
   std::string const file{};   ///< File name where exception occured
   unsigned int const line{};  ///< Line number where exceptin occured
 };

--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -21,12 +21,27 @@
 #include <exception>
 #include <limits>
 
+/** ---------------------------------------------------------------------------*
+ * @file exceptions.hpp
+ * @brief Custom exceptions used by RMM.
+ *
+ * Exceptions for errors occuring due to out-of-memory, CUDA, and CNMEM errors.
+ *
+ * --------------------------------------------------------------------------**/
+
 #ifndef GETNAME
-#define GETNAME(x) case x: return #x;
+#define GETNAME(x) \
+  case x:          \
+    return #x;
 #endif
 
-// Stringify RMM error code.
-inline const char * rmmGetErrorString(rmmError_t errcode) {
+/**---------------------------------------------------------------------------*
+ * @brief Returns name of a specified RMM error code.
+ *
+ * @param errcode  The error code to return the name of.
+ * @return const char*  The name of the specified error code
+ *---------------------------------------------------------------------------**/
+inline const char* rmmGetErrorString(rmmError_t errcode) {
   switch (errcode) {
     GETNAME(RMM_SUCCESS)
     GETNAME(RMM_ERROR_CUDA_ERROR)
@@ -36,18 +51,11 @@ inline const char * rmmGetErrorString(rmmError_t errcode) {
     GETNAME(RMM_ERROR_UNKNOWN)
     GETNAME(RMM_ERROR_IO)
     default:
-        // This means we are missing an entry above for a rmmError_t value.
-        return "Internal error. Unknown error code.";
+      // This means we are missing an entry above for a rmmError_t value.
+      return "Internal error. Unknown error code.";
   }
 }
 
-/** ---------------------------------------------------------------------------*
- * @file exceptions.hpp
- * @brief Custom exceptions used by RMM.
- *
- * Exceptions for errors occuring due to out-of-memory, CUDA, and CNMEM errors.
- *
- * --------------------------------------------------------------------------**/
 namespace rmm {
 
 struct exception : public std::exception {

--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -168,10 +168,12 @@ struct cnmem_error : public std::exception {
 /** ---------------------------------------------------------------------------*
  * @brief Macro wrapper to check for error in RMM API calls.
  * ---------------------------------------------------------------------------**/
-#define RMM_CHECK(call, file, line)         \
-  do {                                      \
-    rmmError_t error = (call);              \
-    if (error != RMM_SUCCESS) return error; \
+#define RMM_CHECK(call, file, line)                \
+  do {                                             \
+    rmmError_t error = (call);                     \
+    if (error != RMM_SUCCESS) {                    \
+      throw rmm::exception(error, (file), (line)); \
+    }                                              \
   } while (0)
 
 /** ---------------------------------------------------------------------------*
@@ -189,24 +191,12 @@ struct cnmem_error : public std::exception {
 /** ---------------------------------------------------------------------------*
  * @brief Macro wrapper for CNMEM API calls to return appropriate RMM errors.
  * ---------------------------------------------------------------------------**/
-#define RMM_CHECK_CNMEM(call, file, line)     \
-  do {                                        \
-    cnmemStatus_t error = (call);             \
-    switch (error) {                          \
-      case CNMEM_STATUS_SUCCESS:              \
-        break; /* don't return on success! */ \
-      case CNMEM_STATUS_CUDA_ERROR:           \
-        return RMM_ERROR_CUDA_ERROR;          \
-      case CNMEM_STATUS_INVALID_ARGUMENT:     \
-        return RMM_ERROR_INVALID_ARGUMENT;    \
-      case CNMEM_STATUS_NOT_INITIALIZED:      \
-        return RMM_ERROR_NOT_INITIALIZED;     \
-      case CNMEM_STATUS_OUT_OF_MEMORY:        \
-        return RMM_ERROR_OUT_OF_MEMORY;       \
-      case CNMEM_STATUS_UNKNOWN_ERROR:        \
-      default:                                \
-        return RMM_ERROR_UNKNOWN;             \
-    }                                         \
+#define RMM_CHECK_CNMEM(call, file, line)        \
+  do {                                           \
+    cnmemStatus_t error = (call);                \
+    if (CNMEM_STATUS_SUCCESS != error) {         \
+      throw rmm::cnmem_error(error, file, line); \
+    }                                            \
   } while (0)
 
 #endif

--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -214,10 +214,11 @@ struct cnmem_error : public std::exception {
 #define RMM_CHECK_CUDA(call, file, line)                \
   do {                                                  \
     cudaError_t cudaError = (call);                     \
-    if (cudaError == cudaErrorMemoryAllocation)         \
+    if (cudaError == cudaErrorMemoryAllocation) {       \
       throw rmm::bad_alloc((file), (line));             \
-    else if (cudaError != cudaSuccess)                  \
+    } else if (cudaError != cudaSuccess) {              \
       throw rmm::cuda_error(cudaError, (file), (line)); \
+    }                                                   \
   } while (0)
 
 /** ---------------------------------------------------------------------------*
@@ -226,7 +227,9 @@ struct cnmem_error : public std::exception {
 #define RMM_CHECK_CNMEM(call, file, line)        \
   do {                                           \
     cnmemStatus_t error = (call);                \
-    if (CNMEM_STATUS_SUCCESS != error) {         \
+    if (CNMEM_STATUS_OUT_OF_MEMORY == error) {    \
+      throw rmm::bad_alloc((file), (line));      \
+    } else if (CNMEM_STATUS_SUCCESS != error) {  \
       throw rmm::cnmem_error(error, file, line); \
     }                                            \
   } while (0)

--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -168,7 +168,7 @@ struct cnmem_error : public std::exception {
 /** ---------------------------------------------------------------------------*
  * @brief Macro wrapper to check for error in RMM API calls.
  * ---------------------------------------------------------------------------**/
-#define RMM_CHECK(call)                     \
+#define RMM_CHECK(call, file, line)         \
   do {                                      \
     rmmError_t error = (call);              \
     if (error != RMM_SUCCESS) return error; \

--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -168,7 +168,7 @@ struct cnmem_error : public std::exception {
 /** ---------------------------------------------------------------------------*
  * @brief Macro wrapper to check for error in RMM API calls.
  * ---------------------------------------------------------------------------**/
-#define RMM_CHECK(call)         \
+#define RMM_CHECK(call)                     \
   do {                                      \
     rmmError_t error = (call);              \
     if (error != RMM_SUCCESS) return error; \
@@ -185,27 +185,28 @@ struct cnmem_error : public std::exception {
     else if (cudaError != cudaSuccess)                  \
       throw rmm::cuda_error(cudaError, (file), (line)); \
   } while (0)
-  
+
 /** ---------------------------------------------------------------------------*
  * @brief Macro wrapper for CNMEM API calls to return appropriate RMM errors.
  * ---------------------------------------------------------------------------**/
-#define RMM_CHECK_CNMEM(call) do {            \
+#define RMM_CHECK_CNMEM(call, file, line)     \
+  do {                                        \
     cnmemStatus_t error = (call);             \
     switch (error) {                          \
-    case CNMEM_STATUS_SUCCESS:                \
+      case CNMEM_STATUS_SUCCESS:              \
         break; /* don't return on success! */ \
-    case CNMEM_STATUS_CUDA_ERROR:             \
+      case CNMEM_STATUS_CUDA_ERROR:           \
         return RMM_ERROR_CUDA_ERROR;          \
-    case CNMEM_STATUS_INVALID_ARGUMENT:       \
+      case CNMEM_STATUS_INVALID_ARGUMENT:     \
         return RMM_ERROR_INVALID_ARGUMENT;    \
-    case CNMEM_STATUS_NOT_INITIALIZED:        \
+      case CNMEM_STATUS_NOT_INITIALIZED:      \
         return RMM_ERROR_NOT_INITIALIZED;     \
-    case CNMEM_STATUS_OUT_OF_MEMORY:          \
+      case CNMEM_STATUS_OUT_OF_MEMORY:        \
         return RMM_ERROR_OUT_OF_MEMORY;       \
-    case CNMEM_STATUS_UNKNOWN_ERROR:          \
-    default:                                  \
+      case CNMEM_STATUS_UNKNOWN_ERROR:        \
+      default:                                \
         return RMM_ERROR_UNKNOWN;             \
     }                                         \
-} while(0)
+  } while (0)
 
 #endif

--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -21,6 +21,26 @@
 #include <exception>
 #include <limits>
 
+#ifndef GETNAME
+#define GETNAME(x) case x: return #x;
+#endif
+
+// Stringify RMM error code.
+inline const char * rmmGetErrorString(rmmError_t errcode) {
+  switch (errcode) {
+    GETNAME(RMM_SUCCESS)
+    GETNAME(RMM_ERROR_CUDA_ERROR)
+    GETNAME(RMM_ERROR_INVALID_ARGUMENT)
+    GETNAME(RMM_ERROR_NOT_INITIALIZED)
+    GETNAME(RMM_ERROR_OUT_OF_MEMORY)
+    GETNAME(RMM_ERROR_UNKNOWN)
+    GETNAME(RMM_ERROR_IO)
+    default:
+        // This means we are missing an entry above for a rmmError_t value.
+        return "Internal error. Unknown error code.";
+  }
+}
+
 /** ---------------------------------------------------------------------------*
  * @file exceptions.hpp
  * @brief Custom exceptions used by RMM.
@@ -37,6 +57,10 @@ struct exception : public std::exception {
     if (not file.empty()) {
       msg += " File: " + file + " line: " + std::to_string(line);
     }
+
+    std::string error_name{rmmGetErrorString(error)};
+
+    msg += " error: " + error_name;
   }
 
   const char* what() const noexcept { return msg.c_str(); }

--- a/include/rmm/detail/exceptions.hpp
+++ b/include/rmm/detail/exceptions.hpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2018, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EXCEPTIONS_HPP
+#define EXCEPTION_HPP
+
+#include <exception>
+
+/** ---------------------------------------------------------------------------*
+ * @file exceptions.hpp
+ * @brief Custom exceptions used by RMM.
+ *
+ * Exceptions for errors occuring due to out-of-memory, CUDA, and CNMEM errors.
+ * 
+ * --------------------------------------------------------------------------**/
+namespace rmm{
+struct bad_alloc: public std::bad_alloc
+{
+  bad_alloc(const char* msg_, const char* file_, unsigned int line_) : msg{msg_}, file{file_}, line {line_}
+  { }
+
+  bad_alloc(const char* file_, unsigned int line_) : file{file_}, line {line_}
+  { }
+
+  bad_alloc(const char* msg_) : msg{msg_}{}
+
+  bad_alloc(){} const char * what () const noexcept
+  {
+    std::string message{"RMM out of memory."};
+
+    if(not msg.empty())
+      message += msg;
+    
+    if(not file.empty())
+      message += " File: " + file + " line: " + std::to_string(line);
+
+    return message.c_str();
+  }
+
+private:
+  std::string const msg;
+  std::string const file;
+  unsigned int line{};
+};
+
+struct cuda_error: public std::runtime_error
+{
+  cuda_error(const char* msg_, const char* file_, unsigned int line_, cudaError_t err_) 
+    : msg{msg_}, file{file_}, line{line_}, error{err_} {}
+
+  cuda_error(const char* file_, unsigned int line_, cudaError_t err_) 
+    : file{file_}, line{line_}, error{err_} {}
+
+  cuda_error(cudaError_t err_) : error{err_}{}
+
+  const char * what () const noexcept
+  {
+    std::string message{"RMM CUDA error."};
+
+    if(not msg.empty())
+      message += msg;
+    
+    if(not file.empty())
+      message += " File: " + file + " line: " + std::to_string(line);
+
+    if(error != cudaSuccess)
+      message += " error code: " + std::to_string(error);
+
+    return message.c_str();
+  }
+
+private:
+  std::string const msg;
+  std::string const file;
+  unsigned int line{};
+  cudaError_t error{cudaSuccess};
+};
+
+struct cnmem_error: public std::runtime_error
+{
+  cuda_error(const char* msg_, const char* file_, unsigned int line_, cnmemStatus_t err_) 
+    : msg{msg_}, file{file_}, line{line_}, error{err_} {}
+
+  cuda_error(const char* file_, unsigned int line_, cnmemStatus_t err_) 
+    : file{file_}, line{line_}, error{err_} {}
+
+  cuda_error(cnmemStatus_t err_) : error{err_}{}
+
+  const char * what () const noexcept
+  {
+    std::string message{"RMM CNMEM error."};
+
+    if(not msg.empty())
+      message += msg;
+    
+    if(not file.empty())
+      message += " File: " + file + " line: " + std::to_string(line);
+
+    if(0 != error)
+      message += " error code: " + std::to_string(error);
+
+    return message.c_str();
+  }
+
+private:
+  std::string const msg;
+  std::string const file;
+  unsigned int line{};
+  cnmemStatus_t error{0};
+};
+} // namespace rmm
+#endif
+

--- a/include/rmm/detail/memory_manager.hpp
+++ b/include/rmm/detail/memory_manager.hpp
@@ -36,27 +36,6 @@ extern "C" {
 }
 #include "rmm/detail/cnmem.h"
 
-/** ---------------------------------------------------------------------------*
- * @brief Macro wrapper for CNMEM API calls to return appropriate RMM errors.
- * ---------------------------------------------------------------------------**/
-#define RMM_CHECK_CNMEM(call) do {            \
-    cnmemStatus_t error = (call);             \
-    switch (error) {                          \
-    case CNMEM_STATUS_SUCCESS:                \
-        break; /* don't return on success! */ \
-    case CNMEM_STATUS_CUDA_ERROR:             \
-        return RMM_ERROR_CUDA_ERROR;          \
-    case CNMEM_STATUS_INVALID_ARGUMENT:       \
-        return RMM_ERROR_INVALID_ARGUMENT;    \
-    case CNMEM_STATUS_NOT_INITIALIZED:        \
-        return RMM_ERROR_NOT_INITIALIZED;     \
-    case CNMEM_STATUS_OUT_OF_MEMORY:          \
-        return RMM_ERROR_OUT_OF_MEMORY;       \
-    case CNMEM_STATUS_UNKNOWN_ERROR:          \
-    default:                                  \
-        return RMM_ERROR_UNKNOWN;             \
-    }                                         \
-} while(0)
 
 typedef struct CUstream_st *cudaStream_t;
 

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -26,6 +26,12 @@ extern "C" {
 #include "rmm/rmm_api.h"
 }
 #include "rmm/detail/memory_manager.hpp"
+#include "rmm/detail/exceptions.hpp"
+
+// forward decalaration
+namespace rmm{
+struct bad_alloc;
+}
 
 /** ---------------------------------------------------------------------------*
  * @brief Macro wrapper to check for error in RMM API calls.
@@ -43,9 +49,9 @@ extern "C" {
   do {                                          \
     cudaError_t cudaError = (call);             \
     if (cudaError == cudaErrorMemoryAllocation) \
-      return RMM_ERROR_OUT_OF_MEMORY;           \
+      throw rmm::bad_alloc();                   \
     else if (cudaError != cudaSuccess)          \
-      return RMM_ERROR_CUDA_ERROR;              \
+      throw std::runtime_error(std::string{"RMM allocation CUDA error. Code = " + std::to_string(cudaError)} ); \
   } while (0)
 
 namespace rmm {
@@ -100,6 +106,7 @@ class LogIt {
   unsigned int line;
   bool usageLogging;
 };
+
 
 /** ---------------------------------------------------------------------------*
  * @brief Allocate memory and return a pointer to device memory.

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -113,7 +113,7 @@ extern "C" {
 
     if (rmm::Manager::usePoolAllocator()) {
       RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
-      RMM_CHECK_CNMEM(cnmemMalloc(reinterpret_cast<void**>(ptr), size, stream));
+      RMM_CHECK_CNMEM(cnmemMalloc(reinterpret_cast<void**>(ptr), size, stream), file, line);
     } else if (rmm::Manager::useManagedMemory()) {
       RMM_CHECK_CUDA(cudaMallocManaged(reinterpret_cast<void**>(ptr), size), file, line);
     } else
@@ -153,9 +153,11 @@ extern "C" {
 
     if (rmm::Manager::usePoolAllocator()) {
       RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
-      RMM_CHECK_CNMEM(cnmemFree(*reinterpret_cast<void**>(ptr), stream));
+      RMM_CHECK_CNMEM(cnmemFree(*reinterpret_cast<void**>(ptr), stream), file,
+                      line);
       RMM_CHECK_CNMEM(
-          cnmemMalloc(reinterpret_cast<void**>(ptr), new_size, stream));
+          cnmemMalloc(reinterpret_cast<void**>(ptr), new_size, stream), file,
+          line);
     } else {
       RMM_CHECK_CUDA(cudaFree(*ptr), file, line);
       if (!new_size)
@@ -194,7 +196,7 @@ extern "C" {
                          unsigned int line) {
     rmm::LogIt log(rmm::Logger::Free, ptr, 0, stream, file, line);
     if (rmm::Manager::usePoolAllocator())
-      RMM_CHECK_CNMEM(cnmemFree(ptr, stream));
+      RMM_CHECK_CNMEM(cnmemFree(ptr, stream), file, line);
     else
       RMM_CHECK_CUDA(cudaFree(ptr), file, line);
     return RMM_SUCCESS;

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -28,196 +28,177 @@ extern "C" {
 #include "rmm/detail/memory_manager.hpp"
 #include "rmm/detail/exceptions.hpp"
 
-// forward decalaration
-namespace rmm{
-struct bad_alloc;
-}
 
-/** ---------------------------------------------------------------------------*
- * @brief Macro wrapper to check for error in RMM API calls.
- * ---------------------------------------------------------------------------**/
-#define RMM_CHECK(call)                     \
-  do {                                      \
-    rmmError_t error = (call);              \
-    if (error != RMM_SUCCESS) return error; \
-  } while (0)
+    namespace rmm {
+  // Set true to enable free/total memory logging at each RMM call (expensive)
+  constexpr bool RMM_USAGE_LOGGING{false};
 
-/** ---------------------------------------------------------------------------*
- * @brief Macro wrapper for RMM API calls to return appropriate RMM errors.
- * ---------------------------------------------------------------------------**/
-#define RMM_CHECK_CUDA(call)                    \
-  do {                                          \
-    cudaError_t cudaError = (call);             \
-    if (cudaError == cudaErrorMemoryAllocation) \
-      throw rmm::bad_alloc();                   \
-    else if (cudaError != cudaSuccess)          \
-      throw std::runtime_error(std::string{"RMM allocation CUDA error. Code = " + std::to_string(cudaError)} ); \
-  } while (0)
-
-namespace rmm {
-
-// Set true to enable free/total memory logging at each RMM call (expensive)
-constexpr bool RMM_USAGE_LOGGING{false};
-
-// RAII logger class
-class LogIt {
- public:
-  LogIt(Logger::MemEvent_t event, void* ptr, size_t size, cudaStream_t stream,
-        const char* filename, unsigned int line,
-        bool usageLogging = RMM_USAGE_LOGGING)
-      : event(event),
-        device(0),
-        ptr(ptr),
-        size(size),
-        stream(stream),
-        usageLogging(usageLogging),
-        line(line) {
-    if (filename) file = filename;
-    if (Manager::getOptions().enable_logging) {
-      cudaGetDevice(&device);
-      start = std::chrono::system_clock::now();
+  // RAII logger class
+  class LogIt {
+   public:
+    LogIt(Logger::MemEvent_t event, void* ptr, size_t size, cudaStream_t stream,
+          const char* filename, unsigned int line,
+          bool usageLogging = RMM_USAGE_LOGGING)
+        : event(event),
+          device(0),
+          ptr(ptr),
+          size(size),
+          stream(stream),
+          usageLogging(usageLogging),
+          line(line) {
+      if (filename) file = filename;
+      if (Manager::getOptions().enable_logging) {
+        cudaGetDevice(&device);
+        start = std::chrono::system_clock::now();
+      }
     }
-  }
 
-  /// Sometimes you need to start logging before the pointer address is
-  /// known
-  inline void setPointer(void* p) {
-    if (Manager::getOptions().enable_logging) ptr = p;
-  }
-
-  ~LogIt() {
-    if (Manager::getOptions().enable_logging) {
-      Logger::TimePt end = std::chrono::system_clock::now();
-      size_t freeMem = 0, totalMem = 0;
-      if (usageLogging) rmmGetInfo(&freeMem, &totalMem, stream);
-      Manager::getLogger().record(event, device, ptr, start, end, freeMem,
-                                  totalMem, size, stream, file, line);
+    /// Sometimes you need to start logging before the pointer address is
+    /// known
+    inline void setPointer(void* p) {
+      if (Manager::getOptions().enable_logging) ptr = p;
     }
-  }
 
- private:
-  rmm::Logger::MemEvent_t event;
-  int device;
-  void* ptr;
-  size_t size;
-  cudaStream_t stream;
-  rmm::Logger::TimePt start;
-  std::string file;
-  unsigned int line;
-  bool usageLogging;
-};
+    ~LogIt() {
+      if (Manager::getOptions().enable_logging) {
+        Logger::TimePt end = std::chrono::system_clock::now();
+        size_t freeMem = 0, totalMem = 0;
+        if (usageLogging) rmmGetInfo(&freeMem, &totalMem, stream);
+        Manager::getLogger().record(event, device, ptr, start, end, freeMem,
+                                    totalMem, size, stream, file, line);
+      }
+    }
 
+   private:
+    rmm::Logger::MemEvent_t event;
+    int device;
+    void* ptr;
+    size_t size;
+    cudaStream_t stream;
+    rmm::Logger::TimePt start;
+    std::string file;
+    unsigned int line;
+    bool usageLogging;
+  };
 
-/** ---------------------------------------------------------------------------*
- * @brief Allocate memory and return a pointer to device memory.
- *
- * @param[out] ptr Returned pointer
- * @param[in] size The size in bytes of the allocated memory region
- * @param[in] stream The stream in which to synchronize this command
- * @param[in] file The filename location of the call to this function, for
- * tracking
- * @param[in] line The line number of the call to this function, for tracking
- * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if rmmInitialize
- *                    has not been called, RMM_ERROR_INVALID_ARGUMENT if ptr is
- *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
- *                    requested size, or RMM_CUDA_ERROR on any other CUDA error.
- * --------------------------------------------------------------------------**/
-template <typename T>
-inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream, const char* file,
-                 unsigned int line) {
-  rmm::LogIt log(rmm::Logger::Alloc, 0, size, stream, file, line);
+  /**
+   * ---------------------------------------------------------------------------*
+   * @brief Allocate memory and return a pointer to device memory.
+   *
+   * @param[out] ptr Returned pointer
+   * @param[in] size The size in bytes of the allocated memory region
+   * @param[in] stream The stream in which to synchronize this command
+   * @param[in] file The filename location of the call to this function, for
+   * tracking
+   * @param[in] line The line number of the call to this function, for tracking
+   * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if
+   * rmmInitialize has not been called, RMM_ERROR_INVALID_ARGUMENT if ptr is
+   *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
+   *                    requested size, or RMM_CUDA_ERROR on any other CUDA
+   * error.
+   * --------------------------------------------------------------------------**/
+  template <typename T>
+  inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream,
+                          const char* file, unsigned int line) {
+    rmm::LogIt log(rmm::Logger::Alloc, 0, size, stream, file, line);
 
-  if (!ptr && !size) {
-    return RMM_SUCCESS;
-  } else if( !size ) {
-    ptr[0] = nullptr;
-    return RMM_SUCCESS;
-  }
-
-  if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
-
-  if (rmm::Manager::usePoolAllocator()) {
-    RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
-    RMM_CHECK_CNMEM(cnmemMalloc(reinterpret_cast<void**>(ptr), size, stream));
-  } else if (rmm::Manager::useManagedMemory()) {
-    RMM_CHECK_CUDA(cudaMallocManaged(reinterpret_cast<void**>(ptr), size));
-  } else
-    RMM_CHECK_CUDA(cudaMalloc(reinterpret_cast<void**>(ptr), size));
-
-  log.setPointer(*ptr);
-  return RMM_SUCCESS;
-}
-
-/** ---------------------------------------------------------------------------*
- * @brief Reallocate device memory block to new size and recycle any remaining
- *        memory.
- *
- * @param[out] ptr Returned pointer
- * @param[in] new_size The size in bytes of the allocated memory region
- * @param[in] stream The stream in which to synchronize this command
- * @param[in] file The filename location of the call to this function, for
- * tracking
- * @param[in] line The line number of the call to this function, for tracking
- * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if rmmInitialize
- *                    has not been called, RMM_ERROR_INVALID_ARGUMENT if ptr is
- *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
- *                    requested size, or RMM_ERROR_CUDA_ERROR on any other CUDA
- *                    error.
- * --------------------------------------------------------------------------**/
-template <typename T>
-inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
-                   const char* file, unsigned int line) {
-  rmm::LogIt log(rmm::Logger::Realloc, ptr, new_size, stream, file, line);
-
-  if (!ptr && !new_size) {
-    return RMM_SUCCESS;
-  }
-
-  if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
-
-  if (rmm::Manager::usePoolAllocator()) {
-    RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
-    RMM_CHECK_CNMEM(cnmemFree(*reinterpret_cast<void**>(ptr), stream));
-    RMM_CHECK_CNMEM(
-        cnmemMalloc(reinterpret_cast<void**>(ptr), new_size, stream));
-  } else {
-    RMM_CHECK_CUDA(cudaFree(*ptr));
-    if (!new_size)
+    if (!ptr && !size) {
+      return RMM_SUCCESS;
+    } else if (!size) {
       ptr[0] = nullptr;
-    else if (rmm::Manager::useManagedMemory())
-      RMM_CHECK_CUDA(cudaMallocManaged(reinterpret_cast<void**>(ptr), new_size));
-    else
-      RMM_CHECK_CUDA(cudaMalloc(reinterpret_cast<void**>(ptr), new_size));
+      return RMM_SUCCESS;
+    }
+
+    if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
+
+    if (rmm::Manager::usePoolAllocator()) {
+      RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
+      RMM_CHECK_CNMEM(cnmemMalloc(reinterpret_cast<void**>(ptr), size, stream));
+    } else if (rmm::Manager::useManagedMemory()) {
+      RMM_CHECK_CUDA(cudaMallocManaged(reinterpret_cast<void**>(ptr), size), file, line);
+    } else
+      RMM_CHECK_CUDA(cudaMalloc(reinterpret_cast<void**>(ptr), size), file, line);
+
+    log.setPointer(*ptr);
+    return RMM_SUCCESS;
   }
-  
-  log.setPointer(*ptr);
-  return RMM_SUCCESS;
-}
 
-/** ---------------------------------------------------------------------------*
- * @brief Release device memory and recycle the associated memory.
- *
- * \note Doesn't need to be a template because T* is implicitly conertible to
- * void*
- *
- * @param[in] ptr The pointer to free
- * @param[in] stream The stream in which to synchronize this command
- * @param[in] file The filename location of the call to this function, for
- * tracking
- * @param[in] line The line number of the call to this function, for tracking
- * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if rmmInitialize
- *                    has not been called,or RMM_ERROR_CUDA_ERROR on any CUDA
- *                    error.
- * --------------------------------------------------------------------------**/
-inline rmmError_t free(void* ptr, cudaStream_t stream, const char* file,
-                   unsigned int line) {
-  rmm::LogIt log(rmm::Logger::Free, ptr, 0, stream, file, line);
-  if (rmm::Manager::usePoolAllocator())
-    RMM_CHECK_CNMEM(cnmemFree(ptr, stream));
-  else
-    RMM_CHECK_CUDA(cudaFree(ptr));
-  return RMM_SUCCESS;
-}
+  /**
+   * ---------------------------------------------------------------------------*
+   * @brief Reallocate device memory block to new size and recycle any remaining
+   *        memory.
+   *
+   * @param[out] ptr Returned pointer
+   * @param[in] new_size The size in bytes of the allocated memory region
+   * @param[in] stream The stream in which to synchronize this command
+   * @param[in] file The filename location of the call to this function, for
+   * tracking
+   * @param[in] line The line number of the call to this function, for tracking
+   * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if
+   * rmmInitialize has not been called, RMM_ERROR_INVALID_ARGUMENT if ptr is
+   *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
+   *                    requested size, or RMM_ERROR_CUDA_ERROR on any other
+   * CUDA error.
+   * --------------------------------------------------------------------------**/
+  template <typename T>
+  inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
+                            const char* file, unsigned int line) {
+    rmm::LogIt log(rmm::Logger::Realloc, ptr, new_size, stream, file, line);
 
-}  // namespace rmm
+    if (!ptr && !new_size) {
+      return RMM_SUCCESS;
+    }
+
+    if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
+
+    if (rmm::Manager::usePoolAllocator()) {
+      RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
+      RMM_CHECK_CNMEM(cnmemFree(*reinterpret_cast<void**>(ptr), stream));
+      RMM_CHECK_CNMEM(
+          cnmemMalloc(reinterpret_cast<void**>(ptr), new_size, stream));
+    } else {
+      RMM_CHECK_CUDA(cudaFree(*ptr), file, line);
+      if (!new_size)
+        ptr[0] = nullptr;
+      else if (rmm::Manager::useManagedMemory()) {
+        RMM_CHECK_CUDA(
+            cudaMallocManaged(reinterpret_cast<void**>(ptr), new_size), file,
+            line);
+      } else {
+        RMM_CHECK_CUDA(cudaMalloc(reinterpret_cast<void**>(ptr), new_size),
+                       file, line);
+      }
+    }
+
+    log.setPointer(*ptr);
+    return RMM_SUCCESS;
+  }
+
+  /**
+   * ---------------------------------------------------------------------------*
+   * @brief Release device memory and recycle the associated memory.
+   *
+   * \note Doesn't need to be a template because T* is implicitly conertible to
+   * void*
+   *
+   * @param[in] ptr The pointer to free
+   * @param[in] stream The stream in which to synchronize this command
+   * @param[in] file The filename location of the call to this function, for
+   * tracking
+   * @param[in] line The line number of the call to this function, for tracking
+   * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if
+   * rmmInitialize has not been called,or RMM_ERROR_CUDA_ERROR on any CUDA
+   *                    error.
+   * --------------------------------------------------------------------------**/
+  inline rmmError_t free(void* ptr, cudaStream_t stream, const char* file,
+                         unsigned int line) {
+    rmm::LogIt log(rmm::Logger::Free, ptr, 0, stream, file, line);
+    if (rmm::Manager::usePoolAllocator())
+      RMM_CHECK_CNMEM(cnmemFree(ptr, stream));
+    else
+      RMM_CHECK_CUDA(cudaFree(ptr), file, line);
+    return RMM_SUCCESS;
+  }
+
+  }  // namespace rmm
 #endif

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -112,7 +112,7 @@ extern "C" {
     if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
 
     if (rmm::Manager::usePoolAllocator()) {
-      RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
+      RMM_CHECK(rmm::Manager::getInstance().registerStream(stream), file, line);
       RMM_CHECK_CNMEM(cnmemMalloc(reinterpret_cast<void**>(ptr), size, stream), file, line);
     } else if (rmm::Manager::useManagedMemory()) {
       RMM_CHECK_CUDA(cudaMallocManaged(reinterpret_cast<void**>(ptr), size), file, line);
@@ -152,7 +152,7 @@ extern "C" {
     if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
 
     if (rmm::Manager::usePoolAllocator()) {
-      RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
+      RMM_CHECK(rmm::Manager::getInstance().registerStream(stream), file, line);
       RMM_CHECK_CNMEM(cnmemFree(*reinterpret_cast<void**>(ptr), stream), file,
                       line);
       RMM_CHECK_CNMEM(

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -29,7 +29,7 @@ extern "C" {
 #include "rmm/detail/exceptions.hpp"
 
 
-    namespace rmm {
+namespace rmm {
   // Set true to enable free/total memory logging at each RMM call (expensive)
   constexpr bool RMM_USAGE_LOGGING{false};
 

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -91,7 +91,7 @@ namespace rmm
             if (registered_streams.empty() || 0 == registered_streams.count(stream)) {
                 registered_streams.insert(stream);
                 if (stream && usePoolAllocator()) // don't register the null stream with CNMem
-                    RMM_CHECK_CNMEM( cnmemRegisterStream(stream) );
+                    RMM_CHECK_CNMEM( cnmemRegisterStream(stream), __FILE__, __LINE__);
             }
             return RMM_SUCCESS;
         }

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "rmm/detail/memory_manager.hpp"
+#include "rmm/detail/exceptions.hpp"
 
 namespace rmm
 {

--- a/src/rmm.cpp
+++ b/src/rmm.cpp
@@ -62,7 +62,7 @@ rmmError_t rmmInitialize(rmmOptions_t *options)
     if (rmm::Manager::usePoolAllocator())
     {
         cnmemDevice_t dev;
-        RMM_CHECK_CUDA( cudaGetDevice(&(dev.device)) );
+        RMM_CHECK_CUDA(cudaGetDevice(&(dev.device)), __FILE__, __LINE__);
         // Note: cnmem defaults to half GPU memory
         dev.size = rmm::Manager::getOptions().initial_pool_size; 
         dev.numStreams = 1;
@@ -70,7 +70,7 @@ rmmError_t rmmInitialize(rmmOptions_t *options)
         dev.streams = streams;
         dev.streamSizes = 0;
         unsigned flags = rmm::Manager::useManagedMemory() ? CNMEM_FLAGS_MANAGED : 0;
-        RMM_CHECK_CNMEM( cnmemInit(1, &dev, flags) );
+        RMM_CHECK_CNMEM(cnmemInit(1, &dev, flags));
     }
     return RMM_SUCCESS;
 }
@@ -129,7 +129,7 @@ rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream)
         RMM_CHECK_CNMEM( cnmemMemGetInfo(freeSize, totalSize, stream) );
     }
     else
-        RMM_CHECK_CUDA(cudaMemGetInfo(freeSize, totalSize));
+        RMM_CHECK_CUDA(cudaMemGetInfo(freeSize, totalSize), __FILE__, __LINE__);
 	return RMM_SUCCESS;
 }
 

--- a/src/rmm.cpp
+++ b/src/rmm.cpp
@@ -70,7 +70,7 @@ rmmError_t rmmInitialize(rmmOptions_t *options)
         dev.streams = streams;
         dev.streamSizes = 0;
         unsigned flags = rmm::Manager::useManagedMemory() ? CNMEM_FLAGS_MANAGED : 0;
-        RMM_CHECK_CNMEM(cnmemInit(1, &dev, flags));
+        RMM_CHECK_CNMEM(cnmemInit(1, &dev, flags), __FILE__, __LINE__);
     }
     return RMM_SUCCESS;
 }
@@ -79,8 +79,8 @@ rmmError_t rmmInitialize(rmmOptions_t *options)
 rmmError_t rmmFinalize()
 {
     if (rmm::Manager::usePoolAllocator())
-        RMM_CHECK_CNMEM( cnmemFinalize() );
-    
+      RMM_CHECK_CNMEM(cnmemFinalize(), __FILE__, __LINE__);
+
     rmm::Manager::getInstance().finalize();
     
     return RMM_SUCCESS;
@@ -126,10 +126,12 @@ rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream)
     if (rmm::Manager::usePoolAllocator())
     {
         RMM_CHECK( rmm::Manager::getInstance().registerStream(stream) );
-        RMM_CHECK_CNMEM( cnmemMemGetInfo(freeSize, totalSize, stream) );
+        RMM_CHECK_CNMEM(cnmemMemGetInfo(freeSize, totalSize, stream), __FILE__,
+                        __LINE__);
     }
-    else
+    else{
         RMM_CHECK_CUDA(cudaMemGetInfo(freeSize, totalSize), __FILE__, __LINE__);
+    }
 	return RMM_SUCCESS;
 }
 

--- a/src/rmm.cpp
+++ b/src/rmm.cpp
@@ -125,9 +125,10 @@ rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream)
 {
     if (rmm::Manager::usePoolAllocator())
     {
-        RMM_CHECK( rmm::Manager::getInstance().registerStream(stream) );
-        RMM_CHECK_CNMEM(cnmemMemGetInfo(freeSize, totalSize, stream), __FILE__,
-                        __LINE__);
+      RMM_CHECK(rmm::Manager::getInstance().registerStream(stream), __FILE__,
+                __LINE__);
+      RMM_CHECK_CNMEM(cnmemMemGetInfo(freeSize, totalSize, stream), __FILE__,
+                      __LINE__);
     }
     else{
         RMM_CHECK_CUDA(cudaMemGetInfo(freeSize, totalSize), __FILE__, __LINE__);

--- a/src/rmm.cpp
+++ b/src/rmm.cpp
@@ -30,26 +30,6 @@
 #include <cstddef>
 #include <cuda.h>
 
-#ifndef GETNAME
-#define GETNAME(x) case x: return #x;
-#endif
-
-// Stringify RMM error code.
-const char * rmmGetErrorString(rmmError_t errcode) {
-  switch (errcode) {
-    // There must be one entry per enum values in gdf_error.
-    GETNAME(RMM_SUCCESS)
-    GETNAME(RMM_ERROR_CUDA_ERROR)
-    GETNAME(RMM_ERROR_INVALID_ARGUMENT)
-    GETNAME(RMM_ERROR_NOT_INITIALIZED)
-    GETNAME(RMM_ERROR_OUT_OF_MEMORY)
-    GETNAME(RMM_ERROR_UNKNOWN)
-    GETNAME(RMM_ERROR_IO)
-    default:
-        // This means we are missing an entry above for a rmmError_t value.
-        return "Internal error. Unknown error code.";
-  }
-}
 
 // Initialize memory manager state and storage.
 rmmError_t rmmInitialize(rmmOptions_t *options)

--- a/tests/memory_tests.cpp
+++ b/tests/memory_tests.cpp
@@ -129,7 +129,8 @@ TYPED_TEST(MemoryManagerTest, AllocateTB) {
         //ASSERT_SUCCESS( RMM_ALLOC(&a, this->size_tb, stream) );
     }
     else {
-        ASSERT_FAILURE( RMM_ALLOC(&a, this->size_tb, stream) );
+        //ASSERT_FAILURE( RMM_ALLOC(&a, this->size_tb, stream) );
+        ASSERT_THROW( RMM_ALLOC(&a, this->size_tb, stream), rmm::bad_alloc );
     }
     
     ASSERT_SUCCESS( RMM_FREE(a, stream) );
@@ -137,7 +138,7 @@ TYPED_TEST(MemoryManagerTest, AllocateTB) {
 
 TYPED_TEST(MemoryManagerTest, AllocateTooMuch) {
     char *a = 0;
-    ASSERT_FAILURE( RMM_ALLOC(&a, this->size_pb, stream) );
+    ASSERT_THROW( RMM_ALLOC(&a, this->size_pb, stream), rmm::bad_alloc );
     ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 


### PR DESCRIPTION
Instead of relying on returning error codes, this PR updates RMM functions to throw exceptions.

If error codes are still desired, top level APIs can convert exceptions to error codes.

- [x] Introduces 3 custom exceptions: `rmm::bad_alloc` for out of memory errors, `rmm::cuda_error` for CUDA errors unrelated to OOM, and `rmm::cnmem_error` for cnmem errors

- [x] Updates all `RMM_*` macros to throw exceptions when an error is detected

- [x] Updates failure GTests to check that the appropriate exceptions are thrown

RMM Python bindings will need to be updated to Cython and allow for catching C++ exceptions. That can either happen in this PR or another PR. See https://github.com/rapidsai/rmm/issues/40