### PR TITLE
[REVIEW] Remove thrown exception in `rmm_allocator::deallocate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #170 Always build librmm and rmm, but conditionally upload based on CUDA / Python version
 - PR #182 Prefix `DeviceBuffer`'s C functions
 - PR #189 Drop `__reduce__` from `DeviceBuffer`
+- PR #193 Remove thrown exception from `rmm_allocator::deallocate`
 
 
 # RMM 0.10.0 (16 Oct 2019)

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -211,9 +211,6 @@ inline rmmError_t free(void* ptr, cudaStream_t stream, const char* file,
 
   rmm::mr::get_default_resource()->deallocate(ptr,0,stream);
 
-  if (cudaSuccess != cudaGetLastError())
-    return RMM_ERROR_CUDA_ERROR;
-
   return RMM_SUCCESS;
 }
 

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -58,12 +58,7 @@ class rmm_allocator : public thrust::device_malloc_allocator<T>
   
     inline void deallocate(pointer ptr, size_t)
     {
-      rmmError_t error = RMM_FREE(thrust::raw_pointer_cast(ptr), stream);
-  
-      if(error != RMM_SUCCESS)
-      {
-        throw thrust::system_error(error, thrust::cuda_category(), "rmm_allocator::deallocate(): RMM_FREE");
-      }
+      RMM_FREE(thrust::raw_pointer_cast(ptr), stream);
     }
 
   private:

--- a/tests/memory_tests.cpp
+++ b/tests/memory_tests.cpp
@@ -104,18 +104,6 @@ TYPED_TEST(MemoryManagerTest, Finalize) {
     // Empty because handled in Fixture class.
 }
 
-TYPED_TEST(MemoryManagerTest, FreeInvalidPointer) {
-    char *a = (char*)100;
-    // TODO: no way to detect cnmem errors from RMM level,
-    // hence ASSERT_SUCCESS here
-    if (this->allocationMode() & PoolAllocation) {
-        ASSERT_SUCCESS(RMM_FREE(a, stream));
-    }
-    else {
-        ASSERT_FAILURE(RMM_FREE(a, stream));
-    }
-}
-
 // zero size tests
 
 TYPED_TEST(MemoryManagerTest, AllocateZeroBytes) {
@@ -181,14 +169,14 @@ TYPED_TEST(MemoryManagerTest, AllocateTB) {
     }
     else {
         ASSERT_FAILURE( RMM_ALLOC(&a, size_tb, stream) );
-        ASSERT_FAILURE( RMM_FREE(a, stream) );
+        RMM_FREE(a, stream);
     }
 }
 
 TYPED_TEST(MemoryManagerTest, AllocateTooMuch) {
     char *a = 0;
     ASSERT_FAILURE( RMM_ALLOC(&a, size_pb, stream) );
-    ASSERT_FAILURE( RMM_FREE(a, stream) );
+    RMM_FREE(a, stream);
 }
 
 TYPED_TEST(MemoryManagerTest, FreeZero) {
@@ -345,7 +333,7 @@ TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTB) {
     }
     else {
         ASSERT_FAILURE( RMM_ALLOC(&a, size_tb, stream) );
-        ASSERT_FAILURE( RMM_FREE(a, stream) );
+        RMM_FREE(a, stream);
     }
     
 }
@@ -353,7 +341,7 @@ TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTB) {
 TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTooMuch) {
     char *a = 0;
     ASSERT_FAILURE( RMM_ALLOC(&a, size_pb, stream) );
-    ASSERT_FAILURE( RMM_FREE(a, stream) );
+    RMM_FREE(a, stream);
 }
 
 TYPED_TEST(MultiGPUMemoryManagerTest, FreeZero) {

--- a/tests/memory_tests.cpp
+++ b/tests/memory_tests.cpp
@@ -104,18 +104,6 @@ TYPED_TEST(MemoryManagerTest, Finalize) {
     // Empty because handled in Fixture class.
 }
 
-TYPED_TEST(MemoryManagerTest, FreeInvalidPointer) {
-    char *a = (char*)100;
-    // TODO: no way to detect cnmem errors from RMM level,
-    // hence ASSERT_SUCCESS here
-    if (this->allocationMode() & PoolAllocation) {
-        ASSERT_SUCCESS(RMM_FREE(a, stream));
-    }
-    else {
-        ASSERT_FAILURE(RMM_FREE(a, stream));
-    }
-}
-
 // zero size tests
 
 TYPED_TEST(MemoryManagerTest, AllocateZeroBytes) {
@@ -181,14 +169,12 @@ TYPED_TEST(MemoryManagerTest, AllocateTB) {
     }
     else {
         ASSERT_FAILURE( RMM_ALLOC(&a, size_tb, stream) );
-        ASSERT_FAILURE( RMM_FREE(a, stream) );
     }
 }
 
 TYPED_TEST(MemoryManagerTest, AllocateTooMuch) {
     char *a = 0;
     ASSERT_FAILURE( RMM_ALLOC(&a, size_pb, stream) );
-    ASSERT_FAILURE( RMM_FREE(a, stream) );
 }
 
 TYPED_TEST(MemoryManagerTest, FreeZero) {
@@ -345,7 +331,6 @@ TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTB) {
     }
     else {
         ASSERT_FAILURE( RMM_ALLOC(&a, size_tb, stream) );
-        ASSERT_FAILURE( RMM_FREE(a, stream) );
     }
     
 }
@@ -353,7 +338,6 @@ TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTB) {
 TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTooMuch) {
     char *a = 0;
     ASSERT_FAILURE( RMM_ALLOC(&a, size_pb, stream) );
-    ASSERT_FAILURE( RMM_FREE(a, stream) );
 }
 
 TYPED_TEST(MultiGPUMemoryManagerTest, FreeZero) {

--- a/tests/memory_tests.cpp
+++ b/tests/memory_tests.cpp
@@ -104,6 +104,18 @@ TYPED_TEST(MemoryManagerTest, Finalize) {
     // Empty because handled in Fixture class.
 }
 
+TYPED_TEST(MemoryManagerTest, FreeInvalidPointer) {
+    char *a = (char*)100;
+    // TODO: no way to detect cnmem errors from RMM level,
+    // hence ASSERT_SUCCESS here
+    if (this->allocationMode() & PoolAllocation) {
+        ASSERT_SUCCESS(RMM_FREE(a, stream));
+    }
+    else {
+        ASSERT_FAILURE(RMM_FREE(a, stream));
+    }
+}
+
 // zero size tests
 
 TYPED_TEST(MemoryManagerTest, AllocateZeroBytes) {
@@ -169,12 +181,14 @@ TYPED_TEST(MemoryManagerTest, AllocateTB) {
     }
     else {
         ASSERT_FAILURE( RMM_ALLOC(&a, size_tb, stream) );
+        ASSERT_FAILURE( RMM_FREE(a, stream) );
     }
 }
 
 TYPED_TEST(MemoryManagerTest, AllocateTooMuch) {
     char *a = 0;
     ASSERT_FAILURE( RMM_ALLOC(&a, size_pb, stream) );
+    ASSERT_FAILURE( RMM_FREE(a, stream) );
 }
 
 TYPED_TEST(MemoryManagerTest, FreeZero) {
@@ -331,6 +345,7 @@ TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTB) {
     }
     else {
         ASSERT_FAILURE( RMM_ALLOC(&a, size_tb, stream) );
+        ASSERT_FAILURE( RMM_FREE(a, stream) );
     }
     
 }
@@ -338,6 +353,7 @@ TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTB) {
 TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTooMuch) {
     char *a = 0;
     ASSERT_FAILURE( RMM_ALLOC(&a, size_pb, stream) );
+    ASSERT_FAILURE( RMM_FREE(a, stream) );
 }
 
 TYPED_TEST(MultiGPUMemoryManagerTest, FreeZero) {


### PR DESCRIPTION
This PR fixes the mysterious and pervasive `__global__ function call is not configured` error that is frequently seen while using RMM. E.g., https://github.com/rapidsai/cudf/issues/3158

This is meant to be a minimal, easy fix. The longer term fix is to remove `rmm_allocator` and use [`rmm::mr::thrust_allocator`](https://github.com/rapidsai/rmm/blob/branch-0.11/include/rmm/mr/thrust_allocator_adaptor.hpp#L34).

# Short Story

There were several issues that are addressed by this change.

1. `rmm_allocator::deallocate` would throw if `RMM_FREE` returns anything other than `RMM_SUCCESS`. It is also called in the destructor for `rmm::device_vector`. [Throwing in destructors is bad](https://isocpp.org/wiki/faq/exceptions#dtors-shouldnt-throw). 

2. A `rmmError_t` was passed as the `error_code` to a `thrust::system_error`. 

Both of these were solved by simply removing the check for the return value from `RMM_FREE`. This is a forward looking change as `RMM_FREE` will eventually move away from returning any error code whatsoever. 

# Long Story

This story has two parts.

## One 

`rmm_allocator::deallocate` would check for the return value of `RMM_FREE` and throw a `thrust::system_error` if any status other than `RMM_SUCCESS` is returned.

If we look at the body of [`RMM_FREE`](https://github.com/rapidsai/rmm/blob/branch-0.11/include/rmm/rmm.hpp#L214):

```C++
inline rmmError_t free(void* ptr, cudaStream_t stream, const char* file,
                   unsigned int line) {
  if (!rmmIsInitialized(nullptr))
    return RMM_ERROR_NOT_INITIALIZED;

  rmm::LogIt log(rmm::Logger::Free, ptr, 0, stream, file, line);

  rmm::mr::get_default_resource()->deallocate(ptr,0,stream);

  if (cudaSuccess != cudaGetLastError())
    return RMM_ERROR_CUDA_ERROR;

  return RMM_SUCCESS;
}
```
we see that it invokes `cudaGetLastError()` and returns an `rmmError_t` of `RMM_ERROR_CUDA_ERROR` if there is any lingering CUDA error. 

The problem is, this is a catch all. This will catch _any_ and _all_ lingering CUDA errors, regardless of where they came from. This can make it appear as though `RMM_FREE` failed, when in reality there was some other prior failure that caused a CUDA error. 

Furthermore, upon a spurious `RMM_FREE` failure, `rmm_allocator::deallocate` would throw an exception, which is bad because it's called in a destructor.

## Two 

The question still remains, why did we see the error `__global__ function call is not configured` all the time? It's obviously not the error that is occurring. 

Here's the fun part of the story. 

As mentioned above, when `RMM_FREE` detects a lingering CUDA error, it returns a `rmmError_t` with the value `RMM_ERROR_CUDA_ERROR`. `rmmErrror_t` is a plain old `enum`:
```C++
typedef enum
{
  RMM_SUCCESS = 0,            //< Success result
  RMM_ERROR_CUDA_ERROR,       //< A CUDA error occurred
  RMM_ERROR_INVALID_ARGUMENT, //< An invalid argument was passed (e.g.null pointer)
  RMM_ERROR_NOT_INITIALIZED,  //< RMM API called before rmmInitialize()
  RMM_ERROR_OUT_OF_MEMORY,    //< The memory manager was unable to allocate more memory
  RMM_ERROR_UNKNOWN,          //< An unknown error occurred
  RMM_ERROR_IO,               //< Stats output error
  N_RMM_ERROR                 //< Count of error types
} rmmError_t;
```

As it happens, the integer value of `RMM_ERROR_CUDA_ERROR` is `1` (because the value of each enum member is implicitly generated by incrementing the value from the one before it). The problem with plain old enums is that they are indistinguishable from an `int`.  (This is why you should always use `enum class`, which doesn't suffer from this problem). 

The constructor for [`thrust::system_error`](https://thrust.github.io/doc/classthrust_1_1system_1_1system__error.html) expects an `int` for the error value. Thrust maintains it's own internal definition of what the value of a particular `int` means. 

Therefore, when the `thrust::system_error` was constructed with the `rmmError_t` returned from `RMM_FREE`, the `rmmError_t` was being treated as an `int` (which happened to be value `1` for `RMM_ERROR_CUDA_ERROR`). 

Now then, Thrust has _no idea_ what `RMM_ERROR_CUDA_ERROR` is, as far as it is concerned, it was passed an error value of `1`. Guess what error it associates with an error value of `1`. 
```
#include <thrust/system/system_error.h>
#include <thrust/system/cuda/error.h>


int main(void){
    thrust::system_error e(1, thrust::cuda_category(), "example");
    std::cout << e.what() << std::endl;
}
```


That's right, `__global__ function call is not configured`.

Moral of the story:
- Don't throw in destructors
- Use `enum class` (obviously this wasn't an option with the original `rmmError_t` because it required a C interface). 


