### PR TITLE
Fix incorrect name of `stream_free_blocks_` debug symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #303 Added replay benchmark.
 - PR #319 Add `thread_safe_resource_adaptor` class.
 - PR #314 New suballocator memory_resources.
+- PR #330 Fixed incorrect name of `stream_free_blocks_` debug symbol.
 
 ## Improvements
 

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -378,6 +378,9 @@ class pool_memory_resource final : public device_memory_resource {
 
   // blocks allocated from upstream: so they can be easily freed
   std::vector<block> upstream_blocks_;
+
+  // blocks allocated from stream: so they can be printed
+  std::map<cudaStream_t, free_list> stream_blocks_;
 };
 
 }  // namespace mr

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -313,7 +313,7 @@ class pool_memory_resource final : public device_memory_resource {
     for (auto b : allocated_blocks_) { b.print(); }
 
     std::cout << "sync free blocks: ";
-    for (auto s : stream_blocks_) { 
+    for (auto s : stream_free_blocks_) {
       std::cout << "stream " << s.first << " ";
       s.second.print();
     }
@@ -378,9 +378,6 @@ class pool_memory_resource final : public device_memory_resource {
 
   // blocks allocated from upstream: so they can be easily freed
   std::vector<block> upstream_blocks_;
-
-  // blocks allocated from stream: so they can be printed
-  std::map<cudaStream_t, free_list> stream_blocks_;
 };
 
 }  // namespace mr


### PR DESCRIPTION
Add missing `pool_memory_resource` attribute `stream_blocks_` that causes errors in debug builds. The error can be reproduced running `./build.sh -g librmm rmm`.