### PR TITLE
Drop conda recipe 'host' reqirement of cudatoolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #239 Cleanup `DeviceBuffer`'s `__cinit__`
 - PR #242 Special case 0-size `DeviceBuffer` in `tobytes`
 - PR #244 Explicitly force `DeviceBuffer.size` to an `int`
+- PR #248 Drop conda recipe 'host' reqirement of cudatoolkit
 
 ## Bug Fixes
 

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -25,8 +25,6 @@ build:
 requirements:
   build:
     - cmake >=3.12.4
-  host:
-    - cudatoolkit {{ cuda_version }}.*
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 


### PR DESCRIPTION
Having CTK in run is sufficient and removes the need to install CTK during conda build. I tested locally with builds in a gpuCI container, everything builds and all tests pass.