### PR TITLE
Fix unintentional use of pool-managed resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Bug Fixes
 
 - PR #347 Mark rmmFinalizeWrapper nogil
+- PR #--- Fix unintentional use of pool-managed resource.
 
 # RMM 0.13.0 (Date TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## Bug Fixes
 
 - PR #347 Mark rmmFinalizeWrapper nogil
-- PR #--- Fix unintentional use of pool-managed resource.
+- PR #348 Fix unintentional use of pool-managed resource.
 
 # RMM 0.13.0 (Date TBD)
 

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -26,7 +26,7 @@ namespace rmm {
 
 using cuda_mr = rmm::mr::cuda_memory_resource;
 using pool_mr = rmm::mr::cnmem_memory_resource;
-using managed_mr = rmm::mr::cnmem_managed_memory_resource;
+using managed_mr = rmm::mr::managed_memory_resource;
 using pool_managed_mr = rmm::mr::cnmem_managed_memory_resource;
 using logging_pool_mr = rmm::mr::logging_resource_adaptor<pool_mr>;
 using logging_pool_managed_mr = rmm::mr::logging_resource_adaptor<pool_managed_mr>;


### PR DESCRIPTION
I _think_ there was a typo in a recent PR causing the pool-managed memory resource to be initialized when the non-pool-managed memory resource is desired.