### PR TITLE
Fix markdown in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@
 
 ## Bug Fixes
 
-    ...
-
+ - PR #116 Fix README.
 
 # RMM 0.8.0 (27 June 2019)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ $ make rmm_install_python                           # build & install CFFI pytho
 $ cd python && pytest -v                            # optional, run python tests on low-level python bindings
 ```
 
+
 Done! You are ready to develop for the RMM OSS project.
 
 ## Using RMM in C/C++ code


### PR DESCRIPTION
README is not currently displaying properly it because of mismatched code sections. 