### PR TITLE
[REVIEW] Fix cython missing symbol errors in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Bug Fixes
 
+- PR #XXX Always build librmm and rmm, but conditionally upload based on CUDA / Python version
+
 
 # RMM 0.10.0 (Date TBD)
 

--- a/ci/cpu/librmm/build_librmm.sh
+++ b/ci/cpu/librmm/build_librmm.sh
@@ -1,8 +1,6 @@
 set -e
 
-if [ "$BUILD_LIBRMM" == '1' ]; then
-  echo "Building librmm"
-  CUDA_REL=${CUDA_VERSION%.*}
+echo "Building librmm"
+CUDA_REL=${CUDA_VERSION%.*}
 
-  conda build conda/recipes/librmm -c nvidia/label/cuda${CUDA_REL} -c rapidsai/label/cuda${CUDA_REL} -c rapidsai-nightly/label/cuda${CUDA_REL} -c conda-forge --python=$PYTHON
-fi
+conda build conda/recipes/librmm --python=$PYTHON

--- a/ci/cpu/librmm/upload-anaconda.sh
+++ b/ci/cpu/librmm/upload-anaconda.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-if [ "$BUILD_LIBRMM" == '1' ]; then
-  export UPLOADFILE=`conda build conda/recipes/librmm -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge --python=$PYTHON --output`
+if [ "$UPLOAD_LIBRMM" == '1' ]; then
+  export UPLOADFILE=$(conda build conda/recipes/librmm --python=$PYTHON --output)
 
   SOURCE_BRANCH=master
   CUDA_REL=${CUDA_VERSION%.*}
@@ -22,8 +22,8 @@ if [ "$BUILD_LIBRMM" == '1' ]; then
   fi
 
   if [ -z "$MY_UPLOAD_KEY" ]; then
-      echo "No upload key"
-      return 0
+    echo "No upload key"
+    return 0
   fi
 
   echo "Upload"

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -2,14 +2,14 @@
 
 #Build rmm once per PYTHON
 if [[ "$CUDA" == "9.2" ]]; then
-    export BUILD_RMM=1
+    export UPLOAD_RMM=1
 else
-    export BUILD_RMM=0
+    export UPLOAD_RMM=0
 fi
 
 #Build librmm once per CUDA
 if [[ "$PYTHON" == "3.6" ]]; then
-    export BUILD_LIBRMM=1
+    export UPLOAD_LIBRMM=1
 else
-    export BUILD_LIBRMM=0
+    export UPLOAD_LIBRMM=0
 fi

--- a/ci/cpu/rmm/build_rmm.sh
+++ b/ci/cpu/rmm/build_rmm.sh
@@ -1,8 +1,6 @@
 set -e
 
-if [ "$BUILD_RMM" == "1" ]; then
-  echo "Building rmm"
-  export RMM_BUILD_NO_GPU_TEST=1
+echo "Building rmm"
+export RMM_BUILD_NO_GPU_TEST=1
 
-  conda build conda/recipes/rmm -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge --python=$PYTHON
-fi
+conda build conda/recipes/rmm --python=$PYTHON

--- a/ci/cpu/rmm/upload-anaconda.sh
+++ b/ci/cpu/rmm/upload-anaconda.sh
@@ -4,12 +4,12 @@
 
 set -e
 
-if [ "$BUILD_RMM" == "1" ]; then
-  export UPLOADFILE=`conda build conda/recipes/rmm -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge --python=$PYTHON --output`
+if [ "$UPLOAD_RMM" == "1" ]; then
+  export UPLOADFILE=$(conda build conda/recipes/rmm --python=$PYTHON --output)
 
   SOURCE_BRANCH=master
 
-  LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0"
+  LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0 --label cuda10.1"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${UPLOADFILE}


### PR DESCRIPTION
Always builds both librmm and rmm, but conditionally uploads based on Python / CUDA version. Prevents Cython errors from getting a librmm with mismatching symbols.