### PR TITLE
Enable logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## New Features
 
+- PR #341 Enable logging
+
 ## Improvements
 
 ## Bug Fixes

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -21,6 +21,7 @@ endfunction(ConfigureBench)
 include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                     "${CMAKE_BINARY_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/include"
+                    "${CMAKE_SOURCE_DIR}/thirdparty"
                     "${CMAKE_SOURCE_DIR}"
                     "${CMAKE_SOURCE_DIR}/src"
                     "${GTEST_INCLUDE_DIR}"

--- a/include/rmm/detail/memory_manager.hpp
+++ b/include/rmm/detail/memory_manager.hpp
@@ -240,6 +240,7 @@ namespace rmm
     bool is_initialized{false};
 
     std::unique_ptr<rmm::mr::device_memory_resource> initialized_resource{};
+    std::unique_ptr<rmm::mr::device_memory_resource> logging_adaptor{};
   };
 }
 

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -20,8 +20,17 @@
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/mr/device/logging_resource_adaptor.hpp>
 
 namespace rmm {
+
+using cuda_mr = rmm::mr::cuda_memory_resource;
+using pool_mr = rmm::mr::cnmem_memory_resource;
+using managed_mr = rmm::mr::cnmem_managed_memory_resource;
+using pool_managed_mr = rmm::mr::cnmem_managed_memory_resource;
+using logging_pool_mr = rmm::mr::logging_resource_adaptor<pool_mr>;
+using logging_pool_managed_mr = rmm::mr::logging_resource_adaptor<pool_managed_mr>;
+
 /**
  * Record a memory manager event in the log.
  *
@@ -93,6 +102,18 @@ rmmError_t Manager::registerStream(cudaStream_t stream) {
   return RMM_SUCCESS;
 }
 
+// reset the initialized resource, enabling logging if set in options
+template <typename MemoryResource>
+void reset_resource(std::unique_ptr<mr::device_memory_resource>& initialized_resource,
+                    MemoryResource *mr,
+                    bool enable_logging) {
+  if (enable_logging) {
+    initialized_resource.reset(new rmm::mr::logging_resource_adaptor<MemoryResource>(mr));
+  } else {
+    initialized_resource.reset(mr);
+  }
+}
+
 // Initialize the manager
 void Manager::initialize(const rmmOptions_t* new_options) {
   std::lock_guard<std::mutex> guard(manager_mutex);
@@ -102,20 +123,21 @@ void Manager::initialize(const rmmOptions_t* new_options) {
 
   if (nullptr != new_options) options = *new_options;
 
+  bool enable_logging = getOptions().enable_logging;
+
   if (usePoolAllocator()) {
     auto pool_size = getOptions().initial_pool_size;
     auto const& devices = getOptions().devices;
+
     if (useManagedMemory()) {
-      initialized_resource.reset(
-          new rmm::mr::cnmem_managed_memory_resource(pool_size, devices));
+      reset_resource(initialized_resource, new pool_managed_mr(pool_size, devices), enable_logging);
     } else {
-      initialized_resource.reset(
-          new rmm::mr::cnmem_memory_resource(pool_size, devices));
+      reset_resource(initialized_resource, new pool_mr(pool_size, devices), enable_logging);
     }
   } else if (rmm::Manager::useManagedMemory()) {
-    initialized_resource.reset(new rmm::mr::managed_memory_resource());
+    reset_resource(initialized_resource, new managed_mr(), enable_logging);
   } else {
-    initialized_resource.reset(new rmm::mr::cuda_memory_resource());
+    reset_resource(initialized_resource, new cuda_mr(), enable_logging);
   }
 
   rmm::mr::set_default_resource(initialized_resource.get());

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -102,7 +102,7 @@ rmmError_t Manager::registerStream(cudaStream_t stream) {
   return RMM_SUCCESS;
 }
 
-// reset the initialized resource, enabling logging if set in options
+// reset the initialized resource, optionally enabling logging via logging_resource_adaptor
 template <typename MemoryResource>
 void reset_resource(std::unique_ptr<mr::device_memory_resource>& initialized_resource,
                     MemoryResource *mr,


### PR DESCRIPTION
Fixes #340 

Plumbs `logging_resource_adaptor` in `memory_manager.cpp` so that it can be enabled by setting `logging = True` in Python `rmm.reinitialize()`.

Example

```
import os

def set_rmm_log_file():
    os.environ["RMM_LOG_FILE"] = "test.txt"
    return os.environ["RMM_LOG_FILE"]

set_rmm_log_file()

import rmm

rmm.reinitialize(
    pool_allocator=True,
    managed_memory=False,
    initial_pool_size=2**31,
    logging=True
    )

rmm.DeviceBuffer(size=1048576)

print(os.environ.get("RMM_LOG_FILE"))
```

Resulting log file:

```
Time,Action,Pointer,Size,Stream
22:37:25:738700,allocate,0x7f68a2000000,1048576,0
22:37:25:738725,free,0x7f68a2000000,1048576,0
```