### PR TITLE
[REVIEW] Replace rmm thrust allocator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PR #309 Sync default stream in `DeviceBuffer` constructor
 - PR #326 Sync only on copy construction
 - PR #308 Fix typo in README
+- PR #334 Replace `rmm_allocator` for Thrust allocations
 
 ## Bug Fixes
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -16,6 +16,10 @@
 
 #pragma once
 
+#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+
+#include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/device_malloc_allocator.h>
 
 namespace rmm {
@@ -30,7 +34,7 @@ namespace mr {
  *
  * @tparam T The type of the objects that will be allocated by this allocator
  */
-template <typename T>
+ template <typename T>
 class thrust_allocator : public thrust::device_malloc_allocator<T> {
  public:
   using Base = thrust::device_malloc_allocator<T>;
@@ -48,6 +52,16 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
     using other = thrust_allocator<U>;
   };
 
+  thrust_allocator() = default;
+
+  /**
+   * @brief Constructs a `thrust_allocator` using the default device memory
+   * resource and specified stream.
+   *
+   * @param stream The stream to be used for device memory (de)allocation
+   */
+  explicit thrust_allocator(cudaStream_t stream) : _stream{stream} {}
+
   /**
    * @brief Constructs a `thrust_allocator` using a device memory resource and
    * stream.
@@ -56,9 +70,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @param stream The stream to be used for device memory (de)allocation
    */
   thrust_allocator(device_memory_resource* mr, cudaStream_t stream)
-      : _mr(mr), _stream{stream} {
-          
-      }
+      : _mr(mr), _stream{stream} {}
 
   /**
    * @brief Copy constructor. Copies the resource pointer and stream.
@@ -76,7 +88,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @return pointer Pointer to the newly allocated storage
    */
   pointer allocate(size_type n) {
-    return static_cast<pointer>(_mr->do_allocate(n * sizeof(T), _stream));
+    return thrust::device_pointer_cast(_mr->allocate(n * sizeof(T), _stream));
   }
 
   /**
@@ -87,7 +99,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * prior `allocate` call that produced `p`
    */
   void deallocate(pointer p, size_type n) {
-    return _mr->do_deallocate(p, n * sizeof(T), _stream);
+    return _mr->deallocate(thrust::raw_pointer_cast(p), n * sizeof(T), _stream);
   }
 
   /**
@@ -98,7 +110,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   /**
    * @brief Returns the stream used by this allocator.
    */
-  cudaStream_t stream() const noexcept { return stream; }
+  cudaStream_t stream() const noexcept { return _stream; }
 
  private:
   device_memory_resource* _mr{rmm::mr::get_default_resource()};

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
-
 #include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/device_malloc_allocator.h>
+
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 namespace rmm {
 namespace mr {
@@ -34,7 +34,7 @@ namespace mr {
  *
  * @tparam T The type of the objects that will be allocated by this allocator
  */
- template <typename T>
+template <typename T>
 class thrust_allocator : public thrust::device_malloc_allocator<T> {
  public:
   using Base = thrust::device_malloc_allocator<T>;
@@ -52,6 +52,11 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
     using other = thrust_allocator<U>;
   };
 
+  /**
+   * @brief Default constructor creates an allocator using the default memory
+   * resource and default stream.
+
+   */
   thrust_allocator() = default;
 
   /**

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -55,7 +55,6 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   /**
    * @brief Default constructor creates an allocator using the default memory
    * resource and default stream.
-
    */
   thrust_allocator() = default;
 
@@ -93,7 +92,8 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @return pointer Pointer to the newly allocated storage
    */
   pointer allocate(size_type n) {
-    return thrust::device_pointer_cast(_mr->allocate(n * sizeof(T), _stream));
+    return thrust::device_pointer_cast(
+        static_cast<T*>(_mr->allocate(n * sizeof(T), _stream)));
   }
 
   /**

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -15,7 +15,8 @@
  */
 
 /**
- Allocator class compatible with thrust arrays that uses RMM device memory manager.
+ Allocator class compatible with thrust arrays that uses RMM device memory
+ manager.
 
  Author: Mark Harris
  */
@@ -23,18 +24,15 @@
 #ifndef THRUST_RMM_ALLOCATOR_H
 #define THRUST_RMM_ALLOCATOR_H
 
-#include <thrust/device_vector.h>
-#include <thrust/device_malloc_allocator.h>
-#include <thrust/system_error.h>
-#include <thrust/system/cuda/error.h>
-#include <thrust/execution_policy.h>
-
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
-namespace rmm{
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+
+namespace rmm {
 /**
  * @brief Alias for a thrust::device_vector that uses RMM for memory allocation.
- * 
+ *
  */
 template <typename T>
 using device_vector = thrust::device_vector<T, rmm::mr::thrust_allocator<T>>;
@@ -56,8 +54,7 @@ using exec_policy_t = std::unique_ptr<par_t, deleter_t>;
  */
 /* --------------------------------------------------------------------------*/
 inline exec_policy_t exec_policy(cudaStream_t stream = 0) {
-
-  auto * alloc = new rmm::mr::thrust_allocator<char>(stream);
+  auto *alloc = new rmm::mr::thrust_allocator<char>(stream);
   auto deleter = [alloc](par_t *pointer) {
     delete alloc;
     delete pointer;
@@ -67,6 +64,6 @@ inline exec_policy_t exec_policy(cudaStream_t stream = 0) {
   return policy;
 }
 
-} // namespace rmm
+}  // namespace rmm
 
-#endif // THRUST_RMM_ALLOCATOR_H
+#endif  // THRUST_RMM_ALLOCATOR_H

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -31,8 +31,7 @@
 
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
-namespace rmm
-{
+namespace rmm{
 /**
  * @brief Alias for a thrust::device_vector that uses RMM for memory allocation.
  * 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,6 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
-
 project(RMM_TESTS LANGUAGES C CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -72,7 +71,7 @@ ConfigureTest(RMM_TEST "${RMM_TEST_SRC}")
 
 set(DEVICE_MR_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/mr/device/mr_tests.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/mr/device/thrust_allocator_tests.cpp")
+    "${CMAKE_CURRENT_SOURCE_DIR}/mr/device/thrust_allocator_tests.cu")
     
 
 ConfigureTest(DEVICE_MR_TEST "${DEVICE_MR_TEST_SRC}")

--- a/tests/mr/device/thrust_allocator_tests.cu
+++ b/tests/mr/device/thrust_allocator_tests.cu
@@ -52,6 +52,7 @@ AllocatorTest<pool_mr>::AllocatorTest() {
   upstreams.emplace_back(std::make_unique<rmm::mr::cuda_memory_resource>());
   auto& cuda_upstream = upstreams.front();
   mr.reset(new pool_mr(static_cast<rmm::mr::cuda_memory_resource*>(cuda_upstream.get())));
+  rmm::mr::set_default_resource(mr.get());
 }
 
 TYPED_TEST_CASE(AllocatorTest, resources);

--- a/tests/mr/device/thrust_allocator_tests.cu
+++ b/tests/mr/device/thrust_allocator_tests.cu
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <gtest/gtest.h>
+
 #include <rmm/mr/device/cnmem_managed_memory_resource.hpp>
+#include <rmm/mr/device/cnmem_memory_resource.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/fixed_size_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
-#include <rmm/mr/device/fixed_size_memory_resource.hpp>
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
+#include <rmm/thrust_rmm_allocator.h>
+#include <thrust/detail/contiguous_storage.h>
 
-
-#include <gtest/gtest.h>
-
-template <typename MemoryResourceType>
+template <typename MR>
 struct AllocatorTest : public ::testing::Test {
-  MemoryResourceType mr{};
+  MR mr{};
   cudaStream_t stream{};
 
   void SetUp() override { EXPECT_EQ(cudaSuccess, cudaStreamCreate(&stream)); }
@@ -39,13 +40,13 @@ struct AllocatorTest : public ::testing::Test {
   };
 };
 
-using resources = ::testing::Types<rmm::mr::cuda_memory_resource,
-                                   rmm::mr::managed_memory_resource,
-                                   rmm::mr::cnmem_memory_resource,
-                                   rmm::mr::cnmem_managed_memory_resource,
-                                   rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>;
+using resources = ::testing::Types<
+    rmm::mr::cuda_memory_resource, rmm::mr::managed_memory_resource,
+    rmm::mr::cnmem_memory_resource, rmm::mr::cnmem_managed_memory_resource>;
+    //rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>;
 
 TYPED_TEST_CASE(AllocatorTest, resources);
 
-
-// TODO Add tests once RMM cmake is updated to allow compiling .cu files
+TYPED_TEST(AllocatorTest, first) {
+    rmm::device_vector<int> ints(100);
+}


### PR DESCRIPTION
Replaces the old `rmm_allocator` used for Thrust with the new `rmm::mr::thrust_allocator`. 