### PR TITLE
`DeviceBuffer` use default constructor for size=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #269 Doc sync behavior in `copy_ptr_to_host`
 - PR #278 Allocate a `bytes` object to fill up with RMM log data
 - PR #280 Drop allocation/deallocation of `offset`
+- PR #282 `DeviceBuffer` use default constructor for size=0
 
 ## Bug Fixes
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -51,7 +51,9 @@ cdef class DeviceBuffer:
             c_ptr = <const void*>ptr
             c_stream = <cudaStream_t>stream
 
-            if c_ptr == NULL:
+            if size == 0:
+                self.c_obj.reset(new device_buffer())
+            elif c_ptr == NULL:
                 self.c_obj.reset(new device_buffer(size, c_stream))
             else:
                 self.c_obj.reset(new device_buffer(c_ptr, size, c_stream))


### PR DESCRIPTION
As there could be some overhead when calling the `rmm::device_buffer` constructor with `size=0`, go ahead and check if `size=0` and then call the default `rmm::device_buffer` constructor to avoid this overhead.

cc @kkraus14 @harrism @jrhemstad (based on our discussion offline 🙂)

<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
