### PR TITLE
Use `DeviceBuffer` in `device_array`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 - PR #246 Type `DeviceBuffer` arguments to `__cinit__`
+- PR #249 Use `DeviceBuffer` in `device_array`
 
 ## Bug Fixes
 

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -172,8 +172,6 @@ def device_array(shape, dtype=np.float, strides=None, order="C", stream=0):
 
     buf = librmm.DeviceBuffer(size=datasize, stream=stream)
 
-    # Note Numba will call the finalizer to free the device memory
-    # allocated above
     ctx = cuda.current_context()
     ptr = ctypes.c_uint64(int(buf.ptr))
     mem = cuda.driver.MemoryPointer(ctx, ptr, datasize, owner=buf)

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -28,15 +28,6 @@ class RMMError(Exception):
         super(RMMError, self).__init__(msg)
 
 
-def _array_helper(addr, datasize, shape, strides, dtype, finalizer=None):
-    ctx = cuda.current_context()
-    ptr = ctypes.c_uint64(int(addr))
-    mem = cuda.driver.MemoryPointer(ctx, ptr, datasize, finalizer=finalizer)
-    return cuda.cudadrv.devicearray.DeviceNDArray(
-        shape, strides, dtype, gpu_data=mem
-    )
-
-
 class rmm_allocation_mode(IntEnum):
     CudaDefaultAllocation = (0,)
     PoolAllocation = (1,)

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -153,14 +153,14 @@ def device_array_from_ptr(ptr, nelem, dtype=np.float, finalizer=None):
 
     elemsize = dtype.itemsize
     datasize = elemsize * nelem
+    shape = (nelem,)
+    strides = (elemsize,)
     # note no finalizer -- freed externally!
-    return _array_helper(
-        addr=ptr,
-        datasize=datasize,
-        shape=(nelem,),
-        strides=(elemsize,),
-        dtype=dtype,
-        finalizer=finalizer,
+    ctx = cuda.current_context()
+    ptr = ctypes.c_uint64(int(ptr))
+    mem = cuda.driver.MemoryPointer(ctx, ptr, datasize, finalizer=finalizer)
+    return cuda.cudadrv.devicearray.DeviceNDArray(
+        shape, strides, dtype, gpu_data=mem
     )
 
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

Instead of relying on using `rmm_alloc`, this uses `DeviceBuffer` to allocate memory to back Numba `DeviceNDArray` objects. This has the benefit that the memory will be freed (by C++) once the `DeviceBuffer` object scopes out. So the finalizer is no longer needed/used here. Have dropped the `_array_helper` function. `_make_finalizer` is kept as downstream projects (cuDF and cuGRAPH) still use it, but is no longer used by RMM.

Note: This is targeting RAPIDS 0.13.0. Making it a draft now for discussion.