### PR TITLE
[REVIEW] Add Docker 19 support to local gpuci build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 - PR #343 Add in option to statically link against cudart
 
 ## Improvements
+
 - PR #350 Add .clang-format file & format all files
+- PR #357 Add Docker 19 support to local gpuci build
 
 ## Bug Fixes
-- PR #346 Add clearer exception message when RMM_LOG_FILE is unset
 
+- PR #346 Add clearer exception message when RMM_LOG_FILE is unset
 - PR #347 Mark rmmFinalizeWrapper nogil
 - PR #348 Fix unintentional use of pool-managed resource.
 
@@ -59,6 +61,7 @@
 - PR #334 Replace `rmm_allocator` for Thrust allocations
 
 ## Bug Fixes
+
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor
 - PR #299 Fix assert condition blocking debug builds
 - PR #300 Fix host mr_tests compile error

--- a/ci/local/README.md
+++ b/ci/local/README.md
@@ -23,7 +23,7 @@ where:
 ```
 
 Example Usage:
-`bash build.sh -r ~/rapids/rmm -i gpuci/rapidsai-base:cuda9.2-ubuntu16.04-gcc5-py3.6`
+`bash build.sh -r ~/rapids/rmm -i gpuci/rapidsai-base:cuda10.1-ubuntu16.04-gcc5-py3.6`
 
 For a full list of available gpuCI docker images, visit our [DockerHub](https://hub.docker.com/r/gpuci/rapidsai-base/tags) page.
 
@@ -42,7 +42,7 @@ There are some caveats to be aware of when using this script, especially if you 
 
 ### Docker Image Build Repository
 
-The docker image will generate build artifacts in a folder on your machine located in the `root` directory of the repository you passed to the script. For the above example, the directory is named `~/rapids/rmm/build_rapidsai-base_cuda9.2-ubuntu16.04-gcc5-py3.6/`. Feel free to remove this directory after the script is finished.
+The docker image will generate build artifacts in a folder on your machine located in the `root` directory of the repository you passed to the script. For the above example, the directory is named `~/rapids/rmm/build_rapidsai-base_cuda10.1-ubuntu16.04-gcc5-py3.6/`. Feel free to remove this directory after the script is finished.
 
 *Note*: The script *will not* override your local build repository. Your local environment stays in tact.
 

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -129,7 +129,15 @@ fi
 
 # Run the generated build script in a container
 docker pull "${DOCKER_IMAGE}"
-docker run --runtime=nvidia --rm -it -e NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES}" \
+
+DOCKER_MAJOR=$(docker -v|sed 's/[^[0-9]*\([0-9]*\).*/\1/')
+GPU_OPTS="--gpus device=${NVIDIA_VISIBLE_DEVICES}"
+if [ "$DOCKER_MAJOR" -lt 19 ]
+then
+    GPU_OPTS="--runtime=nvidia -e NVIDIA_VISIBLE_DEVICES='${NVIDIA_VISIBLE_DEVICES}'"
+fi
+
+docker run --rm -it ${GPU_OPTS} \
        --user "$(id -u)":"$(id -g)" \
        -v "${REPO_PATH}":"${REPO_PATH_IN_CONTAINER}" \
        -v "${CPP_CONTAINER_BUILD_DIR}":"${CPP_BUILD_DIR_IN_CONTAINER}" \


### PR DESCRIPTION
Adds Docker 19 support to local gpuci build while remaining backward compatible to previous Docker versions.