### PR TITLE
[WIP] add 'device_pointer' RAII class to manage raw pointers instead of Cython __dealloc__

### DIFF
--- a/include/rmm/device_pointer.hpp
+++ b/include/rmm/device_pointer.hpp
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include <rmm/rmm.hpp>
+#include <rmm/rmm.h>
 
 #include <cuda_runtime_api.h>
 
@@ -42,22 +42,17 @@ class device_pointer {
    * @param stream CUDA stream on which memory may be allocated if the memory
    * resource supports streams.
    *-------------------------------------------------------------------------**/
-  device_pointer(void const* ptr, cudaStream_t stream = 0)
+  device_pointer(void* ptr, cudaStream_t stream = 0)
       : _ptr{ptr}, _stream{stream} {}
 
   /**--------------------------------------------------------------------------*
    * @brief Destroy the `device_pointer` object and free the underlying memory.
    *-------------------------------------------------------------------------**/
   ~device_pointer() noexcept {
-    free(_data, _stream)
-    _data = nullptr;
+    RMM_FREE(_ptr, _stream);
+    _ptr = nullptr;
     _stream = 0;
   }
-
-  /**--------------------------------------------------------------------------*
-   * @brief Returns pointer being managed
-   *-------------------------------------------------------------------------**/
-  void const* ptr() const noexcept { return _ptr; }
 
   /**--------------------------------------------------------------------------*
    * @brief Returns pointer being managed

--- a/include/rmm/device_pointer.hpp
+++ b/include/rmm/device_pointer.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <rmm/rmm.hpp>
+
+#include <cuda_runtime_api.h>
+
+namespace rmm {
+/**----------------------------------------------------------------------------*
+ * @file device_pointer.hpp
+ * @brief RAII wrapper for an RMM allocated raw device memory pointer
+ *
+ * This class wraps a raw device memory pointer and frees it when the instance
+ * of the class goes out of scope. Effectively, `device_pointer` takes
+ * ownership of the memory pointed to by the pointer.
+ *
+ * Examples:
+ * ```
+ * TBD
+ * ```
+ *---------------------------------------------------------------------------**/
+class device_pointer {
+ public:
+  /**--------------------------------------------------------------------------*
+   * @brief Constructs a new device_pointer from a given pointer
+   *
+   * @param ptr Pointer to the device memory.
+   * @param stream CUDA stream on which memory may be allocated if the memory
+   * resource supports streams.
+   *-------------------------------------------------------------------------**/
+  device_pointer(void const* ptr, cudaStream_t stream = 0)
+      : _ptr{ptr}, _stream{stream} {}
+
+  /**--------------------------------------------------------------------------*
+   * @brief Destroy the `device_pointer` object and free the underlying memory.
+   *-------------------------------------------------------------------------**/
+  ~device_pointer() noexcept {
+    free(_data, _stream)
+    _data = nullptr;
+    _stream = 0;
+  }
+
+  /**--------------------------------------------------------------------------*
+   * @brief Returns pointer being managed
+   *-------------------------------------------------------------------------**/
+  void const* ptr() const noexcept { return _ptr; }
+
+  /**--------------------------------------------------------------------------*
+   * @brief Returns pointer being managed
+   *-------------------------------------------------------------------------**/
+  void* ptr() noexcept { return _ptr; }
+
+  /**--------------------------------------------------------------------------*
+   * @brief Returns stream of pointer being managed
+   *-------------------------------------------------------------------------**/
+  cudaStream_t stream() const noexcept { return _stream; }
+
+ private:
+  void* _ptr{nullptr};     ///< Pointer being managed
+  cudaStream_t _stream{};   ///< Stream to use for device memory deallocation
+};
+}  // namespace rmm

--- a/python/rmm/_lib/device_pointer.pxd
+++ b/python/rmm/_lib/device_pointer.pxd
@@ -1,5 +1,15 @@
-from rmm._lib.lib cimport c_free, cudaStream_t
+from libcpp.memory cimport unique_ptr
+from rmm._lib.lib cimport cudaStream_t
+
+
+cdef extern from "rmm/device_pointer.hpp" namespace "rmm" nogil:
+    cdef cppclass device_pointer:
+        device_pointer(const void* ptr)
+        device_pointer(const void* ptr, cudaStream_t stream)
+        void* ptr()
+        cudaStream_t stream()
 
 cdef class DevicePointer:
-    cdef void* c_ptr
-    cdef cudaStream_t c_stream
+    cdef unique_ptr[device_pointer] c_obj
+    cdef void* c_ptr(self)
+    cdef cudaStream_t c_stream(self)

--- a/python/rmm/_lib/device_pointer.pyx
+++ b/python/rmm/_lib/device_pointer.pyx
@@ -17,16 +17,20 @@ cdef class DevicePointer:
         stream : int, optional
             CUDA stream to use for the deallocation
         """
-        self.c_ptr = <void*><uintptr_t>(ptr)
-        self.c_stream = <cudaStream_t><uintptr_t>(stream)
+        cdef void* c_ptr = <void*><uintptr_t>(ptr)
+        cdef cudaStream_t c_stream = <cudaStream_t><uintptr_t>(stream)
+        self.c_obj.reset(new device_pointer(c_ptr, c_stream))
+
+    cdef void* c_ptr(self):
+        return self.c_obj.get()[0].ptr()
+
+    cdef cudaStream_t c_stream(self):
+        return self.c_obj.get()[0].stream()
 
     @property
     def ptr(self):
-        return int(<uintptr_t>(self.c_ptr))
+        return int(<uintptr_t>(self.c_ptr()))
 
     @property
     def stream(self):
-        return int(<uintptr_t>(self.c_stream))
-
-    def __dealloc__(self):
-        c_free(self.c_ptr, self.c_stream)
+        return int(<uintptr_t>(self.c_stream()))


### PR DESCRIPTION
I apologize in advance for any silly / stupid C++ mistakes I made 😅.

Moves lifetime management of the managed raw pointer away from the Cython class to a C++ RAII class that Cython uses via a `unique_ptr`.