### PR TITLE
[REVIEW] Add random allocation benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #273 Moved device memory resource tests to `device/` directory.
 - PR #274 Add `copy_from_host` method to `DeviceBuffer`
 - PR #275 Add `copy_from_device` method to `DeviceBuffer`
+- PR #283 Add random allocation benchmark.
 
 ## Improvements
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif(CMAKE_CXX11_ABI)
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
-option(BUILD_TESTS "Configure CMake to build tests"
-       ON)
+option(BUILD_TESTS "Configure CMake to build tests" ON)
+option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
+
 
 ###################################################################################################
 # - cnmem ---------------------------------------------------------------------------------
@@ -88,6 +89,24 @@ if(BUILD_TESTS)
         message(AUTHOR_WARNING "Google C++ Testing Framework (Google Test) not found: automated tests are disabled.")
     endif(GTEST_FOUND)
 endif(BUILD_TESTS)
+
+###################################################################################################
+# - add google benchmark --------------------------------------------------------------------------
+
+if(BUILD_BENCHMARKS)
+
+  include(ConfigureGoogleBenchmark)
+
+  if(GBENCH_FOUND)
+    message(STATUS "Google C++ Benchmarking Framework (Google Benchmark) found in ${GBENCH_ROOT}")
+    include_directories(${GBENCH_INCLUDE_DIR})
+    add_subdirectory(${CMAKE_SOURCE_DIR}/benchmarks)
+  else()
+    message(AUTHOR_WARNING "Google C++ Benchmarking Framework (Google Benchmark) not found: automated tests are disabled.")
+  endif(GBENCH_FOUND)
+
+endif(BUILD_BENCHMARKS)
+
 
 ###################################################################################################
 # - include paths ---------------------------------------------------------------------------------

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,57 @@
+﻿cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+project(RMM_BENCHS LANGUAGES C CXX CUDA)
+
+###################################################################################################
+# - compiler function -----------------------------------------------------------------------------
+
+function(ConfigureBench CMAKE_BENCH_NAME CMAKE_BENCH_SRC)
+    add_executable(${CMAKE_BENCH_NAME}
+                   ${CMAKE_BENCH_SRC}
+                   "${CMAKE_CURRENT_SOURCE_DIR}/synchronization/synchronization.cpp")
+    set_target_properties(${CMAKE_BENCH_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_link_libraries(${CMAKE_BENCH_NAME} benchmark benchmark_main pthread rmm )
+    set_target_properties(${CMAKE_BENCH_NAME} PROPERTIES
+                            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gbenchmarks")
+endfunction(ConfigureBench)
+
+###################################################################################################
+# - include paths ---------------------------------------------------------------------------------
+
+include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
+                    "${CMAKE_BINARY_DIR}/include"
+                    "${CMAKE_SOURCE_DIR}/include"
+                    "${CMAKE_SOURCE_DIR}"
+                    "${CMAKE_SOURCE_DIR}/src"
+                    "${GTEST_INCLUDE_DIR}"
+                    "${GBENCH_INCLUDE_DIR}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}")
+
+###################################################################################################
+# - library paths ---------------------------------------------------------------------------------
+
+link_directories("${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}" # CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES is an undocumented/unsupported variable containing the link directories for nvcc
+                 "${CMAKE_BINARY_DIR}/lib"
+                 "${CMAKE_BINARY_DIR}"
+                 "${GTEST_LIBRARY_DIR}"
+                 "${GBENCH_LIBRARY_DIR}")
+
+###################################################################################################
+### test sources ##################################################################################
+###################################################################################################
+
+###################################################################################################
+# - test benchmark --------------------------------------------------------------------------------
+
+set(TEST_BENCH_SRC
+  "${CMAKE_CURRENT_SOURCE_DIR}/test/test_benchmark.cpp")
+
+ConfigureBench(TEST_BENCH "${TEST_BENCH_SRC}")
+
+###################################################################################################
+# - random allocations benchmark --------------------------------------------------------------------------------
+
+set(RANDOM_ALLOCATIONS_BENCH_SRC
+  "${CMAKE_CURRENT_SOURCE_DIR}/random_allocations/random_allocations.cpp")
+
+ConfigureBench(RANDOM_ALLOCATIONS_BENCH "${RANDOM_ALLOCATIONS_BENCH_SRC}")

--- a/benchmarks/random_allocations/random_allocations.cpp
+++ b/benchmarks/random_allocations/random_allocations.cpp
@@ -18,7 +18,6 @@
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
-#include <rmm/mr/device/sub_memory_resource.hpp>
 
 #include <benchmark/benchmark.h>
 
@@ -157,20 +156,7 @@ static void BM_RandomAllocationsCUDA(benchmark::State& state) {
     std::cout << "Error: " << e.what() << "\n";
   }
 }
-//BENCHMARK(BM_RandomAllocationsCUDA)->Unit(benchmark::kMillisecond);
-
-template <typename State>
-static void BM_RandomAllocationsSub(State& state) {
-  rmm::mr::sub_memory_resource mr;
-
-  try {
-    for (auto _ : state)
-      uniform_random_allocations(mr, num_allocations, max_size, max_usage);
-  } catch (std::exception const& e) {
-    std::cout << "Error: " << e.what() << "\n";
-  }
-}
-BENCHMARK(BM_RandomAllocationsSub)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_RandomAllocationsCUDA)->Unit(benchmark::kMillisecond);
 
 template <typename State>
 static void BM_RandomAllocationsCnmem(State& state) {

--- a/benchmarks/random_allocations/random_allocations.cpp
+++ b/benchmarks/random_allocations/random_allocations.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either ex  ess or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/mr/device/sub_memory_resource.hpp>
+
+#include <benchmark/benchmark.h>
+
+#include <random>
+
+#define VERBOSE 0
+
+namespace {
+
+constexpr std::size_t size_mb{1 << 20};
+
+struct allocation {
+  void* p{nullptr};
+  std::size_t size{0};
+  allocation(void* _p, std::size_t _size) : p{_p}, size{_size} {}
+  allocation() = default;
+};
+
+using allocation_vector = std::vector<allocation>;
+
+allocation remove_at(allocation_vector& allocs, std::size_t index) {
+  assert(index < allocs.size());
+  auto removed = allocs[index];
+
+  if ((allocs.size() > 1) && (index < allocs.size() - 1)) {
+    std::swap(allocs[index], allocs.back());
+  }
+  allocs.pop_back();
+
+  return removed;
+}
+
+template <typename SizeDistribution>
+void random_allocation_free(rmm::mr::device_memory_resource& mr,
+                            SizeDistribution size_distribution,
+                            size_t num_allocations,
+                            size_t max_usage, // in MiB
+                            cudaStream_t stream = 0)
+{
+  std::default_random_engine generator;
+
+  max_usage *= size_mb; // convert to bytes
+  
+  constexpr int allocation_probability = 73; // percent
+  std::uniform_int_distribution<int> op_distribution(0, 99);
+  std::uniform_int_distribution<int> index_distribution(0, num_allocations-1);
+
+  int active_allocations{0};
+  int allocation_count{0};
+
+  allocation_vector allocations{};
+  size_t allocation_size{0};
+
+  for (int i = 0; i < num_allocations * 2; ++i) {
+    bool do_alloc = true;
+    size_t size = static_cast<size_t>(size_distribution(generator));
+    
+    if (active_allocations > 0) {
+      int chance = op_distribution(generator);
+      do_alloc = (chance < allocation_probability) &&
+                 (allocation_count < num_allocations) &&
+                 (allocation_size + size < max_usage);
+    }
+
+    void* ptr = nullptr;
+    if (do_alloc) { // try to allocate
+      try {
+        ptr = mr.allocate(size, stream);
+      } catch(std::bad_alloc) {
+        do_alloc = false;
+      }
+    }
+
+    if (do_alloc) { // alloc succeeded
+      allocations.emplace_back(ptr, size);
+      active_allocations++;
+      allocation_count++;
+      allocation_size += size;
+
+      #if VERBOSE
+      std::cout << active_allocations << " | " << allocation_count << " Allocating: " << size 
+                << " | total: " << allocation_size << "\n";
+      #endif
+    }
+    else { // dealloc, or alloc failed
+      if (active_allocations > 0) {
+        size_t index = index_distribution(generator) % active_allocations;
+        active_allocations--;
+        allocation to_free = remove_at(allocations, index);
+        mr.deallocate(to_free.p, to_free.size, stream);
+        allocation_size -= to_free.size;
+
+        #if VERBOSE
+        std::cout << active_allocations << " | " << allocation_count << " Deallocating: " 
+                  << to_free.size << " at " << index << " | total: " << allocation_size << "\n";
+        #endif
+      }
+    }
+  }
+
+  assert(active_allocations == 0);
+  assert(allocations.size() == 0);
+}
+}  // namespace
+
+void uniform_random_allocations(rmm::mr::device_memory_resource& mr,
+                                size_t num_allocations,
+                                size_t max_allocation_size, // in MiB
+                                size_t max_usage,
+                                cudaStream_t stream = 0) {
+  std::uniform_int_distribution<std::size_t> size_distribution(1, max_allocation_size * size_mb);
+  random_allocation_free(mr, size_distribution, num_allocations, max_usage, stream);
+}
+
+// TODO figure out how to map a normal distribution to integers between 1 and max_allocation_size
+/*void normal_random_allocations(rmm::mr::device_memory_resource& mr,
+                                size_t num_allocations = 1000,
+                                size_t mean_allocation_size = 500, // in MiB
+                                size_t stddev_allocation_size = 500, // in MiB
+                                size_t max_usage = 8 << 20,
+                                cudaStream_t stream) {
+  std::normal_distribution<std::size_t> size_distribution(, max_allocation_size * size_mb);
+}*/
+
+constexpr size_t num_allocations = 100000;
+constexpr size_t max_size = 2;
+constexpr size_t max_usage = 16000;
+
+static void BM_RandomAllocationsCUDA(benchmark::State& state) {
+  rmm::mr::cuda_memory_resource mr;
+
+  try {
+    for (auto _ : state)
+      uniform_random_allocations(mr, num_allocations, max_size, max_usage);
+  } catch (std::exception const& e) {
+    std::cout << "Error: " << e.what() << "\n";
+  }
+}
+//BENCHMARK(BM_RandomAllocationsCUDA)->Unit(benchmark::kMillisecond);
+
+template <typename State>
+static void BM_RandomAllocationsSub(State& state) {
+  rmm::mr::sub_memory_resource mr;
+
+  try {
+    for (auto _ : state)
+      uniform_random_allocations(mr, num_allocations, max_size, max_usage);
+  } catch (std::exception const& e) {
+    std::cout << "Error: " << e.what() << "\n";
+  }
+}
+BENCHMARK(BM_RandomAllocationsSub)->Unit(benchmark::kMillisecond);
+
+template <typename State>
+static void BM_RandomAllocationsCnmem(State& state) {
+  rmm::mr::cnmem_memory_resource mr;
+
+  try {
+    for (auto _ : state)
+      uniform_random_allocations(mr, num_allocations, max_size, max_usage);
+  } catch (std::exception const& e) {
+    std::cout << "Error: " << e.what() << "\n";
+  }
+}
+BENCHMARK(BM_RandomAllocationsCnmem)->Unit(benchmark::kMillisecond);
+
+/*int main(void) {
+  std::vector<int> state(1);
+  BM_RandomAllocationsSub(state);
+  return 0;
+}*/
+
+
+

--- a/benchmarks/synchronization/synchronization.cpp
+++ b/benchmarks/synchronization/synchronization.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "synchronization.hpp"
+#include "rmm/rmm.h"
+
+#define CUDA_TRY(call)                                            \
+  do {                                                            \
+    cudaError_t const status = (call);                            \
+    if (cudaSuccess != status) {                                  \
+      throw std::runtime_error("CUDA error");                     \
+    }                                                             \
+  } while (0);
+
+#define RMM_TRY(call)                                             \
+  do {                                                            \
+    rmmError_t const status = (call);                             \
+    if (RMM_SUCCESS != status) {                                  \
+      throw std::runtime_error("RMM error");                      \
+    }                                                             \
+  } while (0);
+
+cuda_event_timer::cuda_event_timer(benchmark::State& state,
+                                   bool flush_l2_cache,
+                                   cudaStream_t stream):
+  p_state(&state), stream(stream) {
+  // flush all of L2$
+  if(flush_l2_cache) {
+    int current_device = 0;
+    CUDA_TRY(cudaGetDevice(&current_device));
+
+    int l2_cache_bytes = 0;
+    CUDA_TRY(cudaDeviceGetAttribute(&l2_cache_bytes, cudaDevAttrL2CacheSize, current_device));
+
+    if (l2_cache_bytes > 0) {
+      const int memset_value = 0;
+      int* l2_cache_buffer = nullptr;
+      RMM_TRY(RMM_ALLOC(&l2_cache_buffer, l2_cache_bytes, stream));
+      CUDA_TRY(cudaMemsetAsync(l2_cache_buffer, memset_value, l2_cache_bytes, stream));
+      RMM_TRY(RMM_FREE(l2_cache_buffer, stream));
+    }
+  }
+
+  CUDA_TRY(cudaEventCreate(&start));
+  CUDA_TRY(cudaEventCreate(&stop));
+  CUDA_TRY(cudaEventRecord(start, stream));
+}
+
+cuda_event_timer::~cuda_event_timer() {
+  CUDA_TRY(cudaEventRecord(stop, stream));
+  CUDA_TRY(cudaEventSynchronize(stop));
+ 
+  float milliseconds = 0.0f;
+  CUDA_TRY(cudaEventElapsedTime(&milliseconds, start, stop));
+  p_state->SetIterationTime(milliseconds/(1000.0f));
+  CUDA_TRY(cudaEventDestroy(start));
+  CUDA_TRY(cudaEventDestroy(stop));
+}
+

--- a/benchmarks/synchronization/synchronization.hpp
+++ b/benchmarks/synchronization/synchronization.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**---------------------------------------------------------------------------*
+ * @file synchronization.hpp
+ * @brief This is the header file for `cuda_event_timer`.
+ *---------------------------------------------------------------------------**/
+
+/**---------------------------------------------------------------------------*
+ * @brief  This class serves as a wrapper for using `cudaEvent_t` as the user 
+ * defined timer within the framework of google benchmark 
+ * (https://github.com/google/benchmark).
+ *
+ * It is built on top of the idea of Resource acquisition is initialization 
+ * (RAII). In the following we show a minimal example of how to use this class.
+
+    #include <benchmark/benchmark.h>
+    
+    static void sample_cuda_benchmark(benchmark::State& state) {
+      
+      for (auto _ : state){
+        
+        cudaStream_t stream = 0;
+        
+        // Create (Construct) an object of this class. You HAVE to pass in the
+        // benchmark::State object you are using. It measures the time from its 
+        // creation to its destruction that is spent on the specified CUDA stream.
+        // It also clears the L2 cache by cudaMemset'ing a device buffer that is of
+        // the size of the L2 cache (if flush_l2_cache is set to true and there is 
+        // an L2 cache on the current device).
+        cuda_event_timer raii(state, true, stream); // flush_l2_cache = true
+        
+        // Now perform the operations that is to be benchmarked
+        sample_kernel<<<1, 256, 0, stream>>>(); // Possibly launching a CUDA kernel
+
+      }
+    }
+
+    // Register the function as a benchmark. You will need to set the `UseManualTime()`
+    // flag in order to use the timer embeded in this class.
+    BENCHMARK(sample_cuda_benchmark)->UseManualTime();
+
+
+ *---------------------------------------------------------------------------**/
+
+#ifndef CUDF_BENCH_SYNCHRONIZATION_H
+#define CUDF_BENCH_SYNCHRONIZATION_H
+
+// Google Benchmark library
+#include <benchmark/benchmark.h>
+#include <cuda_runtime_api.h>
+
+class cuda_event_timer {
+ 
+public:
+
+  /**---------------------------------------------------------------------------*
+   * @brief This c'tor clears the L2$ by cudaMemset'ing a buffer of L2$ size
+   * and starts the timer.
+   *
+   * @param[in,out] state  This is the benchmark::State whose timer we are going 
+   * to update.
+   * @param[in] flush_l2_cache_ whether or not to flush the L2 cache before
+   *                            every iteration.
+   * @param[in] stream_ The CUDA stream we are measuring time on.
+   *---------------------------------------------------------------------------**/
+  cuda_event_timer(benchmark::State& state,
+                   bool flush_l2_cache,
+                   cudaStream_t stream_ = 0);
+ 
+  // The user will HAVE to provide a benchmark::State object to set 
+  // the timer so we disable the default c'tor.
+  cuda_event_timer() = delete;  
+  
+  // The d'tor stops the timer and performs a synchroniazation. 
+  // Time of the benchmark::State object provided to the c'tor
+  // will be set to the value given by `cudaEventElapsedTime`.
+  ~cuda_event_timer();
+
+private:
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  cudaStream_t stream;
+  benchmark::State* p_state;
+};
+
+#endif

--- a/benchmarks/test/test_benchmark.cpp
+++ b/benchmarks/test/test_benchmark.cpp
@@ -1,0 +1,41 @@
+#include <benchmark/benchmark.h>
+
+static void BM_StringCreation(benchmark::State& state) {
+  for (auto _ : state)
+    std::string empty_string;
+}
+// Register the function as a benchmark
+BENCHMARK(BM_StringCreation);
+
+// Define another benchmark
+static void BM_StringCopy(benchmark::State& state) {
+  std::string x = "hello";
+  for (auto _ : state)
+    std::string copy(x);
+}
+BENCHMARK(BM_StringCopy);
+
+static void BM_StringCompare(benchmark::State& state) {
+  std::string s1(state.range(0), '-');
+  std::string s2(state.range(0), '-');
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(s1.compare(s2));
+  }
+  state.SetComplexityN(state.range(0));
+}
+BENCHMARK(BM_StringCompare)
+    ->RangeMultiplier(2)->Range(1<<10, 1<<18)->Complexity(benchmark::oN);
+
+template <class Q> 
+void BM_Sequential(benchmark::State& state) {
+  Q q;
+  typename Q::value_type v(0);
+  for (auto _ : state) {
+    for (int i = state.range(0); i--; )
+      q.push_back(v);
+  }
+  // actually messages, not bytes:
+  state.SetBytesProcessed(
+      static_cast<int64_t>(state.iterations())*state.range(0));
+}
+BENCHMARK_TEMPLATE(BM_Sequential, std::vector<int>)->Range(1<<0, 1<<10);

--- a/cmake/Modules/ConfigureGoogleBenchmark.cmake
+++ b/cmake/Modules/ConfigureGoogleBenchmark.cmake
@@ -1,0 +1,59 @@
+set(GBENCH_ROOT "${CMAKE_BINARY_DIR}/googlebenchmark")
+
+set(GBENCH_CMAKE_ARGS " -DCMAKE_BUILD_TYPE=Release")
+                     #" -Dgtest_build_samples=ON" 
+                     #" -DCMAKE_VERBOSE_MAKEFILE=ON")
+
+if(NOT CMAKE_CXX11_ABI)
+    message(STATUS "GBENCH: Disabling the GLIBCXX11 ABI")
+    list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
+    list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0")
+elseif(CMAKE_CXX11_ABI)
+    message(STATUS "GBENCH: Enabling the GLIBCXX11 ABI")
+    list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_C_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
+    list(APPEND GBENCH_CMAKE_ARGS " -DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=1")
+endif(NOT CMAKE_CXX11_ABI)
+
+configure_file("${CMAKE_SOURCE_DIR}/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake"
+               "${GBENCH_ROOT}/CMakeLists.txt")
+
+file(MAKE_DIRECTORY "${GBENCH_ROOT}/build")
+file(MAKE_DIRECTORY "${GBENCH_ROOT}/install")
+
+execute_process(COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR} .
+                RESULT_VARIABLE GBENCH_CONFIG
+                WORKING_DIRECTORY ${GBENCH_ROOT})
+
+if(GBENCH_CONFIG)
+    message(FATAL_ERROR "Configuring Google Benchmark failed: " ${GBENCH_CONFIG})
+endif(GBENCH_CONFIG)
+
+set(PARALLEL_BUILD -j)
+if($ENV{PARALLEL_LEVEL})
+    set(NUM_JOBS $ENV{PARALLEL_LEVEL})
+    set(PARALLEL_BUILD "${PARALLEL_BUILD}${NUM_JOBS}")
+endif($ENV{PARALLEL_LEVEL})
+
+if(${NUM_JOBS})
+    if(${NUM_JOBS} EQUAL 1)
+        message(STATUS "GBENCH BUILD: Enabling Sequential CMake build")
+    elseif(${NUM_JOBS} GREATER 1)
+        message(STATUS "GBENCH BUILD: Enabling Parallel CMake build with ${NUM_JOBS} jobs")
+    endif(${NUM_JOBS} EQUAL 1)
+else()
+    message(STATUS "GBENCH BUILD: Enabling Parallel CMake build with all threads")
+endif(${NUM_JOBS})
+
+execute_process(COMMAND ${CMAKE_COMMAND} --build .. -- ${PARALLEL_BUILD}
+                RESULT_VARIABLE GBENCH_BUILD
+                WORKING_DIRECTORY ${GBENCH_ROOT}/build)
+
+if(GBENCH_BUILD)
+    message(FATAL_ERROR "Building Google Benchmark failed: " ${GBENCH_BUILD})
+endif(GBENCH_BUILD)
+
+message(STATUS "Google Benchmark installed here: " ${GBENCH_ROOT}/install)
+set(GBENCH_INCLUDE_DIR "${GBENCH_ROOT}/install/include")
+set(GBENCH_LIBRARY_DIR "${GBENCH_ROOT}/install/lib" "${GBENCH_ROOT}/install/lib64")
+set(GBENCH_FOUND TRUE)
+

--- a/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.12)
+
+include(ExternalProject)
+
+ExternalProject_Add(GoogleBenchmark
+                    GIT_REPOSITORY    https://github.com/google/benchmark.git
+                    GIT_TAG           master 
+                    SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
+                    BINARY_DIR        "${GBENCH_ROOT}/build"
+                    INSTALL_DIR		    "${GBENCH_ROOT}/install"
+                    CMAKE_ARGS        ${GBENCH_CMAKE_ARGS} -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=${GBENCH_ROOT}/install)
+                    # The flag BENCHMARK_ENABLE_TESTING=OFF prevents Google Benchmark from asking for Google Test.
+
+
+
+
+
+
+


### PR DESCRIPTION
Extracts the benchmark from https://github.com/rapidsai/rmm/pull/162

@harrism when ran as-is, I was surprised to see CNMEM being slower than CUDA? Is this expected?

```
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
BM_RandomAllocationsCUDA        7595 ms         6422 ms            1
BM_RandomAllocationsCnmem      14571 ms        14544 ms            1

```