### PR TITLE
Define pickling behavior for `DeviceBuffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - PR #253 Add `frombytes` to convert `bytes`-like to `DeviceBuffer`
 - PR #252 Add `__sizeof__` method to `DeviceBuffer`
+- PR #258 Define pickling behavior for `DeviceBuffer`
 
 ## Improvements
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -64,6 +64,13 @@ cdef class DeviceBuffer:
     def size(self):
         return int(self.c_size())
 
+    def __getstate__(self):
+        return self.tobytes()
+
+    def __setstate__(self, state):
+        cdef DeviceBuffer other = DeviceBuffer.c_frombytes(state)
+        self.c_obj = move(other.c_obj)
+
     @property
     def __cuda_array_interface__(self):
         cdef dict intf = {

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 from itertools import product
 
@@ -161,6 +162,16 @@ def test_rmm_device_buffer_bytes_roundtrip(hb):
             hb2 = db.tobytes()
             mv2 = memoryview(hb2)
             assert mv == mv2
+
+
+@pytest.mark.parametrize("hb", [b"", b"123", b"abc"])
+def test_rmm_device_buffer_pickle_roundtrip(hb):
+    db = rmm.DeviceBuffer.frombytes(hb)
+    pb = pickle.dumps(db)
+    del db
+    db2 = pickle.loads(pb)
+    hb2 = db2.tobytes()
+    assert hb == hb2
 
 
 def test_rmm_cupy_allocator():


### PR DESCRIPTION
Follow up to PR ( https://github.com/rapidsai/rmm/pull/163 ) where pickling was initially added and issue ( https://github.com/rapidsai/rmm/issues/179 ) where discussion about this behavior occurred.

This adds pickling behavior as described in [this comment]( https://github.com/rapidsai/rmm/issues/179#issuecomment-558376118 ). Namely it pickles the data by copying it to a Python `bytes` object and unpickles it by loading the data in the Python `bytes` object on the device.

Pickling is defined through the higher-level Python API (using `__getstate__` and `__setstate__`) as opposed to lower-level APIs (like `__reduce__`). This is recommended in the Python docs (see [the section following `__setstate__`]( https://docs.python.org/3.8/library/pickle.html#object.__setstate__ )). As there are already methods to copy data to and from `bytes` objects, these method merely reuse that implementation. In `__setstate__` we construct a `DeviceBuffer`, whose state we steal from to use in our own `DeviceBuffer`.

cc @kkraus14 @shwina

<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
