### PR TITLE
Sync default stream in `DeviceBuffer` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #280 Drop allocation/deallocation of `offset`
 - PR #282 `DeviceBuffer` use default constructor for size=0
 - PR #296 Use CuPy's `UnownedMemory` for RMM-backed allocations
+- PR #309 Sync default stream in `DeviceBuffer` constructor
 
 ## Bug Fixes
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -53,6 +53,13 @@ cdef class DeviceBuffer:
                (and possibly size of data to copy)
         stream : CUDA stream to use for construction and/or copying, default 0
 
+        Note
+        ----
+
+        If ``stream`` is the default stream, it is synchronized after the copy.
+        However if a non-default ``stream`` is provided, this function is fully
+        asynchronous.
+
         Examples
         --------
         >>> import rmm

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -44,6 +44,20 @@ cdef class DeviceBuffer:
                   uintptr_t ptr=0,
                   size_t size=0,
                   uintptr_t stream=0):
+        """Construct a ``DeviceBuffer`` with optional size and data pointer
+
+        Parameters
+        ----------
+        ptr : pointer to some data on host or device to copy over
+        size : size of the buffer to allocate
+               (and possibly size of data to copy)
+        stream : CUDA stream to use for construction and/or copying, default 0
+
+        Examples
+        --------
+        >>> import rmm
+        >>> db = rmm.DeviceBuffer(size=5)
+        """
         cdef const void* c_ptr
         cdef cudaStream_t c_stream
         cdef cudaError_t err


### PR DESCRIPTION
To make sure data is completely copied over to `DeviceBuffer` when using the default stream, make sure to sync on it after constructing the `rmm::device_buffer` object. This ensures it is allocated and its data (if any is provided) is fully populated.