### PR TITLE
[REVIEW] Added in option to staticlly link against cudart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## New Features
 
+- PR #343 Add in option to statically link against cudart
+
 ## Improvements
 
 ## Bug Fixes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,12 +62,12 @@ option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 # cudart can be statically linked or dynamically linked the python ecosystem wants dynamic linking
 
 
-if(CMAKE_CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+if(CUDA_RUNTIME_LIBRARY AND CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
     message(STATUS "Enabling static linking of cudart")
     set(CUDART_LIBRARY "cudart_static")
 else()
     set(CUDART_LIBRARY "cudart")
-endif(CMAKE_CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+endif(CUDA_RUNTIME_LIBRARY AND CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
 
 ###################################################################################################
 # - cnmem ---------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,13 +61,14 @@ option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 # - cudart options --------------------------------------------------------------------------------
 # cudart can be statically linked or dynamically linked the python ecosystem wants dynamic linking
 
+option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
 
-if(CUDA_RUNTIME_LIBRARY AND CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+if(CUDA_STATIC_RUNTIME)
     message(STATUS "Enabling static linking of cudart")
     set(CUDART_LIBRARY "cudart_static")
 else()
     set(CUDART_LIBRARY "cudart")
-endif(CUDA_RUNTIME_LIBRARY AND CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+endif(CUDA_STATIC_RUNTIME)
 
 ###################################################################################################
 # - cnmem ---------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,17 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 
+###################################################################################################
+# - cudart options --------------------------------------------------------------------------------
+# cudart can be statically linked or dynamically linked the python ecosystem wants dynamic linking
+
+
+if(CMAKE_CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
+    message(STATUS "Enabling static linking of cudart")
+    set(CUDART_LIBRARY "cudart_static")
+else()
+    set(CUDART_LIBRARY "cudart")
+endif(CMAKE_CUDA_RUNTIME_LIBRARY MATCHES "^Static$")
 
 ###################################################################################################
 # - cnmem ---------------------------------------------------------------------------------
@@ -152,7 +163,7 @@ endif(USE_NVTX)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(rmm cudart cuda)
+target_link_libraries(rmm ${CUDART_LIBRARY} cuda)
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ function ensureCMakeRan {
     if (( RAN_CMAKE == 0 )); then
         echo "Executing cmake for librmm..."
         cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-              -DCMAKE_CUDA_RUNTIME_LIBRARY="${CUDA_RUNTIME_LIBRARY}" \
+              -DCUDA_RUNTIME_LIBRARY="${CUDA_RUNTIME_LIBRARY}" \
               -DCMAKE_CXX11_ABI=ON \
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
         RAN_CMAKE=1

--- a/build.sh
+++ b/build.sh
@@ -18,14 +18,15 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean librmm rmm -v -g -n -h"
-HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-h]
+VALIDARGS="clean librmm rmm -v -g -n -s -h"
+HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [-h]
    clean  - remove all existing build artifacts and configuration (start over)
    librmm - build and install the librmm C++ code
    rmm    - build and install the rmm Python package
    -v     - verbose build mode
    -g     - build for debug
    -n     - no install step
+   -s     - statically link against cudart
    -h     - print this text
 
    default action (no args) is to build and install 'librmm' and 'rmm' targets
@@ -39,6 +40,7 @@ VERBOSE=""
 BUILD_TYPE=Release
 INSTALL_TARGET=install
 PYTHON=${PYTHON:=python}
+CUDA_RUNTIME_LIBRARY=Shared
 RAN_CMAKE=0
 
 # Set defaults for vars that may not have been defined externally
@@ -59,6 +61,7 @@ function ensureCMakeRan {
     if (( RAN_CMAKE == 0 )); then
         echo "Executing cmake for librmm..."
         cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+              -DCMAKE_CUDA_RUNTIME_LIBRARY="${CUDA_RUNTIME_LIBRARY}" \
               -DCMAKE_CXX11_ABI=ON \
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
         RAN_CMAKE=1
@@ -90,6 +93,9 @@ if hasArg -g; then
 fi
 if hasArg -n; then
     INSTALL_TARGET=""
+fi
+if hasArg -s; then
+    CUDA_RUNTIME_LIBRARY=Static
 fi
 
 # If clean given, run it prior to any other steps

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ VERBOSE=""
 BUILD_TYPE=Release
 INSTALL_TARGET=install
 PYTHON=${PYTHON:=python}
-CUDA_RUNTIME_LIBRARY=Shared
+CUDA_STATIC_RUNTIME=OFF
 RAN_CMAKE=0
 
 # Set defaults for vars that may not have been defined externally
@@ -61,7 +61,7 @@ function ensureCMakeRan {
     if (( RAN_CMAKE == 0 )); then
         echo "Executing cmake for librmm..."
         cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-              -DCUDA_RUNTIME_LIBRARY="${CUDA_RUNTIME_LIBRARY}" \
+              -DCUDA_STATIC_RUNTIME="${CUDA_STATIC_RUNTIME}" \
               -DCMAKE_CXX11_ABI=ON \
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
         RAN_CMAKE=1
@@ -95,7 +95,7 @@ if hasArg -n; then
     INSTALL_TARGET=""
 fi
 if hasArg -s; then
-    CUDA_RUNTIME_LIBRARY=Static
+    CUDA_STATIC_RUNTIME=ON
 fi
 
 # If clean given, run it prior to any other steps

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
     add_executable(${CMAKE_TEST_NAME} ${CMAKE_TEST_SRC})
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-    target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread rmm)
+    target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread cudart rmm)
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES
                             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gtests")
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
@@ -128,6 +128,6 @@ set(RANDOM_ALLOCATE_SRC
 
 add_executable(random_allocate ${RANDOM_ALLOCATE_SRC})
 set_target_properties(random_allocate PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(random_allocate rmm)
+target_link_libraries(random_allocate cudart rmm)
 set_target_properties(random_allocate PROPERTIES
                       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bench")


### PR DESCRIPTION
This fixes #342 

It adds in the ability to statically link against libcudart, and uses the same flag as https://gitlab.kitware.com/cmake/cmake/-/issues/17559 `CMAKE_CUDA_RUNTIME_LIBRARY` to enable it.  The main difference is that this works for RMM which does not have any cuda code in the main library and it also sets the default to be dynamic linking to maintain backwards compatibility.
