### PR TITLE
[REVIEW] Fix for numba GC happening after RMM finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
  - PR #146 Fix rmmFinalize() not freeing memory pools
  - PR #149 Force finalization of RMM objects before RMM is finalized (Python)
  - PR #154 Set ptr to 0 on rmm::alloc error
- - PR #XXX Check if initialized before freeing for Numba finalizer
+ - PR #157 Check if initialized before freeing for Numba finalizer
 
 
 # RMM 0.9.0 (21 August 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - PR #146 Fix rmmFinalize() not freeing memory pools
  - PR #149 Force finalization of RMM objects before RMM is finalized (Python)
  - PR #154 Set ptr to 0 on rmm::alloc error
+ - PR #XXX Check if initialized before freeing for Numba finalizer
 
 
 # RMM 0.9.0 (21 August 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
  - PR #146 Fix rmmFinalize() not freeing memory pools
  - PR #149 Force finalization of RMM objects before RMM is finalized (Python)
  - PR #154 Set ptr to 0 on rmm::alloc error
- - PR #157 Check if initialized before freeing for Numba finalizer
+ - PR #157 Check if initialized before freeing for Numba finalizer and use `weakref` instead of `atexit`
 
 
 # RMM 0.9.0 (21 August 2019)

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import atexit
+import weakref
 
 from rmm import rmm_config
 from rmm.rmm import (
@@ -32,4 +32,6 @@ from rmm.rmm import (
 
 # Initialize RMM on import, finalize RMM on process exit
 initialize()
-atexit.register(finalize)
+
+_rmm_dummy_object = lambda: None
+_rmm_atexit_func = weakref.finalize(_rmm_dummy_object, finalize)

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -30,5 +30,6 @@ from rmm.rmm import (
     to_device,
 )
 
+# Initialize RMM on import, finalize RMM on process exit
 initialize()
 atexit.register(finalize)

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -60,13 +60,6 @@ def finalize():
     """
     Finalizes the RMM library, freeing all allocated memory
     """
-    from numba.utils import finalize as weakref_finalize
-
-    # Call finalize._exitfunc() to force finalization of
-    # any RMM objects *before* RMM is finalized.
-    # See https://github.com/rapidsai/rmm/issues/148
-    weakref_finalize._exitfunc()
-
     return librmm.rmm_finalize()
 
 
@@ -223,6 +216,7 @@ def _make_finalizer(handle, stream):
         """
         Invoked when the MemoryPointer is freed
         """
-        return librmm.rmm_free(handle, stream)
+        if is_initialized():
+            librmm.rmm_free(handle, stream)
 
     return finalizer


### PR DESCRIPTION
On import Numba registers a function to process any deferred cleanup it has to run on exit. Additionally, on import RMM registers a function to call rmmFinalize to run on exit. Whichever library is imported first will have its exit function run last.

If a user imports numba before importing RMM, this means that finalizers we set for numba devicearrays to call rmmFree can be triggered after RMM has been finalized which causes an error. This checks that RMM is initialized before calling rmmFree in the numba array finalizer to make sure we don't try to free after finalizing.

@seibert @sklam If there's a better way you can think of to ensure that Numba triggers the finalizer on all of its device arrays before hitting our atexit registration it would be much appreciated. One idea is that if saved the object here: https://github.com/numba/numba/blob/f629736997eaf83040caecd1fea7322577b7fd89/numba/utils.py#L766 we could unregister the finalizer you register, register ours, and then reregister yours to ensure your cleanup runs before rmmFinalize runs.