### PR TITLE
[REVIEW] Revert explicitly defaulted device_buffer constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor
 - PR #299 Fix assert condition blocking debug builds
 - PR #300 Fix host mr_tests compile error
-- PR #311 Fix libcudf compilation errors due to explicit defaulted device_buffer constructor.
+- PR #312 Fix libcudf compilation errors due to explicit defaulted device_buffer constructor.
 
 
 # RMM 0.12.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor
 - PR #299 Fix assert condition blocking debug builds
 - PR #300 Fix host mr_tests compile error
+- PR #311 Fix libcudf compilation errors due to explicit defaulted device_buffer constructor.
 
 
 # RMM 0.12.0 (Date TBD)

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -73,9 +73,18 @@ class device_buffer {
  public:
   /**
    * @brief Default constructor creates an empty `device_buffer`
-   *
    */
-  device_buffer() = default;
+  // Note: we cannot use `device_buffer() = default;` because nvcc implicitly adds
+  // `__host__ __device__` specifiers to the defaulted constructor when it is called within the 
+  // context of both host and device functions. Specifically, the `cudf::type_dispatcher` is a host-
+  // device function. This causes warnings/errors because this ctor invokes host-only functions.
+  device_buffer()
+      : _data{nullptr},
+        _size{},
+        _capacity{},
+        _stream{},
+        _mr{rmm::mr::get_default_resource()} {}
+
 
   /**
    * @brief Constructs a new device buffer of `size` uninitialized bytes


### PR DESCRIPTION
One of the changes in #310 was to replace an explicit default constructor for `device_buffer` with 

```
device_buffer() = default;
```

Unfortunately, NVCC implicitly adds `__host__ __device__` specifiers to explicitly defaulted functions that are called from both `__host__` and `__device__` (or `__host__ __device__`) functions. In libcudf, the `type_dispatcher` uses a `__host__ __device__` function, so the above changed resulted in compiler errors since the default compiler-generated constructor necessarily invokes a host-only function. The fix is to revert to the explicit default constructor.

See https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compiler-generated-functions