### PR TITLE
Fix mark down rendering for readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ used. For example:
 cudaError_t result = cudaMalloc(&myvar, size_in_bytes) );
 // ...
 cudaError_t result = cudaFree(myvar) );
+```
 
+```
 // new
 rmmError_t result = RMM_ALLOC(&myvar, size_in_bytes, stream_id);
 // ...

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ deallocation; however, the default (also known as null) stream (or `0`) can be
 used. For example:
 
 ```
+
+```
 // old
 cudaError_t result = cudaMalloc(&myvar, size_in_bytes) );
 // ...


### PR DESCRIPTION
The mark down rendering was broken because of missing (```) for README.md. 

 This pr just adds them to enable the rendering again.  