### PR TITLE
[REVIEW] Explicit stream argument for device_buffer methods

### DIFF
--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -23,7 +23,7 @@
 #include <stdexcept>
 
 namespace rmm {
-/**---------------------------------------------------------------------------*
+/**----------------------------------------------------------------------------*
  * @file device_buffer.hpp
  * @brief RAII construct for device memory allocation
  *
@@ -32,21 +32,26 @@ namespace rmm {
  * returned from `get_default_resource()` is used.
  *
  * @note Unlike `std::vector` or `thrust::device_vector`, the device memory
- * allocated by a `device_buffer` is unitialized. Therefore, it is undefined
+ * allocated by a `device_buffer` is uninitialized. Therefore, it is undefined
  * behavior to read the contents of `data()` before first initializing it.
  *
  * Examples:
  * ```
  * //Allocates at least 100 bytes of device memory using the default memory
- * //resource
+ * //resource and default stream.
  * device_buffer buff(100);
  *
- * // allocates at least 100 bytes using the custom memory resource
+ * // allocates at least 100 bytes using the custom memory resource and 
+ * // specified stream
  * custom_memory_resource mr;
- * device_buffer custom_buff(100, &mr);
+ * cudaStream_t stream = 0;
+ * device_buffer custom_buff(100, stream, &mr);
  *
- * // deep copies `buff` into a new device buffer
+ * // deep copies `buff` into a new device buffer using the default stream
  * device_buffer buff_copy(buff);
+ * 
+ * // deep copies `buff` into a new device buffer using the specified stream
+ * device_buffer buff_copy(buff, stream);
  *
  * // shallow copies `buff` into a new device_buffer, `buff` is now empty
  * device_buffer buff_move(std::move(buff));
@@ -54,52 +59,52 @@ namespace rmm {
  * // Default construction. Buffer is empty
  * device_buffer buff_default{};
  *
- * // If the requested sized is larger than the current
- * // size, resizes allocation to the new size and deep copies any previous
- * // contents. Otherwise, simply updates the value of `size()` to the newly
- * // requested size without any allocations or copies
- * buff_default.resize(100);
+ * // If the requested size is larger than the current size, resizes allocation
+ * // to the new size and deep copies any previous contents. Otherwise, simply
+ * // updates the value of `size()` to the newly requested size without any
+ * // allocations or copies. Uses the optionally specified stream or the default
+ * // stream if none specified.
+ * buff_default.resize(100, stream);
  *```
  *---------------------------------------------------------------------------**/
-
 class device_buffer {
  public:
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Constructs an empty `device_buffer` of size 0
-   *---------------------------------------------------------------------------**/
+   *-------------------------------------------------------------------------**/
   device_buffer() = default;
 
-  /**---------------------------------------------------------------------------*
-   * @brief Constructs a new device buffer of `size` unitialized bytes
+  /**--------------------------------------------------------------------------*
+   * @brief Constructs a new device buffer of `size` uninitialized bytes
    *
-   * @throws std::bad_alloc If creating the new allocation fails
+   * @throws std::bad_alloc If allocation fails.
    *
-   * @param size Size in bytes to allocate in device memory
+   * @param size Size in bytes to allocate in device memory.
    * @param stream CUDA stream on which memory may be allocated if the memory
-   * resource supports streams, otherwise the default stream is used.
-   * @param mr Memory resource to use for the device memory allocation
-   *---------------------------------------------------------------------------**/
+   * resource supports streams.
+   * @param mr Memory resource to use for the device memory allocation.
+   *-------------------------------------------------------------------------**/
   explicit device_buffer(
       std::size_t size, cudaStream_t stream = 0,
       mr::device_memory_resource* mr = mr::get_default_resource())
       : _size{size}, _capacity{size}, _stream{stream}, _mr{mr} {
-    _data = _mr->allocate(size, stream);
+    _data = _mr->allocate(size, _stream);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Construct a new device buffer by copying from a raw pointer to an
    * existing host or device memory allocation.
    *
-   * @throws std::bad_alloc If creating the new allocation fails
-   * @throws std::runtime_error If `source_data` is null, and `size != 0`
-   * @throws std::runtime_error if copying from the device memory fails
+   * @throws std::bad_alloc If creating the new allocation fails.
+   * @throws std::runtime_error If `source_data` is null, and `size != 0`.
+   * @throws std::runtime_error if copying from the device memory fails.
    *
-   * @param source_data Pointer to the host or device memory to copy from
-   * @param size Size in bytes to copy
+   * @param source_data Pointer to the host or device memory to copy from.
+   * @param size Size in bytes to copy.
    * @param stream CUDA stream on which memory may be allocated if the memory
-   * resource supports streams, otherwise the default stream is used.
+   * resource supports streams.
    * @param mr Memory resource to use for the device memory allocation
-   *---------------------------------------------------------------------------**/
+   *-------------------------------------------------------------------------**/
   device_buffer(void const* source_data, std::size_t size,
                 cudaStream_t stream = 0,
                 mr::device_memory_resource* mr = mr::get_default_resource())
@@ -108,7 +113,7 @@ class device_buffer {
       throw std::runtime_error{"Invalid size."};
     }
 
-    _data = _mr->allocate(_size, stream);
+    _data = _mr->allocate(_size, _stream);
     auto status =
         cudaMemcpyAsync(_data, source_data, _size, cudaMemcpyDefault, _stream);
     if (cudaSuccess != status) {
@@ -116,54 +121,24 @@ class device_buffer {
     }
   }
 
-  /**---------------------------------------------------------------------------*
-   * @brief Constructs a new `device_buffer` by deep copying the contents of
-   * another `device_buffer`.
-   *
-   * Uses `other.stream()` and `other.memory_resource()` for allocation.
-   *
-   * @note Only copies `other.size()` bytes from `other`, i.e., if
-   *`other.size()
-   * != other.capacity()`, then the size and capacity of the newly constructed
-   *`device_buffer` will be equal to `other.size()`.
-   *
-   * @throws std::bad_alloc If creating the new allocation fails
-   * @throws std::runtime_error if copying from `other` fails
-   *
-   * @param other The other `device_buffer` to deep copy
-   *---------------------------------------------------------------------------**/
-  device_buffer(device_buffer const& other)
-      : _size{other._size},
-        _capacity{other._size},
-        _stream{other._stream},
-        _mr{other._mr} {
-    _data = _mr->allocate(_size, _stream);
-    auto status =
-        cudaMemcpyAsync(_data, other._data, _size, cudaMemcpyDefault, _stream);
-
-    if (cudaSuccess != status) {
-      throw std::runtime_error{"Device memory copy failed."};
-    }
-  }
-
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Construct a new `device_buffer` by deep copying the contents of
-   * another `device_buffer` using the specified stream and memory resource.
+   * another `device_buffer`, optionally using the specified stream and memory
+   * resource.
    *
    * @note Only copies `other.size()` bytes from `other`, i.e., if
-   *`other.size()
-   * != other.capacity()`, then the size and capacity of the newly constructed
-   *`device_buffer` will be equal to `other.size()`.
-
-   * @throws std::bad_alloc If creating the new allocation fails
-   * @throws std::runtime_error if copying from `other` fails
+   *`other.size() != other.capacity()`, then the size and capacity of the newly
+   * constructed `device_buffer` will be equal to `other.size()`.
+   *
+   * @throws std::bad_alloc If creating the new allocation fails.
+   * @throws std::runtime_error if copying from `other` fails.
    *
    * @param other The `device_buffer` whose contents will be copied
    * @param stream The stream to use for the allocation and copy
    * @param mr The resource to use for allocating the new `device_buffer`
-   *---------------------------------------------------------------------------**/
+   *-------------------------------------------------------------------------**/
   device_buffer(
-      device_buffer const& other, cudaStream_t stream,
+      device_buffer const& other, cudaStream_t stream = 0,
       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
       : _size{other.size()}, _capacity{other.size()}, _stream{stream}, _mr{mr} {
     _data = memory_resource()->allocate(size(), _stream);
@@ -176,7 +151,7 @@ class device_buffer {
     }
   }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Constructs a new `device_buffer` by moving the contents of another
    * `device_buffer` into the newly constructed one.
    *
@@ -186,35 +161,35 @@ class device_buffer {
    * @throws Nothing
    *
    * @param other The `device_buffer` whose contents will be moved into the
-   * newly constructed one
-   *---------------------------------------------------------------------------**/
+   * newly constructed one.
+   *-------------------------------------------------------------------------**/
   device_buffer(device_buffer&& other) noexcept
       : _data{other._data},
         _size{other._size},
         _capacity{other._capacity},
-        _stream{other._stream},
+        _stream{other.stream()},
         _mr{other._mr} {
     other._data = nullptr;
     other._size = 0;
     other._capacity = 0;
-    other._stream = 0;
+    other.set_stream(0);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Copy assignment operator copies the contents of `other`
    *
-   * @param other The `device_buffer` to copy
-   *---------------------------------------------------------------------------**/
+   * @param other The `device_buffer` to copy.
+   *-------------------------------------------------------------------------**/
   device_buffer& operator=(device_buffer const& other) {
     if (&other != this) {
-      _mr->deallocate(_data, _capacity, _stream);
+      set_stream(other.stream());
+      _mr->deallocate(_data, _capacity, stream());
       _size = other._size;
       _capacity = other._size;  // only allocate _size bytes
-      _stream = other._stream;
       _mr = other._mr;
-      _data = _mr->allocate(_size, _stream);
+      _data = _mr->allocate(_size, stream());
       auto status = cudaMemcpyAsync(_data, other._data, _size,
-                                    cudaMemcpyDefault, _stream);
+                                    cudaMemcpyDefault, stream());
 
       if (cudaSuccess != status) {
         throw std::runtime_error{"Device memory copy failed."};
@@ -223,30 +198,37 @@ class device_buffer {
     return *this;
   }
 
-  /**---------------------------------------------------------------------------*
-   * @brief Move assignment operator moves the contents from `other`
+  /**--------------------------------------------------------------------------*
+   * @brief Move assignment operator moves the contents from `other`.
    *
-   * @param other The `device_buffer` whose contents will be moved
-   *---------------------------------------------------------------------------**/
+   * @param other The `device_buffer` whose contents will be moved.
+   *-------------------------------------------------------------------------**/
   device_buffer& operator=(device_buffer&& other) {
     if (&other != this) {
+      set_stream(other.stream());
       _mr->deallocate(_data, _capacity, _stream);
       _data = other._data;
       _size = other._size;
       _capacity = other._capacity;
-      _stream = other._stream;
       _mr = other._mr;
 
       other._data = nullptr;
       other._size = 0;
       other._capacity = 0;
-      other._stream = 0;
+      other.set_stream(0);
     }
     return *this;
   }
 
+  /**--------------------------------------------------------------------------*
+   * @brief Destroy the device buffer object
+   *
+   * @note If the memory resource supports streams, this destructor deallocates
+   * using the stream most recently passed to any of this device buffer's
+   * methods. 
+   *-------------------------------------------------------------------------**/
   ~device_buffer() noexcept {
-    _mr->deallocate(_data, _capacity, _stream);
+    _mr->deallocate(_data, _capacity, stream());
     _data = nullptr;
     _size = 0;
     _capacity = 0;
@@ -254,33 +236,35 @@ class device_buffer {
     _mr = nullptr;
   }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Resize the device memory allocation
    *
    * If the requested `new_size` is less than or equal to the current size, no
    * action is taken other than updating the value that is returned from
-   * `size()`. I.e., no memory is allocated nor copied. The value `capacity()`
-   * will remain the actual size of the device memory allocation.
+   * `size()`. Specifically, no memory is allocated nor copied. The value
+   * `capacity()` remains the actual size of the device memory allocation.
    *
    * @note `shrink_to_fit()` may be used to force the deallocation of unused
    * `capacity()`.
    *
    * If `new_size` is larger than the current size, a new allocation is made
-   *to satisfy `new_size`, and the contents of the old allocation are copied
-   *to the new allocation. The old allocation is then freed.
+   * to satisfy `new_size`, and the contents of the old allocation are copied
+   * to the new allocation. The old allocation is then freed.
    *
-   * The invariant `size() <= capacity()` will always be true.
+   * The invariant `size() <= capacity()` holds.
    *
-   * The `stream` returned by `stream()` is used for the allocation and
-   *copying of the new memory.
+   * The specified @p stream is used for allocating and copying the new memory if
+   * the memory resource supports streams.
    *
    * @throws std::bad_alloc If creating the new allocation fails
    * @throws std::runtime_error if the copy from the old to new allocation
    *fails
    *
    * @param new_size The requested new size, in bytes
-   *---------------------------------------------------------------------------**/
-  void resize(std::size_t new_size) {
+   * @param stream The stream to use for allocation and copy
+   *-------------------------------------------------------------------------**/
+  void resize(std::size_t new_size, cudaStream_t stream = 0) {
+    set_stream(stream);
     // If the requested size is smaller, just update the size without any
     // allocations
     if (new_size <= _size) {
@@ -302,7 +286,7 @@ class device_buffer {
     }
   }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Forces the deallocation of unused memory.
    *
    * Reallocates and copies the contents of the device memory allocation to
@@ -311,71 +295,80 @@ class device_buffer {
    * If `size() == capacity()` this function has no effect.
    *
    * @throws std::bad_alloc If creating the new allocation fails
-   * @throws std::runtime_error If the copy from the old to new allocation
-   *fails
-   *
-   *---------------------------------------------------------------------------**/
-  void shrink_to_fit() {
+   * @throws std::runtime_error If the copy from the old to new allocation fails
+   * 
+   * @param stream The stream to use for allocation and copy
+   *-------------------------------------------------------------------------**/
+  void shrink_to_fit(cudaStream_t stream = 0) {
+    set_stream(stream);
     if (size() != capacity()) {
-      void* const new_data = _mr->allocate(size(), stream());
+      void* const new_data = _mr->allocate(size(), _stream);
       if (size() > 0) {
         auto status = cudaMemcpyAsync(new_data, _data, size(),
-                                      cudaMemcpyDefault, stream());
+                                      cudaMemcpyDefault, _stream);
         if (cudaSuccess != status) {
           throw std::runtime_error{"Device memory copy failed."};
         }
       }
-      _mr->deallocate(_data, size(), stream());
+      _mr->deallocate(_data, size(), _stream);
       _data = new_data;
       _capacity = size();
     }
   }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Returns raw pointer to underlying device memory allocation
-   *---------------------------------------------------------------------------**/
+   *-------------------------------------------------------------------------**/
   void const* data() const noexcept { return _data; }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Returns raw pointer to underlying device memory allocation
-   *---------------------------------------------------------------------------**/
+   *-------------------------------------------------------------------------**/
   void* data() noexcept { return _data; }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Returns size in bytes that was requested for the device memory
    * allocation
-   *---------------------------------------------------------------------------**/
+   *-------------------------------------------------------------------------**/
   std::size_t size() const noexcept { return _size; }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
    * @brief Returns actual size in bytes of device memory allocation.
    *
-   * The following invariant will always be true:
-   * ```
-   * size() <= capacity()
-   * ```
-   *---------------------------------------------------------------------------**/
+   * The invariant `size() <= capacity()` holds.
+   *-------------------------------------------------------------------------**/
   std::size_t capacity() const noexcept { return _capacity; }
 
-  /**---------------------------------------------------------------------------*
-   * @brief Returns stream used for allocation/deallocation
-   *---------------------------------------------------------------------------**/
+  /**--------------------------------------------------------------------------*
+   * @brief Returns stream most recently specified for allocation/deallocation
+   *-------------------------------------------------------------------------**/
   cudaStream_t stream() const noexcept { return _stream; }
 
-  /**---------------------------------------------------------------------------*
+  /**--------------------------------------------------------------------------*
+   * @brief Sets the stream to be used for deallocation
+   * 
+   * If no other rmm::device_buffer method that allocates or copies memory is
+   * called after this call with a different stream argument, then @p stream
+   * will be used for deallocation in the `rmm::device_buffer destructor. 
+   * Otherwise, if another rmm::device_buffer method with a stream parameter is
+   * called after this, the later stream parameter will be stored and used in
+   * the destructor.
+   *-------------------------------------------------------------------------**/
+  void set_stream(cudaStream_t stream) noexcept { _stream = stream; }
+
+  /**--------------------------------------------------------------------------*
    * @brief Returns pointer to the memory resource used to allocate and
    * deallocate the device memory
-   *---------------------------------------------------------------------------**/
+   *-------------------------------------------------------------------------**/
   mr::device_memory_resource* memory_resource() const noexcept { return _mr; }
 
  private:
   void* _data{nullptr};     ///< Pointer to device memory allocation
   std::size_t _size{};      ///< Requested size of the device memory allocation
   std::size_t _capacity{};  ///< The actual size of the device memory allocation
-  cudaStream_t _stream{};   ///< Stream which may be used for
-                            ///< allocation/deallocation of device memory
+  cudaStream_t _stream{};   ///< Stream to use for device memory deallocation
   mr::device_memory_resource* _mr{
       mr::get_default_resource()};  ///< The memory resource used to
                                     ///< allocate/deallocate device memory
-};                                  // namespace rmm
+};
 }  // namespace rmm


### PR DESCRIPTION
When reviewing #167 I realized that some of the complexity of that PR is a result of `rmm::device_buffer()` having a reference to a stream that it uses internally. This raised some concerns in my mind.
1. What if the stream no longer exists when rmm::device_buffer calls cudaMemcpyAsync in its copy constructor, `resize`, or `shrink_to_fit`? Error.
2. Possibly more important. If someone uses one of these operators, it’s not clear externally that it is asynchronous. If they then use the device buffer’s memory on a different stream without first syncing its internal stream, there’s a race condition. It’s not obvious that the user needs to call `device_buffer::stream()` to get that stream and then sync it.

I think it's more obvious for `device_buffer` asynchronous methods to take an explicit stream argument. (The exception is `operator=`, since it can't take a stream parameter).

This PR makes that change. Now, the stored _stream is only used by the destructor. To enable changing what stream is used for destruction, this PR also adds a new `set_stream()` method.