### PR TITLE
[FEA] Add method to copy device_buffer back to host memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## New Features
 
+- PR #219 Add method to copy `device_buffer` back to host memory
+
 ## Improvements
 
 - PR #214 Add codeowners

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -387,7 +387,7 @@ class device_buffer {
    * @brief Copies rmm::device_buffer to a preallocated host buffer.
    *-------------------------------------------------------------------------**/
   void copy_to_host(void* host_buffer) const {
-    cudaError_t err = cudaMemcpy(host_buf,
+    cudaError_t err = cudaMemcpy(host_buffer,
                                  this->data(),
                                  this->size(),
                                  cudaMemcpyDeviceToHost);

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -383,6 +383,19 @@ class device_buffer {
    *-------------------------------------------------------------------------**/
   mr::device_memory_resource* memory_resource() const noexcept { return _mr; }
 
+  /**--------------------------------------------------------------------------*
+   * @brief Copies rmm::device_buffer to a preallocated host buffer.
+   *-------------------------------------------------------------------------**/
+  void copy_to_host(void* host_buffer) const {
+    cudaError_t err = cudaMemcpy(host_buf,
+                                 this->data(),
+                                 this->size(),
+                                 cudaMemcpyDeviceToHost);
+    if (status != cudaSuccess) {
+      throw std::runtime_error{"Failed to copy to host."};
+    }
+  }
+
  private:
   void* _data{nullptr};     ///< Pointer to device memory allocation
   std::size_t _size{};      ///< Requested size of the device memory allocation

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -387,6 +387,9 @@ class device_buffer {
    * @brief Copies rmm::device_buffer to a preallocated host buffer.
    *-------------------------------------------------------------------------**/
   void copy_to_host(void* host_buffer) const {
+    if (host_buffer == nullptr) {
+      throw std::runtime_error{"Cannot copy to `nullptr`."};
+    }
     cudaError_t err = cudaMemcpy(host_buffer,
                                  _data,
                                  _size,

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -396,16 +396,15 @@ class device_buffer {
 /**--------------------------------------------------------------------------*
  * @brief Copies rmm::device_buffer to a preallocated host buffer.
  *-------------------------------------------------------------------------**/
-void copy_to_host(device_buffer& db, void* hb, cudaStream_t stream = 0) {
+void copy_to_host(const device_buffer& db, void* hb, cudaStream_t stream = 0) {
   if (hb == nullptr) {
     throw std::runtime_error{"Cannot copy to `nullptr`."};
   }
-  db.set_stream(stream);
   cudaError_t err = cudaMemcpyAsync(hb,
                                     db.data(),
                                     db.size(),
                                     cudaMemcpyDeviceToHost,
-                                    db.stream());
+                                    stream);
   if (err != cudaSuccess) {
     throw std::runtime_error{"Failed to copy to host."};
   }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -410,8 +410,5 @@ void copy_to_host(const device_buffer& db, void* hb, cudaStream_t stream = 0) {
   if (err != cudaSuccess) {
     throw std::runtime_error{"Failed to copy to host."};
   }
-  if (cudaSuccess != cudaStreamSynchronize(stream)) {
-    throw std::runtime_error{"Stream sync failed."};
-  }
 }
 }  // namespace rmm

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -396,7 +396,7 @@ class device_buffer {
                                       _size,
                                       cudaMemcpyDeviceToHost,
                                       this->stream());
-    if (status != cudaSuccess) {
+    if (err != cudaSuccess) {
       throw std::runtime_error{"Failed to copy to host."};
     }
   }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -397,6 +397,10 @@ class device_buffer {
  * @brief Copies rmm::device_buffer to a preallocated host buffer.
  *
  * Copies device memory asynchronously on the specified stream
+ *
+ * @param db `rmm::device_buffer` to copy to host
+ * @param hb host allocated buffer to copy data to
+ * @param stream CUDA stream on which memory may be allocated if the memory
  *-------------------------------------------------------------------------**/
 void copy_to_host(const device_buffer& db, void* hb, cudaStream_t stream = 0) {
   if (hb == nullptr) {

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -398,6 +398,8 @@ class device_buffer {
  *
  * Copies device memory asynchronously on the specified stream
  *
+ * @throws std::runtime_error if `hb` is `nullptr` or copy fails
+ *
  * @param db `rmm::device_buffer` to copy to host
  * @param hb host allocated buffer to copy data to
  * @param stream CUDA stream on which memory may be allocated if the memory

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -386,14 +386,16 @@ class device_buffer {
   /**--------------------------------------------------------------------------*
    * @brief Copies rmm::device_buffer to a preallocated host buffer.
    *-------------------------------------------------------------------------**/
-  void copy_to_host(void* host_buffer) const {
+  void copy_to_host(void* host_buffer, cudaStream_t stream = 0) const {
     if (host_buffer == nullptr) {
       throw std::runtime_error{"Cannot copy to `nullptr`."};
     }
-    cudaError_t err = cudaMemcpy(host_buffer,
-                                 _data,
-                                 _size,
-                                 cudaMemcpyDeviceToHost);
+    set_stream(stream);
+    cudaError_t err = cudaMemcpyAsync(host_buffer,
+                                      _data,
+                                      _size,
+                                      cudaMemcpyDeviceToHost,
+                                      this->stream());
     if (status != cudaSuccess) {
       throw std::runtime_error{"Failed to copy to host."};
     }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -395,6 +395,8 @@ class device_buffer {
 
 /**--------------------------------------------------------------------------*
  * @brief Copies rmm::device_buffer to a preallocated host buffer.
+ *
+ * Copies device memory asynchronously on the specified stream
  *-------------------------------------------------------------------------**/
 void copy_to_host(const device_buffer& db, void* hb, cudaStream_t stream = 0) {
   if (hb == nullptr) {

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -410,5 +410,8 @@ void copy_to_host(const device_buffer& db, void* hb, cudaStream_t stream = 0) {
   if (err != cudaSuccess) {
     throw std::runtime_error{"Failed to copy to host."};
   }
+  if (cudaSuccess != cudaStreamSynchronize(stream)) {
+    throw std::runtime_error{"Stream sync failed."};
+  }
 }
 }  // namespace rmm

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -402,7 +402,7 @@ class device_buffer {
  *
  * @param db `rmm::device_buffer` to copy to host
  * @param hb host allocated buffer to copy data to
- * @param stream CUDA stream on which memory may be allocated if the memory
+ * @param stream CUDA stream on which the device to host copy will be performed
  *-------------------------------------------------------------------------**/
 void copy_to_host(const device_buffer& db, void* hb, cudaStream_t stream = 0) {
   if (hb == nullptr) {

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -388,8 +388,8 @@ class device_buffer {
    *-------------------------------------------------------------------------**/
   void copy_to_host(void* host_buffer) const {
     cudaError_t err = cudaMemcpy(host_buffer,
-                                 this->data(),
-                                 this->size(),
+                                 _data,
+                                 _size,
                                  cudaMemcpyDeviceToHost);
     if (status != cudaSuccess) {
       throw std::runtime_error{"Failed to copy to host."};

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -25,7 +25,7 @@ cdef class DeviceBuffer:
     @staticmethod
     cdef DeviceBuffer c_from_unique_ptr(unique_ptr[device_buffer] ptr)
 
-    cpdef bytes tobytes(self)
+    cpdef bytes tobytes(self, cudaStream_t stream=*)
 
     cdef size_t c_size(self)
     cpdef void resize(self, size_t new_size)

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -21,6 +21,8 @@ cdef class DeviceBuffer:
     @staticmethod
     cdef DeviceBuffer c_from_unique_ptr(unique_ptr[device_buffer] ptr)
 
+    cpdef bytes tobytes(self)
+
     cdef size_t c_size(self)
     cpdef void resize(self, size_t new_size)
     cpdef size_t capacity(self)

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -1,4 +1,5 @@
 from libcpp.memory cimport unique_ptr
+from libc.stdint cimport uintptr_t
 
 from rmm._lib.lib cimport cudaStream_t
 

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -14,7 +14,7 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         size_t size()
         size_t capacity()
 
-    void copy_to_host(device_buffer& db, void* hb) except *
+    void copy_to_host(const device_buffer& db, void* hb) except *
 
 cdef class DeviceBuffer:
     cdef unique_ptr[device_buffer] c_obj

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -25,7 +25,7 @@ cdef class DeviceBuffer:
     @staticmethod
     cdef DeviceBuffer c_from_unique_ptr(unique_ptr[device_buffer] ptr)
 
-    cpdef bytes tobytes(self, cudaStream_t stream=*)
+    cpdef bytes tobytes(self, uintptr_t stream=*)
 
     cdef size_t c_size(self)
     cpdef void resize(self, size_t new_size)

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -14,7 +14,9 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         size_t size()
         size_t capacity()
 
-    void copy_to_host(const device_buffer& db, void* hb) except *
+    void copy_to_host(const device_buffer& db,
+                      void* hb,
+                      cudaStream_t stream=*) except *
 
 cdef class DeviceBuffer:
     cdef unique_ptr[device_buffer] c_obj

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -13,6 +13,7 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         void* data()
         size_t size()
         size_t capacity()
+        void copy_to_host(void* host_buffer) except *
 
 cdef class DeviceBuffer:
     cdef unique_ptr[device_buffer] c_obj

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -13,7 +13,8 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         void* data()
         size_t size()
         size_t capacity()
-        void copy_to_host(void* host_buffer) except *
+
+    void copy_to_host(device_buffer& db, void* hb) except *
 
 cdef class DeviceBuffer:
     cdef unique_ptr[device_buffer] c_obj

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -14,9 +14,10 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         size_t size()
         size_t capacity()
 
+    void copy_to_host(const device_buffer& db, void* hb) except *
     void copy_to_host(const device_buffer& db,
                       void* hb,
-                      cudaStream_t stream=*) except *
+                      cudaStream_t stream) except *
 
 cdef class DeviceBuffer:
     cdef unique_ptr[device_buffer] c_obj

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -54,9 +54,9 @@ cdef class DeviceBuffer:
 
     cpdef bytes tobytes(self):
         cdef bytes b = PyBytes_FromStringAndSize(NULL, self.c_size())
-        cdef void* p = <void*>PyBytes_AS_STRING(b)
+        cdef char* p = PyBytes_AS_STRING(b)
 
-        copy_to_host(self.c_obj.get()[0], p)
+        copy_to_host(self.c_obj.get()[0], <void*>p)
 
         return b
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -57,7 +57,8 @@ cdef class DeviceBuffer:
         cdef bytes b = PyBytes_FromStringAndSize(NULL, self.c_size())
         cdef char* p = PyBytes_AS_STRING(b)
 
-        copy_to_host(dbp[0], <void*>p)
+        with nogil:
+            copy_to_host(dbp[0], <void*>p)
 
         return b
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -53,10 +53,11 @@ cdef class DeviceBuffer:
         return buf
 
     cpdef bytes tobytes(self):
+        cdef const device_buffer* dbp = self.c_obj.get()
         cdef bytes b = PyBytes_FromStringAndSize(NULL, self.c_size())
         cdef char* p = PyBytes_AS_STRING(b)
 
-        copy_to_host(self.c_obj.get()[0], <void*>p)
+        copy_to_host(dbp[0], <void*>p)
 
         return b
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -54,15 +54,15 @@ cdef class DeviceBuffer:
         buf.c_obj = move(ptr)
         return buf
 
-    cpdef bytes tobytes(self, cudaStream_t stream=0):
+    cpdef bytes tobytes(self, uintptr_t stream=0):
         cdef const device_buffer* dbp = self.c_obj.get()
         cdef bytes b = PyBytes_FromStringAndSize(NULL, self.c_size())
         cdef char* p = PyBytes_AS_STRING(b)
         cdef cudaError_t err
 
         with nogil:
-            copy_to_host(dbp[0], <void*>p, stream)
-            err = cudaStreamSynchronize(stream)
+            copy_to_host(dbp[0], <void*>p, <cudaStream_t>stream)
+            err = cudaStreamSynchronize(<cudaStream_t>stream)
         if err != cudaSuccess:
             raise RuntimeError("Stream sync failed.")
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -3,6 +3,8 @@ from libc.stdint cimport uintptr_t
 
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING
 
+from rmm._lib.lib cimport cudaStream_t
+
 
 cdef class DeviceBuffer:
 
@@ -52,13 +54,13 @@ cdef class DeviceBuffer:
         buf.c_obj = move(ptr)
         return buf
 
-    cpdef bytes tobytes(self):
+    cpdef bytes tobytes(self, cudaStream_t stream=0):
         cdef const device_buffer* dbp = self.c_obj.get()
         cdef bytes b = PyBytes_FromStringAndSize(NULL, self.c_size())
         cdef char* p = PyBytes_AS_STRING(b)
 
         with nogil:
-            copy_to_host(dbp[0], <void*>p)
+            copy_to_host(dbp[0], <void*>p, stream)
 
         return b
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -3,7 +3,8 @@ from libc.stdint cimport uintptr_t
 
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING
 
-from rmm._lib.lib cimport cudaError_t, cudaStream_t, cudaStreamSynchronize
+from rmm._lib.lib cimport (cudaError_t, cudaSuccess,
+                           cudaStream_t, cudaStreamSynchronize)
 
 
 cdef class DeviceBuffer:

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -1,6 +1,8 @@
 from libcpp.memory cimport unique_ptr
 from libc.stdint cimport uintptr_t
 
+from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING
+
 
 cdef class DeviceBuffer:
 
@@ -49,6 +51,14 @@ cdef class DeviceBuffer:
         cdef DeviceBuffer buf = DeviceBuffer.__new__(DeviceBuffer)
         buf.c_obj = move(ptr)
         return buf
+
+    cpdef bytes tobytes(self):
+        cdef bytes b = PyBytes_FromStringAndSize(NULL, self.c_size())
+        cdef void* p = <void*>PyBytes_AS_STRING(b)
+
+        self.c_obj.get()[0].copy_to_host(p)
+
+        return b
 
     cdef size_t c_size(self):
         return self.c_obj.get()[0].size()

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -56,7 +56,7 @@ cdef class DeviceBuffer:
         cdef bytes b = PyBytes_FromStringAndSize(NULL, self.c_size())
         cdef void* p = <void*>PyBytes_AS_STRING(b)
 
-        self.c_obj.get()[0].copy_to_host(p)
+        copy_to_host(self.c_obj.get()[0], p)
 
         return b
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -65,7 +65,7 @@ cdef class DeviceBuffer:
             copy_to_host(dbp[0], <void*>p, <cudaStream_t>stream)
             err = cudaStreamSynchronize(<cudaStream_t>stream)
         if err != cudaSuccess:
-            raise RuntimeError("Stream sync failed.")
+            raise RuntimeError(f"Stream sync failed with error: {err}")
 
         return b
 

--- a/python/rmm/_lib/lib.pxd
+++ b/python/rmm/_lib/lib.pxd
@@ -33,7 +33,7 @@ cdef extern from * nogil:
 
     ctypedef void* cudaStream_t "cudaStream_t"
 
-    ctypedef cudaError_t cudaStreamSynchronize(cudaStream_t stream)
+    cudaError_t cudaStreamSynchronize(cudaStream_t stream)
 
 
 cdef uintptr_t c_alloc(

--- a/python/rmm/_lib/lib.pxd
+++ b/python/rmm/_lib/lib.pxd
@@ -33,6 +33,8 @@ cdef extern from * nogil:
 
     ctypedef void* cudaStream_t "cudaStream_t"
 
+    ctypedef cudaError_t cudaStreamSynchronize(cudaStream_t stream)
+
 
 cdef uintptr_t c_alloc(
     size_t size,

--- a/python/rmm/_lib/lib.pxd
+++ b/python/rmm/_lib/lib.pxd
@@ -28,6 +28,9 @@ ctypedef pair[size_t, size_t] memory_pair
 
 cdef extern from * nogil:
 
+    ctypedef enum cudaError_t "cudaError_t":
+        cudaSuccess = 0
+
     ctypedef void* cudaStream_t "cudaStream_t"
 
 

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -105,6 +105,11 @@ def test_rmm_device_buffer(size):
     assert b.__cuda_array_interface__["typestr"] == "|u1"
     assert b.__cuda_array_interface__["version"] == 0
 
+    # Test conversion to bytes
+    s = b.tobytes()
+    assert isinstance(s, bytes)
+    assert len(s) == len(b)
+
     # Test resizing
     b.resize(2)
     assert b.size == 2

--- a/tests/device_buffer_tests.cpp
+++ b/tests/device_buffer_tests.cpp
@@ -111,6 +111,15 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawDevicePointer) {
   EXPECT_EQ(cudaSuccess, cudaFree(device_memory));
 }
 
+TYPED_TEST(DeviceBufferTest, CopyToRawHostPointer) {
+  rmm::device_buffer buff(this->size);
+  std::vector<uint8_t> host_data(this->size);
+  uint8_t* host_data_ptr = host_data.data();
+  rmm::copy_to_host(buff, host_data_ptr);
+  EXPECT_EQ(0, buff.stream());
+  // TODO check for equality between the contents of the two allocations
+}
+
 TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer) {
   std::vector<uint8_t> host_data(this->size);
   rmm::device_buffer buff(static_cast<void*>(host_data.data()), this->size);


### PR DESCRIPTION
Fixes https://github.com/rapidsai/rmm/issues/216

Adds the functionality to `rmm::device_buffer` and `rmm.DeviceBuffer` to copy data back from device memory to host memory. On the C++ side this copies data back to a user allocated buffer. On the Python side this copies data into a Python `bytes` object.

<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
