### PR TITLE
[TEST] Make Thrust pool the default pool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "thirdparty/cnmem"]
 	path = thirdparty/cnmem
 	url = https://github.com/NVIDIA/cnmem.git
+[submodule "thirdparty/thrust"]
+	path = thirdparty/thrust
+	url = https://github.com/thrust/thrust.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "thirdparty/cnmem"]
 	path = thirdparty/cnmem
 	url = https://github.com/NVIDIA/cnmem.git
-[submodule "thirdparty/thrust"]
-	path = thirdparty/thrust
-	url = https://github.com/thrust/thrust.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,7 @@ endif(BUILD_TESTS)
 include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                     "${CMAKE_CURRENT_SOURCE_DIR}/include"
                     "${CMAKE_CURRENT_SOURCE_DIR}/src"
-                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cnmem/include"
-                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/thrust/thrust")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cnmem/include")
 
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,8 @@ endif(BUILD_TESTS)
 include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                     "${CMAKE_CURRENT_SOURCE_DIR}/include"
                     "${CMAKE_CURRENT_SOURCE_DIR}/src"
-                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cnmem/include")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/cnmem/include"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/thrust/thrust")
 
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------

--- a/include/rmm/mr/device/thrust_sync_pool.hpp
+++ b/include/rmm/mr/device/thrust_sync_pool.hpp
@@ -26,7 +26,7 @@
 namespace rmm {
 namespace mr {
 
-static std::size_t RMM_DEFAULT_DEVICE_ALIGNMENT{256};
+static constexpr std::size_t RMM_DEFAULT_DEVICE_ALIGNMENT{256};
 
 /**
  * @brief Memory resource that allocates/deallocates using Thrust's

--- a/include/rmm/mr/device/thrust_sync_pool.hpp
+++ b/include/rmm/mr/device/thrust_sync_pool.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "device_memory_resource.hpp"
+
+#include <stdexcept>
+
+namespace rmm {
+namespace mr {
+/**
+ * @brief Memory resource that allocates/deallocates using Thrust's
+ * `disjoint_synchronized_pool_resource` sub-allocator.
+ */
+class thrust_sync_pool final : public device_memory_resource {
+ public:
+  /**
+   * @brief Construct a `thrust_sync_pool` memory resource.
+   */
+  explicit thrust_sync_pool() = default;
+
+  bool supports_streams() const noexcept override { return false; }
+
+ private:
+  /**
+   * @brief Allocates memory of size at least `bytes`.
+   *
+   * The returned pointer has at least 256B alignment.
+   *
+   * @throws `std::bad_alloc` if the requested allocation could not be fulfilled
+   *
+   * @param bytes The size, in bytes, of the allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* do_allocate(std::size_t bytes, cudaStream_t) override {}
+
+  /**
+   * @brief Deallocate memory pointed to by \p p.
+   *
+   * @throws Nothing.
+   *
+   * @param p Pointer to be deallocated
+   */
+  void do_deallocate(void* p, std::size_t, cudaStream_t) override {}
+
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t) const override {
+    throw std::runtime_error{"Meminfo unsupported."};
+  }
+};
+}  // namespace mr
+}  // namespace rmm

--- a/include/rmm/mr/device/thrust_sync_pool.hpp
+++ b/include/rmm/mr/device/thrust_sync_pool.hpp
@@ -17,6 +17,8 @@
 
 #include "device_memory_resource.hpp"
 
+#include <thrust/mr/disjoint_sync_pool.h>
+
 #include <stdexcept>
 
 namespace rmm {

--- a/include/rmm/mr/device/thrust_sync_pool.hpp
+++ b/include/rmm/mr/device/thrust_sync_pool.hpp
@@ -17,8 +17,6 @@
 
 #include "device_memory_resource.hpp"
 
-#include <thrust/mr/disjoint_sync_pool.h>
-
 #include <stdexcept>
 
 namespace rmm {

--- a/include/rmm/mr/device/thrust_sync_pool.hpp
+++ b/include/rmm/mr/device/thrust_sync_pool.hpp
@@ -32,6 +32,7 @@ static std::size_t RMM_DEFAULT_DEVICE_ALIGNMENT{256};
  * @brief Memory resource that allocates/deallocates using Thrust's
  * `disjoint_synchronized_pool_resource` sub-allocator.
  */
+// Need to use `detail` resource to specify `void*` as the `Pointer` type
 template <typename Upstream = thrust::system::cuda::detail::
               cuda_memory_resource<cudaMalloc, cudaFree, void*>,
           typename Bookkeeper = thrust::mr::new_delete_resource>

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -20,6 +20,7 @@
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/mr/device/thrust_sync_pool.hpp>
 
 namespace rmm {
 /** -------------------------------------------------------------------------*
@@ -106,11 +107,9 @@ void Manager::initialize(const rmmOptions_t* new_options) {
     auto pool_size = getOptions().initial_pool_size;
     auto const& devices = getOptions().devices;
     if (useManagedMemory()) {
-      initialized_resource.reset(
-          new rmm::mr::cnmem_managed_memory_resource(pool_size, devices));
+      throw std::runtime_error{"Managed pool not supported."};
     } else {
-      initialized_resource.reset(
-          new rmm::mr::cnmem_memory_resource(pool_size, devices));
+      initialized_resource.reset(new rmm::mr::thrust_sync_pool<>{});
     }
   } else if (rmm::Manager::useManagedMemory()) {
     initialized_resource.reset(new rmm::mr::managed_memory_resource());

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -88,7 +88,7 @@ struct MRTest : public ::testing::Test {
 using resources = ::testing::Types<
     rmm::mr::cuda_memory_resource, rmm::mr::managed_memory_resource,
     rmm::mr::cnmem_memory_resource, rmm::mr::cnmem_managed_memory_resource,
-    rmm::mr::thrust_sync_pool>;
+    rmm::mr::thrust_sync_pool<>>;
 
 TYPED_TEST_CASE(MRTest, resources);
 

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -16,12 +16,13 @@
 
 #include "gtest/gtest.h"
 
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
 #include <rmm/mr/device/cnmem_managed_memory_resource.hpp>
+#include <rmm/mr/device/cnmem_memory_resource.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/mr/device/thrust_sync_pool.hpp>
 
 #include <cuda_runtime_api.h>
 #include <cstddef>
@@ -84,10 +85,10 @@ struct MRTest : public ::testing::Test {
   ~MRTest() = default;
 };
 
-using resources = ::testing::Types<rmm::mr::cuda_memory_resource,
-                                   rmm::mr::managed_memory_resource,
-                                   rmm::mr::cnmem_memory_resource,
-                                   rmm::mr::cnmem_managed_memory_resource>;
+using resources = ::testing::Types<
+    rmm::mr::cuda_memory_resource, rmm::mr::managed_memory_resource,
+    rmm::mr::cnmem_memory_resource, rmm::mr::cnmem_managed_memory_resource,
+    rmm::mr::thrust_sync_pool>;
 
 TYPED_TEST_CASE(MRTest, resources);
 
@@ -103,7 +104,7 @@ TEST(DefaultTest, UseDefaultResource) {
 
 TYPED_TEST(MRTest, SetDefaultResource) {
   // Not necessarily false, since two cuda_memory_resources are always equal
-  //EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
+  // EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
   rmm::mr::device_memory_resource* old{nullptr};
   EXPECT_NO_THROW(old = rmm::mr::set_default_resource(this->mr.get()));
   EXPECT_NE(nullptr, old);
@@ -118,7 +119,7 @@ TYPED_TEST(MRTest, SetDefaultResource) {
   EXPECT_NO_THROW(rmm::mr::set_default_resource(nullptr));
   EXPECT_TRUE(old->is_equal(*rmm::mr::get_default_resource()));
   // Not necessarily false, since two cuda_memory_resources are always equal
-  //EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
+  // EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
 }
 
 TYPED_TEST(MRTest, SelfEquality) { EXPECT_TRUE(this->mr->is_equal(*this->mr)); }
@@ -366,12 +367,12 @@ TYPED_TEST(MRTest, MixedRandomAllocationFreeStream) {
 }
 
 TYPED_TEST(MRTest, GetMemInfo) {
-  std::pair<std::size_t,std::size_t> mem_info;
+  std::pair<std::size_t, std::size_t> mem_info;
   EXPECT_NO_THROW(mem_info = this->mr->get_mem_info(0));
   std::size_t allocation_size = 16 * 256;
-  void * ptr;
+  void* ptr;
   EXPECT_NO_THROW(ptr = this->mr->allocate(allocation_size));
   EXPECT_NO_THROW(mem_info = this->mr->get_mem_info(0));
   EXPECT_TRUE(mem_info.first >= allocation_size);
-  EXPECT_NO_THROW(this->mr->deallocate(ptr,allocation_size));
+  EXPECT_NO_THROW(this->mr->deallocate(ptr, allocation_size));
 }


### PR DESCRIPTION
For the purposes of testing with Python/Dask, this PR makes the `thrust_sync_pool` the default pool used when RMM is enabled in pool mode.

As the Thrust pool is only available in CUDA 10.1, this will only work for CUDA 10.1+. 

Do not merge. 