### PR TITLE
Set output ptr to 0 on RMM_UNINITIALIZED error in rmm::alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
  - PR #142 Fix ignored exceptions in Cython
  - PR #146 Fix rmmFinalize() not freeing memory pools
  - PR #149 Force finalization of RMM objects before RMM is finalized (Python)
+ - PR #154 Set ptr to 0 on rmm::alloc error
 
 
 # RMM 0.9.0 (21 August 2019)

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -119,7 +119,11 @@ class LogIt {
 template <typename T>
 inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream, const char* file,
                  unsigned int line) {
-  if (!rmmIsInitialized(nullptr)) return RMM_ERROR_NOT_INITIALIZED;
+  if (!rmmIsInitialized(nullptr)) {
+    if (ptr)
+      *ptr = nullptr;
+    return RMM_ERROR_NOT_INITIALIZED;
+  }
 
   rmm::LogIt log(rmm::Logger::Alloc, 0, size, stream, file, line);
 
@@ -127,12 +131,14 @@ inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream, const char* f
     return RMM_SUCCESS;
   }
 
-  if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
-  try{
-     *ptr = static_cast<T*>(
+  if (!ptr)
+    return RMM_ERROR_INVALID_ARGUMENT;
+
+  try {
+    *ptr = static_cast<T*>(
       rmm::mr::get_default_resource()->allocate(size,stream));
 
-  }catch(std::exception e){
+  } catch(std::exception e) {
     *ptr = nullptr;
     return RMM_ERROR_OUT_OF_MEMORY;
   }


### PR DESCRIPTION
We had some cudf build warnings / errors due to a change to rmm::alloc that caused it to exit without setting the input pointer. This PR fixes that.