### PR TITLE
FIX Remove unused CUDA conda labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #186 Add nbytes and len to DeviceBuffer
 - PR #188 Require kwargs in `DeviceBuffer`'s constructor
 - PR #194 Drop unused imports from `device_buffer.pyx`
+- PR #196 Remove unused CUDA conda labels
 
 ## Bug Fixes
 

--- a/ci/cpu/librmm/upload-anaconda.sh
+++ b/ci/cpu/librmm/upload-anaconda.sh
@@ -12,7 +12,7 @@ if [ "$UPLOAD_LIBRMM" == '1' ]; then
 
   SOURCE_BRANCH=master
 
-  LABEL_OPTION="--label main --label cuda${CUDA_REL}"
+  LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   # Restrict uploads to master branch

--- a/ci/cpu/rmm/upload-anaconda.sh
+++ b/ci/cpu/rmm/upload-anaconda.sh
@@ -9,7 +9,7 @@ if [ "$UPLOAD_RMM" == "1" ]; then
 
   SOURCE_BRANCH=master
 
-  LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0 --label cuda10.1"
+  LABEL_OPTION="--label main"
   echo "LABEL_OPTION=${LABEL_OPTION}"
 
   test -e ${UPLOADFILE}

--- a/conda/environments/rmm_dev_cuda10.0.yml
+++ b/conda/environments/rmm_dev_cuda10.0.yml
@@ -1,6 +1,6 @@
 name: rmm_dev
 channels:
-- rapidsai/label/cuda10.0
+- rapidsai
 - conda-forge
 dependencies:
 - cmake>=3.12

--- a/conda/environments/rmm_dev_cuda9.2.yml
+++ b/conda/environments/rmm_dev_cuda9.2.yml
@@ -1,6 +1,6 @@
 name: rmm_dev
 channels:
-- rapidsai/label/cuda9.2
+- rapidsai
 - conda-forge
 dependencies:
 - cmake>=3.12


### PR DESCRIPTION
We no longer rely on these labels for version matching and use `cudatoolkit` package to do so.