### PR TITLE
Allocate a `bytes` object to fill up with RMM log data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #254 Use `const void*` in `DeviceBuffer.__cinit__`
 - PR #257 Mark Cython-exposed C++ functions that raise
 - PR #269 Doc sync behavior in `copy_ptr_to_host`
+- PR #278 Allocate a `bytes` object to fill up with RMM log data
 
 ## Bug Fixes
 

--- a/python/rmm/_lib/lib.pyx
+++ b/python/rmm/_lib/lib.pyx
@@ -145,10 +145,7 @@ def rmm_csv_log():
     cdef char* buf = <char*>malloc(logsize)
 
     with nogil:
-        rmm_error = rmmGetLog(
-            <char*>buf,
-            <size_t>logsize
-        )
+        rmm_error = rmmGetLog(buf, logsize)
 
     check_error(rmm_error)
 

--- a/python/rmm/_lib/lib.pyx
+++ b/python/rmm/_lib/lib.pyx
@@ -23,6 +23,8 @@ from libc.stdint cimport uintptr_t
 from libc.stdlib cimport malloc, free
 from libcpp.vector cimport vector
 
+from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING
+
 
 # Utility Functions
 def _get_error_msg(errcode):
@@ -142,15 +144,14 @@ def rmm_csv_log():
     calling the librmm functions via Cython
     """
     cdef size_t logsize = rmmLogSize()
-    cdef char* buf = <char*>malloc(logsize)
+    cdef bytes py_buf = PyBytes_FromStringAndSize(NULL, logsize)
+    cdef char* buf = PyBytes_AS_STRING(py_buf)
 
     with nogil:
         rmm_error = rmmGetLog(buf, logsize)
 
     check_error(rmm_error)
 
-    cdef bytes py_buf = buf[:logsize]
-    free(buf)
     return py_buf.decode("utf-8")
 
 


### PR DESCRIPTION
Instead of allocating memory at the C-level and then the Python-level to copy it over, just allocate memory in Python to start with. Do this by creating an empty `bytes` object to fill up. Then grab its underlying pointer and pass this to `rmmGetLog` underneath to fill this up. Once back in Python, this is a normal Python object that will handle its own clean up later. Also it can more easily be converted to `unicode`.