### PR TITLE
[REVIEW] Expose free and total memory in Python interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - PR #218 Add `_DevicePointer`
+- PR #222 Expose free and total memory in Python interface
 
 ## Improvements
 
@@ -11,6 +12,7 @@
 ## Bug Fixes
 - PR #215 Catch polymorphic exceptions by reference instead of by value
 - PR #221 Fix segfault calling rmmGetInfo when uninitialized
+
 
 # RMM 0.11.0 (Date TBD)
 

--- a/README.md
+++ b/README.md
@@ -296,8 +296,9 @@ The amount of free and total memory managed by RMM associated with a particular
 stream can be obtained with the `get_info` function:
 
 ```python
-# Returns e.g. (16046292992, 16914055168)
-rmm.get_info()
+meminfo = rmm.get_info()
+print(meminfo.free)  # E.g. "16046292992"
+print(meminfo.total) # E.g. "16914055168"
 ```
 
 ### CUDA Managed Memory

--- a/README.md
+++ b/README.md
@@ -290,6 +290,16 @@ finalize RMM. The Mortgage E2E workflow notebook uses this technique. We are
 working on better ways to reclaim memory, as well as making RAPIDS machine
 learning libraries use the same RMM memory pool.
 
+### Memory info
+
+The amount of free and total memory managed by RMM associated with a particular
+stream can be obtained with the `get_info` function:
+
+```python
+# Returns e.g. (16046292992, 16914055168)
+rmm.get_info()
+```
+
 ### CUDA Managed Memory
 
 RMM can be set to allocate all memory as managed memory (`cudaMallocManaged`

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -26,6 +26,7 @@ from rmm.rmm import (
     device_array_from_ptr,
     device_array_like,
     get_ipc_handle,
+    get_info,
     is_initialized,
     reinitialize,
     to_device,

--- a/python/rmm/_lib/lib.pxd
+++ b/python/rmm/_lib/lib.pxd
@@ -23,6 +23,7 @@ from libcpp.utility cimport pair
 from libcpp.vector cimport vector
 
 ctypedef pair[const char*, unsigned int] caller_pair
+ctypedef pair[size_t, size_t] memory_pair
 
 
 cdef extern from * nogil:
@@ -46,6 +47,10 @@ cdef ptrdiff_t* c_getallocationoffset(
 ) except? <ptrdiff_t*>NULL
 
 cdef caller_pair _get_caller() except *
+
+cdef memory_pair c_getinfo(
+    cudaStream_t stream
+) except *
 
 
 cdef extern from "rmm/rmm.h" nogil:

--- a/python/rmm/_lib/lib.pyx
+++ b/python/rmm/_lib/lib.pyx
@@ -17,6 +17,8 @@
 # cython: embedsignature = True
 # cython: language_level = 3
 
+from collections import namedtuple
+
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport malloc, free
 from libcpp.vector cimport vector
@@ -296,10 +298,11 @@ def rmm_getinfo(stream):
     """Get total and free memory sizes using the RMM memory manager by calling
     the librmm functions via Cython
     """
-    cdef cudaStream_t c_stream = <cudaStream_t><size_t>stream
+    cdef cudaStream_t c_stream = <cudaStream_t><uintptr_t>stream
 
     cdef memory_pair memory_info = c_getinfo(
         <cudaStream_t>c_stream
     )
 
-    return int(memory_info.first), int(memory_info.second)
+    MemoryInfo = namedtuple("MemoryInfo", ['free', 'total'])
+    return MemoryInfo(int(memory_info.first), int(memory_info.second))

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -270,7 +270,7 @@ def get_ipc_handle(ary, stream=0):
 def get_info(stream=0):
     """
     Get the free and total bytes of memory managed by a manager associated with
-    the stream as a tuple of (free, total)
+    the stream as a namedtuple with members `free` and `total`.
     """
     return librmm.rmm_getinfo(stream)
 

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -267,6 +267,14 @@ def get_ipc_handle(ary, stream=0):
     )
 
 
+def get_info(stream=0):
+    """
+    Get the free and total bytes of memory managed by a manager associated with
+    the stream as a tuple of (free, total)
+    """
+    return librmm.rmm_getinfo(stream)
+
+
 try:
     import cupy
 except Exception:

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -96,3 +96,20 @@ def test_rmm_cupy_allocator():
     cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
     a = cupy.arange(10)
     assert hasattr(a.data.mem, "rmm_array")
+
+
+def test_rmm_getinfo():
+    free, total = rmm.get_info()
+    # Basic sanity checks of returned values
+    assert free >= 0
+    assert total >= 0
+    assert free <= total
+
+
+def test_rmm_getinfo_uninitialized():
+    rmm._finalize()
+
+    with pytest.raises(rmm.RMMError):
+        rmm.get_info()
+
+    rmm.reinitialize()

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -99,11 +99,11 @@ def test_rmm_cupy_allocator():
 
 
 def test_rmm_getinfo():
-    free, total = rmm.get_info()
+    meminfo = rmm.get_info()
     # Basic sanity checks of returned values
-    assert free >= 0
-    assert total >= 0
-    assert free <= total
+    assert meminfo.free >= 0
+    assert meminfo.total >= 0
+    assert meminfo.free <= meminfo.total
 
 
 def test_rmm_getinfo_uninitialized():


### PR DESCRIPTION
Whilst thinking about creating a memory manager plugin interface to use RMM with Numba, I noticed that the free and total memory doesn't seem to be available from the Python interface - this PR adds a wrapping of the `rmmGetInfo` function and exposes it as:

```python
rmm.get_info()
```

which will return, for example, `(16046292992, 16914055168)` (free and total memory in bytes).

This PR depends on PR #221, as the `test_rmm_getinfo_uninitialized` test causes a segfault without it.

<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
