### PR TITLE
[REVIEW] avoid using c++14 auto return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - PR #76 Add cudatoolkit conda dependency
 - PR #84 Use latest release version in update-version CI script
+- PR #90 Avoid using c++14 auto return type for thrust_rmm_allocator.h 
 
 ## Bug Fixes
 


### PR DESCRIPTION
Right now the thrust_rmm_allocator.h is relying on c++14 auto return type feature to deduct the return type of exec_policy. However, till now lots of company is still using Ubuntu Jessie which is very difficult to upgrade their c++ compiler to support c++14. 

This diff rewrites the function using decltype to deduct return type thereby removing the dependencies on c++14.