### PR TITLE
[gpuCI] Auto-merge branch-0.6 to branch-0.7 [skip ci]

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -32,7 +32,7 @@ elif [ "$RELEASE_TYPE" == "minor" ]; then
   NEXT_SHORT_TAG="${CURRENT_MAJOR}.${NEXT_MINOR}"
 elif [ "$RELEASE_TYPE" == "patch" ]; then
   NEXT_FULL_TAG="${CURRENT_MAJOR}.${CURRENT_MINOR}.${NEXT_PATCH}"
-  NEXT_SHORT_TAG="${CURRENT_MAJOR}.${NEXT_MINOR}"
+  NEXT_SHORT_TAG="${CURRENT_MAJOR}.${CURRENT_MINOR}"
 else
   echo "Incorrect release type; use 'major', 'minor', or 'patch' as an argument"
   exit 1


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.6` that creates a PR to keep `branch-0.7` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.