### PR TITLE
[REVIEW] Fix segfault calling rmmGetInfo when uninitialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Bug Fixes
 - PR #215 Catch polymorphic exceptions by reference instead of by value
-
+- PR #221 Fix segfault calling rmmGetInfo when uninitialized
 
 # RMM 0.11.0 (Date TBD)
 

--- a/src/rmm.cpp
+++ b/src/rmm.cpp
@@ -116,6 +116,8 @@ rmmError_t rmmGetAllocationOffset(ptrdiff_t *offset,
 // with the stream.
 rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream)
 {
+  if (!rmmIsInitialized(nullptr))
+    return RMM_ERROR_NOT_INITIALIZED;
   try {
     std::pair<size_t,size_t> memInfo = rmm::mr::get_default_resource()->get_mem_info( stream);
     *freeSize = memInfo.first;

--- a/tests/memory_tests.cpp
+++ b/tests/memory_tests.cpp
@@ -86,6 +86,11 @@ TYPED_TEST(MemoryManagerUninitializedTest, UninitializedAllocateFree) {
     ASSERT_FAILURE(RMM_FREE(a, stream));
 }
 
+TYPED_TEST(MemoryManagerUninitializedTest, GetInfoUninitialized) {
+    size_t free, total;
+    ASSERT_FAILURE(rmmGetInfo(&free, &total, stream));
+}
+
 
 // Init / Finalize tests
 


### PR DESCRIPTION
When RMM is uninitialized (e.g. due to calling `rmmFinalize()`) a call to `rmmGetInfo` can segfault in `rmm::detail::mr::device_memory_resource::get_mem_info()` with an invalid instance. This commit fixes the segfault by adding a check to `rmmGetInfo()` which ensures that RMM is initialized before proceeding to call `get_mem_info()`.

<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
