### PR TITLE
Cleanup `DeviceBuffer`'s `__cinit__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #226 Add some tests of the Python `DeviceBuffer`
 - PR #233 Reuse the same `CUDA_HOME` logic from cuDF
 - PR #234 Add missing `size_t` in `DeviceBuffer`
+- PR #239 Cleanup `DeviceBuffer`'s `__cinit__`
 
 ## Bug Fixes
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -12,19 +12,19 @@ cdef class DeviceBuffer:
     def __cinit__(self, *, ptr=None, size=None, stream=None):
         cdef size_t c_size
         if size is None:
-            c_size = 0
+            c_size = <size_t>0
         else:
             c_size = <size_t>size
 
         cdef cudaStream_t c_stream
         if stream is None:
-            c_stream = 0
+            c_stream = <cudaStream_t><uintptr_t>0
         else:
             c_stream = <cudaStream_t><uintptr_t>stream
 
         cdef void * c_ptr
         if ptr is None:
-            c_ptr = NULL
+            c_ptr = <void *>NULL
         else:
             c_ptr = <void *> <uintptr_t> ptr
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -10,24 +10,30 @@ from rmm._lib.lib cimport (cudaError_t, cudaSuccess,
 cdef class DeviceBuffer:
 
     def __cinit__(self, *, ptr=None, size=None, stream=None):
+        cdef size_t c_size
         if size is None:
-            size = 0
+            c_size = 0
+        else:
+            c_size = <size_t>size
 
+        cdef cudaStream_t c_stream
         if stream is None:
-            stream = 0
+            c_stream = 0
+        else:
+            c_stream = <cudaStream_t><uintptr_t>stream
 
         cdef void * c_ptr
         if ptr is None:
             self.c_obj.reset(
                 new device_buffer(
-                    <size_t>size, <cudaStream_t><uintptr_t>stream
+                    c_size, c_stream
                 )
             )
         else:
             c_ptr = <void *> <uintptr_t> ptr
             self.c_obj.reset(
                 new device_buffer(
-                    c_ptr, <size_t>size, <cudaStream_t><uintptr_t>stream
+                    c_ptr, c_size, c_stream
                 )
             )
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -28,10 +28,11 @@ cdef class DeviceBuffer:
         else:
             c_ptr = <void *> <uintptr_t> ptr
 
-        if c_ptr == NULL:
-            self.c_obj.reset(new device_buffer(c_size, c_stream))
-        else:
-            self.c_obj.reset(new device_buffer(c_ptr, c_size, c_stream))
+        with nogil:
+            if c_ptr == NULL:
+                self.c_obj.reset(new device_buffer(c_size, c_stream))
+            else:
+                self.c_obj.reset(new device_buffer(c_ptr, c_size, c_stream))
 
     def __init__(self, *, ptr=None, size=None, stream=None):
         pass

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -24,13 +24,17 @@ cdef class DeviceBuffer:
 
         cdef void * c_ptr
         if ptr is None:
+            c_ptr = NULL
+        else:
+            c_ptr = <void *> <uintptr_t> ptr
+
+        if c_ptr == NULL:
             self.c_obj.reset(
                 new device_buffer(
                     c_size, c_stream
                 )
             )
         else:
-            c_ptr = <void *> <uintptr_t> ptr
             self.c_obj.reset(
                 new device_buffer(
                     c_ptr, c_size, c_stream

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -16,7 +16,7 @@ cdef class DeviceBuffer:
         if stream is None:
             stream = 0
 
-        cdef void * data
+        cdef void * c_ptr
         if ptr is None:
             self.c_obj.reset(
                 new device_buffer(
@@ -24,10 +24,10 @@ cdef class DeviceBuffer:
                 )
             )
         else:
-            data = <void *> <uintptr_t> ptr
+            c_ptr = <void *> <uintptr_t> ptr
             self.c_obj.reset(
                 new device_buffer(
-                    data, <size_t>size, <cudaStream_t><uintptr_t>stream
+                    c_ptr, <size_t>size, <cudaStream_t><uintptr_t>stream
                 )
             )
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -34,9 +34,6 @@ cdef class DeviceBuffer:
             else:
                 self.c_obj.reset(new device_buffer(c_ptr, c_size, c_stream))
 
-    def __init__(self, *, ptr=None, size=None, stream=None):
-        pass
-
     def __len__(self):
         return self.size
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -29,17 +29,9 @@ cdef class DeviceBuffer:
             c_ptr = <void *> <uintptr_t> ptr
 
         if c_ptr == NULL:
-            self.c_obj.reset(
-                new device_buffer(
-                    c_size, c_stream
-                )
-            )
+            self.c_obj.reset(new device_buffer(c_size, c_stream))
         else:
-            self.c_obj.reset(
-                new device_buffer(
-                    c_ptr, c_size, c_stream
-                )
-            )
+            self.c_obj.reset(new device_buffer(c_ptr, c_size, c_stream))
 
     def __init__(self, *, ptr=None, size=None, stream=None):
         pass


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

Defines C typed variables for those provided to the constructor. Casts the Python variables to C variables once and then reuses the C variables. Operates only on the C variables later. This allows the GIL to be released during construction of the underlying `rmm:: device_buffer`.