### PR TITLE
[REVIEW] Implemented rmm.rmm_cupy_allocator()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PR #167 Added value setter to `device_scalar`
 - PR #163 Add Cython bindings to `device_buffer`
 - PR #177 Add `__cuda_array_interface__` to `DeviceBuffer`
+- PR #198 Add `rmm.rmm_cupy_allocator()`
 
 ## Improvements
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,6 +61,9 @@ logger "Build and install librmm and rmm..."
 if hasArg --skip-tests; then
     logger "Skipping Tests..."
 else
+    logger "Installing extra test dependencies..."
+    conda install "cupy>=6.0.0"
+
     logger "Check GPU usage..."
     nvidia-smi
 

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -29,6 +29,7 @@ from rmm.rmm import (
     is_initialized,
     reinitialize,
     to_device,
+    rmm_cupy_allocator,
 )
 
 from rmm._lib.device_buffer import DeviceBuffer

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -283,6 +283,7 @@ try:
                 self.rmm_array = None
                 self.ptr = 0
                 self.device_id = cupy.cuda.device.get_device_id()
+            self.device = cupy.cuda.device.Device(self.device_id)
 
 
 except ImportError:

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -292,6 +292,33 @@ def make_cupy_use_rmm():
     cupy.cuda.set_allocator(rmm_mem_allocator)
 
 
+def rmm_cupy_allocator(nbytes):
+    """
+    A CuPy allocator that make use of RMM.
+
+    Examples
+    --------
+    >>> import rmm
+    >>> import cupy
+    >>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+    """
+    import cupy
+    from rmm._lib.device_buffer import DeviceBuffer
+
+    class RMMMemory(cupy.cuda.memory.BaseMemory):
+        def __init__(self, size):
+            self.size = size
+            self.device_id = cupy.cuda.device.get_device_id()
+            if size > 0:
+                self.rmm_array = DeviceBuffer(size=size)
+                self.ptr = self.rmm_array.ptr
+            else:
+                self.rmm_array = None
+                self.ptr = 0
+
+    return cupy.cuda.memory.MemoryPointer(RMMMemory(nbytes), 0)
+
+
 def _make_finalizer(handle, stream):
     """
     Factory to make the finalizer function.

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -269,6 +269,10 @@ def get_ipc_handle(ary, stream=0):
 
 try:
     import cupy
+except ImportError:
+    cupy = None
+
+if cupy:
 
     class RMMCuPyMemory(cupy.cuda.memory.BaseMemory):
         def __init__(self, size):
@@ -283,10 +287,6 @@ try:
                 self.rmm_array = None
                 self.ptr = 0
                 self.device_id = cupy.cuda.device.get_device_id()
-
-
-except ImportError:
-    pass
 
 
 def rmm_cupy_allocator(nbytes):

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -267,31 +267,6 @@ def get_ipc_handle(ary, stream=0):
     )
 
 
-def make_cupy_use_rmm():
-    """
-    Make CuPy use RMM.
-    Requires the cupy module.
-    """
-    import cupy
-    from rmm._lib.device_buffer import DeviceBuffer
-
-    class RMMMemory(cupy.cuda.memory.BaseMemory):
-        def __init__(self, size):
-            self.size = size
-            self.device_id = cupy.cuda.device.get_device_id()
-            if size > 0:
-                self.rmm_array = DeviceBuffer(size=size)
-                self.ptr = self.rmm_array.ptr
-            else:
-                self.rmm_array = None
-                self.ptr = 0
-
-    def rmm_mem_allocator(bsize):
-        return cupy.cuda.memory.MemoryPointer(RMMMemory(bsize), 0)
-
-    cupy.cuda.set_allocator(rmm_mem_allocator)
-
-
 def rmm_cupy_allocator(nbytes):
     """
     A CuPy allocator that make use of RMM.
@@ -303,14 +278,13 @@ def rmm_cupy_allocator(nbytes):
     >>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
     """
     import cupy
-    from rmm._lib.device_buffer import DeviceBuffer
 
     class RMMMemory(cupy.cuda.memory.BaseMemory):
         def __init__(self, size):
             self.size = size
             self.device_id = cupy.cuda.device.get_device_id()
             if size > 0:
-                self.rmm_array = DeviceBuffer(size=size)
+                self.rmm_array = librmm.device_buffer.DeviceBuffer(size=size)
                 self.ptr = self.rmm_array.ptr
             else:
                 self.rmm_array = None

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -273,13 +273,16 @@ try:
     class RMMCuPyMemory(cupy.cuda.memory.BaseMemory):
         def __init__(self, size):
             self.size = size
-            self.device_id = cupy.cuda.device.get_device_id()
             if size > 0:
                 self.rmm_array = librmm.device_buffer.DeviceBuffer(size=size)
                 self.ptr = self.rmm_array.ptr
+                self.device_id = cupy.cuda.runtime.pointerGetAttributes(
+                    self.ptr
+                ).device
             else:
                 self.rmm_array = None
                 self.ptr = 0
+                self.device_id = cupy.cuda.device.get_device_id()
 
 
 except ImportError:

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -269,7 +269,7 @@ def get_ipc_handle(ary, stream=0):
 
 try:
     import cupy
-except ImportError:
+except Exception:
     cupy = None
 
 if cupy:

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -299,7 +299,8 @@ def rmm_cupy_allocator(nbytes):
     >>> import cupy
     >>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
     """
-    import cupy
+    if cupy is None:
+        raise ModuleNotFoundError("No module named 'cupy'")
 
     return cupy.cuda.memory.MemoryPointer(RMMCuPyMemory(nbytes), 0)
 

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -283,7 +283,6 @@ try:
                 self.rmm_array = None
                 self.ptr = 0
                 self.device_id = cupy.cuda.device.get_device_id()
-            self.device = cupy.cuda.device.Device(self.device_id)
 
 
 except ImportError:

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -275,7 +275,7 @@ def make_cupy_use_rmm():
     import cupy
     from rmm._lib.device_buffer import DeviceBuffer
 
-    class RMMemory(cupy.cuda.memory.BaseMemory):
+    class RMMMemory(cupy.cuda.memory.BaseMemory):
         def __init__(self, size):
             self.size = size
             self.device_id = cupy.cuda.device.get_device_id()
@@ -287,7 +287,7 @@ def make_cupy_use_rmm():
                 self.ptr = 0
 
     def rmm_mem_allocator(bsize):
-        return cupy.cuda.memory.MemoryPointer(RMMemory(bsize), 0)
+        return cupy.cuda.memory.MemoryPointer(RMMMemory(bsize), 0)
 
     cupy.cuda.set_allocator(rmm_mem_allocator)
 

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -78,3 +78,21 @@ def test_rmm_csv_log(dtype, nelem):
         )
         >= 0
     )
+
+
+def test_rmm_cupy_allocator():
+    cupy = pytest.importorskip("cupy")
+
+    mem = rmm.rmm_cupy_allocator(42)
+    assert mem.size == 42
+    assert mem.ptr != 0
+    assert mem.rmm_array is not None
+
+    mem = rmm.rmm_cupy_allocator(0)
+    assert mem.size == 0
+    assert mem.ptr == 0
+    assert mem.rmm_array is None
+
+    cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+    a = cupy.arange(10)
+    assert hasattr(a.data.mem, "rmm_array")

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -83,15 +83,15 @@ def test_rmm_csv_log(dtype, nelem):
 def test_rmm_cupy_allocator():
     cupy = pytest.importorskip("cupy")
 
-    mem = rmm.rmm_cupy_allocator(42)
-    assert mem.size == 42
-    assert mem.ptr != 0
-    assert mem.rmm_array is not None
+    m = rmm.rmm_cupy_allocator(42)
+    assert m.mem.size == 42
+    assert m.mem.ptr != 0
+    assert m.mem.rmm_array is not None
 
-    mem = rmm.rmm_cupy_allocator(0)
-    assert mem.size == 0
-    assert mem.ptr == 0
-    assert mem.rmm_array is None
+    m = rmm.rmm_cupy_allocator(0)
+    assert m.mem.size == 0
+    assert m.mem.ptr == 0
+    assert m.mem.rmm_array is None
 
     cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
     a = cupy.arange(10)


### PR DESCRIPTION
Closes https://github.com/rapidsai/rmm/issues/191 by implementing `rmm.make_cupy_use_rmm()`

I suggest that we add this function here and then make [`cudf.set_allocator()`](https://github.com/rapidsai/cudf/blob/5a73e75be813e76f750f3ad1416d8cdc54906bbd/python/cudf/cudf/utils/utils.py#L253) set it implicitly.

What are your thoughts? 
Do we want `make_cupy_use_rmm()` here? or do we want it in another repos such as cuDF, dask-cuda, or ucx-py?
@kkraus14 @harrism @jakirkham?