### PR TITLE
[REVIEW] Improve `device_buffer` allocation and deallocation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #280 Drop allocation/deallocation of `offset`
 - PR #282 `DeviceBuffer` use default constructor for size=0
 - PR #296 Use CuPy's `UnownedMemory` for RMM-backed allocations
+- PR #310 Improve `device_buffer` allocation logic.
 
 ## Bug Fixes
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -211,7 +211,7 @@ class device_buffer {
    *
    * @param other The `device_buffer` whose contents will be moved.
    */
-  device_buffer& operator=(device_buffer&& other) {
+  device_buffer& operator=(device_buffer&& other) noexcept {
     if (&other != this) {
       deallocate();
 

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -304,6 +304,20 @@ class device_buffer {
   }
 
   /**
+   * @brief Swaps the contents of this `device_buffer` with another
+   * `device_buffer`.
+   *
+   * @param other The `device_buffer` with which to swap.
+   */
+  void swap(device_buffer& other) {
+    std::swap(_data, other._data);
+    std::swap(_size, other._size);
+    std::swap(_capacity, other._capacity);
+    std::swap(_stream, other._stream);
+    std::swap(_mr, other._mr);
+  }
+
+  /**
    * @brief Returns raw pointer to underlying device memory allocation
    */
   void const* data() const noexcept { return _data; }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -160,7 +160,10 @@ class device_buffer {
   }
 
   /**
-   * @brief Copies the contents of `other` into this `device_buffer`
+   * @brief Copies the contents of `other` into this `device_buffer`.
+   *
+   * All operations on the data in this `device_buffer` on all streams must be
+   * complete before using this operator, otherwise behavior is undefined.
    *
    * If the existing capacity is large enough, and the memory resources are
    * compatible, then this `device_buffer`'s existing memory will be reused and
@@ -171,11 +174,6 @@ class device_buffer {
    * Otherwise, the existing memory will be deallocated using
    * `memory_resource()` on `stream()` and new memory will be allocated using
    * `other.memory_resource()` on `other.stream()`.
-   *
-   * TODO: Need to clarify stream behavior here. Since we are potentially
-   * overwriting/deallocating this buffer's memory, the user needs to guarantee
-   * that it is no longer being used. Should the user be responsible for syncing
-   * `stream()` beforehand? Or should we sync here?
    *
    * @throws rmm::bad_alloc if allocation fails
    * @throws rmm::cuda_error if the copy from `other` fails
@@ -305,7 +303,7 @@ class device_buffer {
    * reduce `capacity()` to `size()`.
    *
    * If `size() == capacity()`, no allocations nor copies occur.
-   * 
+   *
    * TODO: Need to clarify stream behavior here. Since we are potentially
    * deallocating this buffer's memory, the user needs to guarantee
    * that it is no longer being used. Should the user be responsible for syncing

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -112,7 +112,8 @@ class device_buffer {
                 cudaStream_t stream = 0,
                 mr::device_memory_resource* mr = mr::get_default_resource())
       : _stream{stream}, _mr{mr} {
-    allocate_and_copy(source_data, size);
+    allocate(size);
+    copy(source_data, size);
   }
 
   /**
@@ -140,8 +141,9 @@ class device_buffer {
    * @brief Constructs a new `device_buffer` by moving the contents of another
    * `device_buffer` into the newly constructed one.
    *
-   * After the new `device_buffer` is constructed, `other` is modified to be
-   * empty, i.e., `data()` returns `nullptr`, and `size()` is zero.
+   * After the new `device_buffer` is constructed, `other` is modified to be a
+   * valid, empty `device_buffer`, i.e., `data()` returns `nullptr`, and
+   * `size()` and `capacity()` are zero.
    *
    * @throws Nothing
    *
@@ -194,7 +196,8 @@ class device_buffer {
         deallocate();
         set_stream(other.stream());
         _mr = other._mr;
-        allocate_and_copy(other.data(), other.size());
+        allocate(other.size());
+        copy(other.data(), other.size());
       }
     }
     return *this;

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -209,6 +209,10 @@ class device_buffer {
    * the instance before assignment. After assignment, this instance's stream is
    * replaced by the stream from `other`.
    *
+   * TODO: Need to clarify stream behavior here. Since we are deallocating this
+   * buffer's memory, the user needs to guarantee that it is no longer being
+   * used. So the user be responsible for syncing `stream()` beforehand
+   *
    * @param other The `device_buffer` whose contents will be moved.
    */
   device_buffer& operator=(device_buffer&& other) {

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -387,5 +387,15 @@ class device_buffer {
   mr::device_memory_resource* _mr{
       mr::get_default_resource()};  ///< The memory resource used to
                                     ///< allocate/deallocate device memory
+
+  /**
+   * @brief If the `device_buffer` holds any memory, deallocate it.
+   *
+   */
+  void deallocate() noexcept {
+    if (capacity() > 0) {
+      _mr->deallocate(data(), capacity());
+    }
+  }
 };
 }  // namespace rmm

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -72,7 +72,7 @@ class device_buffer {
  public:
   /**
    * @brief Default constructor creates an empty `device_buffer`
-   * 
+   *
    */
   device_buffer() = default;
 
@@ -133,8 +133,7 @@ class device_buffer {
   device_buffer(
       device_buffer const& other, cudaStream_t stream = 0,
       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
-      : device_buffer{other.data(), other.size(), stream, mr}{}
-      
+      : device_buffer{other.data(), other.size(), stream, mr} {}
 
   /**
    * @brief Constructs a new `device_buffer` by moving the contents of another
@@ -292,14 +291,10 @@ class device_buffer {
   void shrink_to_fit(cudaStream_t stream = 0) {
     set_stream(stream);
     if (size() != capacity()) {
-      void* const new_data = _mr->allocate(size(), this->stream());
-      if (size() > 0) {
-        RMM_CUDA_TRY(cudaMemcpyAsync(new_data, _data, size(), cudaMemcpyDefault,
-                                     this->stream()));
-      }
-      _mr->deallocate(_data, size(), this->stream());
-      _data = new_data;
-      _capacity = size();
+      // Invoke copy ctor on self which only copies `[0, size())` and swap it
+      // with self. The temporary `device_buffer` will hold the old contents
+      // which will then be destroyed
+      device_buffer(*this).swap(*this);
     }
   }
 

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -72,13 +72,9 @@ class device_buffer {
  public:
   /**
    * @brief Default constructor creates an empty `device_buffer`
+   * 
    */
-  device_buffer()
-      : _data{nullptr},
-        _size{},
-        _capacity{},
-        _stream{},
-        _mr{rmm::mr::get_default_resource()} {}
+  device_buffer() = default;
 
   /**
    * @brief Constructs a new device buffer of `size` uninitialized bytes

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -94,7 +94,7 @@ class device_buffer {
       std::size_t size, cudaStream_t stream = 0,
       mr::device_memory_resource* mr = mr::get_default_resource())
       : _stream{stream}, _mr{mr} {
-    allocate(size, stream());
+    allocate(size);
   }
 
   /**
@@ -392,10 +392,10 @@ class device_buffer {
    * @param bytes The amount of memory to allocate
    * @param stream The stream on which to allocate
    */
-  void allocate(std::size_t bytes, cudaStream_t stream) {
+  void allocate(std::size_t bytes) {
     _size = bytes;
     _capacity = bytes;
-    _data = (bytes > 0) ? _mr->allocate(bytes, stream) : nullptr;
+    _data = (bytes > 0) ? _mr->allocate(bytes, stream()) : nullptr;
   }
 
   /**

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -179,10 +179,8 @@ class device_buffer {
    */
   device_buffer& operator=(device_buffer const& other) {
     if (&other != this) {
-      deallocate();
-      set_stream(other.stream());
-      _mr = other._mr;
-      allocate_and_copy(other.data(), other.size());
+      // copy and swap
+      device_buffer(other).swap(*this);
     }
     return *this;
   }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -22,6 +22,7 @@
 #include <cuda_runtime_api.h>
 #include <cassert>
 #include <stdexcept>
+#include <utility>
 
 namespace rmm {
 /**
@@ -184,7 +185,7 @@ class device_buffer {
     if (&other != this) {
       // If the current capacity is large enough and the resources are
       // compatible, just reuse the existing memory
-      if ((capacity() > other.size()) and _mr.is_equal(*other._mr)) {
+      if ((capacity() > other.size()) and _mr->is_equal(*other._mr)) {
         set_stream(other.stream());
         resize(other.size());
         copy(other.data(), other.size());
@@ -318,7 +319,8 @@ class device_buffer {
       // Invoke copy ctor on self which only copies `[0, size())` and swap it
       // with self. The temporary `device_buffer` will hold the old contents
       // which will then be destroyed
-      std::swap(device_bufer(*this), *this)
+      auto tmp = device_buffer{*this};
+      std::swap(tmp, *this);
     }
   }
 

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -428,11 +428,5 @@ class device_buffer {
           cudaMemcpyAsync(_data, source, bytes, cudaMemcpyDefault, stream()));
     }
   }
-
-  void allocate_and_copy(void const* source, std::size_t bytes) {
-    allocate(bytes);
-    copy(source, bytes);
-  }
 };
-
 }  // namespace rmm

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -185,14 +185,10 @@ class device_buffer {
    */
   device_buffer& operator=(device_buffer const& other) {
     if (&other != this) {
-      _mr->deallocate(_data, _capacity, stream());
-      _size = other._size;
-      _capacity = other._size;  // only allocate _size bytes
-      _mr = other._mr;
+      deallocate();
       set_stream(other.stream());
-      _data = _mr->allocate(_size, stream());
-      RMM_CUDA_TRY(cudaMemcpyAsync(_data, other._data, _size, cudaMemcpyDefault,
-                                   stream()));
+      _mr = other._mr;
+      allocate_and_copy(other.data(), other.size());
     }
     return *this;
   }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -115,8 +115,7 @@ class device_buffer {
                 cudaStream_t stream = 0,
                 mr::device_memory_resource* mr = mr::get_default_resource())
       : _stream{stream}, _mr{mr} {
-    allocate(size);
-    copy(source_data, size);
+    allocate_and_copy(source_data, size);
   }
 
   /**
@@ -138,11 +137,8 @@ class device_buffer {
   device_buffer(
       device_buffer const& other, cudaStream_t stream = 0,
       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
-      : _size{other.size()}, _capacity{other.size()}, _stream{stream}, _mr{mr} {
-    _data = memory_resource()->allocate(size(), this->stream());
-
-    RMM_CUDA_TRY(cudaMemcpyAsync(data(), other.data(), size(),
-                                 cudaMemcpyDefault, this->stream()));
+      : _stream{stream}, _mr{mr} {
+    allocate_and_copy(other.data(), other.size());
   }
 
   /**

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -298,20 +298,15 @@ class device_buffer {
   /**
    * @brief Forces the deallocation of unused memory.
    *
-   * Reallocates and copies the contents of the device memory allocation to
-   * reduce `capacity()` to `size()`.
+   * Reallocates and copies on stream `stream` the contents of the device memory
+   * allocation to reduce `capacity()` to `size()`.
    *
    * If `size() == capacity()`, no allocations nor copies occur.
-   *
-   * TODO: Need to clarify stream behavior here. Since we are potentially
-   * deallocating this buffer's memory, the user needs to guarantee
-   * that it is no longer being used. Should the user be responsible for syncing
-   * `stream()` beforehand? Or should we sync here?
    *
    * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error If the copy from the old to new allocation fails
    *
-   * @param stream The stream to use for allocation and copy
+   * @param stream The stream on which the allocation and copy are performed
    */
   void shrink_to_fit(cudaStream_t stream = 0) {
     set_stream(stream);
@@ -319,7 +314,7 @@ class device_buffer {
       // Invoke copy ctor on self which only copies `[0, size())` and swap it
       // with self. The temporary `device_buffer` will hold the old contents
       // which will then be destroyed
-      auto tmp = device_buffer{*this};
+      auto tmp = device_buffer{*this, stream};
       std::swap(tmp, *this);
     }
   }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -343,6 +343,13 @@ class device_buffer {
   std::size_t size() const noexcept { return _size; }
 
   /**
+   * @brief Returns if the `device_buffer` is empty and does not hold a device
+   * memory allocation.
+   *
+   */
+  bool is_empty() const noexcept { return 0 == size(); }
+
+  /**
    * @brief Returns actual size in bytes of device memory allocation.
    *
    * The invariant `size() <= capacity()` holds.

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -279,7 +279,7 @@ class device_buffer {
    * Reallocates and copies the contents of the device memory allocation to
    * reduce `capacity()` to `size()`.
    *
-   * If `size() == capacity()` this function has no effect.
+   * If `size() == capacity()`, no allocations nor copies occur.
    *
    * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error If the copy from the old to new allocation fails
@@ -292,22 +292,8 @@ class device_buffer {
       // Invoke copy ctor on self which only copies `[0, size())` and swap it
       // with self. The temporary `device_buffer` will hold the old contents
       // which will then be destroyed
-      device_buffer(*this).swap(*this);
+      std::swap(device_bufer(*this), *this)
     }
-  }
-
-  /**
-   * @brief Swaps the contents of this `device_buffer` with another
-   * `device_buffer`.
-   *
-   * @param other The `device_buffer` with which to swap.
-   */
-  void swap(device_buffer& other) noexcept {
-    std::swap(_data, other._data);
-    std::swap(_size, other._size);
-    std::swap(_capacity, other._capacity);
-    std::swap(_stream, other._stream);
-    std::swap(_mr, other._mr);
   }
 
   /**
@@ -432,4 +418,5 @@ class device_buffer {
     copy(source, bytes);
   }
 };
+
 }  // namespace rmm

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -205,7 +205,8 @@ class device_buffer {
    */
   device_buffer& operator=(device_buffer&& other) {
     if (&other != this) {
-      _mr->deallocate(_data, _capacity, stream());
+      deallocate();
+
       _data = other._data;
       _size = other._size;
       _capacity = other._capacity;

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -258,7 +258,7 @@ class device_buffer {
    * `stream` to satisfy `new_size`, and the contents of the old allocation are
    * copied on `stream` to the new allocation. The old allocation is then freed.
    * The bytes from `[old_size, new_size)` are uninitialized.
-   * 
+   *
    * The invariant `size() <= capacity()` holds.
    *
    * @throws rmm::bad_alloc If creating the new allocation fails
@@ -276,11 +276,9 @@ class device_buffer {
       _size = new_size;
     } else {
       void* const new_data = _mr->allocate(new_size, this->stream());
-      if (_size > 0) {
-        RMM_CUDA_TRY(cudaMemcpyAsync(new_data, _data, _size, cudaMemcpyDefault,
-                                     this->stream()));
-      }
-      _mr->deallocate(_data, _size, this->stream());
+      RMM_CUDA_TRY(cudaMemcpyAsync(new_data, data(), size(), cudaMemcpyDefault,
+                                   stream()));
+      deallocate();
       _data = new_data;
       _size = new_size;
       _capacity = new_size;

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -242,11 +242,12 @@ class device_buffer {
    *
    * If `new_size` is larger than the current size, a new allocation is made
    * to satisfy `new_size`, and the contents of the old allocation are copied
-   * to the new allocation. The old allocation is then freed.
+   * to the new allocation. The old allocation is then freed. The bytes from
+   *`[old_size, new_size)` are uninitialized.
    *
    * The invariant `size() <= capacity()` holds.
    *
-   * The specified @p stream is used for allocating and copying the new memory
+   * The specified `stream` is used for allocating and copying the new memory
    *if the memory resource supports streams.
    *
    * @throws rmm::bad_alloc If creating the new allocation fails

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -133,9 +133,8 @@ class device_buffer {
   device_buffer(
       device_buffer const& other, cudaStream_t stream = 0,
       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
-      : _stream{stream}, _mr{mr} {
-    allocate_and_copy(other.data(), other.size());
-  }
+      : device_buffer{other.data(), other.size(), stream, mr}{}
+      
 
   /**
    * @brief Constructs a new `device_buffer` by moving the contents of another

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -266,6 +266,11 @@ class device_buffer {
    *
    * The specified `stream` is used for allocating and copying the new memory
    *if the memory resource supports streams.
+
+   * TODO: Need to clarify stream behavior here. Since we are potentially
+   * deallocating this buffer's memory, the user needs to guarantee
+   * that it is no longer being used. Should the user be responsible for syncing
+   * `stream()` beforehand? Or should we sync here?
    *
    * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error if the copy from the old to new allocation
@@ -300,6 +305,11 @@ class device_buffer {
    * reduce `capacity()` to `size()`.
    *
    * If `size() == capacity()`, no allocations nor copies occur.
+   * 
+   * TODO: Need to clarify stream behavior here. Since we are potentially
+   * deallocating this buffer's memory, the user needs to guarantee
+   * that it is no longer being used. Should the user be responsible for syncing
+   * `stream()` beforehand? Or should we sync here?
    *
    * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error If the copy from the old to new allocation fails

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -304,7 +304,7 @@ class device_buffer {
    *
    * @param other The `device_buffer` with which to swap.
    */
-  void swap(device_buffer& other) {
+  void swap(device_buffer& other) noexcept {
     std::swap(_data, other._data);
     std::swap(_size, other._size);
     std::swap(_capacity, other._capacity);

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -202,14 +202,12 @@ class device_buffer {
   /**
    * @brief Move assignment operator moves the contents from `other`.
    *
-   * Memory deallocation uses the last stream set in a device_buffer method
-   * on this instance. If a different stream is required, call `set_stream()` on
-   * the instance before assignment. After assignment, this instance's stream is
-   * replaced by the stream from `other`.
+   * This `device_buffer`'s current device memory allocation will be deallocated
+   * on `stream()`.
    *
-   * TODO: Need to clarify stream behavior here. Since we are deallocating this
-   * buffer's memory, the user needs to guarantee that it is no longer being
-   * used. So the user be responsible for syncing `stream()` beforehand
+   * If a different stream is required, call `set_stream()` on
+   * the instance before assignment. After assignment, this instance's stream is
+   * replaced by the `other.stream()`.
    *
    * @param other The `device_buffer` whose contents will be moved.
    */

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -410,13 +410,30 @@ class device_buffer {
     _data = nullptr;
   }
 
-  void copy(void* source, std::size_t bytes) {
+  /**
+   * @brief Copies the specified number of `bytes` from `source` into the
+   * internal device allocation.
+   *
+   * `source` can point to either host or device memory.
+   *
+   * This function assumes `_data` already points to an allocation large enough
+   * to hold `bytes` bytes.
+   *
+   * @param source The pointer to copy from
+   * @param bytes The number of bytes to copy
+   */
+  void copy(void const* source, std::size_t bytes) {
     if (bytes > 0) {
       RMM_EXPECTS(nullptr != source, "Invalid copy from nullptr.");
 
       RMM_CUDA_TRY(
           cudaMemcpyAsync(_data, source, bytes, cudaMemcpyDefault, stream()));
     }
+  }
+
+  void allocate_and_copy(void const* source, std::size_t bytes) {
+    allocate(bytes);
+    copy(source, bytes);
   }
 };
 }  // namespace rmm

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -280,7 +280,7 @@ class device_buffer {
     } else {
       void* const new_data = _mr->allocate(new_size, this->stream());
       RMM_CUDA_TRY(cudaMemcpyAsync(new_data, data(), size(), cudaMemcpyDefault,
-                                   stream()));
+                                   this->stream()));
       deallocate();
       _data = new_data;
       _size = new_size;


### PR DESCRIPTION
fixes https://github.com/rapidsai/rmm/issues/307

Primary goal was to avoid any calls to `allocate(0)` or `deallocate(p,0)`.

Additional goals were to just overall improve and remove redundancy in the allocation/deallocation logic in the various buffer ctors and assignment operators.