### PR TITLE
[REVIEW] Fix conda recipe librmm version pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Bug Fixes
 
  - PR #68 Fix signed/unsigned mismatch in random_allocate benchmark
+ - PR #74 Fix rmm conda recipe librmm version pinning
 
 
 # RMM 0.6.0 (18 Mar 2019)

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -18,6 +18,8 @@ build:
     - CXX
     - CUDAHOSTCXX
     - PARALLEL_LEVEL
+  run_exports:
+    - {{ pin_subpackage("librmm", max_pin="x.x") }}
 
 requirements:
   build:


### PR DESCRIPTION
Was pinning to `<1.0a0` instead of `<0.8.0a0`, needed to use a `run_export` to pin the subpackage properly. 