### PR TITLE
[REVIEW] Proposal: Add device memory limit

### DIFF
--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -200,7 +200,6 @@ inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
     if (rmm::Manager::canAllocDeviceMemory(new_size)) {
       if (rmm::Manager::usePoolAllocator()) {
         RMM_CHECK(rmm::Manager::getInstance().registerStream(stream));
-        RMM_CHECK_CNMEM(cnmemFree(*reinterpret_cast<void**>(ptr), stream));
         RMM_CHECK_CNMEM(
             cnmemMalloc(reinterpret_cast<void**>(ptr), new_size, stream));
       } else {

--- a/include/rmm/rmm_api.h
+++ b/include/rmm/rmm_api.h
@@ -52,6 +52,8 @@ typedef enum
   CudaDefaultAllocation = 0,  //< Use cudaMalloc for allocation
   PoolAllocation        = 1,  //< Use pool suballocation strategy
   CudaManagedMemory     = 2,  //< Use cudaMallocManaged rather than cudaMalloc
+  CudaHostAllocMemory   = 4,  //< Use cudaHostAlloc rather than cudaMalloc
+  DeviceMemoryLimit     = 8,  //< Set an upper limit of Device memory usages
 } rmmAllocationMode_t;
 
 /** ---------------------------------------------------------------------------*
@@ -66,6 +68,7 @@ typedef struct
   size_t initial_pool_size;            //< When pool suballocation is enabled, 
                                        //< this is the initial pool size in bytes
   bool enable_logging;                 //< Enable logging memory manager events
+  long maximum_device_memory_size;    //< Set an upper limit of device memory usages
 } rmmOptions_t;
 
 /** ---------------------------------------------------------------------------*

--- a/python/librmm_cffi/librmm_config.py
+++ b/python/librmm_cffi/librmm_config.py
@@ -32,6 +32,19 @@ use_pool_allocator = False
 # create a managed memory pool allocator
 use_managed_memory = False
 
+# Whether to limit device memory
+# True means to limit device memory
+# Can be combined with use_host_memory to
+# avoid OOM error with host memory
+limit_device_memory = False
+
+use_host_memory = False
+
+# When limit_device_memmory is true, this indicates the limit size.
+# Minus used to indicate the default size, which currently is 1/2 total GPU
+# memory.
+maximum_gpu_memory_size = -1
+
 # When `use_pool_allocator` is true, this indicates the initial pool size.
 # Zero is used to indicate the default size, which currently is 1/2 total GPU
 # memory.

--- a/python/librmm_cffi/wrapper.py
+++ b/python/librmm_cffi/wrapper.py
@@ -82,11 +82,16 @@ class _RMMWrapper(object):
             allocation_mode = allocation_mode | self.PoolAllocation
         if rmm_cfg.use_managed_memory:
             allocation_mode = allocation_mode | self.CudaManagedMemory
+        if rmm_cfg.use_host_memory:
+            allocation_mode = allocation_mode | self.CudaHostAllocMemory
+        if rmm_cfg.limit_device_memory:
+            allocation_mode = allocation_mode | self.DeviceMemoryLimit
 
         opts = self._ffi.new("rmmOptions_t *",
                              [allocation_mode,
                               rmm_cfg.initial_pool_size,
-                              rmm_cfg.enable_logging])
+                              rmm_cfg.enable_logging,
+                              rmm_cfg.maximum_gpu_memory_size])
         return self.rmmInitialize(opts)
 
     def finalize(self):

--- a/python/tests/test_rmm.py
+++ b/python/tests/test_rmm.py
@@ -36,12 +36,15 @@ def test_rmm_alloc(dtype, nelem):
 
 
 # Test all combinations of default/managed and pooled/non-pooled allocation
-@pytest.mark.parametrize('managed, pool',
-                         list(product([False, True], [False, True])))
-def test_rmm_modes(managed, pool):
+@pytest.mark.parametrize('managed, pool, limit',
+                         list(product([False, True, False], [False, True, False], [False, True, True], [False, False, True])))
+def test_rmm_modes(managed, pool, limit):
     rmm.finalize()
     rmm_cfg.use_managed_memory = managed
     rmm_cfg.use_pool_allocator = pool
+    if limit:
+        rmm_cfg.use_host_memory = True
+        rmm_cfg.limit_device_memory = True
     rmm.initialize()
 
     assert(rmm.is_initialized())

--- a/src/rmm.cpp
+++ b/src/rmm.cpp
@@ -54,6 +54,14 @@ const char * rmmGetErrorString(rmmError_t errcode) {
 // Initialize memory manager state and storage.
 rmmError_t rmmInitialize(rmmOptions_t *options)
 {
+    if ((options->allocation_mode & DeviceMemoryLimit) &&
+         options->maximum_device_memory_size < 0) {
+        int dev;
+        cudaDeviceProp prop;
+        RMM_CHECK_CUDA(cudaGetDevice(&dev));
+        RMM_CHECK_CUDA(cudaGetDeviceProperties(&prop, dev));
+        options->maximum_device_memory_size = prop.totalGlobalMem / 2;
+    }
     rmm::Manager::getInstance().initialize(options);
 
     if (rmm::Manager::usePoolAllocator())

--- a/tests/performance/random_allocate.cpp
+++ b/tests/performance/random_allocate.cpp
@@ -79,6 +79,11 @@ void setAllocator(const std::string alloc) {
             options.allocation_mode = 
                 static_cast<rmmAllocationMode_t>(PoolAllocation | 
                                                  CudaManagedMemory);
+        else if (alloc == "rmmLimitDeviceMemory")
+            options.allocation_mode =
+                static_cast<rmmAllocationMode_t>(PoolAllocation |
+                                                 CudaHostAllocMemory |
+                                                 DeviceMemoryLimit);
         else assert(alloc == "rmmDefault");
         rmmInitialize(&options);
         gpuAlloc = _rmmAlloc;
@@ -122,7 +127,7 @@ int main(int argc, char** argv) {
 
     if (argc < 5) {
         printf("Usage: %s <allocator> <num allocations> <num unique sizes> <report average time every n allocations>\n", argv[0]);
-        printf("Allocator is one of: cudaDefault, rmmDefault, rmmManaged, rmmDefaultPool, or rmmManagedPool\n");
+        printf("Allocator is one of: cudaDefault, rmmDefault, rmmManaged, rmmDefaultPool, rmmManagedPool, or rmmLimitDeviceMemory\n");
         return 1;
     }
 


### PR DESCRIPTION
So far I have been working on RAPIDS with larger working sets than GPU memory. Let me contribute my finding here as PR.

Currently, RMM does not provide configurations for limiting the amount of GPU memory for each app. As a result, it is difficult to run multiple RAPIDS and other CUDA jobs on the same GPU even if it is underutilized. Managed memory in RMM enables us to consolidate apps, but from my observations, it degraded performance unpredictability and does not allow us to prioritize particular apps by configuring larger GPU memory. I believe future dask-cudf/cuml should have this kinds of memory configurations for optimizing large-scale, complex data processing as done by Spark and Hadoop.

In this PR, I would like to propose a new configuration, limit_device_memory to enable users to set the maximum amount of GPU memory RAPIDS can allocate. I guess this configuration is not perfect and should be enhanced more in near future (e.g., memory limit across processes), but I believe this is a good starting point to enhance RAPIDS for consolidated environments.

I also introduced another configuration CudaHostAllocMemory to avoid OOM if the allocation exceeds the configured limit. This configuration uses pinned host memory instead of device memory. cuDF on host memory looks working (of course, a bit slow) as far as my tests for cudf load, sort, and hash/sort merge with skylake and ppc64le + V100 GPU.

<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
