### PR TITLE
[REVIEW] Make device_scalar asynchronous again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - PR #326 Sync only on copy construction
 - PR #308 Fix typo in README
 - PR #334 Replace `rmm_allocator` for Thrust allocations
+- PR #345 Remove stream synchronization from `device_scalar` constructor and `set_value`
 
 ## Bug Fixes
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -36,8 +36,25 @@ class device_scalar {
                 "Scalar type must be trivially copyable");
 
   /**
-   * @brief Construct a new `device_scalar`
+   * @brief Construct a new uninitialized `device_scalar`
    *
+   * @throws `rmm::bad_alloc` if allocating the device memory for
+   *`initial_value` fails
+   * @throws `rmm::cuda_error` if copying `initial_value` to device memory fails
+   *
+   * @param stream Optional, stream on which to perform allocation and copy
+   * @param mr Optional, resource with which to allocate
+   */
+  device_scalar(
+      cudaStream_t stream = 0,
+      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
+      : buffer{sizeof(T), stream, mr} {}
+
+  /**
+   * @brief Construct a new `device_scalar` with an initial value.
+   *
+   * Does not synchronize the stream.
+   * 
    * @throws `rmm::bad_alloc` if allocating the device memory for
    *`initial_value` fails
    * @throws `rmm::cuda_error` if copying `initial_value` to device memory fails
@@ -47,10 +64,11 @@ class device_scalar {
    * @param mr Optional, resource with which to allocate
    */
   explicit device_scalar(
-      T const &initial_value, cudaStream_t stream = 0,
-      rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource())
-      : buff{sizeof(T), stream, mr} {
-    _memcpy(buff.data(), &initial_value, stream);
+      T const& initial_value,
+      cudaStream_t stream = 0,
+      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
+      : buffer{sizeof(T), stream, mr} {
+    _memcpy(buffer.data(), &initial_value, stream);
   }
 
   /**
@@ -65,12 +83,13 @@ class device_scalar {
    */
   T value(cudaStream_t stream = 0) const {
     T host_value{};
-    _memcpy(&host_value, buff.data(), stream);
+    _memcpy(&host_value, buffer.data(), stream);
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream));
     return host_value;
   }
 
   /**
-   * @brief Copies the value from host to device and synchronizes the stream.
+   * @brief Copies the value from host to device (does not synchronize the stream).
    *
    * @throws `rmm::cuda_error` if copying `host_value` to device memory fails
    * @throws `rmm::cuda_error` if synchronizing `stream` fails
@@ -79,18 +98,18 @@ class device_scalar {
    * @param stream CUDA stream on which to perform the copy
    */
   void set_value(T host_value, cudaStream_t stream = 0) {
-    _memcpy(buff.data(), &host_value, stream);
+    _memcpy(buffer.data(), &host_value, stream);
   }
 
   /**
    * @brief Returns pointer to object in device memory.
    */
-  T *data() noexcept { return static_cast<T *>(buff.data()); }
+  T* data() noexcept { return static_cast<T*>(buffer.data()); }
 
   /**
    * @brief Returns pointer to object in device memory.
    */
-  T const *data() const noexcept { return static_cast<T const *>(buff.data()); }
+  T const *data() const noexcept { return static_cast<T const*>(buffer.data()); }
 
   device_scalar() = default;
   ~device_scalar() = default;
@@ -100,11 +119,10 @@ class device_scalar {
   device_scalar &operator=(device_scalar &&) = delete;
 
  private:
-  rmm::device_buffer buff{sizeof(T)};
+  rmm::device_buffer buffer{sizeof(T)};
 
   inline void _memcpy(void *dst, const void *src, cudaStream_t stream) const {
     RMM_CUDA_TRY(cudaMemcpyAsync(dst, src, sizeof(T), cudaMemcpyDefault, stream));
-    RMM_CUDA_TRY(cudaStreamSynchronize(stream));
   }
 };
 }  // namespace rmm

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -45,7 +45,7 @@ class device_scalar {
    * @param stream Optional, stream on which to perform allocation and copy
    * @param mr Optional, resource with which to allocate
    */
-  device_scalar(
+  explicit device_scalar(
       cudaStream_t stream = 0,
       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
       : buffer{sizeof(T), stream, mr} {}
@@ -111,7 +111,6 @@ class device_scalar {
    */
   T const *data() const noexcept { return static_cast<T const*>(buffer.data()); }
 
-  device_scalar() = default;
   ~device_scalar() = default;
   device_scalar(device_scalar const &) = default;
   device_scalar(device_scalar &&) = default;

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -45,8 +45,7 @@ class device_scalar {
    * @note This device_scalar is only safe to access in kernels and copies on the specified CUDA stream,
    * or on another stream only if a dependency is enforced (e.g. using `cudaStreamWaitEvent()`).
    *
-   * @throws `rmm::bad_alloc` if allocating the device memory for `initial_value` fails.
-   * @throws `rmm::cuda_error` if copying `initial_value` to device memory fails.
+   * @throws `rmm::bad_alloc` if allocating the device memory fails.
    *
    * @param stream Stream on which to perform asynchronous allocation.
    * @param mr Optional, resource with which to allocate.
@@ -112,8 +111,8 @@ class device_scalar {
    *
    * Does not synchronize `stream`.
    * 
-   * @throws `rmm::cuda_error` if copying `host_value` to device memory fails
-   * @throws `rmm::cuda_error` if synchronizing `stream` fails
+   * @throws `rmm::cuda_error` if copying `host_value` to device memory fails.
+   * @throws `rmm::cuda_error` if synchronizing `stream` fails.
    *
    * @param host_value The host value which will be copied to device
    * @param stream CUDA stream on which to perform the copy

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -172,6 +172,7 @@ class device_scalar {
    */
   T const *data() const noexcept { return static_cast<T const*>(buffer.data()); }
 
+  device_scalar() =  default;
   ~device_scalar() = default;
   device_scalar(device_scalar const &) = default;
   device_scalar(device_scalar &&) = default;

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -68,7 +68,7 @@ class device_scalar {
       cudaStream_t stream = 0,
       rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
       : buffer{sizeof(T), stream, mr} {
-    _memcpy(buffer.data(), &initial_value, stream);
+    set_value(initial_value, stream);
   }
 
   /**


### PR DESCRIPTION
* Removes stream synchronization from device_scalar constructor and `device_scalar::set_value()` so that it can be used in stream-ordered code without unnecessary/unintentional synchronization.  
* Adds a constructor that takes a stream and MR but no initial value so that it can be created unitialized (useful when the first use is to write to the device value from the device).
* Adds an optimization for fundamental types to use cudaMemsetAsync instead of cudaMemcpyAsync when the host value to set is zero. This is slightly faster in some profiles (e.g. apply_boolean_mask).
