### PR TITLE
Handle ucpBufferRegion objs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
 
 ## Improvements
 
-- PR #111 Streamline CUDA_REL environment variable
+ - PR #111 Streamline CUDA_REL environment variable
+ - PR #113 Handle ucp.BufferRegion objects in auto_device
 
 ## Bug Fixes
 
-    ...
+   ...
 
 
 # RMM 0.8.0 (27 June 2019)
@@ -22,7 +23,7 @@
 
 ## Improvements
 
-  - PR #113 Handle ucp.BufferRegion objects in auto_device
+   ...
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## Improvements
 
-    ...
+  - PR #113 Handle ucp.BufferRegion objects in auto_device
 
 ## Bug Fixes
 
@@ -42,7 +42,7 @@
 
 - PR #76 Add cudatoolkit conda dependency
 - PR #84 Use latest release version in update-version CI script
-- PR #90 Avoid using c++14 auto return type for thrust_rmm_allocator.h 
+- PR #90 Avoid using c++14 auto return type for thrust_rmm_allocator.h
 
 ## Bug Fixes
 

--- a/python/librmm_cffi/wrapper.py
+++ b/python/librmm_cffi/wrapper.py
@@ -253,6 +253,8 @@ class _RMMWrapper(object):
         """
         if cuda.driver.is_device_memory(obj):
             return obj, False
+        if hasattr(obj, '__cuda_array_interface__'):
+            return cuda.as_cuda_array(obj), False
         else:
             if isinstance(obj, np.void):
                 # raise NotImplementedError("DeviceRecord type not supported "

--- a/python/librmm_cffi/wrapper.py
+++ b/python/librmm_cffi/wrapper.py
@@ -255,8 +255,8 @@ class _RMMWrapper(object):
             return obj, False
         if hasattr(obj, '__cuda_array_interface__'):
             new_dev_array = cuda.as_cuda_array(obj)
-            # Allocate new output array using rmm and copy the numba device array
-            # to an rmm owned device array
+            # Allocate new output array using rmm and copy the numba device
+            # array to an rmm owned device array
             out_dev_array = self.device_array_like(new_dev_array)
             out_dev_array.copy_to_device(new_dev_array)
             return out_dev_array, False

--- a/python/librmm_cffi/wrapper.py
+++ b/python/librmm_cffi/wrapper.py
@@ -254,7 +254,12 @@ class _RMMWrapper(object):
         if cuda.driver.is_device_memory(obj):
             return obj, False
         if hasattr(obj, '__cuda_array_interface__'):
-            return cuda.as_cuda_array(obj), False
+            new_dev_array = cuda.as_cuda_array(obj)
+            # Allocate new output array using rmm and copy the numba device array
+            # to an rmm owned device array
+            out_dev_array = self.device_array_like(new_dev_array)
+            out_dev_array.copy_to_device(new_dev_array)
+            return out_dev_array, False
         else:
             if isinstance(obj, np.void):
                 # raise NotImplementedError("DeviceRecord type not supported "


### PR DESCRIPTION
This PR makes a small change to auto_device to handle `ucp.BufferRegion` objects which have __cuda_array_interface__ metadata and need to cast as a cuda array

cc @kkraus14 