### PR TITLE
[REVIEW] Revamp RMM exceptions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #275 Add `copy_from_device` method to `DeviceBuffer`
 - PR #283 Add random allocation benchmark.
 - PR #287 Enabled CUDA CXX11 for unit tests.
+- PR #292 Revamped RMM exceptions.
 
 ## Improvements
 

--- a/benchmarks/random_allocations/random_allocations.cpp
+++ b/benchmarks/random_allocations/random_allocations.cpp
@@ -86,7 +86,7 @@ void random_allocation_free(rmm::mr::device_memory_resource& mr,
     if (do_alloc) { // try to allocate
       try {
         ptr = mr.allocate(size, stream);
-      } catch(std::bad_alloc) {
+      } catch(rmm::bad_alloc const&) {
         do_alloc = false;
       }
     }

--- a/benchmarks/synchronization/synchronization.cpp
+++ b/benchmarks/synchronization/synchronization.cpp
@@ -17,7 +17,7 @@
 #include "synchronization.hpp"
 #include "rmm/rmm.h"
 
-#define CUDA_TRY(call)                                            \
+#define RMM_CUDA_TRY(call)                                            \
   do {                                                            \
     cudaError_t const status = (call);                            \
     if (cudaSuccess != status) {                                  \
@@ -40,33 +40,33 @@ cuda_event_timer::cuda_event_timer(benchmark::State& state,
   // flush all of L2$
   if(flush_l2_cache) {
     int current_device = 0;
-    CUDA_TRY(cudaGetDevice(&current_device));
+    RMM_CUDA_TRY(cudaGetDevice(&current_device));
 
     int l2_cache_bytes = 0;
-    CUDA_TRY(cudaDeviceGetAttribute(&l2_cache_bytes, cudaDevAttrL2CacheSize, current_device));
+    RMM_CUDA_TRY(cudaDeviceGetAttribute(&l2_cache_bytes, cudaDevAttrL2CacheSize, current_device));
 
     if (l2_cache_bytes > 0) {
       const int memset_value = 0;
       int* l2_cache_buffer = nullptr;
       RMM_TRY(RMM_ALLOC(&l2_cache_buffer, l2_cache_bytes, stream));
-      CUDA_TRY(cudaMemsetAsync(l2_cache_buffer, memset_value, l2_cache_bytes, stream));
+      RMM_CUDA_TRY(cudaMemsetAsync(l2_cache_buffer, memset_value, l2_cache_bytes, stream));
       RMM_TRY(RMM_FREE(l2_cache_buffer, stream));
     }
   }
 
-  CUDA_TRY(cudaEventCreate(&start));
-  CUDA_TRY(cudaEventCreate(&stop));
-  CUDA_TRY(cudaEventRecord(start, stream));
+  RMM_CUDA_TRY(cudaEventCreate(&start));
+  RMM_CUDA_TRY(cudaEventCreate(&stop));
+  RMM_CUDA_TRY(cudaEventRecord(start, stream));
 }
 
 cuda_event_timer::~cuda_event_timer() {
-  CUDA_TRY(cudaEventRecord(stop, stream));
-  CUDA_TRY(cudaEventSynchronize(stop));
+  RMM_CUDA_TRY(cudaEventRecord(stop, stream));
+  RMM_CUDA_TRY(cudaEventSynchronize(stop));
  
   float milliseconds = 0.0f;
-  CUDA_TRY(cudaEventElapsedTime(&milliseconds, start, stop));
+  RMM_CUDA_TRY(cudaEventElapsedTime(&milliseconds, start, stop));
   p_state->SetIterationTime(milliseconds/(1000.0f));
-  CUDA_TRY(cudaEventDestroy(start));
-  CUDA_TRY(cudaEventDestroy(stop));
+  RMM_CUDA_TRY(cudaEventDestroy(start));
+  RMM_CUDA_TRY(cudaEventDestroy(stop));
 }
 

--- a/benchmarks/synchronization/synchronization.cpp
+++ b/benchmarks/synchronization/synchronization.cpp
@@ -17,14 +17,6 @@
 #include "synchronization.hpp"
 #include "rmm/rmm.h"
 
-#define RMM_CUDA_TRY(call)                                            \
-  do {                                                            \
-    cudaError_t const status = (call);                            \
-    if (cudaSuccess != status) {                                  \
-      throw std::runtime_error("CUDA error");                     \
-    }                                                             \
-  } while (0);
-
 #define RMM_TRY(call)                                             \
   do {                                                            \
     rmmError_t const status = (call);                             \

--- a/benchmarks/synchronization/synchronization.hpp
+++ b/benchmarks/synchronization/synchronization.hpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-/**---------------------------------------------------------------------------*
+/**
  * @file synchronization.hpp
  * @brief This is the header file for `cuda_event_timer`.
- *---------------------------------------------------------------------------**/
+ */
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief  This class serves as a wrapper for using `cudaEvent_t` as the user 
  * defined timer within the framework of google benchmark 
  * (https://github.com/google/benchmark).
@@ -54,7 +54,7 @@
     BENCHMARK(sample_cuda_benchmark)->UseManualTime();
 
 
- *---------------------------------------------------------------------------**/
+ */
 
 #ifndef CUDF_BENCH_SYNCHRONIZATION_H
 #define CUDF_BENCH_SYNCHRONIZATION_H
@@ -67,7 +67,7 @@ class cuda_event_timer {
  
 public:
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief This c'tor clears the L2$ by cudaMemset'ing a buffer of L2$ size
    * and starts the timer.
    *
@@ -76,7 +76,7 @@ public:
    * @param[in] flush_l2_cache_ whether or not to flush the L2 cache before
    *                            every iteration.
    * @param[in] stream_ The CUDA stream we are measuring time on.
-   *---------------------------------------------------------------------------**/
+   */
   cuda_event_timer(benchmark::State& state,
                    bool flush_l2_cache,
                    cudaStream_t stream_ = 0);

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -21,7 +21,6 @@
 #include <string>
 
 namespace rmm {
-namespace detail {
 
 /**---------------------------------------------------------------------------*
  * @brief Exception thrown when logical precondition is violated.
@@ -45,7 +44,6 @@ struct logic_error : public std::logic_error {
 struct cuda_error : public std::runtime_error {
   cuda_error(std::string const& message) : std::runtime_error(message) {}
 };
-}  // namespace detail
 }  // namespace rmm
 
 #define STRINGIFY_DETAIL(x) #x
@@ -91,7 +89,7 @@ namespace rmm {
 namespace detail {
 inline void throw_cuda_error(cudaError_t error, const char* file,
                              unsigned int line) {
-  throw rmm::detail::cuda_error(
+  throw rmm::cuda_error(
       std::string{"CUDA error encountered at: " + std::string{file} + ":" +
                   std::to_string(line) + ": " + std::to_string(error) + " " +
                   cudaGetErrorName(error) + " " + cudaGetErrorString(error)});

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -118,18 +118,6 @@ class bad_alloc : public std::bad_alloc {
   throw rmm::logic_error("RMM failure at: " __FILE__ \
                          ":" RMM_STRINGIFY(__LINE__) ": " reason)
 
-namespace rmm {
-namespace detail {
-inline void throw_cuda_error(cudaError_t error, const char* file,
-                             unsigned int line) {
-  throw rmm::cuda_error(
-      std::string{"CUDA error encountered at: " + std::string{file} + ":" +
-                  std::to_string(line) + ": " + std::to_string(error) + " " +
-                  cudaGetErrorName(error) + " " + cudaGetErrorString(error)});
-}
-}  // namespace detail
-}  // namespace rmm
-
 /**
  * @brief Error checking macro for CUDA runtime API functions.
  *

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -126,7 +126,7 @@ class bad_alloc : public std::bad_alloc {
 /**
  * @brief Error checking macro for CUDA runtime API functions.
  *
- * Invokes a CUDA runtime API function call, if the call does not return
+ * Invokes a CUDA runtime API function call. If the call does not return
  * `cudaSuccess`, invokes cudaGetLastError() to clear the error and throws an
  * exception detailing the CUDA error that occurred
  *

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -37,12 +37,33 @@ struct logic_error : public std::logic_error {
   // TODO Add an error code member? This would be useful for translating an
   // exception to an error code in a pure-C API
 };
+
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  *
  */
 struct cuda_error : public std::runtime_error {
   cuda_error(std::string const& message) : std::runtime_error(message) {}
+};
+
+/**
+ * @brief Exception thrown when an RMM allocation fails
+ *
+ */
+class bad_alloc : public std::bad_alloc {
+ public:
+  bad_alloc(const char* w)
+      : std::bad_alloc{},
+        _what{std::string{std::bad_alloc::what()} + ": " + w} {}
+
+  bad_alloc(std::string const& w) : bad_alloc(w.c_str()) {}
+
+  virtual ~bad_alloc() = default;
+
+  virtual const char* what() const noexcept { return _what.c_str(); }
+
+ private:
+  std::string _what;
 };
 }  // namespace rmm
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -113,8 +113,6 @@ class bad_alloc : public std::bad_alloc {
  * // Throws `std::runtime_error`
  * RMM_FAIL(std::runtime_error, "Unsupported code path");
  * ```
- *
- * @param[in] reason String literal description of the reason
  */
 #define RMM_FAIL(...)                                     \
   GET_RMM_FAIL_MACRO(__VA_ARGS__, RMM_FAIL_2, RMM_FAIL_1) \

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -31,11 +31,7 @@ namespace rmm {
  */
 struct logic_error : public std::logic_error {
   logic_error(char const* const message) : std::logic_error(message) {}
-
-  logic_error(std::string const& message) : std::logic_error(message) {}
-
-  // TODO Add an error code member? This would be useful for translating an
-  // exception to an error code in a pure-C API
+  logic_error(std::string const& message) : logic_error{message.c_str()} {}
 };
 
 /**
@@ -43,7 +39,8 @@ struct logic_error : public std::logic_error {
  *
  */
 struct cuda_error : public std::runtime_error {
-  cuda_error(std::string const& message) : std::runtime_error(message) {}
+  cuda_error(const char* message) : std::runtime_error(message) {}
+  cuda_error(std::string const& message) : cuda_error{message.c_str()} {}
 };
 
 /**

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -137,18 +137,18 @@ class bad_alloc : public std::bad_alloc {
  * ```c++
  *
  * // Throws `rmm::cuda_error` if `cudaMalloc` fails
- * CUDA_TRY(cudaMalloc(&p, 100));
+ * RMM_CUDA_TRY(cudaMalloc(&p, 100));
  *
  * // Throws `std::runtime_error` if `cudaMalloc` fails
- * CUDA_TRY(cudaMalloc(&p, 100), std::runtime_error);
+ * RMM_CUDA_TRY(cudaMalloc(&p, 100), std::runtime_error);
  * ```
  *
  */
-#define CUDA_TRY(...)                                     \
-  GET_CUDA_TRY_MACRO(__VA_ARGS__, CUDA_TRY_2, CUDA_TRY_1) \
+#define RMM_CUDA_TRY(...)                                     \
+  GET_RMM_CUDA_TRY_MACRO(__VA_ARGS__, RMM_CUDA_TRY_2, RMM_CUDA_TRY_1) \
   (__VA_ARGS__)
-#define GET_CUDA_TRY_MACRO(_1, _2, NAME, ...) NAME
-#define CUDA_TRY_2(_call, _exception_type)                              \
+#define GET_RMM_CUDA_TRY_MACRO(_1, _2, NAME, ...) NAME
+#define RMM_CUDA_TRY_2(_call, _exception_type)                              \
   do {                                                                  \
     cudaError_t const error = (_call);                                  \
     if (cudaSuccess != error) {                                         \
@@ -159,4 +159,4 @@ class bad_alloc : public std::bad_alloc {
                             cudaGetErrorString(error)};                 \
     }                                                                   \
   } while (0);
-#define CUDA_TRY_1(_call) CUDA_TRY_2(_call, rmm::cuda_error)
+#define RMM_CUDA_TRY_1(_call) RMM_CUDA_TRY_2(_call, rmm::cuda_error)

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+#include <stdexcept>
+#include <string>
+
+namespace rmm {
+namespace detail {
+
+/**---------------------------------------------------------------------------*
+ * @brief Exception thrown when logical precondition is violated.
+ *
+ * This exception should not be thrown directly and is instead thrown by the
+ * RMM_EXPECTS macro.
+ *
+ *---------------------------------------------------------------------------**/
+struct logic_error : public std::logic_error {
+  logic_error(char const* const message) : std::logic_error(message) {}
+
+  logic_error(std::string const& message) : std::logic_error(message) {}
+
+  // TODO Add an error code member? This would be useful for translating an
+  // exception to an error code in a pure-C API
+};
+/**---------------------------------------------------------------------------*
+ * @brief Exception thrown when a CUDA error is encountered.
+ *
+ *---------------------------------------------------------------------------**/
+struct cuda_error : public std::runtime_error {
+  cuda_error(std::string const& message) : std::runtime_error(message) {}
+};
+}  // namespace detail
+}  // namespace rmm
+
+#define STRINGIFY_DETAIL(x) #x
+#define RMM_STRINGIFY(x) STRINGIFY_DETAIL(x)
+
+/**---------------------------------------------------------------------------*
+ * @brief Macro for checking (pre-)conditions that throws an exception when
+ * a condition is violated.
+ *
+ * Example usage:
+ * ```
+ * RMM_EXPECTS(p != nullptr, "Unexpected null pointer");
+ * ```
+ *
+ * @throw rmm::logic_error if the condition evaluates to false.
+ *
+ * @param[in] cond Expression that evaluates to true or false
+ * @param[in] reason String literal description of the reason that cond is
+ * expected to be true
+ *---------------------------------------------------------------------------**/
+#define RMM_EXPECTS(cond, reason)                                 \
+  (!!(cond)) ? static_cast<void>(0)                               \
+             : throw rmm::logic_error("RMM failure at: " __FILE__ \
+                                      ":" RMM_STRINGIFY(__LINE__) ": " reason)
+
+/**---------------------------------------------------------------------------*
+ * @brief Indicates that an erroneous code path has been taken.
+ *
+ * @throws `rmm::logic_error` always
+ *
+ * Example usage:
+ * ```
+ * RMM_FAIL("Unsupported code path");
+ * ```
+ *
+ * @param[in] reason String literal description of the reason
+ *---------------------------------------------------------------------------**/
+#define RMM_FAIL(reason)                             \
+  throw rmm::logic_error("RMM failure at: " __FILE__ \
+                         ":" RMM_STRINGIFY(__LINE__) ": " reason)
+
+namespace rmm {
+namespace detail {
+inline void throw_cuda_error(cudaError_t error, const char* file,
+                             unsigned int line) {
+  throw rmm::detail::cuda_error(
+      std::string{"CUDA error encountered at: " + std::string{file} + ":" +
+                  std::to_string(line) + ": " + std::to_string(error) + " " +
+                  cudaGetErrorName(error) + " " + cudaGetErrorString(error)});
+}
+}  // namespace detail
+}  // namespace rmm
+
+/**---------------------------------------------------------------------------*
+ * @brief Error checking macro for CUDA runtime API functions.
+ *
+ * Invokes a CUDA runtime API function call, if the call does not return
+ * cudaSuccess, invokes cudaGetLastError() to clear the error and throws an
+ * exception detailing the CUDA error that occurred
+ *
+ *---------------------------------------------------------------------------**/
+#define CUDA_TRY(call)                                           \
+  do {                                                           \
+    cudaError_t const status = (call);                           \
+    if (cudaSuccess != status) {                                 \
+      cudaGetLastError();                                        \
+      rmm::detail::throw_cuda_error(status, __FILE__, __LINE__); \
+    }                                                            \
+  } while (0);
+
+/**---------------------------------------------------------------------------*
+ * @brief Debug macro to check for CUDA errors
+ *
+ * In a non-release build, this macro will synchronize the specified stream
+ * before error checking. In both release and non-release builds, this macro
+ * checks for any pending CUDA errors from previous calls. If an error is
+ * reported, an exception is thrown detailing the CUDA error that occurred.
+ *
+ * The intent of this macro is to provide a mechanism for synchronous and
+ * deterministic execution for debugging asynchronous CUDA execution. It should
+ * be used after any asynchronous CUDA call, e.g., cudaMemcpyAsync, or an
+ * asynchronous kernel launch.
+ *
+ *---------------------------------------------------------------------------**/
+#ifndef NDEBUG
+#define CHECK_CUDA(stream) CUDA_TRY(cudaStreamSynchronize(stream));
+#else
+#define CHECK_CUDA(stream) CUDA_TRY(cudaPeekAtLastError());
+#endif

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -22,13 +22,13 @@
 
 namespace rmm {
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Exception thrown when logical precondition is violated.
  *
  * This exception should not be thrown directly and is instead thrown by the
  * RMM_EXPECTS macro.
  *
- *---------------------------------------------------------------------------**/
+ */
 struct logic_error : public std::logic_error {
   logic_error(char const* const message) : std::logic_error(message) {}
 
@@ -37,10 +37,10 @@ struct logic_error : public std::logic_error {
   // TODO Add an error code member? This would be useful for translating an
   // exception to an error code in a pure-C API
 };
-/**---------------------------------------------------------------------------*
+/**
  * @brief Exception thrown when a CUDA error is encountered.
  *
- *---------------------------------------------------------------------------**/
+ */
 struct cuda_error : public std::runtime_error {
   cuda_error(std::string const& message) : std::runtime_error(message) {}
 };
@@ -84,7 +84,7 @@ struct cuda_error : public std::runtime_error {
 #define RMM_EXPECTS_2(_condition, _reason) \
   RMM_EXPECTS_3(_condition, rmm::logic_error, _reason)
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Indicates that an erroneous code path has been taken.
  *
  * @throws `rmm::logic_error` always
@@ -95,7 +95,7 @@ struct cuda_error : public std::runtime_error {
  * ```
  *
  * @param[in] reason String literal description of the reason
- *---------------------------------------------------------------------------**/
+ */
 #define RMM_FAIL(reason)                             \
   throw rmm::logic_error("RMM failure at: " __FILE__ \
                          ":" RMM_STRINGIFY(__LINE__) ": " reason)
@@ -112,14 +112,14 @@ inline void throw_cuda_error(cudaError_t error, const char* file,
 }  // namespace detail
 }  // namespace rmm
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Error checking macro for CUDA runtime API functions.
  *
  * Invokes a CUDA runtime API function call, if the call does not return
  * cudaSuccess, invokes cudaGetLastError() to clear the error and throws an
  * exception detailing the CUDA error that occurred
  *
- *---------------------------------------------------------------------------**/
+ */
 #define CUDA_TRY(call)                                           \
   do {                                                           \
     cudaError_t const status = (call);                           \
@@ -129,7 +129,7 @@ inline void throw_cuda_error(cudaError_t error, const char* file,
     }                                                            \
   } while (0);
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Debug macro to check for CUDA errors
  *
  * In a non-release build, this macro will synchronize the specified stream
@@ -142,7 +142,7 @@ inline void throw_cuda_error(cudaError_t error, const char* file,
  * be used after any asynchronous CUDA call, e.g., cudaMemcpyAsync, or an
  * asynchronous kernel launch.
  *
- *---------------------------------------------------------------------------**/
+ */
 #ifndef NDEBUG
 #define CHECK_CUDA(stream) CUDA_TRY(cudaStreamSynchronize(stream));
 #else

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -83,7 +83,7 @@ class device_buffer {
   /**--------------------------------------------------------------------------*
    * @brief Constructs a new device buffer of `size` uninitialized bytes
    *
-   * @throws std::bad_alloc If allocation fails.
+   * @throws rmm::bad_alloc If allocation fails.
    *
    * @param size Size in bytes to allocate in device memory.
    * @param stream CUDA stream on which memory may be allocated if the memory
@@ -101,7 +101,7 @@ class device_buffer {
    * @brief Construct a new device buffer by copying from a raw pointer to an
    * existing host or device memory allocation.
    *
-   * @throws std::bad_alloc If creating the new allocation fails.
+   * @throws rmm::bad_alloc If creating the new allocation fails.
    * @throws rmm::logic_error If `source_data` is null, and `size != 0`.
    * @throws rmm::cuda_error if copying from the device memory fails.
    *
@@ -133,7 +133,7 @@ class device_buffer {
    *`other.size() != other.capacity()`, then the size and capacity of the newly
    * constructed `device_buffer` will be equal to `other.size()`.
    *
-   * @throws std::bad_alloc If creating the new allocation fails.
+   * @throws rmm::bad_alloc If creating the new allocation fails.
    * @throws rmm::cuda_error if copying from `other` fails.
    *
    * @param other The `device_buffer` whose contents will be copied
@@ -187,7 +187,7 @@ class device_buffer {
    * `set_stream()` on `other` before assignment. After assignment, this
    * instance's stream is replaced by the stream from `other`.
    *
-   * @throws std::bad_alloc if allocation fails
+   * @throws rmm::bad_alloc if allocation fails
    * @throws rmm::cuda_error if the copy from `other` fails
    *
    * @param other The `device_buffer` to copy.
@@ -269,7 +269,7 @@ class device_buffer {
    * The specified @p stream is used for allocating and copying the new memory
    *if the memory resource supports streams.
    *
-   * @throws std::bad_alloc If creating the new allocation fails
+   * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error if the copy from the old to new allocation
    *fails
    *
@@ -303,7 +303,7 @@ class device_buffer {
    *
    * If `size() == capacity()` this function has no effect.
    *
-   * @throws std::bad_alloc If creating the new allocation fails
+   * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error If the copy from the old to new allocation fails
    *
    * @param stream The stream to use for allocation and copy

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -119,7 +119,7 @@ class device_buffer {
       RMM_EXPECTS((nullptr != source_data), "Attempt to copy from nullptr.");
 
       _data = _mr->allocate(_size, this->stream());
-      CUDA_TRY(cudaMemcpyAsync(_data, source_data, _size, cudaMemcpyDefault,
+      RMM_CUDA_TRY(cudaMemcpyAsync(_data, source_data, _size, cudaMemcpyDefault,
                                this->stream()));
     }
   }
@@ -146,7 +146,7 @@ class device_buffer {
       : _size{other.size()}, _capacity{other.size()}, _stream{stream}, _mr{mr} {
     _data = memory_resource()->allocate(size(), this->stream());
 
-    CUDA_TRY(cudaMemcpyAsync(data(), other.data(), size(), cudaMemcpyDefault,
+    RMM_CUDA_TRY(cudaMemcpyAsync(data(), other.data(), size(), cudaMemcpyDefault,
                              this->stream()));
   }
 
@@ -200,7 +200,7 @@ class device_buffer {
       _mr = other._mr;
       set_stream(other.stream());
       _data = _mr->allocate(_size, stream());
-      CUDA_TRY(cudaMemcpyAsync(_data, other._data, _size, cudaMemcpyDefault,
+      RMM_CUDA_TRY(cudaMemcpyAsync(_data, other._data, _size, cudaMemcpyDefault,
                                stream()));
     }
     return *this;
@@ -285,7 +285,7 @@ class device_buffer {
     } else {
       void* const new_data = _mr->allocate(new_size, this->stream());
       if (_size > 0) {
-        CUDA_TRY(cudaMemcpyAsync(new_data, _data, _size, cudaMemcpyDefault,
+        RMM_CUDA_TRY(cudaMemcpyAsync(new_data, _data, _size, cudaMemcpyDefault,
                                  this->stream()));
       }
       _mr->deallocate(_data, _size, this->stream());
@@ -313,7 +313,7 @@ class device_buffer {
     if (size() != capacity()) {
       void* const new_data = _mr->allocate(size(), this->stream());
       if (size() > 0) {
-        CUDA_TRY(cudaMemcpyAsync(new_data, _data, size(), cudaMemcpyDefault,
+        RMM_CUDA_TRY(cudaMemcpyAsync(new_data, _data, size(), cudaMemcpyDefault,
                                  this->stream()));
       }
       _mr->deallocate(_data, size(), this->stream());

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -24,7 +24,7 @@
 #include <stdexcept>
 
 namespace rmm {
-/**----------------------------------------------------------------------------*
+/**
  * @file device_buffer.hpp
  * @brief RAII construct for device memory allocation
  *
@@ -67,12 +67,12 @@ namespace rmm {
  * // stream if none specified.
  * buff_default.resize(100, stream);
  *```
- *---------------------------------------------------------------------------**/
+ */
 class device_buffer {
  public:
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Default constructor creates an empty `device_buffer`
-   *---------------------------------------------------------------------------**/
+   */
   device_buffer()
       : _data{nullptr},
         _size{},
@@ -80,7 +80,7 @@ class device_buffer {
         _stream{},
         _mr{rmm::mr::get_default_resource()} {}
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Constructs a new device buffer of `size` uninitialized bytes
    *
    * @throws rmm::bad_alloc If allocation fails.
@@ -89,7 +89,7 @@ class device_buffer {
    * @param stream CUDA stream on which memory may be allocated if the memory
    * resource supports streams.
    * @param mr Memory resource to use for the device memory allocation.
-   *-------------------------------------------------------------------------**/
+   */
   explicit device_buffer(
       std::size_t size, cudaStream_t stream = 0,
       mr::device_memory_resource* mr = mr::get_default_resource())
@@ -97,7 +97,7 @@ class device_buffer {
     _data = _mr->allocate(size, this->stream());
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Construct a new device buffer by copying from a raw pointer to an
    * existing host or device memory allocation.
    *
@@ -110,7 +110,7 @@ class device_buffer {
    * @param stream CUDA stream on which memory may be allocated if the memory
    * resource supports streams.
    * @param mr Memory resource to use for the device memory allocation
-   *-------------------------------------------------------------------------**/
+   */
   device_buffer(void const* source_data, std::size_t size,
                 cudaStream_t stream = 0,
                 mr::device_memory_resource* mr = mr::get_default_resource())
@@ -124,7 +124,7 @@ class device_buffer {
     }
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Construct a new `device_buffer` by deep copying the contents of
    * another `device_buffer`, optionally using the specified stream and memory
    * resource.
@@ -139,7 +139,7 @@ class device_buffer {
    * @param other The `device_buffer` whose contents will be copied
    * @param stream The stream to use for the allocation and copy
    * @param mr The resource to use for allocating the new `device_buffer`
-   *-------------------------------------------------------------------------**/
+   */
   device_buffer(
       device_buffer const& other, cudaStream_t stream = 0,
       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
@@ -150,7 +150,7 @@ class device_buffer {
                              this->stream()));
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Constructs a new `device_buffer` by moving the contents of another
    * `device_buffer` into the newly constructed one.
    *
@@ -161,7 +161,7 @@ class device_buffer {
    *
    * @param other The `device_buffer` whose contents will be moved into the
    * newly constructed one.
-   *-------------------------------------------------------------------------**/
+   */
   device_buffer(device_buffer&& other) noexcept
       : _data{other._data},
         _size{other._size},
@@ -174,7 +174,7 @@ class device_buffer {
     other.set_stream(0);
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Copy assignment operator copies the contents of `other`
    *
    * Memory deallocation uses this instance's memory_resource and the last
@@ -191,7 +191,7 @@ class device_buffer {
    * @throws rmm::cuda_error if the copy from `other` fails
    *
    * @param other The `device_buffer` to copy.
-   *-------------------------------------------------------------------------**/
+   */
   device_buffer& operator=(device_buffer const& other) {
     if (&other != this) {
       _mr->deallocate(_data, _capacity, stream());
@@ -206,7 +206,7 @@ class device_buffer {
     return *this;
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Move assignment operator moves the contents from `other`.
    *
    * Memory deallocation uses the last stream set in a device_buffer method
@@ -215,7 +215,7 @@ class device_buffer {
    * replaced by the stream from `other`.
    *
    * @param other The `device_buffer` whose contents will be moved.
-   *-------------------------------------------------------------------------**/
+   */
   device_buffer& operator=(device_buffer&& other) {
     if (&other != this) {
       _mr->deallocate(_data, _capacity, stream());
@@ -233,13 +233,13 @@ class device_buffer {
     return *this;
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Destroy the device buffer object
    *
    * @note If the memory resource supports streams, this destructor deallocates
    * using the stream most recently passed to any of this device buffer's
    * methods.
-   *-------------------------------------------------------------------------**/
+   */
   ~device_buffer() noexcept {
     _mr->deallocate(_data, _capacity, stream());
     _data = nullptr;
@@ -249,7 +249,7 @@ class device_buffer {
     _mr = nullptr;
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Resize the device memory allocation
    *
    * If the requested `new_size` is less than or equal to the current size, no
@@ -275,7 +275,7 @@ class device_buffer {
    *
    * @param new_size The requested new size, in bytes
    * @param stream The stream to use for allocation and copy
-   *-------------------------------------------------------------------------**/
+   */
   void resize(std::size_t new_size, cudaStream_t stream = 0) {
     set_stream(stream);
     // If the requested size is smaller, just update the size without any
@@ -295,7 +295,7 @@ class device_buffer {
     }
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Forces the deallocation of unused memory.
    *
    * Reallocates and copies the contents of the device memory allocation to
@@ -307,7 +307,7 @@ class device_buffer {
    * @throws rmm::cuda_error If the copy from the old to new allocation fails
    *
    * @param stream The stream to use for allocation and copy
-   *-------------------------------------------------------------------------**/
+   */
   void shrink_to_fit(cudaStream_t stream = 0) {
     set_stream(stream);
     if (size() != capacity()) {
@@ -322,35 +322,35 @@ class device_buffer {
     }
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Returns raw pointer to underlying device memory allocation
-   *-------------------------------------------------------------------------**/
+   */
   void const* data() const noexcept { return _data; }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Returns raw pointer to underlying device memory allocation
-   *-------------------------------------------------------------------------**/
+   */
   void* data() noexcept { return _data; }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Returns size in bytes that was requested for the device memory
    * allocation
-   *-------------------------------------------------------------------------**/
+   */
   std::size_t size() const noexcept { return _size; }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Returns actual size in bytes of device memory allocation.
    *
    * The invariant `size() <= capacity()` holds.
-   *-------------------------------------------------------------------------**/
+   */
   std::size_t capacity() const noexcept { return _capacity; }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Returns stream most recently specified for allocation/deallocation
-   *-------------------------------------------------------------------------**/
+   */
   cudaStream_t stream() const noexcept { return _stream; }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Sets the stream to be used for deallocation
    *
    * If no other rmm::device_buffer method that allocates or copies memory is
@@ -359,13 +359,13 @@ class device_buffer {
    * Otherwise, if another rmm::device_buffer method with a stream parameter is
    * called after this, the later stream parameter will be stored and used in
    * the destructor.
-   *-------------------------------------------------------------------------**/
+   */
   void set_stream(cudaStream_t stream) noexcept { _stream = stream; }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Returns pointer to the memory resource used to allocate and
    * deallocate the device memory
-   *-------------------------------------------------------------------------**/
+   */
   mr::device_memory_resource* memory_resource() const noexcept { return _mr; }
 
  private:

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -38,6 +38,10 @@ class device_scalar {
   /**---------------------------------------------------------------------------*
    * @brief Construct a new `device_scalar`
    *
+   * @throws `rmm::bad_alloc` if allocating the device memory for
+   *`initial_value` fails
+   * @throws `rmm::cuda_error` if copying `initial_value` to device memory fails
+   *
    * @param initial_value The initial value of the object in device memory
    * @param stream Optional, stream on which to perform allocation and copy
    * @param mr Optional, resource with which to allocate
@@ -46,13 +50,15 @@ class device_scalar {
       T const &initial_value, cudaStream_t stream = 0,
       rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource())
       : buff{sizeof(T), stream, mr} {
-    
     _memcpy(buff.data(), &initial_value, stream);
   }
 
   /**---------------------------------------------------------------------------*
    * @brief Copies the value from device to host, synchronizes, and returns the
    * value.
+   *
+   * @throws `rmm::cuda_error` If the copy fails
+   * @throws `rmm::cuda_error` If synchronizing `stream` fails
    *
    * @return T The value of the scalar after synchronizing the stream
    * @param stream CUDA stream on which to perform the copy
@@ -65,6 +71,9 @@ class device_scalar {
 
   /**---------------------------------------------------------------------------*
    * @brief Copies the value from host to device and synchronizes the stream.
+   *
+   * @throws `rmm::cuda_error` if copying `host_value` to device memory fails
+   * @throws `rmm::cuda_error` if synchronizing `stream` fails
    *
    * @param host_value The host value which will be copied to device
    * @param stream CUDA stream on which to perform the copy
@@ -93,17 +102,9 @@ class device_scalar {
  private:
   rmm::device_buffer buff{sizeof(T)};
 
-  inline void _memcpy(void *dst, const void *src,
-                      cudaStream_t stream) const{
-    auto status = cudaMemcpyAsync(dst, src, sizeof(T), cudaMemcpyDefault, stream);
-
-    if (cudaSuccess != status) {
-      throw std::runtime_error{"Device memcpy failed."};
-    }
-
-    if (cudaSuccess != cudaStreamSynchronize(stream)) {
-      throw std::runtime_error{"Stream sync failed."};
-    }
+  inline void _memcpy(void *dst, const void *src, cudaStream_t stream) const {
+    CUDA_TRY(cudaMemcpyAsync(dst, src, sizeof(T), cudaMemcpyDefault, stream));
+    CUDA_TRY(cudaStreamSynchronize(stream));
   }
 };
 

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -22,20 +22,20 @@
 
 namespace rmm {
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Container for a single object of type `T` in device memory.
  *
  * `T` must be trivially copyable.
  *
  * @tparam T The object's type
- *---------------------------------------------------------------------------**/
+ */
 template <typename T>
 class device_scalar {
  public:
   static_assert(std::is_trivially_copyable<T>::value,
                 "Scalar type must be trivially copyable");
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Construct a new `device_scalar`
    *
    * @throws `rmm::bad_alloc` if allocating the device memory for
@@ -45,7 +45,7 @@ class device_scalar {
    * @param initial_value The initial value of the object in device memory
    * @param stream Optional, stream on which to perform allocation and copy
    * @param mr Optional, resource with which to allocate
-   *---------------------------------------------------------------------------**/
+   */
   explicit device_scalar(
       T const &initial_value, cudaStream_t stream = 0,
       rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource())
@@ -53,7 +53,7 @@ class device_scalar {
     _memcpy(buff.data(), &initial_value, stream);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Copies the value from device to host, synchronizes, and returns the
    * value.
    *
@@ -62,14 +62,14 @@ class device_scalar {
    *
    * @return T The value of the scalar after synchronizing the stream
    * @param stream CUDA stream on which to perform the copy
-   *---------------------------------------------------------------------------**/
+   */
   T value(cudaStream_t stream = 0) const {
     T host_value{};
     _memcpy(&host_value, buff.data(), stream);
     return host_value;
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Copies the value from host to device and synchronizes the stream.
    *
    * @throws `rmm::cuda_error` if copying `host_value` to device memory fails
@@ -77,19 +77,19 @@ class device_scalar {
    *
    * @param host_value The host value which will be copied to device
    * @param stream CUDA stream on which to perform the copy
-   *---------------------------------------------------------------------------**/
+   */
   void set_value(T host_value, cudaStream_t stream = 0) {
     _memcpy(buff.data(), &host_value, stream);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Returns pointer to object in device memory.
-   *---------------------------------------------------------------------------**/
+   */
   T *data() noexcept { return static_cast<T *>(buff.data()); }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Returns pointer to object in device memory.
-   *---------------------------------------------------------------------------**/
+   */
   T const *data() const noexcept { return static_cast<T const *>(buff.data()); }
 
   device_scalar() = default;
@@ -107,5 +107,4 @@ class device_scalar {
     CUDA_TRY(cudaStreamSynchronize(stream));
   }
 };
-
 }  // namespace rmm

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -103,8 +103,8 @@ class device_scalar {
   rmm::device_buffer buff{sizeof(T)};
 
   inline void _memcpy(void *dst, const void *src, cudaStream_t stream) const {
-    CUDA_TRY(cudaMemcpyAsync(dst, src, sizeof(T), cudaMemcpyDefault, stream));
-    CUDA_TRY(cudaStreamSynchronize(stream));
+    RMM_CUDA_TRY(cudaMemcpyAsync(dst, src, sizeof(T), cudaMemcpyDefault, stream));
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream));
   }
 };
 }  // namespace rmm

--- a/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
@@ -29,14 +29,14 @@
 
 namespace rmm {
 namespace mr {
-/**----------------------------------------------------------------------------*
+/**
  * @brief Memory resource that allocates/deallocates managed device memory
     (CUDA Unified Memory) using the cnmem pool sub-allocator.
  * the cnmem pool sub-allocator for allocation/deallocation.
- *---------------------------------------------------------------------------**/
+ */
 class cnmem_managed_memory_resource final : public cnmem_memory_resource {
  public:
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Construct a cnmem memory resource and allocate the initial device
    * memory pool
 
@@ -44,7 +44,7 @@ class cnmem_managed_memory_resource final : public cnmem_memory_resource {
    *
    * @param initial_pool_size Size, in bytes, of the intial pool size. When
    * zero, an implementation defined pool size is used.
-   *-------------------------------------------------------------------------**/
+   */
   explicit cnmem_managed_memory_resource(std::size_t initial_pool_size = 0,
                                          std::vector<int> const& devices = {})
       : cnmem_memory_resource(initial_pool_size, devices,

--- a/include/rmm/mr/device/cnmem_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_memory_resource.hpp
@@ -166,7 +166,7 @@ class cnmem_memory_resource : public device_memory_resource {
    * If a stream equal to `stream` has already been registered, this function
    * has no effect.
    *
-   * This function is threadsafe.
+   * This function is thread safe.
    *
    * @throws `rmm::cnmem_error` if registering the stream with cnmem fails.
    *

--- a/include/rmm/mr/device/cnmem_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_memory_resource.hpp
@@ -107,7 +107,7 @@ class cnmem_memory_resource : public device_memory_resource {
     // If no devices were specified, use the current one
     if (devices.empty()) {
       int current_device{};
-      CUDA_TRY(cudaGetDevice(&current_device));
+      RMM_CUDA_TRY(cudaGetDevice(&current_device));
       cnmemDevice_t dev{};
       dev.device = current_device;
       dev.size = initial_pool_size;

--- a/include/rmm/mr/device/cnmem_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_memory_resource.hpp
@@ -170,7 +170,6 @@ class cnmem_memory_resource : public device_memory_resource {
    *
    * @throws `rmm::cnmem_error` if registering the stream with cnmem fails.
    *
-   *
    * @param stream The stream to register
    */
   void register_stream(cudaStream_t stream) {

--- a/include/rmm/mr/device/cnmem_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_memory_resource.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <rmm/detail/cnmem.h>
+#include <rmm/detail/error.hpp>
 #include "device_memory_resource.hpp"
 
 #include <cuda_runtime_api.h>
@@ -54,33 +55,37 @@ struct cnmem_error : public std::runtime_error {
 
 namespace rmm {
 namespace mr {
-/**---------------------------------------------------------------------------*
+/**
  * @brief Memory resource that allocates/deallocates using the cnmem pool
  * sub-allocator.
- *---------------------------------------------------------------------------**/
+ */
 class cnmem_memory_resource : public device_memory_resource {
  public:
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Construct a cnmem memory resource and allocate the initial device
    * memory pool.
-
-   * TODO Add constructor arguments for other CNMEM options/flags
+   *
+   * @throws `rmm::cuda_error` if getting the current device fails
+   * @throws `rmm::cnmem_error` if initializing CNMEM fails
    *
    * @param initial_pool_size Size, in bytes, of the initial pool size. When
    * zero, an implementation defined pool size is used.
    * @param devices List of GPU device IDs to register with CNMEM
-   *---------------------------------------------------------------------------**/
+   */
   explicit cnmem_memory_resource(std::size_t initial_pool_size = 0,
                                  std::vector<int> const& devices = {})
       : cnmem_memory_resource(initial_pool_size, devices, memory_kind::CUDA) {}
 
+  /**
+   * @brief Destroy the CNMEM resource, finalizing CNMEM and freeing all pool
+   * memory.
+   *
+   * @throws Nothing.
+   *
+   */
   virtual ~cnmem_memory_resource() {
     auto status = cnmemFinalize();
-#ifndef NDEBUG
-    if (status != CNMEM_STATUS_SUCCESS) {
-      std::cerr << "cnmemFinalize failed.\n";
-    }
-#endif
+    assert(CNMEM_STATUS_SUCCESS == status);
   }
 
   bool supports_streams() const noexcept override { return true; }
@@ -102,10 +107,7 @@ class cnmem_memory_resource : public device_memory_resource {
     // If no devices were specified, use the current one
     if (devices.empty()) {
       int current_device{};
-      auto status = cudaGetDevice(&current_device);
-      if(status != cudaSuccess){
-         throw std::runtime_error{"Failed to get current device."};
-      }
+      CUDA_TRY(cudaGetDevice(&current_device));
       cnmemDevice_t dev{};
       dev.device = current_device;
       dev.size = initial_pool_size;
@@ -121,56 +123,56 @@ class cnmem_memory_resource : public device_memory_resource {
 
     unsigned long flags =
         (pool_type == memory_kind::MANAGED) ? CNMEM_FLAGS_MANAGED : 0;
-    // TODO Update exception
-    auto status = cnmemInit(cnmem_devices.size(), cnmem_devices.data(), flags);
-    if (CNMEM_STATUS_SUCCESS != status) {
-      std::string msg = cnmemGetErrorString(status);
-      throw std::runtime_error{"Failed to initialize cnmem: " + msg};
-    }
+
+    CNMEM_TRY(cnmemInit(cnmem_devices.size(), cnmem_devices.data(), flags));
   }
 
  private:
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Allocates memory of size at least \p bytes using cnmem.
    *
    * The returned pointer has at least 256B alignment.
    *
-   * @throws `std::runtime_error` if cnmem failed to register the stream
-   * @throws `std::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws `rmm::cnmem_error` if cnmem failed to register the stream
+   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
    *
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
-   *-------------------------------------------------------------------------**/
+   */
   void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
     register_stream(stream);
     void* p{nullptr};
-    auto status = cnmemMalloc(&p, bytes, stream);
-    if (CNMEM_STATUS_SUCCESS != status) {
-#ifndef NDEBUG
-      std::cerr << "cnmemMalloc failed: " << cnmemGetErrorString(status)
-                << "\n";
-#endif
-      throw std::bad_alloc{};
-    }
+    CNMEM_TRY(cnmemMalloc(&p, bytes, stream), rmm::bad_alloc);
     return p;
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Deallocate memory pointed to by \p p.
    *
    * @throws Nothing.
    *
    * @param p Pointer to be deallocated
-   *-------------------------------------------------------------------------**/
+   */
   void do_deallocate(void* p, std::size_t, cudaStream_t stream) override {
     auto status = cnmemFree(p, stream);
-    if (CNMEM_STATUS_SUCCESS != status) {
-#ifndef NDEBUG
-      std::cerr << "cnmemFree failed: " << cnmemGetErrorString(status) << "\n";
-#endif
-    }
+    assert(CNMEM_STATUS_SUCCESS == status);
   }
 
+  /**
+   * @brief Registers `stream` with CNMEM if not already registered.
+   *
+   * The null stream is ignored.
+   *
+   * If a stream equal to `stream` has already been registered, this function
+   * has no effect.
+   *
+   * This function is threadsafe.
+   *
+   * @throws `rmm::cnmem_error` if registering the stream with cnmem fails.
+   *
+   *
+   * @param stream The stream to register
+   */
   void register_stream(cudaStream_t stream) {
     // Don't register null stream with CNMEM
     if (stream != 0) {
@@ -178,39 +180,30 @@ class cnmem_memory_resource : public device_memory_resource {
       // allocation
       std::lock_guard<std::mutex> lock(streams_mutex);
       auto result = registered_streams.insert(stream);
-
       if (result.second == true) {
-        auto status = cnmemRegisterStream(stream);
-        if (CNMEM_STATUS_SUCCESS != status) {
-          std::string msg = cnmemGetErrorString(status);
-          throw std::runtime_error{"Failed to register stream with cnmem: " +
-                                   msg};
-        }
+        CNMEM_TRY(cnmemRegisterStream(stream));
       }
     }
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Get free and available memory for memory resource
    *
-   * @throws std::runtime_error if we could not get cnmem free / total memory
+   * @throws rmm::cnmem_error if we could not get cnmem free / total memory
    *
    * @param stream to execute on
    * @return std::pair contaiing free_size and total_size of memory
-   *-------------------------------------------------------------------------**/
+   */
   std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const {
     std::size_t free_size;
     std::size_t total_size;
-    auto status = cnmemMemGetInfo(&free_size, &total_size, stream);
-    if (CNMEM_STATUS_SUCCESS != status) {
-      std::string msg = cnmemGetErrorString(status);
-      throw std::runtime_error{"cnmemMemGetInfo failed: " + msg};
-    }
+    CNMEM_TRY(cnmemMemGetInfo(&free_size, &total_size, stream));
     return std::make_pair(free_size, total_size);
   }
-
-  std::set<cudaStream_t> registered_streams{};
-  std::mutex streams_mutex{};
+  std::set<cudaStream_t> registered_streams{};  // Unique streams that have been
+                                                // registered with cnmem
+  std::mutex streams_mutex{};  // Mutex used to guard concurrent access to
+                               // `registered_streams`
 };
 
 }  // namespace mr

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -26,16 +26,16 @@
 
 namespace rmm {
 namespace mr {
-/**---------------------------------------------------------------------------*
+/**
  * @brief `device_memory_resource` derived class that uses cudaMalloc/Free for
  * allocation/deallocation.
- *---------------------------------------------------------------------------**/
+ */
 class cuda_memory_resource final : public device_memory_resource {
  public:
   bool supports_streams() const noexcept override { return false; }
 
  private:
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Allocates memory of size at least `bytes` using cudaMalloc.
    *
    * The returned pointer has at least 256B alignment.
@@ -46,14 +46,14 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
-   *-------------------------------------------------------------------------**/
+   */
   void* do_allocate(std::size_t bytes, cudaStream_t) override {
     void* p{nullptr};
     CUDA_TRY(cudaMalloc(&p, bytes), rmm::bad_alloc);
     return p;
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Deallocate memory pointed to by \p p.
    *
    * @note Stream argument is ignored.
@@ -61,13 +61,13 @@ class cuda_memory_resource final : public device_memory_resource {
    * @throws Nothing.
    *
    * @param p Pointer to be deallocated
-   *-------------------------------------------------------------------------**/
+   */
   void do_deallocate(void* p, std::size_t, cudaStream_t) override {
     cudaError_t const status = cudaFree(p);
     assert(cudaSuccess == status);
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Compare this resource to another.
    *
    * Two cuda_memory_resources always compare equal, because they can each
@@ -78,18 +78,18 @@ class cuda_memory_resource final : public device_memory_resource {
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
-   *-------------------------------------------------------------------------**/
+   */
   bool do_is_equal(device_memory_resource const& other) const noexcept {
     return dynamic_cast<cuda_memory_resource const*>(&other) != nullptr;
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Get free and available memory for memory resource
    *
    * @throws `rmm::cuda_error` if unable to retrieve memory info.
    *
    * @return std::pair contaiing free_size and total_size of memory
-   *-------------------------------------------------------------------------**/
+   */
   std::pair<size_t, size_t> do_get_mem_info(cudaStream_t) const {
     std::size_t free_size;
     std::size_t total_size;
@@ -97,6 +97,5 @@ class cuda_memory_resource final : public device_memory_resource {
     return std::make_pair(free_size, total_size);
   }
 };
-
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -36,7 +36,7 @@ class cuda_memory_resource final : public device_memory_resource {
 
  private:
   /**--------------------------------------------------------------------------*
-   * @brief Allocates memory of size at least \p bytes using cudaMalloc.
+   * @brief Allocates memory of size at least `bytes` using cudaMalloc.
    *
    * The returned pointer has at least 256B alignment.
    *
@@ -72,6 +72,8 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * Two cuda_memory_resources always compare equal, because they can each
    * deallocate memory allocated by the other.
+   *
+   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -49,7 +49,7 @@ class cuda_memory_resource final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cudaStream_t) override {
     void* p{nullptr};
-    CUDA_TRY(cudaMalloc(&p, bytes), rmm::bad_alloc);
+    RMM_CUDA_TRY(cudaMalloc(&p, bytes), rmm::bad_alloc);
     return p;
   }
 
@@ -93,7 +93,7 @@ class cuda_memory_resource final : public device_memory_resource {
   std::pair<size_t, size_t> do_get_mem_info(cudaStream_t) const {
     std::size_t free_size;
     std::size_t total_size;
-    CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));
+    RMM_CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));
     return std::make_pair(free_size, total_size);
   }
 };

--- a/include/rmm/mr/device/default_memory_resource.hpp
+++ b/include/rmm/mr/device/default_memory_resource.hpp
@@ -20,7 +20,7 @@
 namespace rmm {
 namespace mr {
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Get the default device memory resource pointer.
  *
  * The default device memory resource is used when an explicit memory resource
@@ -31,10 +31,10 @@ namespace mr {
  *
  * @return device_memory_resource* Pointer to the current default memory
  * resource
- *---------------------------------------------------------------------------**/
+ */
 device_memory_resource* get_default_resource();
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Sets the default device memory resource pointer.
  *
  * If `new_resource` is not `nullptr`, sets the default device memory resource
@@ -50,20 +50,20 @@ device_memory_resource* get_default_resource();
  * default device memory resource
  * @return device_memory_resource* The previous value of the default device
  * memory resource pointer
- *---------------------------------------------------------------------------**/
+ */
 device_memory_resource* set_default_resource(
     device_memory_resource* new_resource);
 
 namespace detail{
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief gets the default memory_resource when none is set
  *
  * A static function which will return a singleton cuda_memory_resource
  *
  * @return device_memory_resource* a pointer to the static
  * cuda_memory_resource
- *---------------------------------------------------------------------------**/
+ */
 device_memory_resource* initial_resource();
 
 }  // namespace detail

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -25,19 +25,19 @@ namespace rmm {
 
 namespace detail {
 /**
- * @brief Align up to a power of 2, align_bytes is expected to be a nonzero power of 2
+ * @brief Align up to a power of 2, align_bytes is expected to be a nonzero
+ * power of 2
  *
  * @param[in] v value to align
- * @param[in] alignment amount, in bytes, must be a power of 2 
+ * @param[in] alignment amount, in bytes, must be a power of 2
  *
  * @return Return the aligned value, as one would expect
  */
-inline std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept
-{
-    return (v + (align_bytes - 1)) & ~(align_bytes - 1);
+inline std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept {
+  return (v + (align_bytes - 1)) & ~(align_bytes - 1);
 }
 
-} // namespace detail
+}  // namespace detail
 
 namespace mr {
 /**---------------------------------------------------------------------------*
@@ -46,9 +46,10 @@ namespace mr {
  * This class serves as the interface that all custom device memory
  * implementations must satisfy.
  *
- * There are two private, pure virtual functions that all derived classes must implement: `do_allocate` and
- * `do_deallocate`. Optionally, derived classes may also override `is_equal`. By default,
- * `is_equal` simply performs an identity comparison.
+ * There are two private, pure virtual functions that all derived classes must
+ *implement: `do_allocate` and `do_deallocate`. Optionally, derived classes may
+ *also override `is_equal`. By default, `is_equal` simply performs an identity
+ *comparison.
  *
  * The public, non-virtual functions `allocate`, `deallocate`, and `is_equal`
  * simply call the private virtual functions. The reason for this is to allow
@@ -70,7 +71,8 @@ class device_memory_resource {
    * If supported, this operation may optionally be executed on a stream.
    * Otherwise, the stream is ignored and the null stream is used.
    *
-   * @throws std::bad_alloc When the requested size cannot be allocated.
+   * @throws `rmm::bad_alloc` When the requested `bytes` cannot be allocated on
+   * the specified `stream`.
    *
    * @param bytes The size of the allocation
    * @param stream Stream on which to perform allocation
@@ -90,6 +92,8 @@ class device_memory_resource {
    *
    * If supported, this operation may optionally be executed on a stream.
    * Otherwise, the stream is ignored and the null stream is used.
+   * 
+   * @throws Nothing.
    *
    * @param p Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
@@ -136,6 +140,7 @@ class device_memory_resource {
   std::pair<std::size_t, std::size_t> get_mem_info(cudaStream_t stream) const {
     return do_get_mem_info(stream);
   }
+
  private:
   /**---------------------------------------------------------------------------*
    * @brief Allocates memory of size at least \p bytes.
@@ -191,7 +196,8 @@ class device_memory_resource {
    * @param stream the stream being executed on
    * @return std::pair with available and free memory for resource
    *---------------------------------------------------------------------------**/
-  virtual std::pair<std::size_t, std::size_t> do_get_mem_info( cudaStream_t stream) const = 0;
+  virtual std::pair<std::size_t, std::size_t> do_get_mem_info(
+      cudaStream_t stream) const = 0;
 };
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -40,7 +40,7 @@ inline std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept {
 }  // namespace detail
 
 namespace mr {
-/**---------------------------------------------------------------------------*
+/**
  * @brief Base class for all libcudf device memory allocation.
  *
  * This class serves as the interface that all custom device memory
@@ -57,13 +57,13 @@ namespace mr {
  * base class' `allocate` function may log every allocation, no matter what
  * derived class implementation is used.
  *
- *---------------------------------------------------------------------------**/
+ */
 class device_memory_resource {
  public:
   device_memory_resource() = default;
   virtual ~device_memory_resource() = default;
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Allocates memory of size at least \p bytes.
    *
    * The returned pointer will have at minimum 256 byte alignment.
@@ -77,12 +77,12 @@ class device_memory_resource {
    * @param bytes The size of the allocation
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
-   *---------------------------------------------------------------------------**/
+   */
   void* allocate(std::size_t bytes, cudaStream_t stream = 0) {
     return do_allocate(detail::align_up(bytes, 8), stream);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Deallocate memory pointed to by \p p.
    *
    * `p` must have been returned by a prior call to `allocate(bytes,stream)` on
@@ -92,19 +92,19 @@ class device_memory_resource {
    *
    * If supported, this operation may optionally be executed on a stream.
    * Otherwise, the stream is ignored and the null stream is used.
-   * 
+   *
    * @throws Nothing.
    *
    * @param p Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
-   *---------------------------------------------------------------------------**/
+   */
   void deallocate(void* p, std::size_t bytes, cudaStream_t stream = 0) {
     do_deallocate(p, detail::align_up(bytes, 8), stream);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Compare this resource to another.
    *
    * Two device_memory_resources compare equal if and only if memory allocated
@@ -116,33 +116,33 @@ class device_memory_resource {
    *
    * @param other The other resource to compare to
    * @returns If the two resources are equivalent
-   *---------------------------------------------------------------------------**/
+   */
   bool is_equal(device_memory_resource const& other) const noexcept {
     return do_is_equal(other);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Queries if the resource supports use of non-null streams for
    * allocation/deallocation.
    *
    * @returns If the resource supports non-null streams
-   *---------------------------------------------------------------------------**/
+   */
   virtual bool supports_streams() const noexcept = 0;
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Queries the amount of free and total memory for the resource.
    *
    * @param stream the stream whose memory manager we want to retrieve
    *
    * @returns a std::pair<size_t,size_t> which contains free memory in bytes
    * in .first and total amount of memory in .second
-   *---------------------------------------------------------------------------**/
+   */
   std::pair<std::size_t, std::size_t> get_mem_info(cudaStream_t stream) const {
     return do_get_mem_info(stream);
   }
 
  private:
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Allocates memory of size at least \p bytes.
    *
    * The returned pointer will have at minimum 256 byte alignment.
@@ -153,10 +153,10 @@ class device_memory_resource {
    * @param bytes The size of the allocation
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
-   *---------------------------------------------------------------------------**/
+   */
   virtual void* do_allocate(std::size_t bytes, cudaStream_t stream) = 0;
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Deallocate memory pointed to by \p p.
    *
    * If supported, this operation may optionally be executed on a stream.
@@ -166,11 +166,11 @@ class device_memory_resource {
    * @param bytes The size in bytes of the allocation. This must be equal to the
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
-   *---------------------------------------------------------------------------**/
+   */
   virtual void do_deallocate(void* p, std::size_t bytes,
                              cudaStream_t stream) = 0;
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Compare this resource to another.
    *
    * Two device_memory_resources compare equal if and only if memory allocated
@@ -183,19 +183,19 @@ class device_memory_resource {
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
-   *---------------------------------------------------------------------------**/
+   */
   virtual bool do_is_equal(device_memory_resource const& other) const noexcept {
     return this == &other;
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Get free and available memory for memory resource
    *
    * @throws std::runtime_error if we could not get free / total memory
    *
    * @param stream the stream being executed on
    * @return std::pair with available and free memory for resource
-   *---------------------------------------------------------------------------**/
+   */
   virtual std::pair<std::size_t, std::size_t> do_get_mem_info(
       cudaStream_t stream) const = 0;
 };

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -55,7 +55,7 @@ class managed_memory_resource final : public device_memory_resource {
     }
 
     void* p{nullptr};
-    CUDA_TRY(cudaMallocManaged(&p, bytes), rmm::bad_alloc);
+    RMM_CUDA_TRY(cudaMallocManaged(&p, bytes), rmm::bad_alloc);
     return p;
   }
 
@@ -100,7 +100,7 @@ class managed_memory_resource final : public device_memory_resource {
   std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const {
     std::size_t free_size{};
     std::size_t total_size{};
-    CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));
+    RMM_CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));
     return std::make_pair(free_size, total_size);
   }
 };

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -17,6 +17,8 @@
 
 #include "device_memory_resource.hpp"
 
+#include <rmm/detail/error.hpp>
+
 #include <cuda_runtime_api.h>
 #include <cassert>
 #include <exception>
@@ -24,27 +26,27 @@
 
 namespace rmm {
 namespace mr {
-/**---------------------------------------------------------------------------*
+/**
  * @brief `device_memory_resource` derived class that uses
  * cudaMallocManaged/Free for allocation/deallocation.
- *---------------------------------------------------------------------------**/
+ */
 class managed_memory_resource final : public device_memory_resource {
  public:
   bool supports_streams() const noexcept override { return false; }
 
  private:
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Allocates memory of size at least \p bytes using cudaMallocManaged.
    *
    * The returned pointer has at least 256B alignment.
    *
    * @note Stream argument is ignored
    *
-   * @throws `std::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
    *
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
-   *-------------------------------------------------------------------------**/
+   */
   void* do_allocate(std::size_t bytes, cudaStream_t) override {
     // FIXME: Unlike cudaMalloc, cudaMallocManaged will throw an error for 0
     // size allocations.
@@ -53,18 +55,11 @@ class managed_memory_resource final : public device_memory_resource {
     }
 
     void* p{nullptr};
-    cudaError_t const status = cudaMallocManaged(&p, bytes);
-    if (cudaSuccess != status) {
-#ifndef NDEBUG
-      std::cerr << "cudaMallocManaged failed: " << cudaGetErrorName(status)
-                << " " << cudaGetErrorString(status) << "\n";
-#endif
-      throw std::bad_alloc{};
-    }
+    CUDA_TRY(cudaMallocManaged(&p, bytes), rmm::bad_alloc);
     return p;
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Deallocate memory pointed to by \p p.
    *
    * @note Stream argument is ignored.
@@ -72,51 +67,40 @@ class managed_memory_resource final : public device_memory_resource {
    * @throws Nothing.
    *
    * @param p Pointer to be deallocated
-   *-------------------------------------------------------------------------**/
+   */
   void do_deallocate(void* p, std::size_t, cudaStream_t) override {
     cudaError_t const status = cudaFree(p);
-#ifndef NDEBUG
-    if (status != cudaSuccess) {
-      std::cerr << "cudaFree failed: " << cudaGetErrorName(status) << " "
-                << cudaGetErrorString(status) << "\n";
-    }
-#endif
+    assert(cudaSuccess = status);
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Compare this resource to another.
    *
-   * Two managed_memory_resources always compare equal, because they can each 
+   * Two `managed_memory_resources` always compare equal, because they can each
    * deallocate memory allocated by the other.
+   *
+   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
-   *-------------------------------------------------------------------------**/
+   */
   bool do_is_equal(device_memory_resource const& other) const noexcept {
     return dynamic_cast<managed_memory_resource const*>(&other) != nullptr;
   }
 
-  /**--------------------------------------------------------------------------*
+  /**
    * @brief Get free and available memory for memory resource
    *
-   * @throws std::runtime_error if cudaMemGetInfo fails
+   * @throws `rmm::cuda_error` if unable to retrieve memory info
    *
    * @param stream to execute on
    * @return std::pair contaiing free_size and total_size of memory
-   *-------------------------------------------------------------------------**/
-  std::pair<size_t,size_t> do_get_mem_info( cudaStream_t stream) const{
-    std::size_t free_size;
-    std::size_t total_size;
-    auto status = cudaMemGetInfo(&free_size, &total_size);
-    if (cudaSuccess != status) {
-#ifndef NDEBUG
-      std::cerr << "cudaMemGetInfo failed: " << cudaGetErrorName(status) << " "
-          << cudaGetErrorString(status) << "\n";
-      throw std::runtime_error{
-        "Failed to to call get_mem_info on memory resource"};
-#endif
-    }
+   */
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const {
+    std::size_t free_size{};
+    std::size_t total_size{};
+    CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));
     return std::make_pair(free_size, total_size);
   }
 };

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -20,7 +20,7 @@
 
 namespace rmm {
 namespace mr {
-/**---------------------------------------------------------------------------*
+/**
  * @brief An `allocator` compatible with Thrust containers and algorithms using
  * a `device_memory_resource` for memory (de)allocation.
  *
@@ -29,7 +29,7 @@ namespace mr {
  * types.
  *
  * @tparam T The type of the objects that will be allocated by this allocator
- *---------------------------------------------------------------------------**/
+ */
 template <typename T>
 class thrust_allocator : public thrust::device_malloc_allocator<T> {
  public:
@@ -37,67 +37,67 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   using pointer = typename Base::pointer;
   using size_type = typename Base::size_type;
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Provides the type of a `thrust_allocator` instantiated with another
    * type.
    *
    * @tparam U the other type to use for instantiation
-   *---------------------------------------------------------------------------**/
+   */
   template <typename U>
   struct rebind {
     using other = thrust_allocator<U>;
   };
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Constructs a `thrust_allocator` using a device memory resource and
    * stream.
    *
    * @param mr The resource to be used for device memory allocation
    * @param stream The stream to be used for device memory (de)allocation
-   *---------------------------------------------------------------------------**/
+   */
   thrust_allocator(device_memory_resource* mr, cudaStream_t stream)
       : _mr(mr), _stream{stream} {
           
       }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Copy constructor. Copies the resource pointer and stream.
    *
    * @param other The `thrust_allocator` to copy
-   *---------------------------------------------------------------------------**/
+   */
   template <typename U>
   thrust_allocator(thrust_allocator<U> const& other)
       : _mr(other.resource()), _stream{other.stream()} {}
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Allocate objects of type `T`
    *
    * @param n  The number of elements of type `T` to allocate
    * @return pointer Pointer to the newly allocated storage
-   *---------------------------------------------------------------------------**/
+   */
   pointer allocate(size_type n) {
     return static_cast<pointer>(_mr->do_allocate(n * sizeof(T), _stream));
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Deallocates objects of type `T`
    *
    * @param p Pointer returned by a previous call to `allocate`
    * @param n number of elements, *must* be equal to the argument passed to the
    * prior `allocate` call that produced `p`
-   *---------------------------------------------------------------------------**/
+   */
   void deallocate(pointer p, size_type n) {
     return _mr->do_deallocate(p, n * sizeof(T), _stream);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Returns the device memory resource used by this allocator.
-   *---------------------------------------------------------------------------**/
+   */
   device_memory_resource* resource() const noexcept { return _mr; }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Returns the stream used by this allocator.
-   *---------------------------------------------------------------------------**/
+   */
   cudaStream_t stream() const noexcept { return stream; }
 
  private:

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-/** ---------------------------------------------------------------------------*
+/**
  * @brief Device Memory Manager public C++ interface.
  *
  * Efficient allocation, deallocation and tracking of GPU memory.
- * --------------------------------------------------------------------------**/
+ */
 
 #ifndef MEMORY_HPP
 #define MEMORY_HPP
 #include <rmm/rmm_api.h>
+#include <rmm/detail/error.hpp>
 #include <rmm/detail/memory_manager.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
-#include <rmm/detail/error.hpp>
 
-/** ---------------------------------------------------------------------------*
+/**
  * @brief Macro wrapper to check for error in RMM API calls.
- * ---------------------------------------------------------------------------**/
+ */
 #define RMM_CHECK(call)                     \
   do {                                      \
     rmmError_t error = (call);              \
@@ -89,7 +89,7 @@ class LogIt {
   bool usageLogging;
 };
 
-/** ---------------------------------------------------------------------------*
+/**
  * @brief Allocate memory and return a pointer to device memory.
  *
  * @param[out] ptr Returned pointer
@@ -102,13 +102,12 @@ class LogIt {
  *                    has not been called, RMM_ERROR_INVALID_ARGUMENT if ptr is
  *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
  *                    requested size, or RMM_CUDA_ERROR on any other CUDA error.
- * --------------------------------------------------------------------------**/
+ */
 template <typename T>
-inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream, const char* file,
-                 unsigned int line) {
+inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream,
+                        const char* file, unsigned int line) {
   if (!rmmIsInitialized(nullptr)) {
-    if (ptr)
-      *ptr = nullptr;
+    if (ptr) *ptr = nullptr;
     return RMM_ERROR_NOT_INITIALIZED;
   }
 
@@ -118,14 +117,13 @@ inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream, const char* f
     return RMM_SUCCESS;
   }
 
-  if (!ptr)
-    return RMM_ERROR_INVALID_ARGUMENT;
+  if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
 
   try {
     *ptr = static_cast<T*>(
-      rmm::mr::get_default_resource()->allocate(size,stream));
+        rmm::mr::get_default_resource()->allocate(size, stream));
 
-  } catch(std::exception const& e) {
+  } catch (std::exception const& e) {
     *ptr = nullptr;
     return RMM_ERROR_OUT_OF_MEMORY;
   }
@@ -134,7 +132,7 @@ inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream, const char* f
   return RMM_SUCCESS;
 }
 
-/** ---------------------------------------------------------------------------*
+/**
  * @brief Reallocate device memory block to new size and recycle any remaining
  *        memory.
  *
@@ -149,7 +147,7 @@ inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream, const char* f
  *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
  *                    requested size, or RMM_ERROR_CUDA_ERROR on any other CUDA
  *                    error.
- * --------------------------------------------------------------------------**/
+ */
 /*template <typename T>
 inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
                    const char* file, unsigned int line) {
@@ -176,7 +174,7 @@ inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
   return RMM_SUCCESS;
 }
 */
-/** ---------------------------------------------------------------------------*
+/**
  * @brief Release device memory and recycle the associated memory.
  *
  * \note Doesn't need to be a template because T* is implicitly conertible to
@@ -190,15 +188,14 @@ inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
  * @return rmmError_t RMM_SUCCESS, or RMM_ERROR_NOT_INITIALIZED if rmmInitialize
  *                    has not been called,or RMM_ERROR_CUDA_ERROR on any CUDA
  *                    error.
- * --------------------------------------------------------------------------**/
+ */
 inline rmmError_t free(void* ptr, cudaStream_t stream, const char* file,
-                   unsigned int line) {
-  if (!rmmIsInitialized(nullptr))
-    return RMM_ERROR_NOT_INITIALIZED;
+                       unsigned int line) {
+  if (!rmmIsInitialized(nullptr)) return RMM_ERROR_NOT_INITIALIZED;
 
   rmm::LogIt log(rmm::Logger::Free, ptr, 0, stream, file, line);
 
-  rmm::mr::get_default_resource()->deallocate(ptr,0,stream);
+  rmm::mr::get_default_resource()->deallocate(ptr, 0, stream);
 
   return RMM_SUCCESS;
 }

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -22,9 +22,10 @@
 
 #ifndef MEMORY_HPP
 #define MEMORY_HPP
-#include "rmm/rmm_api.h"
-#include "rmm/detail/memory_manager.hpp"
-#include "rmm/mr/device/default_memory_resource.hpp"
+#include <rmm/rmm_api.h>
+#include <rmm/detail/memory_manager.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/detail/error.hpp>
 
 /** ---------------------------------------------------------------------------*
  * @brief Macro wrapper to check for error in RMM API calls.
@@ -33,18 +34,6 @@
   do {                                      \
     rmmError_t error = (call);              \
     if (error != RMM_SUCCESS) return error; \
-  } while (0)
-
-/** ---------------------------------------------------------------------------*
- * @brief Macro wrapper for RMM API calls to return appropriate RMM errors.
- * ---------------------------------------------------------------------------**/
-#define RMM_CHECK_CUDA(call)                    \
-  do {                                          \
-    cudaError_t cudaError = (call);             \
-    if (cudaError == cudaErrorMemoryAllocation) \
-      return RMM_ERROR_OUT_OF_MEMORY;           \
-    else if (cudaError != cudaSuccess)          \
-      return RMM_ERROR_CUDA_ERROR;              \
   } while (0)
 
 namespace rmm {
@@ -67,7 +56,7 @@ class LogIt {
         usageLogging(usageLogging) {
     if (filename) file = filename;
     if (Manager::getOptions().enable_logging) {
-      cudaGetDevice(&device);
+      CUDA_TRY(cudaGetDevice(&device));
       start = std::chrono::system_clock::now();
     }
   }

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -56,7 +56,7 @@ class LogIt {
         usageLogging(usageLogging) {
     if (filename) file = filename;
     if (Manager::getOptions().enable_logging) {
-      CUDA_TRY(cudaGetDevice(&device));
+      RMM_CUDA_TRY(cudaGetDevice(&device));
       start = std::chrono::system_clock::now();
     }
   }

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -22,7 +22,7 @@
 #include <rmm/mr/device/managed_memory_resource.hpp>
 
 namespace rmm {
-/** -------------------------------------------------------------------------*
+/**
  * Record a memory manager event in the log.
  *
  * @param[in] event The type of event (Alloc, Realloc, or Free)
@@ -32,7 +32,7 @@ namespace rmm {
  * @param[in] size The size of allocation (only needed for Alloc/Realloc).
  * @param[in] stream The stream on which the allocation is happening
  *                   (only needed for Alloc/Realloc).
- * ------------------------------------------------------------------------**/
+ */
 void Logger::record(MemEvent_t event, int deviceId, void* ptr, TimePt start,
                     TimePt end, size_t freeMem, size_t totalMem, size_t size,
                     cudaStream_t stream, std::string filename,
@@ -48,12 +48,12 @@ void Logger::record(MemEvent_t event, int deviceId, void* ptr, TimePt start,
                     current_allocations.size(), start, end, filename, line});
 }
 
-/** -------------------------------------------------------------------------*
+/**
  * @brief Output a comma-separated value string of the current log to the
  *        provided ostream
  *
  * @param[in] csv The output stream to put the CSV log string into.
- * ------------------------------------------------------------------------**/
+ */
 void Logger::to_csv(std::ostream& csv) {
   csv << "Event Type,Device ID,Address,Stream,Size (bytes),Free Memory,"
       << "Total Memory,Current Allocs,Start,End,Elapsed,Location\n";
@@ -74,9 +74,9 @@ void Logger::to_csv(std::ostream& csv) {
   }
 }
 
-/** ---------------------------------------------------------------------------*
+/**
  * @brief Clear the log
- * --------------------------------------------------------------------------**/
+ */
 void Logger::clear() {
   std::lock_guard<std::mutex> guard(log_mutex);
   events.clear();

--- a/src/rmm.cpp
+++ b/src/rmm.cpp
@@ -28,8 +28,6 @@
 #include "rmm/mr/device/managed_memory_resource.hpp"
 #include "rmm/mr/device/cuda_memory_resource.hpp"
 
-
-
 #include <fstream>
 #include <sstream>
 #include <cstddef>

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -23,6 +23,7 @@
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/detail/error.hpp>
 
 
 #include <thrust/sequence.h>
@@ -136,7 +137,7 @@ TYPED_TEST(DeviceBufferTest, CopyFromNullptr) {
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZero) {
   // can  copy from a nullptr only if size == 0
-  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1), std::runtime_error);
+  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1), rmm::logic_error);
 }
 
 TYPED_TEST(DeviceBufferTest, CopyConstructor) {

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -220,13 +220,13 @@ TYPED_TEST(MRTest, AllocateGBStream) {
 
 TYPED_TEST(MRTest, AllocateTooMuch) {
   void* p{nullptr};
-  EXPECT_THROW(p = this->mr->allocate(size_pb), std::bad_alloc);
+  EXPECT_THROW(p = this->mr->allocate(size_pb), rmm::bad_alloc);
   EXPECT_EQ(nullptr, p);
 }
 
 TYPED_TEST(MRTest, AllocateTooMuchStream) {
   void* p{nullptr};
-  EXPECT_THROW(p = this->mr->allocate(size_pb, this->stream), std::bad_alloc);
+  EXPECT_THROW(p = this->mr->allocate(size_pb, this->stream), rmm::bad_alloc);
   EXPECT_EQ(nullptr, p);
 }
 

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -34,10 +34,10 @@ inline bool is_aligned(void* p, std::size_t alignment = ALIGNMENT) {
   return (0 == reinterpret_cast<uintptr_t>(p) % alignment);
 }
 
-/**---------------------------------------------------------------------------*
+/**
  * @brief Returns if a pointer points to a device memory or managed memory
  * allocation.
- *---------------------------------------------------------------------------**/
+ */
 inline bool is_device_memory(void* p) {
   cudaPointerAttributes attributes{};
   if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) {


### PR DESCRIPTION
Supersedes https://github.com/rapidsai/rmm/pull/38 

- [x] Adds `RMM_EXCPETS`
- [x] Adds `CUDA_TRY`
- [x] Adds RMM exceptions `logic_error` and `cuda_error`
- [x] Updates `device_buffer.hpp` to use new error checking as proof of concept
- [x] Update `RMM_EXPECTS` and `CUDA_TRY` to allow specifying the exception to throw
- [x] Update code to use new error checking macros and exceptions

Cleaned up the old Doxygen style while I was at it. 