### PR TITLE
Fix merge errors and missing 0.9 date in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
  - PR #99 Added `device_buffer` class
+ - PR #133 Added `device_scalar` class
 
 ## Improvements
  - PR #123 Remove driver install from ci scripts
@@ -10,18 +11,17 @@
 
 ## Bug Fixes
 
+ - PR #107 Fix local build generated file ownerships
  - PR #125 Fixed order of private variables in LogIt
 
-# RMM 0.9.0 (Date TBD)
+
+# RMM 0.9.0 (21 August 2019)
 
 ## New Features
 
  - PR #96 Added `device_memory_resource` for beginning of overhaul of RMM design
- - PR #99 Added `device_buffer` class
  - PR #103 Add and use unified build script
- - PR #107 Fix local build generated file ownerships 
- - PR #133 Added `device_scalar` class
-
+ 
 ## Improvements
 
  - PR #111 Streamline CUDA_REL environment variable
@@ -29,7 +29,7 @@
 
 ## Bug Fixes
 
- - PR #107 Fix local build generated file ownerships
+   ...
 
 
 # RMM 0.8.0 (27 June 2019)


### PR DESCRIPTION
A bunch of PRs merged in 0.10 got attributed to 0.9 in the CHANGELOG. Fixing that, and added a date that got missed in the 0.9 changelog due to a failed automerge.