### PR TITLE
[REVIEW] Add cudatoolkit dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Improvements
 
+- PR #76 Add cudatoolkit conda dependency
+
 ## Bug Fixes
 
  - PR #68 Fix signed/unsigned mismatch in random_allocate benchmark

--- a/ci/cpu/librmm/upload-anaconda.sh
+++ b/ci/cpu/librmm/upload-anaconda.sh
@@ -16,14 +16,7 @@ if [ "$BUILD_LIBRMM" == '1' ]; then
 
   SOURCE_BRANCH=master
 
-  if [ "$LABEL_MAIN" == "1" ]; then
-    LABEL_OPTION="--label main --label cuda${CUDA_REL}"
-  elif [ "$LABEL_MAIN" == "0" ]; then
-    LABEL_OPTION="--label dev --label cuda${CUDA_REL}"
-  else
-    echo "Unknown label configuration LABEL_MAIN='$LABEL_MAIN'"
-    exit 1
-  fi
+  LABEL_OPTION="--label main --label cuda${CUDA_REL}"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   # Restrict uploads to master branch

--- a/ci/cpu/rmm/upload-anaconda.sh
+++ b/ci/cpu/rmm/upload-anaconda.sh
@@ -9,15 +9,7 @@ if [ "$BUILD_RMM" == "1" ]; then
 
   SOURCE_BRANCH=master
 
-  # Have to label all CUDA versions due to the compatibility to work with any CUDA
-  if [ "$LABEL_MAIN" == "1" ]; then
-    LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
-  elif [ "$LABEL_MAIN" == "0" ]; then
-    LABEL_OPTION="--label dev --label cuda9.2 --label cuda10.0"
-  else
-    echo "Unknown label configuration LABEL_MAIN='$LABEL_MAIN'"
-    exit 1
-  fi
+  LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${UPLOADFILE}

--- a/conda/environments/rmm_dev_cuda10.0.yml
+++ b/conda/environments/rmm_dev_cuda10.0.yml
@@ -8,3 +8,4 @@ dependencies:
 - numba>=0.41
 - cffi>=1.10.0
 - pytest
+- cudatoolkit=10.0

--- a/conda/environments/rmm_dev_cuda9.2.yml
+++ b/conda/environments/rmm_dev_cuda9.2.yml
@@ -8,3 +8,4 @@ dependencies:
 - numba>=0.41
 - cffi>=1.10.0
 - pytest
+- cudatoolkit=9.2

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -2,7 +2,7 @@
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
-{% set cuda_version='.'.join(environ.get('CUDA_VERSION', 'unknown').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '9.2').split('.')[:2]) %}
 package:
   name: librmm
   version: {{ version }}
@@ -25,6 +25,7 @@ requirements:
   build:
     - cmake >=3.12.4
   host:
+    - cudatoolkit {{ cuda_version }}.*
 
 test:
   commands:

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -26,6 +26,8 @@ requirements:
     - cmake >=3.12.4
   host:
     - cudatoolkit {{ cuda_version }}.*
+  run:
+    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 test:
   commands:


### PR DESCRIPTION
Refs conda-forge/conda-forge.github.io#687

This is to bring our conda packages in line with the community effort above and remove our current use of labels.