### PR TITLE
[REVIEW] Use `std::atexit` to finalize RMM in Cython

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #161 Use `std::atexit` to finalize RMM after Python interpreter shutdown
+
 ## Bug Fixes
 
 

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -18,7 +18,7 @@ from rmm import rmm_config
 from rmm.rmm import (
     RMMError,
     _make_finalizer,
-    _register_finalize,
+    _register_atexit_finalize,
     auto_device,
     csv_log,
     device_array,
@@ -33,4 +33,4 @@ from rmm.rmm import (
 
 # Initialize RMM on import, finalize RMM on process exit
 initialize()
-_register_finalize()
+_register_atexit_finalize()

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -18,6 +18,7 @@ from rmm import rmm_config
 from rmm.rmm import (
     RMMError,
     _make_finalizer,
+    _register_finalize,
     auto_device,
     csv_log,
     device_array,
@@ -32,6 +33,4 @@ from rmm.rmm import (
 
 # Initialize RMM on import, finalize RMM on process exit
 initialize()
-
-_rmm_dummy_object = lambda: None
-_rmm_atexit_func = weakref.finalize(_rmm_dummy_object, finalize)
+_register_finalize()

--- a/python/rmm/_lib/lib.pxd
+++ b/python/rmm/_lib/lib.pxd
@@ -141,4 +141,4 @@ cdef extern from "rmm/rmm.hpp" namespace "rmm" nogil:
 
 
 cdef extern from "cstdlib":
-    int atexit( void (*func)() )
+    int atexit(void (*func)())

--- a/python/rmm/_lib/lib.pxd
+++ b/python/rmm/_lib/lib.pxd
@@ -138,3 +138,7 @@ cdef extern from "rmm/rmm.hpp" namespace "rmm" nogil:
         const char* file,
         unsigned int line
     ) except +
+
+
+cdef extern from "cstdlib":
+    int atexit( void (*func)() )

--- a/python/rmm/_lib/lib.pyx
+++ b/python/rmm/_lib/lib.pyx
@@ -125,7 +125,7 @@ cdef void _rmmFinalizeWrapper ():
     rmmFinalize()
 
 
-def register_finalize():
+def register_atexit_finalize():
     atexit(&_rmmFinalizeWrapper)
 
 

--- a/python/rmm/_lib/lib.pyx
+++ b/python/rmm/_lib/lib.pyx
@@ -22,7 +22,6 @@ from libc.stdint cimport uintptr_t
 from libc.stdlib cimport malloc, free
 from libcpp.vector cimport vector
 
-
 # Global options, set on initialization, freed on finalization
 cdef rmmOptions_t *opts = NULL
 
@@ -117,6 +116,17 @@ def rmm_finalize():
     check_error(rmm_error)
 
     return 0
+
+
+cdef void _rmmFinalizeWrapper ():
+    global opts
+    free(opts)
+    opts = NULL
+    rmmFinalize()
+
+
+def register_finalize():
+    atexit(&_rmmFinalizeWrapper)
 
 
 def rmm_is_initialized():

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -222,5 +222,8 @@ def _make_finalizer(handle, stream):
     return finalizer
 
 
-def _register_finalize():
-    librmm.register_finalize()
+def _register_atexit_finalize():
+    """
+    Registers rmmFinalize() with ``std::atexit``.
+    """
+    librmm.register_atexit_finalize()

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -216,8 +216,7 @@ def _make_finalizer(handle, stream):
         """
         Invoked when the MemoryPointer is freed
         """
-        if is_initialized():
-            librmm.rmm_free(handle, stream)
+        librmm.rmm_free(handle, stream)
 
     return finalizer
 

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -220,3 +220,7 @@ def _make_finalizer(handle, stream):
             librmm.rmm_free(handle, stream)
 
     return finalizer
+
+
+def _register_finalize():
+    librmm.register_finalize()


### PR DESCRIPTION
@kkraus14 and I noticed that memory allocated in Cython is freed *after* RMM finalization.

Currently, we use `weakref.finalize` to finalize RMM when a dummy object defined in `rmm/__init__.py` goes out of scope. However, [from the Python docs](https://docs.python.org/3/c-api/init.html#c.Py_FinalizeEx):

> The destruction of modules and objects in modules is done in random order

This might mean that some RMM objects may still be alive after the dummy object is GC'd (thus, after RMM is finalized).

In this PR, we use [`std::atexit`](https://en.cppreference.com/w/cpp/utility/program/atexit) via Cython to register RMM finalization instead. The nice thing about this approach is that `rmmFinalize()` seems to run *after* the Python interpreter has completely shut down (thus, after all Python objects have been GC'd).