### PR TITLE
Eliminate check for change in available memory in getInfo test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Bug Fixes
 
+ - PR #58 Eliminate unreliable check for change in available memory in test
  - PR #49 Fix pep8 style errors detected by flake8
 
 

--- a/tests/memory_tests.cpp
+++ b/tests/memory_tests.cpp
@@ -192,21 +192,6 @@ TYPED_TEST(MemoryManagerTest, GetInfo) {
     ASSERT_SUCCESS( rmmGetInfo(&freeBefore, &totalBefore, stream) );
     ASSERT_GE(freeBefore, 0);
     ASSERT_GE(totalBefore, 0);
-
-    char *a = 0;
-    size_t sz = this->size_mb / 2;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, sz, stream) );
-
-    // make sure the available free memory goes down after an allocation
-    size_t freeAfter = 0, totalAfter = 0;
-    ASSERT_SUCCESS( rmmGetInfo(&freeAfter, &totalAfter, stream) );
-    ASSERT_GE(totalAfter, totalBefore);
-    
-    // For some reason the free memory sometimes goes up in this mode?!
-    if (this->allocationMode() != (CudaManagedMemory | PoolAllocation))
-        ASSERT_LE(freeAfter, freeBefore);
-
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 
 TYPED_TEST(MemoryManagerTest, AllocationOffset) {


### PR DESCRIPTION
fixes https://github.com/rapidsai/rmm/issues/57

Avoids failing when multiple processes are using the GPU
