### PR TITLE
Drop `__reduce__` from `DeviceBuffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #174 Make `device_buffer` default ctor explicit to work around type_dispatcher issue in libcudf.
 - PR #170 Always build librmm and rmm, but conditionally upload based on CUDA / Python version
 - PR #182 Prefix `DeviceBuffer`'s C functions
+- PR #189 Drop `__reduce__` from `DeviceBuffer`
 
 
 # RMM 0.10.0 (16 Oct 2019)

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -23,9 +23,6 @@ cdef class DeviceBuffer:
     def __init__(self, ptr=None, size=None):
         pass
 
-    def __reduce__(self):
-        return DeviceBuffer, (self.ptr, self.size())
-
     def __len__(self):
         return self.size
 


### PR DESCRIPTION
Partially addresses ( https://github.com/rapidsai/rmm/issues/179 )

Currently we are not handling pickling of `DeviceBuffer` correctly. So go ahead and drop the `__reduce__` method until we have a chance to implement it in a more reasonable way.

cc @kkraus14 @shwina

<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
