### PR TITLE
[REVIEW] Remove RMM_CUDA_TRY from cuda_event_timer destructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #296 Use CuPy's `UnownedMemory` for RMM-backed allocations
 
 ## Bug Fixes
+- PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor
 
 
 # RMM 0.12.0 (Date TBD)

--- a/benchmarks/synchronization/synchronization.cpp
+++ b/benchmarks/synchronization/synchronization.cpp
@@ -25,6 +25,12 @@
     }                                                             \
   } while (0);
 
+#define RMM_CUDA_ASSERT_OK(expr)                                  \
+  do {                                                            \
+    cudaError_t const status = (expr);                            \
+    assert(cudaSuccess == status);                                \
+  } while (0);
+
 cuda_event_timer::cuda_event_timer(benchmark::State& state,
                                    bool flush_l2_cache,
                                    cudaStream_t stream):
@@ -52,13 +58,13 @@ cuda_event_timer::cuda_event_timer(benchmark::State& state,
 }
 
 cuda_event_timer::~cuda_event_timer() {
-  if (cudaEventRecord(stop, stream) != cudaSuccess) return;
-  if (cudaEventSynchronize(stop) != cudaSuccess) return;
+  RMM_CUDA_ASSERT_OK(cudaEventRecord(stop, stream));
+  RMM_CUDA_ASSERT_OK(cudaEventSynchronize(stop));
  
   float milliseconds = 0.0f;
-  if (cudaEventElapsedTime(&milliseconds, start, stop) != cudaSuccess) return;
+  RMM_CUDA_ASSERT_OK(cudaEventElapsedTime(&milliseconds, start, stop));
   p_state->SetIterationTime(milliseconds/(1000.0f));
-  if (cudaEventDestroy(start) != cudaSuccess) return;
-  if (cudaEventDestroy(stop) != cudaSuccess) return;
+  RMM_CUDA_ASSERT_OK(cudaEventDestroy(start));
+  RMM_CUDA_ASSERT_OK(cudaEventDestroy(stop));
 }
 

--- a/benchmarks/synchronization/synchronization.cpp
+++ b/benchmarks/synchronization/synchronization.cpp
@@ -52,13 +52,13 @@ cuda_event_timer::cuda_event_timer(benchmark::State& state,
 }
 
 cuda_event_timer::~cuda_event_timer() {
-  RMM_CUDA_TRY(cudaEventRecord(stop, stream));
-  RMM_CUDA_TRY(cudaEventSynchronize(stop));
+  if (cudaEventRecord(stop, stream) != cudaSuccess) return;
+  if (cudaEventSynchronize(stop) != cudaSuccess) return;
  
   float milliseconds = 0.0f;
-  RMM_CUDA_TRY(cudaEventElapsedTime(&milliseconds, start, stop));
+  if (cudaEventElapsedTime(&milliseconds, start, stop) != cudaSuccess) return;
   p_state->SetIterationTime(milliseconds/(1000.0f));
-  RMM_CUDA_TRY(cudaEventDestroy(start));
-  RMM_CUDA_TRY(cudaEventDestroy(stop));
+  if (cudaEventDestroy(start) != cudaSuccess) return;
+  if (cudaEventDestroy(stop) != cudaSuccess) return;
 }
 


### PR DESCRIPTION
Remove `RMM_CUDA_TRY` from the `cuda_event_timer` destructor. Fixes https://github.com/rapidsai/rmm/issues/293.