### PR TITLE
[REVIEW] Use latest tag in update-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Improvements
 
 - PR #76 Add cudatoolkit conda dependency
+- PR #84 Use latest release version in update-version CI script
 
 ## Bug Fixes
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -13,7 +13,7 @@ set -e
 RELEASE_TYPE=$1
 
 # Get current version and calculate next versions
-CURRENT_TAG=`git describe --abbrev=0 --tags | tr -d 'v'`
+CURRENT_TAG=`git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v'`
 CURRENT_MAJOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}'`
 CURRENT_MINOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}'`
 CURRENT_PATCH=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}'`
@@ -38,8 +38,6 @@ else
   exit 1
 fi
 
-# Move to root of repo
-cd ../..
 echo "Preparing '$RELEASE_TYPE' release [$CURRENT_TAG -> $NEXT_FULL_TAG]"
 
 # Inplace sed replace; workaround for Linux and Mac
@@ -47,8 +45,8 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-# cpp update
-sed_runner 's/'"RMM VERSION ${CURRENT_TAG}"'/'"RMM VERSION ${NEXT_FULL_TAG}"'/g' CMakeLists.txt
+sed_runner 's/'"RMM VERSION .* LANGUAGES"'/'"RMM VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' CMakeLists.txt
 
-# libcudf
 sed_runner 's/version=.*/version=\"'"${NEXT_FULL_TAG}"'\",/g' python/setup.py
+
+sed_runner 's/'"PROJECT_NUMBER         = 0.7"'/'"PROJECT_NUMBER         = ${NEXT_SHORT_TAG}"'/g' doxygen/Doxyfile

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -49,4 +49,4 @@ sed_runner 's/'"RMM VERSION .* LANGUAGES"'/'"RMM VERSION ${NEXT_FULL_TAG} LANGUA
 
 sed_runner 's/version=.*/version=\"'"${NEXT_FULL_TAG}"'\",/g' python/setup.py
 
-sed_runner 's/'"PROJECT_NUMBER         = 0.7"'/'"PROJECT_NUMBER         = ${NEXT_SHORT_TAG}"'/g' doxygen/Doxyfile
+sed_runner 's/'"PROJECT_NUMBER         = .*"'/'"PROJECT_NUMBER         = ${NEXT_SHORT_TAG}"'/g' doxygen/Doxyfile


### PR DESCRIPTION
Change update-version script to ignore dev/alpha/rc versions and use only the latest version

Also updated where changes are made