### PR TITLE
Revert "Synchronize stream in `DeviceBuffer` only on copy"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - PR #310 Improve `device_buffer` allocation logic.
 - PR #309 Sync default stream in `DeviceBuffer` constructor
 - PR #326 Sync only on copy construction
+- PR #329 Revert #326
 - PR #308 Fix typo in README
 
 ## Bug Fixes

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -80,13 +80,13 @@ cdef class DeviceBuffer:
             else:
                 self.c_obj.reset(new device_buffer(c_ptr, size, c_stream))
 
-                if c_stream == NULL:
-                    err = cudaStreamSynchronize(c_stream)
-                    if err != cudaSuccess:
-                        with gil:
-                            raise RuntimeError(
-                                f"Stream sync failed with error: {err}"
-                            )
+            if c_stream == NULL:
+                err = cudaStreamSynchronize(c_stream)
+                if err != cudaSuccess:
+                    with gil:
+                        raise RuntimeError(
+                            f"Stream sync failed with error: {err}"
+                        )
 
     def __len__(self):
         return self.size


### PR DESCRIPTION
Appears PR ( https://github.com/rapidsai/rmm/pull/326 ) resulted in segfaults when using cuDF with UCX that appears to be caused by a race condition. Given this, go ahead and revert that change for now to unblock users until we can come up with something better.

cc @kkraus14 @jrhemstad @pentschev @beckernick