### PR TITLE
Fix CMakeLists.txt for building on host system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,10 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
-project(RMM VERSION 0.9.0 LANGUAGES C CXX CUDA)
+project(RMM VERSION 0.9.0 LANGUAGES C CXX)
+# Workaround environment variables CC/CXX having no effect on `CUDA_HOST_COMPILER'.
+set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
+enable_language(CUDA)
 
 ###################################################################################################
 # - build type ------------------------------------------------------------------------------------
@@ -37,8 +40,6 @@ endif()
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_C_COMPILER $ENV{CC})
-set(CMAKE_CXX_COMPILER $ENV{CXX})
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
@@ -54,13 +55,12 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif(CMAKE_CXX11_ABI)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
-option(BUILD_TESTS "Configure CMake to build tests"
-       ON)
+option(BUILD_TESTS "Configure CMake to build tests" ON)
 
 ###################################################################################################
 # - cnmem ---------------------------------------------------------------------------------
 # include cnmem.h in the include/detail directory
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cnmem/include/cnmem.h" 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cnmem/include/cnmem.h"
                "${CMAKE_CURRENT_SOURCE_DIR}/include/rmm/detail/cnmem.h" COPYONLY)
 
 
@@ -77,16 +77,15 @@ include(CheckLibraryExists)
 # - add gtest -------------------------------------------------------------------------------------
 
 if(BUILD_TESTS)
-    include(CTest)
-    include(ConfigureGoogleTest)
-
-    if(GTEST_FOUND)
-        message(STATUS "Google C++ Testing Framework (Google Test) found in ${GTEST_ROOT}")
-        include_directories(${GTEST_INCLUDE_DIR})
-        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    else()
-        message(AUTHOR_WARNING "Google C++ Testing Framework (Google Test) not found: automated tests are disabled.")
-    endif(GTEST_FOUND)
+  include(CTest)
+  include(ConfigureGoogleTest)
+  if(GTEST_FOUND)
+    message(STATUS "Google C++ Testing Framework (Google Test) found in ${GTEST_ROOT}")
+    include_directories(${GTEST_INCLUDE_DIR})
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tests)
+  else()
+    message(AUTHOR_WARNING "Google C++ Testing Framework (Google Test) not found: automated tests are disabled.")
+  endif(GTEST_FOUND)
 endif(BUILD_TESTS)
 
 ###################################################################################################
@@ -140,7 +139,7 @@ target_link_libraries(rmm cudart cuda)
 set(RMM_API_H_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/rmm/rmm_api.h")
 # Input is a template which assigns MEMORY_H_PATH to a variable. This command replaces the variable with its value
 # and saves the file as librmm_build.py
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/python/librmm_cffi/librmm_build.py.in" 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/python/librmm_cffi/librmm_build.py.in"
                "${CMAKE_CURRENT_SOURCE_DIR}/python/librmm_cffi/librmm_build.py")
 
 add_custom_command(OUTPUT RMM_PYTHON_CFFI

--- a/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cmake/Modules/ConfigureGoogleTest.cmake
@@ -1,59 +1,63 @@
-set(GTEST_ROOT "${CMAKE_BINARY_DIR}/googletest")
+find_package(GTest)
+if(NOT GTEST_FOUND)
+  set(GTEST_ROOT "${CMAKE_BINARY_DIR}/googletest")
 
-set(GTEST_CMAKE_ARGS "")
-		     # " -Dgtest_build_samples=ON" 
-                     # " -DCMAKE_VERBOSE_MAKEFILE=ON")
+  set(GTEST_CMAKE_ARGS "")
+  # " -Dgtest_build_samples=ON"
+  # " -DCMAKE_VERBOSE_MAKEFILE=ON")
 
-if(NOT CMAKE_CXX11_ABI)
+  if(NOT CMAKE_CXX11_ABI)
     message(STATUS "GTEST: Disabling the GLIBCXX11 ABI")
     list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
     list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
-elseif(CMAKE_CXX11_ABI)
+  elseif(CMAKE_CXX11_ABI)
     message(STATUS "GTEST: Enabling the GLIBCXX11 ABI")
     list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
     list(APPEND GTEST_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
-endif(NOT CMAKE_CXX11_ABI)
+  endif(NOT CMAKE_CXX11_ABI)
 
-configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/GoogleTest.CMakeLists.txt.cmake"
-               "${GTEST_ROOT}/CMakeLists.txt")
+  configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/GoogleTest.CMakeLists.txt.cmake"
+    "${GTEST_ROOT}/CMakeLists.txt")
 
-file(MAKE_DIRECTORY "${GTEST_ROOT}/build")
-file(MAKE_DIRECTORY "${GTEST_ROOT}/install")
+  file(MAKE_DIRECTORY "${GTEST_ROOT}/build")
+  file(MAKE_DIRECTORY "${GTEST_ROOT}/install")
 
-execute_process(COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR} .
-                RESULT_VARIABLE GTEST_CONFIG
-                WORKING_DIRECTORY ${GTEST_ROOT})
+  execute_process(COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR} .
+    RESULT_VARIABLE GTEST_CONFIG
+    WORKING_DIRECTORY ${GTEST_ROOT})
 
-if(GTEST_CONFIG)
+  if(GTEST_CONFIG)
     message(FATAL_ERROR "Configuring GoogleTest failed: " ${GTEST_CONFIG})
-endif(GTEST_CONFIG)
+  endif(GTEST_CONFIG)
 
-set(PARALLEL_BUILD -j)
-if($ENV{PARALLEL_LEVEL})
+  set(PARALLEL_BUILD -j)
+  if($ENV{PARALLEL_LEVEL})
     set(NUM_JOBS $ENV{PARALLEL_LEVEL})
     set(PARALLEL_BUILD "${PARALLEL_BUILD}${NUM_JOBS}")
-endif($ENV{PARALLEL_LEVEL})
+  endif($ENV{PARALLEL_LEVEL})
 
-if(${NUM_JOBS})
+  if(${NUM_JOBS})
     if(${NUM_JOBS} EQUAL 1)
-        message(STATUS "GTEST BUILD: Enabling Sequential CMake build")
+      message(STATUS "GTEST BUILD: Enabling Sequential CMake build")
     elseif(${NUM_JOBS} GREATER 1)
-        message(STATUS "GTEST BUILD: Enabling Parallel CMake build with ${NUM_JOBS} jobs")
+      message(STATUS "GTEST BUILD: Enabling Parallel CMake build with ${NUM_JOBS} jobs")
     endif(${NUM_JOBS} EQUAL 1)
-else()
+  else()
     message(STATUS "GTEST BUILD: Enabling Parallel CMake build with all threads")
-endif(${NUM_JOBS})
+  endif(${NUM_JOBS})
 
-execute_process(COMMAND ${CMAKE_COMMAND} --build .. -- ${PARALLEL_BUILD}
-                RESULT_VARIABLE GTEST_BUILD
-                WORKING_DIRECTORY ${GTEST_ROOT}/build)
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .. -- ${PARALLEL_BUILD}
+    RESULT_VARIABLE GTEST_BUILD
+    WORKING_DIRECTORY ${GTEST_ROOT}/build)
 
-if(GTEST_BUILD)
+  if(GTEST_BUILD)
     message(FATAL_ERROR "Building GoogleTest failed: " ${GTEST_BUILD})
-endif(GTEST_BUILD)
+  endif(GTEST_BUILD)
 
-message(STATUS "GoogleTest installed here: " ${GTEST_ROOT}/install)
-set(GTEST_INCLUDE_DIR "${GTEST_ROOT}/install/include")
-set(GTEST_LIBRARY_DIR "${GTEST_ROOT}/install/lib")
-set(GTEST_FOUND TRUE)
-
+  message(STATUS "GoogleTest installed here: " ${GTEST_ROOT}/install)
+  set(GTEST_INCLUDE_DIR "${GTEST_ROOT}/install/include")
+  set(GTEST_LIBRARY_DIR "${GTEST_ROOT}/install/lib")
+  set(GTEST_FOUND TRUE)
+else ()
+  message(STATUS "RMM: Using system GoogleTest.")
+endif(NOT GTEST_FOUND)

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,9 +1,39 @@
-from setuptools import setup
+from setuptools import setup, find_packages
+from setuptools.command.install import install
+import os
+import subprocess
+import multiprocessing
+
+CURRENT_DIR = os.path.dirname(os.path.normpath(os.path.abspath(__file__)))
+ROOT_DIR = os.path.join(CURRENT_DIR, '..')
+LIB_PATH = [os.path.join(CURRENT_DIR, 'build', 'librmm.so')]
+BUILD_DIR = os.path.join(CURRENT_DIR, 'build')
+
+def call(command):
+    p = subprocess.Popen(command,
+                         stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+    for line in iter(p.stdout.readline, b''):
+        print(line.rstrip().decode('utf-8'))
+
+def cmake_build():
+    call(['cmake', ROOT_DIR])
+    call(['make', '-j', str(multiprocessing.cpu_count())])
+
+
+if not os.path.exists(BUILD_DIR):
+    os.mkdir(BUILD_DIR)
+    os.chdir(BUILD_DIR)
+    cmake_build()
+    os.chdir(os.path.pardir)
+
 
 setup(name='librmm_cffi',
       version="0.9.0",
       packages=["librmm_cffi"],
       setup_requires=["cffi>=1.0.0"],
       cffi_modules=["librmm_cffi/librmm_build.py:ffibuilder"],
-      install_requires=["cffi>=1.0.0"],
-      )
+      install_requires=["cffi>=1.0.0",
+                        'numpy',
+                        'numba'],
+      zip_safe=False,
+      data_files=[('.', LIB_PATH)])

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,13 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-
-
-project(RMM_TESTS LANGUAGES C CXX CUDA)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ###################################################################################################
 # - compiler function -----------------------------------------------------------------------------
@@ -68,7 +61,7 @@ ConfigureTest(RMM_TEST "${RMM_TEST_SRC}")
 set(MR_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/mr/mr_tests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mr/thrust_allocator_tests.cpp")
-    
+
 
 ConfigureTest(MR_TEST "${MR_TEST_SRC}")
 


### PR DESCRIPTION
* Enable Compiler env variables CC/CXX for CUDA host compiler.
* Use system GTest if found.

There's a concept of "Modern CMake", which can make library much easier to work with on various distributions other than fixed docker/conda environment.  I have done that for XGBoost before: https://github.com/dmlc/xgboost/pull/4323#issuecomment-480162720 .  I hope we can introduce these CMake features into rapidsai projects in the future so that they can be much more portable.