### PR TITLE
Fix README.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ $ make test
 $ make rmm_python_cffi                              # build CFFI bindings for librmm.so
 $ make rmm_install_python                           # build & install CFFI python bindings. Depends on cffi package from PyPi or Conda
 $ cd python && pytest -v                            # optional, run python tests on low-level python bindings
+```
 
 Done! You are ready to develop for the RMM OSS project.
 


### PR DESCRIPTION
This PR just add a missing code block closure that was messing with the formatting of `README.md` on the repo's front page.