### PR TITLE
[REVIEW] Fix polymorphic exception caught by value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
+- PR #215 Catch polymorphic exceptions by reference instead of by value
 
 
 # RMM 0.11.0 (Date TBD)

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -177,7 +177,7 @@ inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
       try{
         *ptr = static_cast<char *>(
           rmm::mr::get_default_resource()->allocate(new_size,stream));
-      }catch(std::exception e){
+      }catch(std::exception const& e){
         *ptr = nullptr;
         return RMM_ERROR_OUT_OF_MEMORY;
       }

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -136,7 +136,7 @@ inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream, const char* f
     *ptr = static_cast<T*>(
       rmm::mr::get_default_resource()->allocate(size,stream));
 
-  } catch(std::exception e) {
+  } catch(std::exception const& e) {
     *ptr = nullptr;
     return RMM_ERROR_OUT_OF_MEMORY;
   }

--- a/src/rmm.cpp
+++ b/src/rmm.cpp
@@ -120,7 +120,7 @@ rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream)
     std::pair<size_t,size_t> memInfo = rmm::mr::get_default_resource()->get_mem_info( stream);
     *freeSize = memInfo.first;
     *totalSize = memInfo.second;
-  } catch(std::runtime_error){
+  } catch(std::runtime_error const&){
     return RMM_ERROR_CUDA_ERROR;
   }
   return RMM_SUCCESS;


### PR DESCRIPTION
Closes https://github.com/rapidsai/rmm/issues/205
Catch `std::exception` by reference instead of by value