### PR TITLE
[REVIEW] Fix host mr_tests compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ## Bug Fixes
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor
 - PR #299 Fix assert condition blocking debug builds
+- PR #300 Fix host mr_tests compile error
 
 
 # RMM 0.12.0 (Date TBD)

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -31,7 +31,7 @@ inline bool is_aligned(void* p,
   return (0 == reinterpret_cast<uintptr_t>(p) % alignment);
 }
 
-inline bool expect_aligned(void* p, std::size_t alignment) {
+inline void expect_aligned(void* p, std::size_t alignment) {
   EXPECT_EQ(0, reinterpret_cast<uintptr_t>(p) % alignment);
 }
 


### PR DESCRIPTION
Fix compile error in host `mr_tests` caused by function with no return marked as returning `bool`.