### PR TITLE
[REVIEW] Deprecate legacy APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #319 Add `thread_safe_resource_adaptor` class.
 - PR #314 New suballocator memory_resources.
 - PR #330 Fixed incorrect name of `stream_free_blocks_` debug symbol.
+- PR #331 Move to C++14 and deprecate legacy APIs.
 
 ## Improvements
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CMAKE_C_COMPILER $ENV{CC})
 set(CMAKE_CXX_COMPILER $ENV{CXX})
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-error=deprecated-declarations")
 
     option(CMAKE_CXX11_ABI "Enable the GLIBCXX11 ABI" ON)
     if(CMAKE_CXX11_ABI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 ###################################################################################################
 # - compiler options ------------------------------------------------------------------------------
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_COMPILER $ENV{CC})
 set(CMAKE_CXX_COMPILER $ENV{CXX})

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -104,7 +104,7 @@ class LogIt {
  *                    requested size, or RMM_CUDA_ERROR on any other CUDA error.
  */
 template <typename T>
-inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream,
+[[deprecated]] inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream,
                         const char* file, unsigned int line) {
   if (!rmmIsInitialized(nullptr)) {
     if (ptr) *ptr = nullptr;
@@ -189,7 +189,7 @@ inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
  *                    has not been called,or RMM_ERROR_CUDA_ERROR on any CUDA
  *                    error.
  */
-inline rmmError_t free(void* ptr, cudaStream_t stream, const char* file,
+[[deprecated]] inline rmmError_t free(void* ptr, cudaStream_t stream, const char* file,
                        unsigned int line) {
   if (!rmmIsInitialized(nullptr)) return RMM_ERROR_NOT_INITIALIZED;
 

--- a/include/rmm/rmm_api.h
+++ b/include/rmm/rmm_api.h
@@ -87,7 +87,7 @@ struct rmmOptions_t {
  *                    used if it is null.
  * @return rmmError_t RMM_SUCCESS or RMM_ERROR_CUDA_ERROR on any CUDA error.
  * --------------------------------------------------------------------------**/
-rmmError_t rmmInitialize(rmmOptions_t *options);
+[[deprecated]] rmmError_t rmmInitialize(rmmOptions_t *options);
 
 /** ---------------------------------------------------------------------------*
  * @brief Shutdown memory manager.
@@ -99,7 +99,7 @@ rmmError_t rmmInitialize(rmmOptions_t *options);
  * @return rmmError_t RMM_SUCCESS, or RMM_NOT_INITIALIZED if rmmInitialize() has
  *                    not been called, or RMM_ERROR_CUDA_ERROR on any CUDA error.
  * ---------------------------------------------------------------------------**/
-rmmError_t rmmFinalize();
+[[deprecated]] rmmError_t rmmFinalize();
 
 /** --------------------------------------------------------------------------*
  * @brief Query the initialization state of RMM.
@@ -110,7 +110,7 @@ rmmError_t rmmFinalize();
  * @return true if rmmInitialize has been called successfully.
  * @return false if rmmInitialize has not been called successfully.
  * --------------------------------------------------------------------------**/
-bool rmmIsInitialized(rmmOptions_t *options);
+[[deprecated]] bool rmmIsInitialized(rmmOptions_t *options);
 
 /** ---------------------------------------------------------------------------*
  * @brief Stringify RMM error code.
@@ -118,7 +118,7 @@ bool rmmIsInitialized(rmmOptions_t *options);
  * @param errcode The error returned by an RMM function
  * @return const char* The input error code in string form
  * --------------------------------------------------------------------------**/
-const char * rmmGetErrorString(rmmError_t errcode);
+[[deprecated]] const char * rmmGetErrorString(rmmError_t errcode);
 
 /** ---------------------------------------------------------------------------*
  * @brief Allocate memory and return a pointer to device memory.
@@ -137,7 +137,7 @@ const char * rmmGetErrorString(rmmError_t errcode);
  *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
  *                    requested size, or RMM_CUDA_ERROR on any other CUDA error.
  * --------------------------------------------------------------------------**/
-rmmError_t rmmAlloc(void **ptr, size_t size, cudaStream_t stream,
+[[deprecated]] rmmError_t rmmAlloc(void **ptr, size_t size, cudaStream_t stream,
                     const char* file, unsigned int line);
 
 /** ---------------------------------------------------------------------------*
@@ -173,7 +173,7 @@ rmmError_t rmmAlloc(void **ptr, size_t size, cudaStream_t stream,
  *                    has not been called,or RMM_ERROR_CUDA_ERROR on any CUDA
  *                    error.
  * --------------------------------------------------------------------------**/
-rmmError_t rmmFree(void *ptr, cudaStream_t stream,
+[[deprecated]] rmmError_t rmmFree(void *ptr, cudaStream_t stream,
                    const char* file, unsigned int line);
 
 /** ---------------------------------------------------------------------------*
@@ -212,7 +212,7 @@ rmmError_t rmmGetAllocationOffset(ptrdiff_t *offset,
  *                    has not been called, or RMM_ERROR_CUDA_ERROR on any CUDA
  *                    error
  * --------------------------------------------------------------------------**/
-rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream);
+[[deprecated]] rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream);
 
 /** ---------------------------------------------------------------------------*
  * @brief Write the memory event stats log to specified path/filename
@@ -222,14 +222,14 @@ rmmError_t rmmGetInfo(size_t *freeSize, size_t *totalSize, cudaStream_t stream);
  * @param filename The full path and filename to write.
  * @return rmmError_t RMM_SUCCESS or RMM_ERROR_IO on output failure.
  * --------------------------------------------------------------------------**/
-rmmError_t rmmWriteLog(const char* filename);
+[[deprecated]] rmmError_t rmmWriteLog(const char* filename);
 
 /** ---------------------------------------------------------------------------*
  * @brief Get the size of the CSV log string in memory.
  *
  * @return size_t The size of the log (as a C string) in memory.
  * --------------------------------------------------------------------------**/
-size_t rmmLogSize();
+[[deprecated]] size_t rmmLogSize();
 
 /** ---------------------------------------------------------------------------*
  * @brief Get the RMM log as CSV in a C string.
@@ -238,4 +238,4 @@ size_t rmmLogSize();
  * @param[in] buffer_size The size allocated for buffer.
  * @return rmmError_t RMM_SUCCESS, or RMM_IO_ERROR on any failure.
  * --------------------------------------------------------------------------**/
-rmmError_t rmmGetLog(char* buffer, size_t buffer_size);
+[[deprecated]] rmmError_t rmmGetLog(char* buffer, size_t buffer_size);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,10 +18,10 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 project(RMM_TESTS LANGUAGES C CXX CUDA)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_CUDA_STANDARD 11)
+set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 ###################################################################################################


### PR DESCRIPTION
Part of https://github.com/rapidsai/rmm/issues/305 https://github.com/rapidsai/rmm/issues/302 https://github.com/rapidsai/rmm/issues/301

Deprecates the "legacy" RMM APIs.

Also bumps RMM to C++14 to make it easier to use the `[[deprecated]]` attribute.

Since using a deprecated function generates a warning, updated the CMake to avoid having deprecation warnings cause errors. 

Using these APIs will generate a warning at compile time: 
```c++
warning: 'rmmError_t rmm::free(void*, cudaStream_t, const char*, unsigned int)' is deprecated [-Wdeprecated-declarations]
```

If compiling with the `-Werror` flag. errors can be disabled for this warning by using the flag `-Wno-error=deprecated-declarations`.