### PR TITLE
[REVIEW] Fix `clang-format` missing comma bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #347 Mark rmmFinalizeWrapper nogil
 - PR #348 Fix unintentional use of pool-managed resource.
 - PR #367 Fix flake8 issues
+- PR #368 Fix `clang-format` missing comma bug
 
 # RMM 0.13.0 (Date TBD)
 

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -29,8 +29,7 @@ namespace detail {
  * @brief Default alignment used for host memory allocated by RMM.
  *
  */
-static constexpr std::size_t RMM_DEFAULT_HOST_ALIGNMENT{
-    alignof(std::max_align_t)};
+static constexpr std::size_t RMM_DEFAULT_HOST_ALIGNMENT{alignof(std::max_align_t)};
 
 /**
  * @brief Returns whether or not `n` is a power of 2.
@@ -42,9 +41,7 @@ constexpr bool is_pow2(std::size_t n) { return (0 == (n & (n - 1))); }
  * @brief Returns whether or not `alignment` is a valid memory alignment.
  *
  */
-constexpr bool is_supported_alignment(std::size_t alignment) {
-  return is_pow2(alignment);
-}
+constexpr bool is_supported_alignment(std::size_t alignment) { return is_pow2(alignment); }
 
 /**
  * @brief Allocates sufficient memory to satisfy the requested size `bytes` with
@@ -74,13 +71,13 @@ constexpr bool is_supported_alignment(std::size_t alignment) {
  * `alignment`.
  */
 template <typename Alloc>
-void *aligned_allocate(std::size_t bytes, std::size_t alignment, Alloc alloc) {
+void *aligned_allocate(std::size_t bytes, std::size_t alignment, Alloc alloc)
+{
   assert(is_pow2(alignment));
 
   // allocate memory for bytes, plus potential alignment correction,
   // plus store of the correction offset
-  std::size_t padded_allocation_size{bytes + alignment +
-                                     sizeof(std::ptrdiff_t)};
+  std::size_t padded_allocation_size{bytes + alignment + sizeof(std::ptrdiff_t)};
 
   char *const original = static_cast<char *>(alloc(padded_allocation_size));
 
@@ -115,8 +112,8 @@ void *aligned_allocate(std::size_t bytes, std::size_t alignment, Alloc alloc) {
  * @tparam Dealloc A unary callable type that deallocates memory.
  */
 template <typename Dealloc>
-void aligned_deallocate(void *p, std::size_t bytes, std::size_t alignment,
-                        Dealloc dealloc) {
+void aligned_deallocate(void *p, std::size_t bytes, std::size_t alignment, Dealloc dealloc)
+{
   (void)alignment;
 
   // Get offset from the location immediately prior to the aligned pointer

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -49,9 +49,9 @@ struct cuda_error : public std::runtime_error {
  */
 class bad_alloc : public std::bad_alloc {
  public:
-  bad_alloc(const char* w)
-      : std::bad_alloc{},
-        _what{std::string{std::bad_alloc::what()} + ": " + w} {}
+  bad_alloc(const char* w) : std::bad_alloc{}, _what{std::string{std::bad_alloc::what()} + ": " + w}
+  {
+  }
 
   bad_alloc(std::string const& w) : bad_alloc(w.c_str()) {}
 
@@ -96,11 +96,9 @@ class bad_alloc : public std::bad_alloc {
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
 #define RMM_EXPECTS_3(_condition, _exception_type, _what) \
   (!!(_condition))                                        \
-      ? static_cast<void>(0)                              \
-      : throw _exception_type("RMM failure at: " __FILE__ \
-                              ":" RMM_STRINGIFY(__LINE__) ": " _what)
-#define RMM_EXPECTS_2(_condition, _reason) \
-  RMM_EXPECTS_3(_condition, rmm::logic_error, _reason)
+    ? static_cast<void>(0)                                \
+    : throw _exception_type("RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what)
+#define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, rmm::logic_error, _reason)
 
 /**
  * @brief Indicates that an erroneous code path has been taken.
@@ -118,9 +116,8 @@ class bad_alloc : public std::bad_alloc {
   GET_RMM_FAIL_MACRO(__VA_ARGS__, RMM_FAIL_2, RMM_FAIL_1) \
   (__VA_ARGS__)
 #define GET_RMM_FAIL_MACRO(_1, _2, NAME, ...) NAME
-#define RMM_FAIL_2(_what, _exception_type)         \
-  throw _exception_type{"RMM failure at:" __FILE__ \
-                        ":" RMM_STRINGIFY(__LINE__) ": " _what};
+#define RMM_FAIL_2(_what, _exception_type) \
+  throw _exception_type{"RMM failure at:" __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what};
 #define RMM_FAIL_1(_what) RMM_FAIL_2(_call, rmm::logic_error)
 
 /**
@@ -144,19 +141,17 @@ class bad_alloc : public std::bad_alloc {
  * ```
  *
  */
-#define RMM_CUDA_TRY(...)                                     \
+#define RMM_CUDA_TRY(...)                                             \
   GET_RMM_CUDA_TRY_MACRO(__VA_ARGS__, RMM_CUDA_TRY_2, RMM_CUDA_TRY_1) \
   (__VA_ARGS__)
 #define GET_RMM_CUDA_TRY_MACRO(_1, _2, NAME, ...) NAME
-#define RMM_CUDA_TRY_2(_call, _exception_type)                              \
-  do {                                                                  \
-    cudaError_t const error = (_call);                                  \
-    if (cudaSuccess != error) {                                         \
-      cudaGetLastError();                                               \
-      throw _exception_type{std::string{"CUDA error at: "} + __FILE__ + \
-                            RMM_STRINGIFY(__LINE__) + ": " +            \
-                            cudaGetErrorName(error) + " " +             \
-                            cudaGetErrorString(error)};                 \
-    }                                                                   \
+#define RMM_CUDA_TRY_2(_call, _exception_type)                                                    \
+  do {                                                                                            \
+    cudaError_t const error = (_call);                                                            \
+    if (cudaSuccess != error) {                                                                   \
+      cudaGetLastError();                                                                         \
+      throw _exception_type{std::string{"CUDA error at: "} + __FILE__ + RMM_STRINGIFY(__LINE__) + \
+                            ": " + cudaGetErrorName(error) + " " + cudaGetErrorString(error)};    \
+    }                                                                                             \
   } while (0);
 #define RMM_CUDA_TRY_1(_call) RMM_CUDA_TRY_2(_call, rmm::cuda_error)

--- a/include/rmm/detail/memory_manager.hpp
+++ b/include/rmm/detail/memory_manager.hpp
@@ -16,232 +16,222 @@
 
 /** ---------------------------------------------------------------------------*
  * @brief Memory Manager class
- * 
+ *
  * Note: assumes at least C++11
  * --------------------------------------------------------------------------**/
 
 #ifndef MEMORY_MANAGER_H
 #define MEMORY_MANAGER_H
 
-#include <vector>
 #include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <iostream>
-#include <set>
 #include <mutex>
+#include <set>
+#include <vector>
 
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-#include <rmm/rmm_api.h>
 #include <rmm/detail/cnmem.h>
+#include <rmm/rmm_api.h>
 
 /** ---------------------------------------------------------------------------*
  * @brief Macro wrapper for CNMEM API calls to return appropriate RMM errors.
  * --------------------------------------------------------------------------**/
-#define RMM_CHECK_CNMEM(call) do {            \
-  cnmemStatus_t error = (call);             \
-  switch (error) {                          \
-  case CNMEM_STATUS_SUCCESS:                \
-      break; /* don't return on success! */ \
-  case CNMEM_STATUS_CUDA_ERROR:             \
-      return RMM_ERROR_CUDA_ERROR;          \
-  case CNMEM_STATUS_INVALID_ARGUMENT:       \
-      return RMM_ERROR_INVALID_ARGUMENT;    \
-  case CNMEM_STATUS_NOT_INITIALIZED:        \
-      return RMM_ERROR_NOT_INITIALIZED;     \
-  case CNMEM_STATUS_OUT_OF_MEMORY:          \
-      return RMM_ERROR_OUT_OF_MEMORY;       \
-  case CNMEM_STATUS_UNKNOWN_ERROR:          \
-  default:                                  \
-      return RMM_ERROR_UNKNOWN;             \
-  }                                         \
-} while(0)
+#define RMM_CHECK_CNMEM(call)                                                \
+  do {                                                                       \
+    cnmemStatus_t error = (call);                                            \
+    switch (error) {                                                         \
+      case CNMEM_STATUS_SUCCESS: break; /* don't return on success! */       \
+      case CNMEM_STATUS_CUDA_ERROR: return RMM_ERROR_CUDA_ERROR;             \
+      case CNMEM_STATUS_INVALID_ARGUMENT: return RMM_ERROR_INVALID_ARGUMENT; \
+      case CNMEM_STATUS_NOT_INITIALIZED: return RMM_ERROR_NOT_INITIALIZED;   \
+      case CNMEM_STATUS_OUT_OF_MEMORY: return RMM_ERROR_OUT_OF_MEMORY;       \
+      case CNMEM_STATUS_UNKNOWN_ERROR:                                       \
+      default: return RMM_ERROR_UNKNOWN;                                     \
+    }                                                                        \
+  } while (0)
 
 // forward declaration
-typedef struct CUstream_st *cudaStream_t;
+typedef struct CUstream_st* cudaStream_t;
 
-namespace rmm 
-{
-  /** -------------------------------------------------------------------------*
-   * @brief An event logger for RMM
-   * 
-   * Calling record() records various data about a memory manager event,
-   * includingthe type of event (alloc, free, realloc), the start and end time,
-   * the device, the pointer, free and total available memory, the size (for
-   * alloc/realloc), the stream, and location (file and line).
-   * 
-   * The log can be retreived as a CSV stream using to_csv().
-   * 
-   * ------------------------------------------------------------------------**/
-  class Logger
-  {
-  public:        
-      Logger() { base_time = std::chrono::system_clock::now(); }
+namespace rmm {
+/** -------------------------------------------------------------------------*
+ * @brief An event logger for RMM
+ *
+ * Calling record() records various data about a memory manager event,
+ * includingthe type of event (alloc, free, realloc), the start and end time,
+ * the device, the pointer, free and total available memory, the size (for
+ * alloc/realloc), the stream, and location (file and line).
+ *
+ * The log can be retreived as a CSV stream using to_csv().
+ *
+ * ------------------------------------------------------------------------**/
+class Logger {
+ public:
+  Logger() { base_time = std::chrono::system_clock::now(); }
 
-      enum MemEvent_t {
-          Alloc = 0,
-          Realloc,
-          Free
-      };
+  enum MemEvent_t { Alloc = 0, Realloc, Free };
 
-      using TimePt = std::chrono::system_clock::time_point;
+  using TimePt = std::chrono::system_clock::time_point;
 
-      /// Record a memory manager event in the log.
-      void record(MemEvent_t event, int deviceId, void* ptr,
-                  TimePt start, TimePt end, 
-                  size_t freeMem, size_t totalMem,
-                  size_t size, cudaStream_t stream,
-                  std::string filename,
-                  unsigned int line);
+  /// Record a memory manager event in the log.
+  void record(MemEvent_t event,
+              int deviceId,
+              void* ptr,
+              TimePt start,
+              TimePt end,
+              size_t freeMem,
+              size_t totalMem,
+              size_t size,
+              cudaStream_t stream,
+              std::string filename,
+              unsigned int line);
 
-      /// Clear the log
-      void clear();
-      
-      /// Write the log to comma-separated value file
-      void to_csv(std::ostream &csv);
-  private:
-      std::set<void*> current_allocations;
+  /// Clear the log
+  void clear();
 
-      struct MemoryEvent {
-          MemEvent_t event;
-          int deviceId;
-          void* ptr;
-          size_t size;
-          cudaStream_t stream;
-          size_t freeMem;
-          size_t totalMem;
-          size_t currentAllocations;
-          TimePt start;
-          TimePt end;
-          std::string filename;
-          unsigned int line;
-      };
-      
-      TimePt base_time;
-      std::vector<MemoryEvent> events;
-      std::mutex log_mutex;
+  /// Write the log to comma-separated value file
+  void to_csv(std::ostream& csv);
+
+ private:
+  std::set<void*> current_allocations;
+
+  struct MemoryEvent {
+    MemEvent_t event;
+    int deviceId;
+    void* ptr;
+    size_t size;
+    cudaStream_t stream;
+    size_t freeMem;
+    size_t totalMem;
+    size_t currentAllocations;
+    TimePt start;
+    TimePt end;
+    std::string filename;
+    unsigned int line;
   };
 
-  /** -------------------------------------------------------------------------*
-   * @brief RMM Manager class maintains the memory manager context, including
-   * the RMM event log, configuration options, and registered streams.
-   * 
-   * Manager is a singleton class, and should be accessed via getInstance(). 
-   * A number of static convenience methods are provided that wrap getInstance(),
-   * such as getLogger() and getOptions().
-   * ------------------------------------------------------------------------**/
-  class Manager
+  TimePt base_time;
+  std::vector<MemoryEvent> events;
+  std::mutex log_mutex;
+};
+
+/** -------------------------------------------------------------------------*
+ * @brief RMM Manager class maintains the memory manager context, including
+ * the RMM event log, configuration options, and registered streams.
+ *
+ * Manager is a singleton class, and should be accessed via getInstance().
+ * A number of static convenience methods are provided that wrap getInstance(),
+ * such as getLogger() and getOptions().
+ * ------------------------------------------------------------------------**/
+class Manager {
+ public:
+  /** -----------------------------------------------------------------------*
+   * @brief Get the Manager instance singleton object
+   *
+   * @return Manager& the Manager singleton
+   * ----------------------------------------------------------------------**/
+  static Manager& getInstance()
   {
-  public:
-    /** -----------------------------------------------------------------------*
-     * @brief Get the Manager instance singleton object
-     * 
-     * @return Manager& the Manager singleton
-     * ----------------------------------------------------------------------**/
-    static Manager& getInstance(){
-        // Myers' singleton. Thread safe and unique. Note: C++11 required.
-        static Manager instance;
-        return instance;
-    }
+    // Myers' singleton. Thread safe and unique. Note: C++11 required.
+    static Manager instance;
+    return instance;
+  }
 
-    /** -----------------------------------------------------------------------*
-     * @brief Get the RMM Logger object
-     * 
-     * @return Logger& the logger object
-     * ----------------------------------------------------------------------**/
-    static Logger& getLogger() { return getInstance().logger; }
+  /** -----------------------------------------------------------------------*
+   * @brief Get the RMM Logger object
+   *
+   * @return Logger& the logger object
+   * ----------------------------------------------------------------------**/
+  static Logger& getLogger() { return getInstance().logger; }
 
-    /** -----------------------------------------------------------------------*
-     * @brief Initialize RMM options
-     * 
-     * Accepts an optional rmmOptions_t struct that describes the settings used
-     * to initialize the memory manager. If no `options` is passed, default
-     * options are used.
-     * 
-     * @param[in] options Optional options to set
-     * ----------------------------------------------------------------------**/
-    void initialize(const rmmOptions_t *options = nullptr);
+  /** -----------------------------------------------------------------------*
+   * @brief Initialize RMM options
+   *
+   * Accepts an optional rmmOptions_t struct that describes the settings used
+   * to initialize the memory manager. If no `options` is passed, default
+   * options are used.
+   *
+   * @param[in] options Optional options to set
+   * ----------------------------------------------------------------------**/
+  void initialize(const rmmOptions_t* options = nullptr);
 
-    /** -----------------------------------------------------------------------*
-     * @brief Shut down the Manager (clears the context)
-     * 
-     * ----------------------------------------------------------------------**/
-    void finalize();
+  /** -----------------------------------------------------------------------*
+   * @brief Shut down the Manager (clears the context)
+   *
+   * ----------------------------------------------------------------------**/
+  void finalize();
 
-    /** -----------------------------------------------------------------------*
-     * @brief Check whether the Manager has been initialized.
-     * 
-     * @return true if Manager has been initialized.
-     * @return false if Manager has not been initialized.
-     * ----------------------------------------------------------------------**/
-    bool isInitialized() {
-        return getInstance().is_initialized;
-    }
+  /** -----------------------------------------------------------------------*
+   * @brief Check whether the Manager has been initialized.
+   *
+   * @return true if Manager has been initialized.
+   * @return false if Manager has not been initialized.
+   * ----------------------------------------------------------------------**/
+  bool isInitialized() { return getInstance().is_initialized; }
 
-    /** -----------------------------------------------------------------------*
-     * @brief Get the Options object
-     * 
-     * @return rmmOptions_t the currently set RMM options
-     * ----------------------------------------------------------------------**/
-    static rmmOptions_t getOptions() { return getInstance().options; }
+  /** -----------------------------------------------------------------------*
+   * @brief Get the Options object
+   *
+   * @return rmmOptions_t the currently set RMM options
+   * ----------------------------------------------------------------------**/
+  static rmmOptions_t getOptions() { return getInstance().options; }
 
-    /** -----------------------------------------------------------------------*
-     * @brief Returns true when pool allocation is enabled
-     * 
-     * @return true if pool allocation is enabled
-     * @return false if pool allocation is disabled
-     * ----------------------------------------------------------------------**/
-    static inline bool usePoolAllocator() {
-        return getOptions().allocation_mode & PoolAllocation;
-    }
+  /** -----------------------------------------------------------------------*
+   * @brief Returns true when pool allocation is enabled
+   *
+   * @return true if pool allocation is enabled
+   * @return false if pool allocation is disabled
+   * ----------------------------------------------------------------------**/
+  static inline bool usePoolAllocator() { return getOptions().allocation_mode & PoolAllocation; }
 
-    /** -----------------------------------------------------------------------*
-     * @brief Returns true if CUDA Managed Memory allocation is enabled
-     * 
-     * @return true if CUDA Managed Memory allocation is enabled
-     * @return false if CUDA Managed Memory allocation is disabled
-     * ----------------------------------------------------------------------**/
-    static inline bool useManagedMemory() {
-        return getOptions().allocation_mode & CudaManagedMemory;
-    }
+  /** -----------------------------------------------------------------------*
+   * @brief Returns true if CUDA Managed Memory allocation is enabled
+   *
+   * @return true if CUDA Managed Memory allocation is enabled
+   * @return false if CUDA Managed Memory allocation is disabled
+   * ----------------------------------------------------------------------**/
+  static inline bool useManagedMemory() { return getOptions().allocation_mode & CudaManagedMemory; }
 
-    /** -----------------------------------------------------------------------*
-     * @brief Returns true when CUDA default allocation is enabled
-     *          * 
-     * @return true if CUDA default allocation is enabled
-     * @return false if CUDA default allocation is disabled
-     * ----------------------------------------------------------------------**/
-    inline bool useCudaDefaultAllocator() {
-        return CudaDefaultAllocation == getOptions().allocation_mode;
-    }
+  /** -----------------------------------------------------------------------*
+   * @brief Returns true when CUDA default allocation is enabled
+   *          *
+   * @return true if CUDA default allocation is enabled
+   * @return false if CUDA default allocation is disabled
+   * ----------------------------------------------------------------------**/
+  inline bool useCudaDefaultAllocator()
+  {
+    return CudaDefaultAllocation == getOptions().allocation_mode;
+  }
 
-    /** -----------------------------------------------------------------------*
-     * @brief Register a new stream into the device memory manager.
-     * 
-     * Also returns success if the stream is already registered.
-     * 
-     * @param stream The stream to register
-     * @return rmmError_t RMM_SUCCESS if all goes well,
-     *                    RMM_ERROR_INVALID_ARGUMENT if the stream is invalid.
-     * ----------------------------------------------------------------------**/
-    rmmError_t registerStream(cudaStream_t stream);
+  /** -----------------------------------------------------------------------*
+   * @brief Register a new stream into the device memory manager.
+   *
+   * Also returns success if the stream is already registered.
+   *
+   * @param stream The stream to register
+   * @return rmmError_t RMM_SUCCESS if all goes well,
+   *                    RMM_ERROR_INVALID_ARGUMENT if the stream is invalid.
+   * ----------------------------------------------------------------------**/
+  rmmError_t registerStream(cudaStream_t stream);
 
-  private:
-    Manager() = default;
-    ~Manager() = default;
-    Manager(const Manager&) = delete;
-    Manager& operator=(const Manager&) = delete;
-    std::mutex manager_mutex;
-    std::set<cudaStream_t> registered_streams;
-    Logger logger;
+ private:
+  Manager()               = default;
+  ~Manager()              = default;
+  Manager(const Manager&) = delete;
+  Manager& operator=(const Manager&) = delete;
+  std::mutex manager_mutex;
+  std::set<cudaStream_t> registered_streams;
+  Logger logger;
 
-    rmmOptions_t options{};
-    bool is_initialized{false};
+  rmmOptions_t options{};
+  bool is_initialized{false};
 
-    std::unique_ptr<rmm::mr::device_memory_resource> initialized_resource{};
-    std::unique_ptr<rmm::mr::device_memory_resource> logging_adaptor{};
-  };
-}
+  std::unique_ptr<rmm::mr::device_memory_resource> initialized_resource{};
+  std::unique_ptr<rmm::mr::device_memory_resource> logging_adaptor{};
+};
+}  // namespace rmm
 
-#endif // MEMORY_MANAGER_H
+#endif  // MEMORY_MANAGER_H

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -75,16 +75,13 @@ class device_buffer {
    * @brief Default constructor creates an empty `device_buffer`
    */
   // Note: we cannot use `device_buffer() = default;` because nvcc implicitly adds
-  // `__host__ __device__` specifiers to the defaulted constructor when it is called within the 
+  // `__host__ __device__` specifiers to the defaulted constructor when it is called within the
   // context of both host and device functions. Specifically, the `cudf::type_dispatcher` is a host-
   // device function. This causes warnings/errors because this ctor invokes host-only functions.
   device_buffer()
-      : _data{nullptr},
-        _size{},
-        _capacity{},
-        _stream{},
-        _mr{rmm::mr::get_default_resource()} {}
-
+    : _data{nullptr}, _size{}, _capacity{}, _stream{}, _mr{rmm::mr::get_default_resource()}
+  {
+  }
 
   /**
    * @brief Constructs a new device buffer of `size` uninitialized bytes
@@ -96,10 +93,11 @@ class device_buffer {
    * resource supports streams.
    * @param mr Memory resource to use for the device memory allocation.
    */
-  explicit device_buffer(
-      std::size_t size, cudaStream_t stream = 0,
-      mr::device_memory_resource* mr = mr::get_default_resource())
-      : _stream{stream}, _mr{mr} {
+  explicit device_buffer(std::size_t size,
+                         cudaStream_t stream            = 0,
+                         mr::device_memory_resource* mr = mr::get_default_resource())
+    : _stream{stream}, _mr{mr}
+  {
     allocate(size);
   }
 
@@ -117,10 +115,12 @@ class device_buffer {
    * resource supports streams.
    * @param mr Memory resource to use for the device memory allocation
    */
-  device_buffer(void const* source_data, std::size_t size,
-                cudaStream_t stream = 0,
+  device_buffer(void const* source_data,
+                std::size_t size,
+                cudaStream_t stream            = 0,
                 mr::device_memory_resource* mr = mr::get_default_resource())
-      : _stream{stream}, _mr{mr} {
+    : _stream{stream}, _mr{mr}
+  {
     allocate(size);
     copy(source_data, size);
   }
@@ -141,10 +141,12 @@ class device_buffer {
    * @param stream The stream to use for the allocation and copy
    * @param mr The resource to use for allocating the new `device_buffer`
    */
-  device_buffer(
-      device_buffer const& other, cudaStream_t stream = 0,
-      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
-      : device_buffer{other.data(), other.size(), stream, mr} {}
+  device_buffer(device_buffer const& other,
+                cudaStream_t stream                 = 0,
+                rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
+    : device_buffer{other.data(), other.size(), stream, mr}
+  {
+  }
 
   /**
    * @brief Constructs a new `device_buffer` by moving the contents of another
@@ -160,13 +162,14 @@ class device_buffer {
    * newly constructed one.
    */
   device_buffer(device_buffer&& other) noexcept
-      : _data{other._data},
-        _size{other._size},
-        _capacity{other._capacity},
-        _stream{other.stream()},
-        _mr{other._mr} {
-    other._data = nullptr;
-    other._size = 0;
+    : _data{other._data},
+      _size{other._size},
+      _capacity{other._capacity},
+      _stream{other.stream()},
+      _mr{other._mr}
+  {
+    other._data     = nullptr;
+    other._size     = 0;
     other._capacity = 0;
     other.set_stream(0);
   }
@@ -192,7 +195,8 @@ class device_buffer {
    *
    * @param other The `device_buffer` to copy.
    */
-  device_buffer& operator=(device_buffer const& other) {
+  device_buffer& operator=(device_buffer const& other)
+  {
     if (&other != this) {
       // If the current capacity is large enough and the resources are
       // compatible, just reuse the existing memory
@@ -224,18 +228,19 @@ class device_buffer {
    *
    * @param other The `device_buffer` whose contents will be moved.
    */
-  device_buffer& operator=(device_buffer&& other) noexcept {
+  device_buffer& operator=(device_buffer&& other) noexcept
+  {
     if (&other != this) {
       deallocate();
 
-      _data = other._data;
-      _size = other._size;
+      _data     = other._data;
+      _size     = other._size;
       _capacity = other._capacity;
       set_stream(other.stream());
       _mr = other._mr;
 
-      other._data = nullptr;
-      other._size = 0;
+      other._data     = nullptr;
+      other._size     = 0;
       other._capacity = 0;
       other.set_stream(0);
     }
@@ -249,9 +254,10 @@ class device_buffer {
    * using the stream most recently passed to any of this device buffer's
    * methods.
    */
-  ~device_buffer() noexcept {
+  ~device_buffer() noexcept
+  {
     deallocate();
-    _mr = nullptr;
+    _mr     = nullptr;
     _stream = 0;
   }
 
@@ -280,7 +286,8 @@ class device_buffer {
    * @param new_size The requested new size, in bytes
    * @param stream The stream to use for allocation and copy
    */
-  void resize(std::size_t new_size, cudaStream_t stream = 0) {
+  void resize(std::size_t new_size, cudaStream_t stream = 0)
+  {
     set_stream(stream);
     // If the requested size is smaller than the current capacity, just update
     // the size without any allocations
@@ -288,11 +295,10 @@ class device_buffer {
       _size = new_size;
     } else {
       void* const new_data = _mr->allocate(new_size, this->stream());
-      RMM_CUDA_TRY(cudaMemcpyAsync(new_data, data(), size(), cudaMemcpyDefault,
-                                   this->stream()));
+      RMM_CUDA_TRY(cudaMemcpyAsync(new_data, data(), size(), cudaMemcpyDefault, this->stream()));
       deallocate();
-      _data = new_data;
-      _size = new_size;
+      _data     = new_data;
+      _size     = new_size;
       _capacity = new_size;
     }
   }
@@ -310,7 +316,8 @@ class device_buffer {
    *
    * @param stream The stream on which the allocation and copy are performed
    */
-  void shrink_to_fit(cudaStream_t stream = 0) {
+  void shrink_to_fit(cudaStream_t stream = 0)
+  {
     set_stream(stream);
     if (size() != capacity()) {
       // Invoke copy ctor on self which only copies `[0, size())` and swap it
@@ -382,8 +389,8 @@ class device_buffer {
   std::size_t _capacity{};  ///< The actual size of the device memory allocation
   cudaStream_t _stream{};   ///< Stream to use for device memory deallocation
   mr::device_memory_resource* _mr{
-      mr::get_default_resource()};  ///< The memory resource used to
-                                    ///< allocate/deallocate device memory
+    mr::get_default_resource()};  ///< The memory resource used to
+                                  ///< allocate/deallocate device memory
 
   /**
    * @brief Allocates the specified amount of memory and updates the
@@ -394,10 +401,11 @@ class device_buffer {
    * @param bytes The amount of memory to allocate
    * @param stream The stream on which to allocate
    */
-  void allocate(std::size_t bytes) {
-    _size = bytes;
+  void allocate(std::size_t bytes)
+  {
+    _size     = bytes;
     _capacity = bytes;
-    _data = (bytes > 0) ? _mr->allocate(bytes, stream()) : nullptr;
+    _data     = (bytes > 0) ? _mr->allocate(bytes, stream()) : nullptr;
   }
 
   /**
@@ -408,13 +416,12 @@ class device_buffer {
    * call the resource deallocation.
    *
    */
-  void deallocate() noexcept {
-    if (capacity() > 0) {
-      _mr->deallocate(data(), capacity());
-    }
-    _size = 0;
+  void deallocate() noexcept
+  {
+    if (capacity() > 0) { _mr->deallocate(data(), capacity()); }
+    _size     = 0;
     _capacity = 0;
-    _data = nullptr;
+    _data     = nullptr;
   }
 
   /**
@@ -429,12 +436,12 @@ class device_buffer {
    * @param source The pointer to copy from
    * @param bytes The number of bytes to copy
    */
-  void copy(void const* source, std::size_t bytes) {
+  void copy(void const* source, std::size_t bytes)
+  {
     if (bytes > 0) {
       RMM_EXPECTS(nullptr != source, "Invalid copy from nullptr.");
 
-      RMM_CUDA_TRY(
-          cudaMemcpyAsync(_data, source, bytes, cudaMemcpyDefault, stream()));
+      RMM_CUDA_TRY(cudaMemcpyAsync(_data, source, bytes, cudaMemcpyDefault, stream()));
     }
   }
 };

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -20,7 +20,7 @@
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-#include  <type_traits>
+#include <type_traits>
 
 namespace rmm {
 
@@ -34,35 +34,37 @@ namespace rmm {
 template <typename T>
 class device_scalar {
  public:
-  static_assert(std::is_trivially_copyable<T>::value,
-                "Scalar type must be trivially copyable");
+  static_assert(std::is_trivially_copyable<T>::value, "Scalar type must be trivially copyable");
 
   /**
    * @brief Construct a new uninitialized `device_scalar`.
    *
-   * Does not synchronize the stream. 
+   * Does not synchronize the stream.
    *
-   * @note This device_scalar is only safe to access in kernels and copies on the specified CUDA stream,
-   * or on another stream only if a dependency is enforced (e.g. using `cudaStreamWaitEvent()`).
+   * @note This device_scalar is only safe to access in kernels and copies on the specified CUDA
+   * stream, or on another stream only if a dependency is enforced (e.g. using
+   * `cudaStreamWaitEvent()`).
    *
    * @throws `rmm::bad_alloc` if allocating the device memory fails.
    *
    * @param stream Stream on which to perform asynchronous allocation.
    * @param mr Optional, resource with which to allocate.
    */
-  explicit device_scalar(
-      cudaStream_t stream,
-      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
-      : buffer{sizeof(T), stream, mr} {}
+  explicit device_scalar(cudaStream_t stream,
+                         rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource())
+    : buffer{sizeof(T), stream, mr}
+  {
+  }
 
   /**
    * @brief Construct a new `device_scalar` with an initial value.
    *
-   * Does not synchronize the stream. 
+   * Does not synchronize the stream.
    *
-   * @note This device_scalar is only safe to access in kernels and copies on the specified CUDA stream,
-   * or on another stream only if a dependency is enforced (e.g. using `cudaStreamWaitEvent()`).
-   * 
+   * @note This device_scalar is only safe to access in kernels and copies on the specified CUDA
+   * stream, or on another stream only if a dependency is enforced (e.g. using
+   * `cudaStreamWaitEvent()`).
+   *
    * @throws `rmm::bad_alloc` if allocating the device memory for `initial_value` fails.
    * @throws `rmm::cuda_error` if copying `initial_value` to device memory fails.
    *
@@ -70,21 +72,21 @@ class device_scalar {
    * @param stream Optional, stream on which to perform allocation and copy.
    * @param mr Optional, resource with which to allocate.
    */
-  explicit device_scalar(
-      T const& initial_value,
-      cudaStream_t stream = 0,
-      rmm::mr::device_memory_resource* mr = rmm::mr::get_default_resource())
-      : buffer{sizeof(T), stream, mr} {
+  explicit device_scalar(T const &initial_value,
+                         cudaStream_t stream                 = 0,
+                         rmm::mr::device_memory_resource *mr = rmm::mr::get_default_resource())
+    : buffer{sizeof(T), stream, mr}
+  {
     set_value(initial_value, stream);
   }
 
   /**
    * @brief Copies the value from device to host, synchronizes, and returns the value.
-   * 
+   *
    * Synchronizes `stream` after copying the data from device to host.
-   * 
+   *
    * @note If the stream specified to this function is different from the stream specified
-   * to the constructor, then an appropriate dependency must be inserted between the streams 
+   * to the constructor, then an appropriate dependency must be inserted between the streams
    * (e.g. using `cudaStreamWaitEvent()` or `cudaStreamSynchronize()`) before calling this function,
    * otherwise there may be a race condition.
    *
@@ -94,7 +96,8 @@ class device_scalar {
    * @return T The value of the scalar.
    * @param stream CUDA stream on which to perform the copy and synchronize.
    */
-  T value(cudaStream_t stream = 0) const {
+  T value(cudaStream_t stream = 0) const
+  {
     T host_value{};
     _memcpy(&host_value, buffer.data(), stream);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream));
@@ -105,12 +108,12 @@ class device_scalar {
    * @brief Sets the value of the `device_scalar` to the given `host_value`.
    *
    * @note If the stream specified to this function is different from the stream specified
-   * to the constructor, then appropriate dependencies must be inserted between the streams 
+   * to the constructor, then appropriate dependencies must be inserted between the streams
    * (e.g. using `cudaStreamWaitEvent()` or `cudaStreamSynchronize()`) before and after calling
    * this function, otherwise there may be a race condition.
    *
    * Does not synchronize `stream`.
-   * 
+   *
    * @throws `rmm::cuda_error` if copying `host_value` to device memory fails.
    * @throws `rmm::cuda_error` if synchronizing `stream` fails.
    *
@@ -132,12 +135,12 @@ class device_scalar {
    * @brief Sets the value of the `device_scalar` to the given `host_value`.
    *
    * @note If the stream specified to this function is different from the stream specified
-   * to the constructor, then appropriate dependencies must be inserted between the streams 
+   * to the constructor, then appropriate dependencies must be inserted between the streams
    * (e.g. using `cudaStreamWaitEvent()` or `cudaStreamSynchronize()`) before and after calling
    * this function, otherwise there may be a race condition.
    *
    * Does not synchronize `stream`.
-   * 
+   *
    * @throws `rmm::cuda_error` if copying `host_value` to device memory fails
    * @throws `rmm::cuda_error` if synchronizing `stream` fails
    *
@@ -159,7 +162,7 @@ class device_scalar {
    * streams (e.g. using `cudaStreamWaitEvent()` or `cudaStreamSynchronize()`), otherwise there may
    * be a race condition.
    */
-  T* data() noexcept { return static_cast<T*>(buffer.data()); }
+  T *data() noexcept { return static_cast<T *>(buffer.data()); }
 
   /**
    * @brief Returns const pointer to object in device memory.
@@ -169,19 +172,20 @@ class device_scalar {
    * streams (e.g. using `cudaStreamWaitEvent()` or `cudaStreamSynchronize()`), otherwise there may
    * be a race condition.
    */
-  T const *data() const noexcept { return static_cast<T const*>(buffer.data()); }
+  T const *data() const noexcept { return static_cast<T const *>(buffer.data()); }
 
-  device_scalar() =  default;
-  ~device_scalar() = default;
+  device_scalar()                      = default;
+  ~device_scalar()                     = default;
   device_scalar(device_scalar const &) = default;
-  device_scalar(device_scalar &&) = default;
+  device_scalar(device_scalar &&)      = default;
   device_scalar &operator=(device_scalar const &) = delete;
   device_scalar &operator=(device_scalar &&) = delete;
 
  private:
   rmm::device_buffer buffer{sizeof(T)};
 
-  inline void _memcpy(void *dst, const void *src, cudaStream_t stream) const {
+  inline void _memcpy(void *dst, const void *src, cudaStream_t stream) const
+  {
     RMM_CUDA_TRY(cudaMemcpyAsync(dst, src, sizeof(T), cudaMemcpyDefault, stream));
   }
 };

--- a/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
@@ -45,10 +45,11 @@ class cnmem_managed_memory_resource final : public cnmem_memory_resource {
    * @param initial_pool_size Size, in bytes, of the intial pool size. When
    * zero, an implementation defined pool size is used.
    */
-  explicit cnmem_managed_memory_resource(std::size_t initial_pool_size = 0,
+  explicit cnmem_managed_memory_resource(std::size_t initial_pool_size   = 0,
                                          std::vector<int> const& devices = {})
-      : cnmem_memory_resource(initial_pool_size, devices,
-                              memory_kind::MANAGED) {}
+    : cnmem_memory_resource(initial_pool_size, devices, memory_kind::MANAGED)
+  {
+  }
 };
 
 }  // namespace mr

--- a/include/rmm/mr/device/cnmem_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_memory_resource.hpp
@@ -42,14 +42,13 @@ struct cnmem_error : public std::runtime_error {
   GET_CNMEM_TRY_MACRO(__VA_ARGS__, CNMEM_TRY_2, CNMEM_TRY_1) \
   (__VA_ARGS__)
 #define GET_CNMEM_TRY_MACRO(_1, _2, NAME, ...) NAME
-#define CNMEM_TRY_2(_call, _exception_type)                              \
-  do {                                                                   \
-    cnmemStatus_t const error = (_call);                                 \
-    if (CNMEM_STATUS_SUCCESS != error) {                                 \
-      throw _exception_type{std::string{"CNMEM error at: "} + __FILE__ + \
-                            RMM_STRINGIFY(__LINE__) + ": " +             \
-                            cnmemGetErrorString(error)};                 \
-    }                                                                    \
+#define CNMEM_TRY_2(_call, _exception_type)                                                        \
+  do {                                                                                             \
+    cnmemStatus_t const error = (_call);                                                           \
+    if (CNMEM_STATUS_SUCCESS != error) {                                                           \
+      throw _exception_type{std::string{"CNMEM error at: "} + __FILE__ + RMM_STRINGIFY(__LINE__) + \
+                            ": " + cnmemGetErrorString(error)};                                    \
+    }                                                                                              \
   } while (0);
 #define CNMEM_TRY_1(_call) CNMEM_TRY_2(_call, rmm::cnmem_error)
 
@@ -72,9 +71,11 @@ class cnmem_memory_resource : public device_memory_resource {
    * zero, an implementation defined pool size is used.
    * @param devices List of GPU device IDs to register with CNMEM
    */
-  explicit cnmem_memory_resource(std::size_t initial_pool_size = 0,
+  explicit cnmem_memory_resource(std::size_t initial_pool_size   = 0,
                                  std::vector<int> const& devices = {})
-      : cnmem_memory_resource(initial_pool_size, devices, memory_kind::CUDA) {}
+    : cnmem_memory_resource(initial_pool_size, devices, memory_kind::CUDA)
+  {
+  }
 
   /**
    * @brief Destroy the CNMEM resource, finalizing CNMEM and freeing all pool
@@ -83,7 +84,8 @@ class cnmem_memory_resource : public device_memory_resource {
    * @throws Nothing.
    *
    */
-  virtual ~cnmem_memory_resource() {
+  virtual ~cnmem_memory_resource()
+  {
     auto status = cnmemFinalize();
     assert(CNMEM_STATUS_SUCCESS == status);
   }
@@ -98,7 +100,7 @@ class cnmem_memory_resource : public device_memory_resource {
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
   bool supports_get_mem_info() const noexcept override { return true; }
@@ -114,7 +116,8 @@ class cnmem_memory_resource : public device_memory_resource {
 
   cnmem_memory_resource(std::size_t initial_pool_size,
                         std::vector<int> const& devices,
-                        memory_kind pool_type) {
+                        memory_kind pool_type)
+  {
     std::vector<cnmemDevice_t> cnmem_devices;
 
     // If no devices were specified, use the current one
@@ -123,19 +126,18 @@ class cnmem_memory_resource : public device_memory_resource {
       RMM_CUDA_TRY(cudaGetDevice(&current_device));
       cnmemDevice_t dev{};
       dev.device = current_device;
-      dev.size = initial_pool_size;
+      dev.size   = initial_pool_size;
       cnmem_devices.push_back(dev);
     } else {
       for (auto const& d : devices) {
         cnmemDevice_t dev{};
         dev.device = d;
-        dev.size = initial_pool_size;
+        dev.size   = initial_pool_size;
         cnmem_devices.push_back(dev);
       }
     }
 
-    unsigned long flags =
-        (pool_type == memory_kind::MANAGED) ? CNMEM_FLAGS_MANAGED : 0;
+    unsigned long flags = (pool_type == memory_kind::MANAGED) ? CNMEM_FLAGS_MANAGED : 0;
 
     CNMEM_TRY(cnmemInit(cnmem_devices.size(), cnmem_devices.data(), flags));
   }
@@ -152,7 +154,8 @@ class cnmem_memory_resource : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
     register_stream(stream);
     void* p{nullptr};
     CNMEM_TRY(cnmemMalloc(&p, bytes, stream), rmm::bad_alloc);
@@ -166,7 +169,8 @@ class cnmem_memory_resource : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, cudaStream_t stream) override {
+  void do_deallocate(void* p, std::size_t, cudaStream_t stream) override
+  {
     auto status = cnmemFree(p, stream);
     assert(CNMEM_STATUS_SUCCESS == status);
   }
@@ -185,16 +189,15 @@ class cnmem_memory_resource : public device_memory_resource {
    *
    * @param stream The stream to register
    */
-  void register_stream(cudaStream_t stream) {
+  void register_stream(cudaStream_t stream)
+  {
     // Don't register null stream with CNMEM
     if (stream != 0) {
       // TODO Probably don't want to have to take a lock for every memory
       // allocation
       std::lock_guard<std::mutex> lock(streams_mutex);
       auto result = registered_streams.insert(stream);
-      if (result.second == true) {
-        CNMEM_TRY(cnmemRegisterStream(stream));
-      }
+      if (result.second == true) { CNMEM_TRY(cnmemRegisterStream(stream)); }
     }
   }
 
@@ -206,7 +209,8 @@ class cnmem_memory_resource : public device_memory_resource {
    * @param stream to execute on
    * @return std::pair contaiing free_size and total_size of memory
    **/
-  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override {
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
     std::size_t free_size;
     std::size_t total_size;
     CNMEM_TRY(cnmemMemGetInfo(&free_size, &total_size, stream));
@@ -214,8 +218,8 @@ class cnmem_memory_resource : public device_memory_resource {
   }
   std::set<cudaStream_t> registered_streams{};  // Unique streams that have been
                                                 // registered with cnmem
-  std::mutex streams_mutex{};  // Mutex used to guard concurrent access to
-                               // `registered_streams`
+  std::mutex streams_mutex{};                   // Mutex used to guard concurrent access to
+                                                // `registered_streams`
 };
 
 }  // namespace mr

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -32,7 +32,6 @@ namespace mr {
  */
 class cuda_memory_resource final : public device_memory_resource {
  public:
-
   /**
    * @brief Query whether the resource supports use of non-null CUDA streams for
    * allocation/deallocation. `cuda_memory_resource` does not support streams.
@@ -43,7 +42,7 @@ class cuda_memory_resource final : public device_memory_resource {
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return true
    */
   bool supports_get_mem_info() const noexcept override { return true; }
@@ -61,7 +60,8 @@ class cuda_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t) override
+  {
     void* p{nullptr};
     RMM_CUDA_TRY(cudaMalloc(&p, bytes), rmm::bad_alloc);
     return p;
@@ -76,7 +76,8 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, cudaStream_t) override {
+  void do_deallocate(void* p, std::size_t, cudaStream_t) override
+  {
     cudaError_t const status = cudaFree(p);
     assert(cudaSuccess == status);
   }
@@ -93,7 +94,8 @@ class cuda_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override {
+  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  {
     return dynamic_cast<cuda_memory_resource const*>(&other) != nullptr;
   }
 
@@ -104,7 +106,8 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t) const override {
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t) const override
+  {
     std::size_t free_size;
     std::size_t total_size;
     RMM_CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));

--- a/include/rmm/mr/device/default_memory_resource.hpp
+++ b/include/rmm/mr/device/default_memory_resource.hpp
@@ -51,10 +51,9 @@ device_memory_resource* get_default_resource();
  * @return device_memory_resource* The previous value of the default device
  * memory resource pointer
  */
-device_memory_resource* set_default_resource(
-    device_memory_resource* new_resource);
+device_memory_resource* set_default_resource(device_memory_resource* new_resource);
 
-namespace detail{
+namespace detail {
 
 /**
  * @brief gets the default memory_resource when none is set

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -18,10 +18,10 @@
 
 #include <rmm/detail/error.hpp>
 
-#include <list>
 #include <algorithm>
-#include <iostream>
 #include <cassert>
+#include <iostream>
+#include <list>
 
 namespace rmm {
 namespace mr {
@@ -32,18 +32,17 @@ namespace detail {
  *        of memory, with a flag indicating whether it is the head of a block
  *        of memory allocated from the heap (or upstream allocator).
  */
-struct block
-{
-  char* ptr;          ///< Raw memory pointer
-  size_t size;        ///< Size in bytes
-  bool is_head;       ///< Indicates whether ptr was allocated from the heap
+struct block {
+  char* ptr;     ///< Raw memory pointer
+  size_t size;   ///< Size in bytes
+  bool is_head;  ///< Indicates whether ptr was allocated from the heap
 
   /**
    * @brief Comparison operator to enable comparing blocks and storing in ordered containers.
-   * 
+   *
    * Orders by ptr address.
 
-   * @param rhs 
+   * @param rhs
    * @return true if this block's ptr is < than `rhs` block pointer.
    * @return false if this block's ptr is >= than `rhs` block pointer.
    */
@@ -51,21 +50,20 @@ struct block
 
   /**
    * @brief Verifies whether this block can be merged to the beginning of block b.
-   * 
+   *
    * @param b The block to check for contiguity.
-   * @return true Returns true if this blocks's `ptr` + `size` == `b.ptr`, and `not b.is_head`, 
+   * @return true Returns true if this blocks's `ptr` + `size` == `b.ptr`, and `not b.is_head`,
                   false otherwise.
    */
-  bool is_contiguous_before(block const& b) const noexcept {
-    return (this->ptr + this->size == b.ptr) and not (b.is_head);
+  bool is_contiguous_before(block const& b) const noexcept
+  {
+    return (this->ptr + this->size == b.ptr) and not(b.is_head);
   }
 
   /**
    * @brief Print this block. For debugging.
    */
-  void print() const {
-    std::cout << reinterpret_cast<void*>(ptr) << " " << size << "B\n";
-  }
+  void print() const { std::cout << reinterpret_cast<void*>(ptr) << " " << size << "B\n"; }
 };
 
 /**
@@ -80,65 +78,66 @@ struct block
  */
 inline block merge_blocks(block const& a, block const& b)
 {
-  assert(a.ptr + a.size == b.ptr); // non-contiguous blocks
-  assert(not b.is_head); // Can't merge across upstream allocation boundaries
+  assert(a.ptr + a.size == b.ptr);  // non-contiguous blocks
+  assert(not b.is_head);            // Can't merge across upstream allocation boundaries
 
   return block{a.ptr, a.size + b.size};
 }
 
 /**
  * @brief An ordered list of free memory blocks that coalesces contiguous blocks on insertion.
- * 
+ *
  * @tparam list_type the type of the internal list data structure.
  */
-template < typename list_type = std::list<block> >
+template <typename list_type = std::list<block>>
 struct free_list {
-  free_list() = default;
+  free_list()  = default;
   ~free_list() = default;
 
-  using size_type = typename list_type::size_type;
-  using iterator = typename list_type::iterator;
+  using size_type      = typename list_type::size_type;
+  using iterator       = typename list_type::iterator;
   using const_iterator = typename list_type::const_iterator;
 
-  iterator begin() noexcept              { return blocks.begin(); } /// beginning of the free list
-  const_iterator begin() const noexcept  { return begin(); }        /// beginning of the free list
-  const_iterator cbegin() const noexcept { return blocks.cbegin(); } /// beginning of the free list
+  iterator begin() noexcept { return blocks.begin(); }                /// beginning of the free list
+  const_iterator begin() const noexcept { return begin(); }           /// beginning of the free list
+  const_iterator cbegin() const noexcept { return blocks.cbegin(); }  /// beginning of the free list
 
-  iterator end() noexcept                { return blocks.end(); }   /// end of the free list
-  const_iterator end() const noexcept    { return end(); }          /// end of the free list
-  const_iterator cend() const noexcept   { return blocks.cend(); }  /// end of the free list
+  iterator end() noexcept { return blocks.end(); }                /// end of the free list
+  const_iterator end() const noexcept { return end(); }           /// end of the free list
+  const_iterator cend() const noexcept { return blocks.cend(); }  /// end of the free list
 
   /**
    * @brief The size of the free list in blocks.
-   * 
+   *
    * @return size_type The number of blocks in the free list.
    */
-  size_type size() const noexcept        { return blocks.size(); }
+  size_type size() const noexcept { return blocks.size(); }
 
   /**
    * @brief checks whether the free_list is empty.
-   * 
+   *
    * @return true If there are blocks in the free_list.
    * @return false If there are no blocks in the free_list.
    */
-  bool is_empty() const noexcept         { return blocks.empty(); }
+  bool is_empty() const noexcept { return blocks.empty(); }
 
   /**
    * @brief Inserts a block into the `free_list` in the correct order, coalescing it with the
    *        preceding and following blocks if either is contiguous.
-   * 
+   *
    * @param b The block to insert.
    */
-  void insert(block const& b) {
-    if (is_empty()) { 
+  void insert(block const& b)
+  {
+    if (is_empty()) {
       insert(blocks.end(), b);
       return;
     }
 
     // Find the right place (in ascending ptr order) to insert the block
     // Can't use binary_search because it's a linked list and will be quadratic
-    auto const next = std::find_if(blocks.begin(), blocks.end(),
-                             [b](block const& i) { return i.ptr > b.ptr; });
+    auto const next =
+      std::find_if(blocks.begin(), blocks.end(), [b](block const& i) { return i.ptr > b.ptr; });
     auto const previous = (next == blocks.begin()) ? next : std::prev(next);
 
     // Coalesce with neighboring blocks or insert the new block if it can't be coalesced
@@ -154,86 +153,84 @@ struct free_list {
     } else if (merge_next) {
       *next = detail::merge_blocks(b, *next);
     } else {
-      insert(next, b); // cannot be coalesced, just insert
+      insert(next, b);  // cannot be coalesced, just insert
     }
   }
 
   /**
-   * @brief Inserts blocks from range `[first, last)` into the free_list in their correct order, 
+   * @brief Inserts blocks from range `[first, last)` into the free_list in their correct order,
    *        coalescing them with their preceding and following blocks if they are contiguous.
-   * 
+   *
    * @tparam InputIt iterator type
    * @param first The beginning of the range of blocks to insert
    * @param last The end of the range of blocks to insert.
    */
-  template< class InputIt >
-  void insert( InputIt first, InputIt last ) {
+  template <class InputIt>
+  void insert(InputIt first, InputIt last)
+  {
     std::for_each(first, last, [this](block const& b) { this->insert(b); });
   }
 
   /**
    * @brief Removes the block indicated by `iter` from the free list.
-   * 
+   *
    * @param iter An iterator referring to the block to erase.
    */
-  void erase(iterator const& iter) {
-    blocks.erase(iter);
-  }
+  void erase(iterator const& iter) { blocks.erase(iter); }
 
   /**
-  * @brief Erase all blocks from the free_list.
-  * 
-  */
+   * @brief Erase all blocks from the free_list.
+   *
+   */
   void clear() noexcept { blocks.clear(); }
 
   /**
    * @brief Finds the smallest block in the `free_list` large enough to fit `size` bytes.
-   * 
+   *
    * @param size The size in bytes of the desired block.
    * @return block A block large enough to store `size` bytes.
    */
-  block best_fit(size_t size) {
+  block best_fit(size_t size)
+  {
     // find best fit block
-    auto const iter = std::min_element(
-      blocks.begin(), blocks.end(), [size](block lhs, block rhs) {
-        return (lhs.size >= size) &&
-                ((lhs.size < rhs.size) || (rhs.size < size));
-      });
+    auto const iter = std::min_element(blocks.begin(), blocks.end(), [size](block lhs, block rhs) {
+      return (lhs.size >= size) && ((lhs.size < rhs.size) || (rhs.size < size));
+    });
 
-    if (iter->size >= size)
-    {
+    if (iter->size >= size) {
       // Remove the block from the free_list and return it.
       block const found = *iter;
       erase(iter);
       return found;
     }
-    
-    return block{}; // not found
+
+    return block{};  // not found
   }
 
   /**
    * @brief Print all blocks in the free_list.
    */
-  void print() const {
+  void print() const
+  {
     std::cout << blocks.size() << '\n';
-    for (block const& b : blocks) { b.print(); }
+    for (block const& b : blocks) {
+      b.print();
+    }
   }
 
-protected:
+ protected:
   /**
    * @brief Insert a block in the free list before the specified position
-   * 
+   *
    * @param pos iterator before which the block will be inserted. pos may be the end() iterator.
    * @param b The block to insert.
    */
-  void insert(const_iterator pos, block const& b) {
-    blocks.insert(pos, b);
-  }
+  void insert(const_iterator pos, block const& b) { blocks.insert(pos, b); }
 
-private:
-  list_type blocks; // The internal container of blocks
-}; // free_list
+ private:
+  list_type blocks;  // The internal container of blocks
+};                   // free_list
 
-} // namespace rmm::mr::detail
-} // namespace rmm::mr
-} // namespace rmm
+}  // namespace detail
+}  // namespace mr
+}  // namespace rmm

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -33,7 +33,8 @@ namespace detail {
  *
  * @return Return the aligned value, as one would expect
  */
-inline std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept {
+inline std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept
+{
   return (v + (align_bytes - 1)) & ~(align_bytes - 1);
 }
 
@@ -60,7 +61,7 @@ namespace mr {
  */
 class device_memory_resource {
  public:
-  device_memory_resource() = default;
+  device_memory_resource()          = default;
   virtual ~device_memory_resource() = default;
 
   /**
@@ -78,7 +79,8 @@ class device_memory_resource {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* allocate(std::size_t bytes, cudaStream_t stream = 0) {
+  void* allocate(std::size_t bytes, cudaStream_t stream = 0)
+  {
     return do_allocate(detail::align_up(bytes, 8), stream);
   }
 
@@ -100,7 +102,8 @@ class device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  void deallocate(void* p, std::size_t bytes, cudaStream_t stream = 0) {
+  void deallocate(void* p, std::size_t bytes, cudaStream_t stream = 0)
+  {
     do_deallocate(p, detail::align_up(bytes, 8), stream);
   }
 
@@ -117,9 +120,7 @@ class device_memory_resource {
    * @param other The other resource to compare to
    * @returns If the two resources are equivalent
    */
-  bool is_equal(device_memory_resource const& other) const noexcept {
-    return do_is_equal(other);
-  }
+  bool is_equal(device_memory_resource const& other) const noexcept { return do_is_equal(other); }
 
   /**
    * @brief Query whether the resource supports use of non-null CUDA streams for
@@ -131,7 +132,7 @@ class device_memory_resource {
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
   virtual bool supports_get_mem_info() const noexcept = 0;
@@ -144,7 +145,8 @@ class device_memory_resource {
    * @returns a std::pair<size_t,size_t> which contains free memory in bytes
    * in .first and total amount of memory in .second
    */
-  std::pair<std::size_t, std::size_t> get_mem_info(cudaStream_t stream) const {
+  std::pair<std::size_t, std::size_t> get_mem_info(cudaStream_t stream) const
+  {
     return do_get_mem_info(stream);
   }
 
@@ -174,8 +176,7 @@ class device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  virtual void do_deallocate(void* p, std::size_t bytes,
-                             cudaStream_t stream) = 0;
+  virtual void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) = 0;
 
   /**
    * @brief Compare this resource to another.
@@ -191,7 +192,8 @@ class device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  virtual bool do_is_equal(device_memory_resource const& other) const noexcept {
+  virtual bool do_is_equal(device_memory_resource const& other) const noexcept
+  {
     return this == &other;
   }
 
@@ -203,8 +205,7 @@ class device_memory_resource {
    * @param stream the stream being executed on
    * @return std::pair with available and free memory for resource
    */
-  virtual std::pair<std::size_t, std::size_t> do_get_mem_info(
-      cudaStream_t stream) const = 0;
+  virtual std::pair<std::size_t, std::size_t> do_get_mem_info(cudaStream_t stream) const = 0;
 };
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/device/fixed_multisize_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_multisize_memory_resource.hpp
@@ -15,22 +15,22 @@
  */
 #pragma once
 
+#include <rmm/detail/aligned.hpp>
+#include <rmm/detail/error.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/fixed_size_memory_resource.hpp>
-#include <rmm/detail/error.hpp>
-#include <rmm/detail/aligned.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 
 #include <cuda_runtime_api.h>
 
-#include <list>
-#include <unordered_map>
-#include <cstddef>
-#include <utility>
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <list>
 #include <memory>
+#include <unordered_map>
+#include <utility>
 
 #include <iostream>
 #include "thrust/iterator/transform_iterator.h"
@@ -45,45 +45,44 @@ namespace mr {
 namespace {
 
 // Integer pow function
-std::size_t ipow(std::size_t base, std::size_t exp) {
+std::size_t ipow(std::size_t base, std::size_t exp)
+{
   std::size_t ret = 1;
   while (exp > 0) {
     if (exp & 1) ret *= base;  // multiply the result by the current base
-    base *= base;    // square the base
-    exp = exp >> 1;  // divide the exponent in half
+    base *= base;              // square the base
+    exp = exp >> 1;            // divide the exponent in half
   }
   return ret;
 }
 
-} // namespace anonymous
-
+}  // namespace
 
 /**
  * @brief Allocates fixed-size memory blocks of a range of sizes.
- * 
- * Allocates blocks in the range `[min_size], max_size]` in power of two steps, 
+ *
+ * Allocates blocks in the range `[min_size], max_size]` in power of two steps,
  * where `min_size` and `max_size` are both powers of two.
- * 
+ *
  * @tparam UpstreamResource memory_resource to use for allocating the pool. Implements
  *                          rmm::mr::device_memory_resource interface.
  */
 template <typename Upstream>
 class fixed_multisize_memory_resource : public device_memory_resource {
  public:
-
   // Sizes are 2 << k, for k in [default_min_exponent, default_max_exponent]
-  static constexpr std::size_t default_size_base = 2; 
-  static constexpr std::size_t default_min_exponent = 18; // 256 KiB
-  static constexpr std::size_t default_max_exponent = 22; // 4 MiB
+  static constexpr std::size_t default_size_base    = 2;
+  static constexpr std::size_t default_min_exponent = 18;  // 256 KiB
+  static constexpr std::size_t default_max_exponent = 22;  // 4 MiB
 
   /**
    * @brief Construct a new fixed multisize memory resource object
-   * 
+   *
    * Allocates multiple fixed block sizes. The block sizes start at `size_base << min_size_exponent`
    * and grow by powers of `size_base` up to `size_base << max_size_exponent`. So, by default there
    * are 5 block sizes: 2 << 18 (256 KiB), 2 << 19 (512 KiB), 2 << 20 (1 MiB), 2 << 21 (2 MiB), and
    * 2 << 22 (4 MiB).
-   * 
+   *
    * @throws rmm::logic_error if size_base is not a power of two.
    *
    * @param upstream_resource The upstream memory resource used to allocate pools of blocks
@@ -93,20 +92,20 @@ class fixed_multisize_memory_resource : public device_memory_resource {
    * @param initial_blocks_per_size The number of blocks to preallocate from the upstream memory
    *        resource, and to allocate when all current blocks are in use.
    */
-  explicit fixed_multisize_memory_resource(
-      Upstream* upstream_resource,
-      std::size_t size_base = default_size_base,
-      std::size_t min_size_exponent = default_min_exponent,
-      std::size_t max_size_exponent = default_max_exponent,
-      std::size_t initial_blocks_per_size = 128)
-      : upstream_mr_{upstream_resource},
-        size_base_{size_base},
-        min_size_exponent_{min_size_exponent},
-        max_size_exponent_{max_size_exponent},
-        min_size_bytes_{ipow(size_base, min_size_exponent)},
-        max_size_bytes_{ipow(size_base, max_size_exponent)} {
+  explicit fixed_multisize_memory_resource(Upstream* upstream_resource,
+                                           std::size_t size_base         = default_size_base,
+                                           std::size_t min_size_exponent = default_min_exponent,
+                                           std::size_t max_size_exponent = default_max_exponent,
+                                           std::size_t initial_blocks_per_size = 128)
+    : upstream_mr_{upstream_resource},
+      size_base_{size_base},
+      min_size_exponent_{min_size_exponent},
+      max_size_exponent_{max_size_exponent},
+      min_size_bytes_{ipow(size_base, min_size_exponent)},
+      max_size_bytes_{ipow(size_base, max_size_exponent)}
+  {
     RMM_EXPECTS(rmm::detail::is_pow2(size_base), "size_base must be a power of two");
-    
+
     // allocate initial blocks and insert into free list
     for (std::size_t i = min_size_exponent_; i <= max_size_exponent_; i++) {
       fixed_size_mr_.emplace_back(new fixed_size_memory_resource<Upstream>(
@@ -119,7 +118,7 @@ class fixed_multisize_memory_resource : public device_memory_resource {
    *        upstream resource.
    */
   virtual ~fixed_multisize_memory_resource() {}
-    
+
   /**
    * @brief Query whether the resource supports use of non-null streams for
    * allocation/deallocation.
@@ -130,10 +129,10 @@ class fixed_multisize_memory_resource : public device_memory_resource {
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override {return false; }
+  bool supports_get_mem_info() const noexcept override { return false; }
 
   /**
    * @brief Get the upstream memory_resource object.
@@ -144,20 +143,19 @@ class fixed_multisize_memory_resource : public device_memory_resource {
 
   /**
    * @brief Get the minimum block size that this memory_resource can allocate.
-   * 
+   *
    * @return std::size_t The minimum block size this memory_resource can allocate.
    */
   std::size_t get_min_size() const noexcept { return min_size_bytes_; }
 
   /**
    * @brief Get the maximum block size that this memory_resource can allocate.
-   * 
+   *
    * @return std::size_t The maximum block size this memory_resource can allocate.
    */
   std::size_t get_max_size() const noexcept { return max_size_bytes_; }
 
  private:
-
   /**
    * @brief Get the memory resource for the requested size
    *
@@ -168,15 +166,18 @@ class fixed_multisize_memory_resource : public device_memory_resource {
    * @param bytes Requested allocation size in bytes
    * @return rmm::mr::device_memory_resource& memory_resource that can allocate the requested size.
    */
-  device_memory_resource* get_resource(std::size_t bytes) {
+  device_memory_resource* get_resource(std::size_t bytes)
+  {
     assert(bytes <= get_max_size());
 
     auto exponentiate = [this](std::size_t const& k) { return ipow(size_base_, k); };
-    auto min_exp = thrust::make_transform_iterator(
+    auto min_exp      = thrust::make_transform_iterator(
       thrust::make_counting_iterator(min_size_exponent_), exponentiate);
-      
-    auto iter = std::upper_bound(min_exp, min_exp + (max_size_exponent_ - min_size_exponent_),
-      bytes, [](std::size_t const& a, std::size_t const& b) { return a <= b; });
+
+    auto iter = std::upper_bound(min_exp,
+                                 min_exp + (max_size_exponent_ - min_size_exponent_),
+                                 bytes,
+                                 [](std::size_t const& a, std::size_t const& b) { return a <= b; });
 
     return fixed_size_mr_[std::distance(min_exp, iter)].get();
   }
@@ -192,7 +193,8 @@ class fixed_multisize_memory_resource : public device_memory_resource {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
     if (bytes <= 0) return nullptr;
     RMM_EXPECTS(bytes <= get_max_size(), rmm::bad_alloc, "bytes must be <= max_size");
     return get_resource(bytes)->allocate(bytes, stream);
@@ -208,7 +210,8 @@ class fixed_multisize_memory_resource : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override {
+  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
+  {
     auto res = get_resource(bytes);
     if (res != nullptr) res->deallocate(p, bytes, stream);
   }
@@ -221,17 +224,18 @@ class fixed_multisize_memory_resource : public device_memory_resource {
    * @param stream the stream being executed on
    * @return std::pair with available and free memory for resource
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info( cudaStream_t stream) const override {
-    return std::make_pair(0, 0);  
+  std::pair<std::size_t, std::size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
+    return std::make_pair(0, 0);
   }
 
   Upstream* upstream_mr_;  // The upstream memory_resource from which to allocate blocks.
 
-  std::size_t const size_base_;         // base of the allocation block sizes (power of 2)
-  std::size_t const min_size_exponent_; // exponent of the size of smallest blocks allocated
-  std::size_t const max_size_exponent_; // exponent of the size of largest blocks allocated
-  std::size_t const min_size_bytes_;    // minimum fixed size in bytes
-  std::size_t const max_size_bytes_;    // maximum fixed size in bytes
+  std::size_t const size_base_;          // base of the allocation block sizes (power of 2)
+  std::size_t const min_size_exponent_;  // exponent of the size of smallest blocks allocated
+  std::size_t const max_size_exponent_;  // exponent of the size of largest blocks allocated
+  std::size_t const min_size_bytes_;     // minimum fixed size in bytes
+  std::size_t const max_size_bytes_;     // maximum fixed size in bytes
 
   // allocators for fixed-size blocks <= max_fixed_size_
   std::vector<std::unique_ptr<fixed_size_memory_resource<Upstream>>> fixed_size_mr_;

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -15,20 +15,20 @@
  */
 #pragma once
 
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <cuda_runtime_api.h>
 
-#include <list>
-#include <map>
-#include <cstddef>
-#include <utility>
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <list>
+#include <map>
+#include <utility>
 
 namespace rmm {
 
@@ -36,50 +36,48 @@ namespace mr {
 
 /**
  * @brief A `device_memory_resource` which allocates memory blocks of a single fixed size.
- * 
+ *
  * Supports only allocations of size smaller than the configured block_size.
  */
 template <typename Upstream>
 class fixed_size_memory_resource : public device_memory_resource {
  public:
-
   // A block is the fixed size this resource alloates
-  static constexpr std::size_t default_block_size = 1<<20; // 1 MiB
-  // This is the number of blocks that the pool starts out with, and also the number of 
+  static constexpr std::size_t default_block_size = 1 << 20;  // 1 MiB
+  // This is the number of blocks that the pool starts out with, and also the number of
   // blocks by which the pool grows when all of its current blocks are allocated
   static constexpr std::size_t default_blocks_to_preallocate = 128;
   // The required alignment of this allocator
   static constexpr std::size_t allocation_alignment = 256;
 
   /**
-   * @brief Construct a new `fixed_size_memory_resource` that allocates memory from 
+   * @brief Construct a new `fixed_size_memory_resource` that allocates memory from
    * `upstream_resource`.
    *
    * When the pool of blocks is all allocated, grows the pool by allocating
    * `blocks_to_preallocate` more blocks from `upstream_mr`.
-   * 
+   *
    * @param upstream_mr The memory_resource from which to allocate blocks for the pool.
    * @param block_size The size of blocks to allocate.
    * @param blocks_to_preallocate The number of blocks to allocate to initialize the pool.
    */
   explicit fixed_size_memory_resource(
     Upstream* upstream_mr,
-    std::size_t block_size = default_block_size,
+    std::size_t block_size            = default_block_size,
     std::size_t blocks_to_preallocate = default_blocks_to_preallocate)
     : upstream_mr_{upstream_mr},
       block_size_{rmm::detail::align_up(block_size, allocation_alignment)},
-      upstream_chunk_size_{block_size * blocks_to_preallocate} {
+      upstream_chunk_size_{block_size * blocks_to_preallocate}
+  {
     // allocate initial blocks and insert into free list
     new_blocks_from_upstream(0, stream_blocks_[0]);
   }
 
   /**
    * @brief Destroy the `fixed_size_memory_resource` and free all memory allocated from upstream.
-   * 
+   *
    */
-  virtual ~fixed_size_memory_resource() {
-    release();
-  }
+  virtual ~fixed_size_memory_resource() { release(); }
 
   /**
    * @brief Query whether the resource supports use of non-null streams for
@@ -91,7 +89,7 @@ class fixed_size_memory_resource : public device_memory_resource {
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
   bool supports_get_mem_info() const noexcept override { return false; }
@@ -104,14 +102,13 @@ class fixed_size_memory_resource : public device_memory_resource {
   Upstream* get_upstream() const noexcept { return upstream_mr_; }
 
   /**
-   * @brief Get the size of blocks allocated by this memory resource. 
-   * 
+   * @brief Get the size of blocks allocated by this memory resource.
+   *
    * @return std::size_t size in bytes of allocated blocks.
    */
   std::size_t get_block_size() const noexcept { return block_size_; }
 
  private:
-
   // blocks are maintained in a simple list of pointers
   // Allocation is simply popping off the list, and freeing is pushing onto the back.
   using free_list = std::list<void*>;
@@ -127,7 +124,8 @@ class fixed_size_memory_resource : public device_memory_resource {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
     if (bytes <= 0) return nullptr;
     bytes = rmm::detail::align_up(bytes, allocation_alignment);
     RMM_EXPECTS(bytes <= block_size_, rmm::bad_alloc, "bytes must be <= block_size");
@@ -145,7 +143,8 @@ class fixed_size_memory_resource : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override {
+  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
+  {
     bytes = rmm::detail::align_up(bytes, allocation_alignment);
     assert(bytes <= block_size_);
     stream_blocks_[stream].push_back(p);
@@ -159,23 +158,23 @@ class fixed_size_memory_resource : public device_memory_resource {
    * @param stream the stream being executed on
    * @return std::pair with available and free memory for resource
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info( cudaStream_t stream) const override {
-    return std::make_pair(0, 0);  
+  std::pair<std::size_t, std::size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
+    return std::make_pair(0, 0);
   }
 
   /**
-   * @brief Find a free block in `free_list` `blocks` associated with stream `blocks_stream`, for 
+   * @brief Find a free block in `free_list` `blocks` associated with stream `blocks_stream`, for
    *        use on `stream`.
-   * 
+   *
    * @param blocks The `free_list` to look in for a free block.
    * @param blocks_stream The stream that all blocks in `blocks` are associated with.
    * @param stream The stream on which the allocation is being requested.
    * @return block A pointer to memory of `get_block_size()` bytes, or nullptr if no blocks are
    *               available in `blocks`.
    */
-  void* block_from_stream(free_list& blocks,
-                          cudaStream_t blocks_stream,
-                          cudaStream_t stream) {
+  void* block_from_stream(free_list& blocks, cudaStream_t blocks_stream, cudaStream_t stream)
+  {
     void* p = nullptr;
 
     if (!blocks.empty()) {
@@ -183,13 +182,13 @@ class fixed_size_memory_resource : public device_memory_resource {
       blocks.pop_front();
     }
 
-    // If we found a block associated with a different stream, 
+    // If we found a block associated with a different stream,
     // we have to synchronize the stream in order to use it
     if ((blocks_stream != stream) && (p != nullptr)) {
       cudaError_t result = cudaStreamSynchronize(blocks_stream);
 
-      if (result != cudaErrorInvalidResourceHandle && // stream deleted
-          result != cudaSuccess)                      // stream synced
+      if (result != cudaErrorInvalidResourceHandle &&  // stream deleted
+          result != cudaSuccess)                       // stream synced
         throw std::runtime_error{"cudaStreamSynchronize failure"};
 
       // insert all other blocks into this stream's list
@@ -206,16 +205,17 @@ class fixed_size_memory_resource : public device_memory_resource {
 
   /**
    * @brief Find an available block in the pool, for use on `stream`.
-   * 
+   *
    * Attempts to find a free block that was last used on `stream` to avoid synchronization. If none
    * is available, it finds a block last used on another stream. In this case, the stream associated
    * with the found block is synchronized to ensure all asynchronous work on the memory is finished
    * before it is used on `stream`.
-   * 
+   *
    * @param stream The stream on which the allocation will be used.
    * @return block A pointer to memory of size `get_block_size()`.
    */
-  void* get_block(cudaStream_t stream) {
+  void* get_block(cudaStream_t stream)
+  {
     // Try to find a block in the same stream
     auto iter = stream_blocks_.find(stream);
     if (iter != stream_blocks_.end()) {
@@ -233,7 +233,7 @@ class fixed_size_memory_resource : public device_memory_resource {
       }
       ++s;
     }
-    
+
     // nothing available in other streams, get new blocks
     // avoid searching for this stream's list again
     free_list* plist = (iter != stream_blocks_.end()) ? &iter->second : &stream_blocks_[stream];
@@ -242,27 +242,28 @@ class fixed_size_memory_resource : public device_memory_resource {
     return get_block(stream);
   }
 
-  // 
+  //
   /**
    * @brief Allocate new blocks from the upstream memory resource into `free list` `blocks`.
-   * 
+   *
    * @param stream The stream to associate the new blocks with.
    * @param blocks The `free_list` to insert the blocks into.
    */
-  void new_blocks_from_upstream(cudaStream_t stream, free_list& blocks) {
+  void new_blocks_from_upstream(cudaStream_t stream, free_list& blocks)
+  {
     void* p = upstream_mr_->allocate(upstream_chunk_size_, stream);
     upstream_blocks_.push_back(p);
 
     auto num_blocks = upstream_chunk_size_ / block_size_;
 
-    auto g = [p, this](int i) { return static_cast<char*>(p) + i * block_size_; };
-    auto first = thrust::make_transform_iterator(thrust::make_counting_iterator(std::size_t{0}), g); 
+    auto g     = [p, this](int i) { return static_cast<char*>(p) + i * block_size_; };
+    auto first = thrust::make_transform_iterator(thrust::make_counting_iterator(std::size_t{0}), g);
     blocks.insert(blocks.cend(), first, first + num_blocks);
   }
 
   /**
    * @brief free all memory allocated using the upstream resource.
-   * 
+   *
    */
   void release()
   {
@@ -274,8 +275,8 @@ class fixed_size_memory_resource : public device_memory_resource {
 
   Upstream* upstream_mr_;  // The resource from which to allocate new blocks
 
-  std::size_t const block_size_;          // size of blocks this MR allocates
-  std::size_t const upstream_chunk_size_; // size of chunks allocated from heap MR
+  std::size_t const block_size_;           // size of blocks this MR allocates
+  std::size_t const upstream_chunk_size_;  // size of chunks allocated from heap MR
 
   // stream free lists: map of [stream_id, free_list] pairs
   // stream stream_id must be synced before allocating from this list

--- a/include/rmm/mr/device/hybrid_memory_resource.hpp
+++ b/include/rmm/mr/device/hybrid_memory_resource.hpp
@@ -15,20 +15,19 @@
  */
 #pragma once
 
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda_runtime_api.h>
 
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
 #include <list>
 #include <memory>
 #include <unordered_map>
-#include <cstddef>
 #include <utility>
-#include <algorithm>
-#include <cassert>
-
 
 // forward decl
 using cudaStream_t = struct CUstream_st*;
@@ -41,40 +40,39 @@ namespace mr {
  * @brief Allocates memory from one of two allocators selected based on the requested size.
  *
  * For example, using a fixed_multisize_memory_resource for allocations below the size
- * threshold, and a pool_memory_resource for allocations above the size threshold. This can be 
- * advantageous if there are many small allocations, because fixed_multisize_memory_resource is much 
+ * threshold, and a pool_memory_resource for allocations above the size threshold. This can be
+ * advantageous if there are many small allocations, because fixed_multisize_memory_resource is much
  * faster than pool_memory_resource, and it can reduce fragmentation that can impact the
  * availability of large contiguous blocks of memory.
  *
  * @tparam SmallAllocMemoryResource the memory_resource type to use for small allocations.
  * @tparam LargeAllocMemoryResource the memory_resource type to use for large allocations.
  */
- template <typename SmallAllocMemoryResource, typename LargeAllocMemoryResource>
+template <typename SmallAllocMemoryResource, typename LargeAllocMemoryResource>
 class hybrid_memory_resource : public device_memory_resource {
  public:
-
   // The default size used to select between the two allocators.
-  static constexpr std::size_t default_threshold_size = 1 << 22; // 4 MiB
+  static constexpr std::size_t default_threshold_size = 1 << 22;  // 4 MiB
 
   /**
    * @brief Construct a new hybrid_memory_resource_object that selects between the two
    * specified memory_resources based on the `threshold_size`.
-   * 
+   *
    * @param small_mr The memory_resource to use for small allocations.
    * @param large_mr The memory_resource to use for large allocations.
    * @param threshold_size Allocations > this size (in bytes) use large_mr. Allocations <= this size
    *                       use small_mr.
    */
-  hybrid_memory_resource(
-    SmallAllocMemoryResource* small_mr,
-    LargeAllocMemoryResource* large_mr,
-    std::size_t threshold_size = default_threshold_size)
-  : small_mr_{small_mr}, large_mr_{large_mr}, threshold_size_{threshold_size} {
+  hybrid_memory_resource(SmallAllocMemoryResource* small_mr,
+                         LargeAllocMemoryResource* large_mr,
+                         std::size_t threshold_size = default_threshold_size)
+    : small_mr_{small_mr}, large_mr_{large_mr}, threshold_size_{threshold_size}
+  {
   }
 
   /**
    * @brief Destroy the hybrid-memory_resource object.
-   * 
+   *
    * @note since hybrid_memory_resource does not own its upstream memory_resources, this does not
    *       free any memory.
    */
@@ -90,38 +88,40 @@ class hybrid_memory_resource : public device_memory_resource {
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
   bool supports_get_mem_info() const noexcept override { return false; }
 
   /**
    * @brief Get the upstream memory_resource used for small allocations.
-   * 
+   *
    * @return SmallAllocMemoryResource* the upstream resource used for small allocations.
    */
   SmallAllocMemoryResource* get_small_mr() { return small_mr_; }
   /**
    * @brief Get the upstream memory_resource used for large allocations.
-   * 
+   *
    * @return LargeAllocMemoryResource* the upstream resource used for large allocations.
    */
   LargeAllocMemoryResource* get_large_mr() { return large_mr_; }
 
  private:
-
   /**
    * @brief Get the memory resource to use to allocate the requested size.
-   * 
+   *
    * Returns the small memory_resource if `bytes` is <= the threshold size, or the large
    * memory_resource otherwise.
    *
    * @param bytes Requested allocation size in bytes.
    * @return rmm::mr::device_memory_resource& memory_resource that can allocate the requested size.
    */
-  rmm::mr::device_memory_resource* get_resource(std::size_t bytes) {
-    if (bytes <= threshold_size_) return small_mr_;
-    else return large_mr_;
+  rmm::mr::device_memory_resource* get_resource(std::size_t bytes)
+  {
+    if (bytes <= threshold_size_)
+      return small_mr_;
+    else
+      return large_mr_;
   }
 
   /**
@@ -131,7 +131,8 @@ class hybrid_memory_resource : public device_memory_resource {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
     if (bytes <= 0) return nullptr;
     return get_resource(bytes)->allocate(bytes, stream);
   }
@@ -144,7 +145,8 @@ class hybrid_memory_resource : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override {
+  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
+  {
     get_resource(bytes)->deallocate(p, bytes, stream);
   }
 
@@ -156,14 +158,15 @@ class hybrid_memory_resource : public device_memory_resource {
    * @param stream the stream being executed on
    * @return std::pair with available and free memory for resource
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info( cudaStream_t stream) const override {
+  std::pair<std::size_t, std::size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
     return std::make_pair(0, 0);
   }
 
   std::size_t const threshold_size_;  // threshold for choosing memory_resource
 
-  SmallAllocMemoryResource *small_mr_; // allocator for <= max_small_size
-  LargeAllocMemoryResource *large_mr_; // allocator for > max_small_size
+  SmallAllocMemoryResource* small_mr_;  // allocator for <= max_small_size
+  LargeAllocMemoryResource* large_mr_;  // allocator for > max_small_size
 };
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -22,8 +22,8 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/ostream_sink.h>
 #include <spdlog/spdlog.h>
-#include <sstream>
 #include <memory>
+#include <sstream>
 
 namespace rmm {
 namespace mr {
@@ -60,14 +60,13 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param filename Name of file to write log info. If not specified, retrieves
    * the file name from the environment variable "RMM_LOG_FILE".
    */
-  logging_resource_adaptor(Upstream* upstream, std::string const& filename =
-                                                   get_default_filename())
-      : upstream_{upstream},
-        logger_{std::make_shared<spdlog::logger>(
-            "RMM", std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-                       filename, true /*truncate file*/))} {
-    RMM_EXPECTS(nullptr != upstream,
-                "Unexpected null upstream resource pointer.");
+  logging_resource_adaptor(Upstream* upstream, std::string const& filename = get_default_filename())
+    : upstream_{upstream},
+      logger_{std::make_shared<spdlog::logger>(
+        "RMM",
+        std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename, true /*truncate file*/))}
+  {
+    RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
 
     init_logger();
   }
@@ -85,11 +84,11 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param stream The ostream to write log info.
    */
   logging_resource_adaptor(Upstream* upstream, std::ostream& stream)
-      : upstream_{upstream},
-        logger_{std::make_shared<spdlog::logger>(
-            "RMM", std::make_shared<spdlog::sinks::ostream_sink_mt>(stream))} {
-    RMM_EXPECTS(nullptr != upstream,
-                "Unexpected null upstream resource pointer.");
+    : upstream_{upstream},
+      logger_{std::make_shared<spdlog::logger>(
+        "RMM", std::make_shared<spdlog::sinks::ostream_sink_mt>(stream))}
+  {
+    RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
 
     init_logger();
   }
@@ -107,13 +106,11 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @return true The upstream resource supports streams
    * @return false The upstream resource does not support streams.
    */
-  bool supports_streams() const noexcept override {
-    return upstream_->supports_streams();
-  }
+  bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool true if the upstream resource supports get_mem_info, false otherwise.
    */
   bool supports_get_mem_info() const noexcept override { return upstream_->supports_streams(); }
@@ -121,26 +118,28 @@ class logging_resource_adaptor final : public device_memory_resource {
  private:
   // make_logging_adaptor needs access to private get_default_filename
   template <typename T>
-  friend logging_resource_adaptor<T> make_logging_adaptor(
-      T* upstream, std::string const& filename);
+  friend logging_resource_adaptor<T> make_logging_adaptor(T* upstream, std::string const& filename);
 
   /**
    * @brief Return the value of the environment variable RMM_LOG_FILE.
-   * 
+   *
    * @throws `rmm::logic_error` if `RMM_LOG_FILE` is not set.
-   * 
+   *
    * @return The value of RMM_LOG_FILE as `std::string`.
    */
-  static std::string get_default_filename() {
+  static std::string get_default_filename()
+  {
     auto filename = std::getenv("RMM_LOG_FILE");
-    RMM_EXPECTS(filename != nullptr, "RMM logging requested without an explicit file name, but RMM_LOG_FILE is unset");
+    RMM_EXPECTS(filename != nullptr,
+                "RMM logging requested without an explicit file name, but RMM_LOG_FILE is unset");
     return std::string{filename};
   }
 
   /**
    * @brief Initialize the logger.
    */
-  void init_logger() const {
+  void init_logger() const
+  {
     auto const csv_header{"Time,Action,Pointer,Size,Stream"};
     logger_->set_pattern("%v");
     logger_->info(csv_header);
@@ -166,7 +165,8 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
     auto const p = upstream_->allocate(bytes, stream);
     std::string msg{"allocate,"};
     std::stringstream ss;
@@ -196,7 +196,8 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override {
+  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
+  {
     std::string msg{"free,"};
     std::stringstream ss;
     ss << p;
@@ -218,12 +219,13 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const &other) const noexcept override {
+  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  {
     if (this == &other)
       return true;
     else {
-      logging_resource_adaptor<Upstream> const *cast =
-          dynamic_cast<logging_resource_adaptor<Upstream> const *>(&other);
+      logging_resource_adaptor<Upstream> const* cast =
+        dynamic_cast<logging_resource_adaptor<Upstream> const*>(&other);
       if (cast != nullptr)
         return upstream_->is_equal(*cast->get_upstream());
       else
@@ -239,7 +241,8 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override {
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
     return upstream_->get_mem_info(stream);
   }
 
@@ -260,9 +263,9 @@ class logging_resource_adaptor final : public device_memory_resource {
  */
 template <typename Upstream>
 logging_resource_adaptor<Upstream> make_logging_adaptor(
-    Upstream* upstream,
-    std::string const& filename =
-        logging_resource_adaptor<Upstream>::get_default_filename()) {
+  Upstream* upstream,
+  std::string const& filename = logging_resource_adaptor<Upstream>::get_default_filename())
+{
   return logging_resource_adaptor<Upstream>{upstream, filename};
 }
 
@@ -275,7 +278,8 @@ logging_resource_adaptor<Upstream> make_logging_adaptor(
  * @param stream The ostream to write log info.
  */
 template <typename Upstream>
-logging_resource_adaptor<Upstream> make_logging_adaptor(Upstream* upstream, std::ostream& stream) {
+logging_resource_adaptor<Upstream> make_logging_adaptor(Upstream* upstream, std::ostream& stream)
+{
   return logging_resource_adaptor<Upstream>{upstream, stream};
 }
 

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -32,7 +32,6 @@ namespace mr {
  */
 class managed_memory_resource final : public device_memory_resource {
  public:
-
   /**
    * @brief Query whether the resource supports use of non-null streams for
    * allocation/deallocation.
@@ -43,10 +42,10 @@ class managed_memory_resource final : public device_memory_resource {
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override {return true; }
+  bool supports_get_mem_info() const noexcept override { return true; }
 
  private:
   /**
@@ -61,12 +60,11 @@ class managed_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t) override
+  {
     // FIXME: Unlike cudaMalloc, cudaMallocManaged will throw an error for 0
     // size allocations.
-    if (bytes == 0) {
-      return nullptr;
-    }
+    if (bytes == 0) { return nullptr; }
 
     void* p{nullptr};
     RMM_CUDA_TRY(cudaMallocManaged(&p, bytes), rmm::bad_alloc);
@@ -82,7 +80,8 @@ class managed_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, cudaStream_t) override {
+  void do_deallocate(void* p, std::size_t, cudaStream_t) override
+  {
     cudaError_t const status = cudaFree(p);
     assert(cudaSuccess == status);
   }
@@ -99,7 +98,8 @@ class managed_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override {
+  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  {
     return dynamic_cast<managed_memory_resource const*>(&other) != nullptr;
   }
 
@@ -111,7 +111,8 @@ class managed_memory_resource final : public device_memory_resource {
    * @param stream to execute on
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override {
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
     std::size_t free_size{};
     std::size_t total_size{};
     RMM_CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -15,21 +15,21 @@
  */
 #pragma once
 
-#include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/mr/device/detail/free_list.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/mr/device/detail/free_list.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda_runtime_api.h>
 
+#include <algorithm>
 #include <cassert>
 #include <exception>
 #include <iostream>
 #include <list>
-#include <set>
 #include <map>
-#include <numeric>
-#include <algorithm>
 #include <mutex>
+#include <numeric>
+#include <set>
 
 namespace rmm {
 namespace mr {
@@ -37,14 +37,13 @@ namespace mr {
 /**
  * @brief A coalescing best-fit suballocator which uses a pool of memory allocated from
  *        an upstream memory_resource.
- * 
+ *
  * @tparam UpstreamResource memory_resource to use for allocating the pool. Implements
  *                          rmm::mr::device_memory_resource interface.
  */
 template <typename Upstream>
 class pool_memory_resource final : public device_memory_resource {
  public:
-
   static constexpr size_t default_initial_size = ~0;
   static constexpr size_t default_maximum_size = ~0;
   // TODO use rmm-level def of this.
@@ -59,25 +58,21 @@ class pool_memory_resource final : public device_memory_resource {
    * zero, an implementation-defined pool size is used.
    * @param maximum_pool_size Maximum size, in bytes, that the pool can grow to.
    */
-  explicit pool_memory_resource(
-      Upstream* upstream_mr,
-      std::size_t initial_pool_size = default_initial_size,
-      std::size_t maximum_pool_size = default_maximum_size)
-      : upstream_mr_{upstream_mr},
-        maximum_pool_size_{maximum_pool_size} {
+  explicit pool_memory_resource(Upstream* upstream_mr,
+                                std::size_t initial_pool_size = default_initial_size,
+                                std::size_t maximum_pool_size = default_maximum_size)
+    : upstream_mr_{upstream_mr}, maximum_pool_size_{maximum_pool_size}
+  {
     cudaDeviceProp props;
     int device{0};
     RMM_CUDA_TRY(cudaGetDevice(&device));
     RMM_CUDA_TRY(cudaGetDeviceProperties(&props, device));
 
-    if (initial_pool_size == default_initial_size) {
-      initial_pool_size = props.totalGlobalMem / 2;
-    }
+    if (initial_pool_size == default_initial_size) { initial_pool_size = props.totalGlobalMem / 2; }
 
     initial_pool_size = rmm::detail::align_up(initial_pool_size, allocation_alignment);
 
-    if (maximum_pool_size == default_maximum_size)
-        maximum_pool_size_ = props.totalGlobalMem;
+    if (maximum_pool_size == default_maximum_size) maximum_pool_size_ = props.totalGlobalMem;
 
     // Allocate initial block
     stream_free_blocks_[0].insert(block_from_upstream(initial_pool_size, 0));
@@ -87,9 +82,7 @@ class pool_memory_resource final : public device_memory_resource {
    * @brief Destroy the `pool_memory_resource` and deallocate all memory it allocated using
    * the upstream resource.
    */
-  ~pool_memory_resource() {
-    release();
-  }
+  ~pool_memory_resource() { release(); }
 
   /**
    * @brief Queries whether the resource supports use of non-null CUDA streams for
@@ -101,10 +94,10 @@ class pool_memory_resource final : public device_memory_resource {
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool false
    */
-  bool supports_get_mem_info() const noexcept override {return false; }
+  bool supports_get_mem_info() const noexcept override { return false; }
 
   /**
    * @brief Get the upstream memory_resource object.
@@ -114,36 +107,37 @@ class pool_memory_resource final : public device_memory_resource {
   Upstream* get_upstream() const noexcept { return upstream_mr_; }
 
  private:
-
-  using block = rmm::mr::detail::block;
+  using block     = rmm::mr::detail::block;
   using free_list = rmm::mr::detail::free_list<>;
 
   /**
    * @brief Find a free block of at least `size` bytes in `free_list` `blocks` associated with
    *        stream `blocks_stream`, for use on `stream`.
-   * 
+   *
    * @param blocks The `free_list` to look in for a free block of sufficient size.
    * @param blocks_stream The stream that all blocks in `blocks` are associated with.
    * @param size The requested size of the allocation.
-   
+
    * @param stream The stream on which the allocation is being requested.
-   * @return block A block with non-null pointer and size >= `size`, or a nullptr block if none is 
+   * @return block A block with non-null pointer and size >= `size`, or a nullptr block if none is
    *               available in `blocks`.
    */
   block block_from_stream(free_list& blocks,
                           cudaStream_t blocks_stream,
                           size_t size,
-                          cudaStream_t stream) {
-    block const b = blocks.best_fit(size); // get the best fit block
+                          cudaStream_t stream)
+  {
+    block const b = blocks.best_fit(size);  // get the best fit block
 
-    // If we found a block associated with a different stream, 
+    // If we found a block associated with a different stream,
     // we have to synchronize the stream in order to use it
-    if ((blocks_stream != stream) && (b.ptr != nullptr)) { 
+    if ((blocks_stream != stream) && (b.ptr != nullptr)) {
       cudaError_t result = cudaStreamSynchronize(blocks_stream);
 
-      RMM_EXPECTS((result == cudaSuccess ||                   // stream synced
-                   result == cudaErrorInvalidResourceHandle), // stream deleted
-                  rmm::bad_alloc, "cudaStreamSynchronize failure");
+      RMM_EXPECTS((result == cudaSuccess ||                    // stream synced
+                   result == cudaErrorInvalidResourceHandle),  // stream deleted
+                  rmm::bad_alloc,
+                  "cudaStreamSynchronize failure");
 
       // Now that this stream is synced, insert all other blocks into this stream's list
       // Note: This could cause thrashing between two streams. On the other hand, it reduces
@@ -158,17 +152,18 @@ class pool_memory_resource final : public device_memory_resource {
 
   /**
    * @brief Find an available block in the pool of at least `size` bytes, for use on `stream`.
-   * 
+   *
    * Attempts to find a free block that was last used on `stream` to avoid synchronization. If none
    * is available, it finds a block last used on another stream. In this case, the stream associated
    * with the found block is synchronized to ensure all asynchronous work on the memory is finished
    * before it is used on `stream`.
-   * 
+   *
    * @param size The size of the requested allocation, in bytes.
    * @param stream The stream on which the allocation will be used.
    * @return block A block with non-null pointer and size >= `size`.
    */
-  block available_larger_block(size_t size, cudaStream_t stream) {
+  block available_larger_block(size_t size, cudaStream_t stream)
+  {
     // Try to find a larger block in free list for the same stream
     auto iter = stream_free_blocks_.find(stream);
     if (iter != stream_free_blocks_.end()) {
@@ -196,7 +191,7 @@ class pool_memory_resource final : public device_memory_resource {
    * @brief Splits block `b` if necessary to return a pointer to memory of `size` bytes.
    *
    * If the block is split, the remainder is returned to the pool.
-   * 
+   *
    * @param b The block to allocate from.
    * @param size The size in bytes of the requested allocation.
    * @param stream The stream on which the allocation will be used.
@@ -206,8 +201,7 @@ class pool_memory_resource final : public device_memory_resource {
   {
     block const alloc{b.ptr, size, b.is_head};
 
-    if (b.size > size)
-    {
+    if (b.size > size) {
       block rest{b.ptr + size, b.size - size, false};
       stream_free_blocks_[stream].insert(rest);
     }
@@ -218,12 +212,12 @@ class pool_memory_resource final : public device_memory_resource {
 
   /**
    * @brief Frees the block associated with pointer `p`, returning it to the pool.
-   * 
+   *
    * @param p The pointer to the memory to free.
    * @param size The size of the memory to free. Must be equal to the original allocation size.
    * @param stream The stream on which the memory was last used.
    */
-  void free_block(void *p, size_t size, cudaStream_t stream)
+  void free_block(void* p, size_t size, cudaStream_t stream)
   {
     if (p == nullptr) return;
 
@@ -237,25 +231,30 @@ class pool_memory_resource final : public device_memory_resource {
 
   /**
    * @brief Given a minimum size, computes an appropriate size to grow the pool.
-   * 
+   *
    * Current strategy is to try to grow the pool by half the difference between
    * the configured maximum pool size and the current pool size.
-   * 
+   *
    * @param size The size of the minimum allocation immediately needed
    * @return size_t The computed size to grow the pool.
    */
-  size_t size_to_grow(size_t size) const {
-    auto const remaining = rmm::detail::align_up(maximum_pool_size_ - pool_size(),
-                                                 allocation_alignment);
+  size_t size_to_grow(size_t size) const
+  {
+    auto const remaining =
+      rmm::detail::align_up(maximum_pool_size_ - pool_size(), allocation_alignment);
     auto const aligned_size = rmm::detail::align_up(size, allocation_alignment);
-    if (aligned_size <= remaining / 2) { return remaining / 2; }
-    else if (aligned_size <= remaining) { return remaining; }
-    else { return 0; }
+    if (aligned_size <= remaining / 2) {
+      return remaining / 2;
+    } else if (aligned_size <= remaining) {
+      return remaining;
+    } else {
+      return 0;
+    }
   };
 
   /**
    * @brief Allocates memory of `size` bytes using the upstream memory_resource, on `stream`.
-   * 
+   *
    * @param size The size of the requested allocation.
    * @param stream The stream on which the requested allocation will be used.
    * @return block A block of at least `size` bytes.
@@ -271,16 +270,16 @@ class pool_memory_resource final : public device_memory_resource {
 
   /**
    * @brief Computes the size of the current pool
-   * 
+   *
    * Includes allocated as well as free memory.
-   * 
+   *
    * @return size_t The total size of the currently allocated pool.
    */
   size_t pool_size() const noexcept { return current_pool_size_; }
 
   /**
    * @brief Free all memory allocated from the upstream memory_resource.
-   * 
+   *
    */
   void release()
   {
@@ -293,9 +292,10 @@ class pool_memory_resource final : public device_memory_resource {
 #ifndef NDEBUG
   /**
    * @brief Print debugging information about all blocks in the pool.
-   * 
+   *
    */
-  void print() {
+  void print()
+  {
     std::size_t free, total;
     std::tie(free, total) = upstream_mr_->get_mem_info(0);
     std::cout << "GPU free memory: " << free << "total: " << total << "\n";
@@ -303,14 +303,16 @@ class pool_memory_resource final : public device_memory_resource {
     std::cout << "upstream_blocks: " << upstream_blocks_.size() << "\n";
     std::size_t upstream_total{0};
 
-    for (auto h : upstream_blocks_) { 
+    for (auto h : upstream_blocks_) {
       h.print();
       upstream_total += h.size;
     }
     std::cout << "total upstream: " << upstream_total << " B\n";
 
     std::cout << "allocated_blocks: " << allocated_blocks_.size() << "\n";
-    for (auto b : allocated_blocks_) { b.print(); }
+    for (auto b : allocated_blocks_) {
+      b.print();
+    }
 
     std::cout << "sync free blocks: ";
     for (auto s : stream_free_blocks_) {
@@ -319,7 +321,7 @@ class pool_memory_resource final : public device_memory_resource {
     }
     std::cout << "\n";
   }
-#endif // DEBUG
+#endif  // DEBUG
 
   /**
    * @brief Allocates memory of size at least \p bytes.
@@ -332,9 +334,10 @@ class pool_memory_resource final : public device_memory_resource {
    * @param The stream to associate this allocation with
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
     if (bytes <= 0) return nullptr;
-    bytes = rmm::detail::align_up(bytes, allocation_alignment);
+    bytes         = rmm::detail::align_up(bytes, allocation_alignment);
     block const b = available_larger_block(bytes, stream);
     return allocate_from_block(b, bytes, stream);
   }
@@ -346,7 +349,8 @@ class pool_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override {
+  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
+  {
     free_block(p, bytes, stream);
   }
 
@@ -358,7 +362,8 @@ class pool_memory_resource final : public device_memory_resource {
    * @param stream to execute on
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<size_t,size_t> do_get_mem_info( cudaStream_t stream) const override {
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
     std::size_t free_size{};
     std::size_t total_size{};
     // TODO implement this

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <mutex>
 
@@ -28,13 +28,12 @@ namespace mr {
  * An instance of this resource can be constructured with an existing, upstream resource in order
  * to satisfy allocation requests. This adaptor wraps allocations and deallocations from Upstream
  * in a mutex lock.
- * 
+ *
  * @tparam Upstream Type of the upstream resource used for allocation/deallocation.
  */
 template <typename Upstream>
 class thread_safe_resource_adaptor final : public device_memory_resource {
  public:
-
   using lock_t = std::lock_guard<std::mutex>;
 
   /**
@@ -47,26 +46,26 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    *
    * @param upstream The resource used for allocating/deallocating device memory.
    */
-  thread_safe_resource_adaptor(Upstream* upstream)
-   : upstream_{upstream} {
+  thread_safe_resource_adaptor(Upstream* upstream) : upstream_{upstream}
+  {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
   }
 
   /**
-  * @brief Get the upstream memory resource.
-  * 
-  * @return Upstream* pointer to a memory resource object.
-  */
+   * @brief Get the upstream memory resource.
+   *
+   * @return Upstream* pointer to a memory resource object.
+   */
   Upstream* get_upstream() const noexcept { return upstream_; }
 
   /**
-  * @copydoc rmm::mr::device_memory_resource::supports_streams()
-  */
+   * @copydoc rmm::mr::device_memory_resource::supports_streams()
+   */
   bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
-   * 
+   *
    * @return bool true if the upstream resource supports get_mem_info, false otherwise.
    */
   bool supports_get_mem_info() const noexcept override { return upstream_->supports_streams(); }
@@ -83,7 +82,8 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cudaStream_t stream) override {
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
     lock_t lock(mtx);
     return upstream_->allocate(bytes, stream);
   }
@@ -98,7 +98,8 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override {
+  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
+  {
     lock_t lock(mtx);
     upstream_->deallocate(p, bytes, stream);
   }
@@ -112,14 +113,16 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equivalent
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override {
-
-    if (this == &other) return true;
+  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  {
+    if (this == &other)
+      return true;
     else {
       auto thread_safe_other = dynamic_cast<thread_safe_resource_adaptor<Upstream> const*>(&other);
-      if (thread_safe_other != nullptr) 
+      if (thread_safe_other != nullptr)
         return upstream_->is_equal(*thread_safe_other->get_upstream());
-      else return upstream_->is_equal(other);
+      else
+        return upstream_->is_equal(other);
     }
   }
 
@@ -131,13 +134,14 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override {
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
     lock_t lock(mtx);
     return upstream_->get_mem_info(stream);
   }
 
-  std::mutex mutable mtx; // mutex for thread safe access to upstream
-  Upstream* upstream_;  ///< The upstream resource used for satisfying allocation requests
+  std::mutex mutable mtx;  // mutex for thread safe access to upstream
+  Upstream* upstream_;     ///< The upstream resource used for satisfying allocation requests
 };
 
 }  // namespace mr

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -37,8 +37,8 @@ namespace mr {
 template <typename T>
 class thrust_allocator : public thrust::device_malloc_allocator<T> {
  public:
-  using Base = thrust::device_malloc_allocator<T>;
-  using pointer = typename Base::pointer;
+  using Base      = thrust::device_malloc_allocator<T>;
+  using pointer   = typename Base::pointer;
   using size_type = typename Base::size_type;
 
   /**
@@ -73,8 +73,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @param mr The resource to be used for device memory allocation
    * @param stream The stream to be used for device memory (de)allocation
    */
-  thrust_allocator(device_memory_resource* mr, cudaStream_t stream)
-      : _mr(mr), _stream{stream} {}
+  thrust_allocator(device_memory_resource* mr, cudaStream_t stream) : _mr(mr), _stream{stream} {}
 
   /**
    * @brief Copy constructor. Copies the resource pointer and stream.
@@ -83,7 +82,9 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    */
   template <typename U>
   thrust_allocator(thrust_allocator<U> const& other)
-      : _mr(other.resource()), _stream{other.stream()} {}
+    : _mr(other.resource()), _stream{other.stream()}
+  {
+  }
 
   /**
    * @brief Allocate objects of type `T`
@@ -91,9 +92,9 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @param n  The number of elements of type `T` to allocate
    * @return pointer Pointer to the newly allocated storage
    */
-  pointer allocate(size_type n) {
-    return thrust::device_pointer_cast(
-        static_cast<T*>(_mr->allocate(n * sizeof(T), _stream)));
+  pointer allocate(size_type n)
+  {
+    return thrust::device_pointer_cast(static_cast<T*>(_mr->allocate(n * sizeof(T), _stream)));
   }
 
   /**
@@ -103,7 +104,8 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @param n number of elements, *must* be equal to the argument passed to the
    * prior `allocate` call that produced `p`
    */
-  void deallocate(pointer p, size_type n) {
+  void deallocate(pointer p, size_type n)
+  {
     return _mr->deallocate(thrust::raw_pointer_cast(p), n * sizeof(T), _stream);
   }
 

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -46,7 +46,7 @@ namespace mr {
  *---------------------------------------------------------------------------**/
 class host_memory_resource {
  public:
-  host_memory_resource() = default;
+  host_memory_resource()          = default;
   virtual ~host_memory_resource() = default;
 
   /**---------------------------------------------------------------------------*
@@ -62,8 +62,8 @@ class host_memory_resource {
    * @param alignment Alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    *---------------------------------------------------------------------------**/
-  void* allocate(std::size_t bytes,
-                 std::size_t alignment = alignof(std::max_align_t)) {
+  void* allocate(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
+  {
     return do_allocate(bytes, alignment);
   }
 
@@ -85,8 +85,8 @@ class host_memory_resource {
    *`p`.
    * @param stream Stream on which to perform deallocation
    *---------------------------------------------------------------------------**/
-  void deallocate(void* p, std::size_t bytes,
-                  std::size_t alignment = alignof(std::max_align_t)) {
+  void deallocate(void* p, std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
+  {
     do_deallocate(p, bytes, alignment);
   }
 
@@ -103,9 +103,7 @@ class host_memory_resource {
    * @param other The other resource to compare to
    * @returns If the two resources are equivalent
    *---------------------------------------------------------------------------**/
-  bool is_equal(host_memory_resource const& other) const noexcept {
-    return do_is_equal(other);
-  }
+  bool is_equal(host_memory_resource const& other) const noexcept { return do_is_equal(other); }
 
  private:
   /**---------------------------------------------------------------------------*
@@ -121,8 +119,8 @@ class host_memory_resource {
    * @param alignment Alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    *---------------------------------------------------------------------------**/
-  virtual void* do_allocate(
-      std::size_t bytes, std::size_t alignment = alignof(std::max_align_t)) = 0;
+  virtual void* do_allocate(std::size_t bytes,
+                            std::size_t alignment = alignof(std::max_align_t)) = 0;
 
   /**---------------------------------------------------------------------------*
    * @brief Deallocate memory pointed to by `p`.
@@ -142,9 +140,9 @@ class host_memory_resource {
    *`p`.
    * @param stream Stream on which to perform deallocation
    *---------------------------------------------------------------------------**/
-  virtual void do_deallocate(
-      void* p, std::size_t bytes,
-      std::size_t alignment = alignof(std::max_align_t)) = 0;
+  virtual void do_deallocate(void* p,
+                             std::size_t bytes,
+                             std::size_t alignment = alignof(std::max_align_t)) = 0;
 
   /**---------------------------------------------------------------------------*
    * @brief Compare this resource to another.
@@ -160,7 +158,8 @@ class host_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    *---------------------------------------------------------------------------**/
-  virtual bool do_is_equal(host_memory_resource const& other) const noexcept {
+  virtual bool do_is_equal(host_memory_resource const& other) const noexcept
+  {
     return this == &other;
   }
 };

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -44,21 +44,19 @@ class new_delete_resource final : public host_memory_resource {
    * @param alignment Alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    *---------------------------------------------------------------------------**/
-  void *do_allocate(
-      std::size_t bytes,
-      std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override {
+  void *do_allocate(std::size_t bytes,
+                    std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
+  {
 #if __cplusplus >= 201703L
     return ::operator new(bytes, std::align_val_t(alignment));
 #else
 
     // If the requested alignment isn't supported, use default
-    alignment = (detail::is_supported_alignment(alignment))
-                    ? alignment
-                    : detail::RMM_DEFAULT_HOST_ALIGNMENT;
+    alignment =
+      (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
-    return detail::aligned_allocate(bytes, alignment, [](std::size_t size) {
-      return ::operator new(size);
-    });
+    return detail::aligned_allocate(
+      bytes, alignment, [](std::size_t size) { return ::operator new(size); });
 #endif
   }
 
@@ -80,14 +78,14 @@ class new_delete_resource final : public host_memory_resource {
    *`p`.
    * @param stream Stream on which to perform deallocation
    *---------------------------------------------------------------------------**/
-  void do_deallocate(
-      void *p, std::size_t bytes,
-      std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override {
+  void do_deallocate(void *p,
+                     std::size_t bytes,
+                     std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
+  {
 #if __cplusplus >= 201703L
     ::operator delete(p, bytes, std::align_val_t(alignment));
 #else
-    detail::aligned_deallocate(p, bytes, alignment,
-                               [](void *p) { ::operator delete(p); });
+    detail::aligned_deallocate(p, bytes, alignment, [](void *p) { ::operator delete(p); });
 #endif
   }
 };

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -45,24 +45,19 @@ class pinned_memory_resource final : public host_memory_resource {
    * @param alignment Alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    *---------------------------------------------------------------------------**/
-  void *do_allocate(std::size_t bytes, std::size_t alignment =
-                                           alignof(std::max_align_t)) override {
+  void *do_allocate(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t)) override
+  {
     // don't allocate anything if the user requested zero bytes
-    if (0 == bytes) {
-      return nullptr;
-    }
+    if (0 == bytes) { return nullptr; }
 
     // If the requested alignment isn't supported, use default
-    alignment = (detail::is_supported_alignment(alignment))
-                    ? alignment
-                    : detail::RMM_DEFAULT_HOST_ALIGNMENT;
+    alignment =
+      (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
     return detail::aligned_allocate(bytes, alignment, [](std::size_t size) {
       void *p{nullptr};
       auto status = cudaMallocHost(&p, size);
-      if (cudaSuccess != status) {
-        throw std::bad_alloc{};
-      }
+      if (cudaSuccess != status) { throw std::bad_alloc{}; }
       return p;
     });
   }
@@ -85,13 +80,12 @@ class pinned_memory_resource final : public host_memory_resource {
    *`p`.
    * @param stream Stream on which to perform deallocation
    *---------------------------------------------------------------------------**/
-  void do_deallocate(
-      void *p, std::size_t bytes,
-      std::size_t alignment = alignof(std::max_align_t)) override {
+  void do_deallocate(void *p,
+                     std::size_t bytes,
+                     std::size_t alignment = alignof(std::max_align_t)) override
+  {
     (void)alignment;
-    if (nullptr == p) {
-      return;
-    }
+    if (nullptr == p) { return; }
     detail::aligned_deallocate(p, bytes, alignment, [](void *p) {
       auto status = cudaFreeHost(p);
       assert(status == cudaSuccess);

--- a/include/rmm/rmm.h
+++ b/include/rmm/rmm.h
@@ -10,12 +10,11 @@
  * @brief Device memory alloc / realloc / free macros that pass the calling file
  * and line number to RMM for tracking.
  * ---------------------------------------------------------------------------**/
-#define RMM_ALLOC(ptr, sz, stream) \
-  rmm::alloc((ptr), (sz), (stream), __FILE__, __LINE__)
+#define RMM_ALLOC(ptr, sz, stream) rmm::alloc((ptr), (sz), (stream), __FILE__, __LINE__)
 
-//#define RMM_REALLOC(ptr, new_sz, stream) 
+//#define RMM_REALLOC(ptr, new_sz, stream)
 //  rmm::realloc((ptr), (new_sz), (stream), __FILE__, __LINE__)
 
 #define RMM_FREE(ptr, stream) rmm::free((ptr), (stream), __FILE__, __LINE__)
 
-#endif // RMM_H
+#endif  // RMM_H

--- a/include/rmm/rmm.hpp
+++ b/include/rmm/rmm.hpp
@@ -44,16 +44,21 @@ constexpr bool RMM_USAGE_LOGGING{false};
 // RAII logger class
 class LogIt {
  public:
-  LogIt(Logger::MemEvent_t event, void* ptr, size_t size, cudaStream_t stream,
-        const char* filename, unsigned int line,
+  LogIt(Logger::MemEvent_t event,
+        void* ptr,
+        size_t size,
+        cudaStream_t stream,
+        const char* filename,
+        unsigned int line,
         bool usageLogging = RMM_USAGE_LOGGING)
-      : event(event),
-        device(0),
-        ptr(ptr),
-        size(size),
-        stream(stream),
-        line(line),
-        usageLogging(usageLogging) {
+    : event(event),
+      device(0),
+      ptr(ptr),
+      size(size),
+      stream(stream),
+      line(line),
+      usageLogging(usageLogging)
+  {
     if (filename) file = filename;
     if (Manager::getOptions().enable_logging) {
       RMM_CUDA_TRY(cudaGetDevice(&device));
@@ -63,17 +68,19 @@ class LogIt {
 
   /// Sometimes you need to start logging before the pointer address is
   /// known
-  inline void setPointer(void* p) {
+  inline void setPointer(void* p)
+  {
     if (Manager::getOptions().enable_logging) ptr = p;
   }
 
-  ~LogIt() {
+  ~LogIt()
+  {
     if (Manager::getOptions().enable_logging) {
       Logger::TimePt end = std::chrono::system_clock::now();
       size_t freeMem = 0, totalMem = 0;
       if (usageLogging) rmmGetInfo(&freeMem, &totalMem, stream);
-      Manager::getLogger().record(event, device, ptr, start, end, freeMem,
-                                  totalMem, size, stream, file, line);
+      Manager::getLogger().record(
+        event, device, ptr, start, end, freeMem, totalMem, size, stream, file, line);
     }
   }
 
@@ -104,8 +111,9 @@ class LogIt {
  *                    requested size, or RMM_CUDA_ERROR on any other CUDA error.
  */
 template <typename T>
-[[deprecated]] inline rmmError_t alloc(T** ptr, size_t size, cudaStream_t stream,
-                        const char* file, unsigned int line) {
+[[deprecated]] inline rmmError_t alloc(
+  T** ptr, size_t size, cudaStream_t stream, const char* file, unsigned int line)
+{
   if (!rmmIsInitialized(nullptr)) {
     if (ptr) *ptr = nullptr;
     return RMM_ERROR_NOT_INITIALIZED;
@@ -113,15 +121,12 @@ template <typename T>
 
   rmm::LogIt log(rmm::Logger::Alloc, 0, size, stream, file, line);
 
-  if (!ptr && !size) {
-    return RMM_SUCCESS;
-  }
+  if (!ptr && !size) { return RMM_SUCCESS; }
 
   if (!ptr) return RMM_ERROR_INVALID_ARGUMENT;
 
   try {
-    *ptr = static_cast<T*>(
-        rmm::mr::get_default_resource()->allocate(size, stream));
+    *ptr = static_cast<T*>(rmm::mr::get_default_resource()->allocate(size, stream));
 
   } catch (std::exception const& e) {
     *ptr = nullptr;
@@ -189,8 +194,11 @@ inline rmmError_t realloc(T** ptr, size_t new_size, cudaStream_t stream,
  *                    has not been called,or RMM_ERROR_CUDA_ERROR on any CUDA
  *                    error.
  */
-[[deprecated]] inline rmmError_t free(void* ptr, cudaStream_t stream, const char* file,
-                       unsigned int line) {
+[[deprecated]] inline rmmError_t free(void* ptr,
+                                      cudaStream_t stream,
+                                      const char* file,
+                                      unsigned int line)
+{
   if (!rmmIsInitialized(nullptr)) return RMM_ERROR_NOT_INITIALIZED;
 
   rmm::LogIt log(rmm::Logger::Free, ptr, 0, stream, file, line);

--- a/include/rmm/rmm_api.h
+++ b/include/rmm/rmm_api.h
@@ -30,16 +30,15 @@ typedef struct CUstream_st *cudaStream_t;
 /** ---------------------------------------------------------------------------*
  * @brief RMM error codes
  * --------------------------------------------------------------------------**/
-typedef enum
-{
-  RMM_SUCCESS = 0,            //< Success result
-  RMM_ERROR_CUDA_ERROR,       //< A CUDA error occurred
-  RMM_ERROR_INVALID_ARGUMENT, //< An invalid argument was passed (e.g.null pointer)
-  RMM_ERROR_NOT_INITIALIZED,  //< RMM API called before rmmInitialize()
-  RMM_ERROR_OUT_OF_MEMORY,    //< The memory manager was unable to allocate more memory
-  RMM_ERROR_UNKNOWN,          //< An unknown error occurred
-  RMM_ERROR_IO,               //< Stats output error
-  N_RMM_ERROR                 //< Count of error types
+typedef enum {
+  RMM_SUCCESS = 0,             //< Success result
+  RMM_ERROR_CUDA_ERROR,        //< A CUDA error occurred
+  RMM_ERROR_INVALID_ARGUMENT,  //< An invalid argument was passed (e.g.null pointer)
+  RMM_ERROR_NOT_INITIALIZED,   //< RMM API called before rmmInitialize()
+  RMM_ERROR_OUT_OF_MEMORY,     //< The memory manager was unable to allocate more memory
+  RMM_ERROR_UNKNOWN,           //< An unknown error occurred
+  RMM_ERROR_IO,                //< Stats output error
+  N_RMM_ERROR                  //< Count of error types
 } rmmError_t;
 
 /** ---------------------------------------------------------------------------*
@@ -48,8 +47,7 @@ typedef enum
  * These settings can be ORed together. For example to use a pool of managed
  * memory, use `mode = PoolAllocation | CudaManagedMemory`.
  * --------------------------------------------------------------------------**/
-typedef enum
-{
+typedef enum {
   CudaDefaultAllocation = 0,  //< Use cudaMalloc for allocation
   PoolAllocation        = 1,  //< Use pool suballocation strategy
   CudaManagedMemory     = 2,  //< Use cudaMallocManaged rather than cudaMalloc
@@ -57,7 +55,7 @@ typedef enum
 
 /** ---------------------------------------------------------------------------*
  * @brief Options for initializing the memory manager
- * 
+ *
  * By default, uses `CudaDefaultAllocation`, which uses `cudaMalloc/cudaFree`.
  *
  * If set to zero, `initial_pool_size` defaults to half of the total GPU memory
@@ -68,8 +66,7 @@ typedef enum
  * used. These are only used when `allocation_mode == PoolAllocation`.
  * --------------------------------------------------------------------------**/
 struct rmmOptions_t {
-  rmmAllocationMode_t allocation_mode{
-      CudaDefaultAllocation};       //< Allocation strategy to use
+  rmmAllocationMode_t allocation_mode{CudaDefaultAllocation};  //< Allocation strategy to use
   std::size_t initial_pool_size{};  //< When pool suballocation is enabled,
                                     //< this is the initial pool size in bytes
   bool enable_logging{false};       //< Enable logging memory manager events
@@ -82,7 +79,7 @@ struct rmmOptions_t {
  * This function is thread-safe with respect to other calls to this function
  * and calls to rmmFinalize(), but it is not thread-safe with respect to calls
  * to rmmAlloc() and rmmFree().
- * 
+ *
  * @param[in] options Structure of options for the memory manager. Defaults are
  *                    used if it is null.
  * @return rmmError_t RMM_SUCCESS or RMM_ERROR_CUDA_ERROR on any CUDA error.
@@ -91,7 +88,7 @@ struct rmmOptions_t {
 
 /** ---------------------------------------------------------------------------*
  * @brief Shutdown memory manager.
- * 
+ *
  * This function is thread-safe with respect to other calls to this function
  * and calls to rmmInitialize(), but it is not thread-safe with respect to calls
  * to rmmAlloc() and rmmFree().
@@ -118,11 +115,11 @@ struct rmmOptions_t {
  * @param errcode The error returned by an RMM function
  * @return const char* The input error code in string form
  * --------------------------------------------------------------------------**/
-[[deprecated]] const char * rmmGetErrorString(rmmError_t errcode);
+[[deprecated]] const char *rmmGetErrorString(rmmError_t errcode);
 
 /** ---------------------------------------------------------------------------*
  * @brief Allocate memory and return a pointer to device memory.
- * 
+ *
  * This function is thread-safe with respect to other calls to rmmAlloc()
  * and rmmFree(), but it is not thread-safe with respect to calls
  * to rmmInitialize() and rmmFinalize().
@@ -137,8 +134,8 @@ struct rmmOptions_t {
  *                    null, RMM_ERROR_OUT_OF_MEMORY if unable to allocate the
  *                    requested size, or RMM_CUDA_ERROR on any other CUDA error.
  * --------------------------------------------------------------------------**/
-[[deprecated]] rmmError_t rmmAlloc(void **ptr, size_t size, cudaStream_t stream,
-                    const char* file, unsigned int line);
+[[deprecated]] rmmError_t rmmAlloc(
+  void **ptr, size_t size, cudaStream_t stream, const char *file, unsigned int line);
 
 /** ---------------------------------------------------------------------------*
  * @brief Reallocate device memory block to new size and recycle any remaining
@@ -155,7 +152,7 @@ struct rmmOptions_t {
  *                    requested size, or RMM_ERROR_CUDA_ERROR on any other CUDA
  *                    error.
  * --------------------------------------------------------------------------**/
-//rmmError_t rmmRealloc(void **ptr, size_t new_size, cudaStream_t stream,
+// rmmError_t rmmRealloc(void **ptr, size_t new_size, cudaStream_t stream,
 //                      const char* file, unsigned int line);
 
 /** ---------------------------------------------------------------------------*
@@ -164,7 +161,7 @@ struct rmmOptions_t {
  * This function is thread-safe with respect to other calls to rmmAlloc()
  * and rmmFree(), but it is not thread-safe with respect to calls
  * to rmmInitialize() and rmmFinalize().
- * 
+ *
  * @param[in] ptr The pointer to free
  * @param[in] stream The stream in which to synchronize this command
  * @param[in] file The filename location of the call to this function, for tracking
@@ -173,8 +170,10 @@ struct rmmOptions_t {
  *                    has not been called,or RMM_ERROR_CUDA_ERROR on any CUDA
  *                    error.
  * --------------------------------------------------------------------------**/
-[[deprecated]] rmmError_t rmmFree(void *ptr, cudaStream_t stream,
-                   const char* file, unsigned int line);
+[[deprecated]] rmmError_t rmmFree(void *ptr,
+                                  cudaStream_t stream,
+                                  const char *file,
+                                  unsigned int line);
 
 /** ---------------------------------------------------------------------------*
  * @brief Get the offset of ptr from its base allocation.
@@ -192,9 +191,7 @@ struct rmmOptions_t {
  *                   ptr.
  * @return rmmError_t RMM_SUCCESS if all goes well
  * --------------------------------------------------------------------------**/
-rmmError_t rmmGetAllocationOffset(ptrdiff_t *offset,
-                                  void *ptr,
-                                  cudaStream_t stream);
+rmmError_t rmmGetAllocationOffset(ptrdiff_t *offset, void *ptr, cudaStream_t stream);
 
 /** ---------------------------------------------------------------------------*
  * @brief Get amounts of free and total memory managed by a manager associated
@@ -222,7 +219,7 @@ rmmError_t rmmGetAllocationOffset(ptrdiff_t *offset,
  * @param filename The full path and filename to write.
  * @return rmmError_t RMM_SUCCESS or RMM_ERROR_IO on output failure.
  * --------------------------------------------------------------------------**/
-[[deprecated]] rmmError_t rmmWriteLog(const char* filename);
+[[deprecated]] rmmError_t rmmWriteLog(const char *filename);
 
 /** ---------------------------------------------------------------------------*
  * @brief Get the size of the CSV log string in memory.
@@ -238,4 +235,4 @@ rmmError_t rmmGetAllocationOffset(ptrdiff_t *offset,
  * @param[in] buffer_size The size allocated for buffer.
  * @return rmmError_t RMM_SUCCESS, or RMM_IO_ERROR on any failure.
  * --------------------------------------------------------------------------**/
-[[deprecated]] rmmError_t rmmGetLog(char* buffer, size_t buffer_size);
+[[deprecated]] rmmError_t rmmGetLog(char *buffer, size_t buffer_size);

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -37,9 +37,8 @@ namespace rmm {
 template <typename T>
 using device_vector = thrust::device_vector<T, rmm::mr::thrust_allocator<T>>;
 
-using par_t =
-    decltype(thrust::cuda::par(*(new rmm::mr::thrust_allocator<char>(0))));
-using deleter_t = std::function<void(par_t *)>;
+using par_t         = decltype(thrust::cuda::par(*(new rmm::mr::thrust_allocator<char>(0))));
+using deleter_t     = std::function<void(par_t *)>;
 using exec_policy_t = std::unique_ptr<par_t, deleter_t>;
 
 /* --------------------------------------------------------------------------*/
@@ -53,8 +52,9 @@ using exec_policy_t = std::unique_ptr<par_t, deleter_t>;
  * allocation.
  */
 /* --------------------------------------------------------------------------*/
-inline exec_policy_t exec_policy(cudaStream_t stream = 0) {
-  auto *alloc = new rmm::mr::thrust_allocator<char>(stream);
+inline exec_policy_t exec_policy(cudaStream_t stream = 0)
+{
+  auto *alloc  = new rmm::mr::thrust_allocator<char>(stream);
   auto deleter = [alloc](par_t *pointer) {
     delete alloc;
     delete pointer;

--- a/scripts/run-clang-format.py
+++ b/scripts/run-clang-format.py
@@ -26,7 +26,7 @@ EXPECTED_VERSION = "8.0.1"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
 # NOTE: populate this list with more top-level dirs as we add more of them to the rmm repo
 DEFAULT_DIRS = ["src",
-                "include"
+                "include",
                 "tests",
                 "benchmarks"]
 

--- a/scripts/run-clang-format.py
+++ b/scripts/run-clang-format.py
@@ -14,42 +14,64 @@
 #
 
 from __future__ import print_function
-import sys
-import re
-import os
-import subprocess
-import argparse
-import tempfile
 
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
 
 EXPECTED_VERSION = "8.0.1"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
-# NOTE: populate this list with more top-level dirs as we add more of them to the rmm repo
-DEFAULT_DIRS = ["src",
-                "include",
-                "tests",
-                "benchmarks"]
+# NOTE: populate this list with more top-level dirs as we add more of them
+# to the rmm repo
+DEFAULT_DIRS = ["src", "include", "tests", "benchmarks"]
 
 
 def parse_args():
     argparser = argparse.ArgumentParser("Runs clang-format on a project")
-    argparser.add_argument("-dstdir", type=str, default=None,
-                           help="Directory to store the temporary outputs of"
-                           " clang-format. If nothing is passed for this, then"
-                           " a temporary dir will be created using `mkdtemp`")
-    argparser.add_argument("-exe", type=str, default="clang-format",
-                           help="Path to clang-format exe")
-    argparser.add_argument("-inplace", default=False, action="store_true",
-                           help="Replace the source files itself.")
-    argparser.add_argument("-regex", type=str,
-                           default=r"[.](cu|cuh|h|hpp|cpp)$",
-                           help="Regex string to filter in sources")
-    argparser.add_argument("-ignore", type=str, default=r"cannylab/bh[.]cu$",
-                           help="Regex used to ignore files from matched list")
-    argparser.add_argument("-v", dest="verbose", action="store_true",
-                           help="Print verbose messages")
-    argparser.add_argument("dirs", type=str, nargs="*",
-                           help="List of dirs where to find sources")
+    argparser.add_argument(
+        "-dstdir",
+        type=str,
+        default=None,
+        help="Directory to store the temporary outputs of"
+        " clang-format. If nothing is passed for this, then"
+        " a temporary dir will be created using `mkdtemp`",
+    )
+    argparser.add_argument(
+        "-exe",
+        type=str,
+        default="clang-format",
+        help="Path to clang-format exe",
+    )
+    argparser.add_argument(
+        "-inplace",
+        default=False,
+        action="store_true",
+        help="Replace the source files itself.",
+    )
+    argparser.add_argument(
+        "-regex",
+        type=str,
+        default=r"[.](cu|cuh|h|hpp|cpp)$",
+        help="Regex string to filter in sources",
+    )
+    argparser.add_argument(
+        "-ignore",
+        type=str,
+        default=r"cannylab/bh[.]cu$",
+        help="Regex used to ignore files from matched list",
+    )
+    argparser.add_argument(
+        "-v",
+        dest="verbose",
+        action="store_true",
+        help="Print verbose messages",
+    )
+    argparser.add_argument(
+        "dirs", type=str, nargs="*", help="List of dirs where to find sources"
+    )
     args = argparser.parse_args()
     args.regex_compiled = re.compile(args.regex)
     args.ignore_compiled = re.compile(args.ignore)
@@ -62,8 +84,10 @@ def parse_args():
         raise Exception("Failed to figure out clang-format version!")
     version = version.group(1)
     if version != EXPECTED_VERSION:
-        raise Exception("clang-format exe must be v%s found '%s'" % \
-                        (EXPECTED_VERSION, version))
+        raise Exception(
+            "clang-format exe must be v%s found '%s'"
+            % (EXPECTED_VERSION, version)
+        )
     if len(args.dirs) == 0:
         args.dirs = DEFAULT_DIRS
     return args
@@ -108,8 +132,10 @@ def run_clang_format(src, dst, exe, verbose):
         if verbose:
             print("%s passed" % os.path.basename(src))
     except subprocess.CalledProcessError:
-        print("%s failed! 'diff %s %s' will show formatting violations!" % \
-              (os.path.basename(src), src, dst))
+        print(
+            "%s failed! 'diff %s %s' will show formatting violations!"
+            % (os.path.basename(src), src, dst)
+        )
         return False
     return True
 
@@ -120,8 +146,13 @@ def main():
     if not os.path.exists(".git"):
         print("Error!! This needs to always be run from the root of repo")
         sys.exit(-1)
-    all_files = list_all_src_files(args.regex_compiled, args.ignore_compiled,
-                                   args.dirs, args.dstdir, args.inplace)
+    all_files = list_all_src_files(
+        args.regex_compiled,
+        args.ignore_compiled,
+        args.dirs,
+        args.dstdir,
+        args.inplace,
+    )
     # actual format checker
     status = True
     for src, dst in all_files:
@@ -132,8 +163,10 @@ def main():
         print(" 1. Look at formatting differences above and fix them manually")
         print(" 2. Or run the below command to bulk-fix all these at once")
         print("Bulk-fix command: ")
-        print("  python scripts/run-clang-format.py %s -inplace" % \
-              " ".join(sys.argv[1:]))
+        print(
+            "  python scripts/run-clang-format.py %s -inplace"
+            % " ".join(sys.argv[1:])
+        )
         sys.exit(-1)
     return
 

--- a/tests/device_scalar_tests.cpp
+++ b/tests/device_scalar_tests.cpp
@@ -25,9 +25,7 @@
 #include <cstddef>
 #include <random>
 
-void sync_stream(cudaStream_t stream) {
-  EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
-}
+void sync_stream(cudaStream_t stream) { EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream)); }
 
 template <typename T>
 struct DeviceScalarTest : public ::testing::Test {
@@ -35,34 +33,35 @@ struct DeviceScalarTest : public ::testing::Test {
   rmm::mr::device_memory_resource* mr{rmm::mr::get_default_resource()};
   T value{};
   std::default_random_engine generator{};
-  std::uniform_int_distribution<T> distribution{
-      std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max()};
+  std::uniform_int_distribution<T> distribution{std::numeric_limits<T>::lowest(),
+                                                std::numeric_limits<T>::max()};
 
   DeviceScalarTest() { value = distribution(generator); }
 
   void SetUp() override { EXPECT_EQ(cudaSuccess, cudaStreamCreate(&stream)); }
 
-  void TearDown() override {
-    EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream));
-  };
+  void TearDown() override { EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream)); };
 };
 
 using Types = ::testing::Types<int8_t, int16_t, int32_t, int64_t>;
 
 TYPED_TEST_CASE(DeviceScalarTest, Types);
 
-TYPED_TEST(DeviceScalarTest, DefaultUninitialized) {
+TYPED_TEST(DeviceScalarTest, DefaultUninitialized)
+{
   rmm::device_scalar<TypeParam> scalar{};
   EXPECT_NE(nullptr, scalar.data());
 }
 
-TYPED_TEST(DeviceScalarTest, InitialValue) {
+TYPED_TEST(DeviceScalarTest, InitialValue)
+{
   rmm::device_scalar<TypeParam> scalar{this->value, this->stream, this->mr};
   EXPECT_NE(nullptr, scalar.data());
   EXPECT_EQ(this->value, scalar.value());
 }
 
-TYPED_TEST(DeviceScalarTest, CopyCtor) {
+TYPED_TEST(DeviceScalarTest, CopyCtor)
+{
   rmm::device_scalar<TypeParam> scalar{this->value, this->stream, this->mr};
   EXPECT_NE(nullptr, scalar.data());
   EXPECT_EQ(this->value, scalar.value());
@@ -73,13 +72,14 @@ TYPED_TEST(DeviceScalarTest, CopyCtor) {
   EXPECT_EQ(copy.value(), scalar.value());
 }
 
-TYPED_TEST(DeviceScalarTest, MoveCtor) {
+TYPED_TEST(DeviceScalarTest, MoveCtor)
+{
   rmm::device_scalar<TypeParam> scalar{this->value, this->stream, this->mr};
   EXPECT_NE(nullptr, scalar.data());
   EXPECT_EQ(this->value, scalar.value());
 
   auto original_pointer = scalar.data();
-  auto original_value = scalar.value();
+  auto original_value   = scalar.value();
 
   rmm::device_scalar<TypeParam> moved_to{std::move(scalar)};
   EXPECT_NE(nullptr, moved_to.data());
@@ -88,7 +88,8 @@ TYPED_TEST(DeviceScalarTest, MoveCtor) {
   EXPECT_EQ(nullptr, scalar.data());
 }
 
-TYPED_TEST(DeviceScalarTest, SetValue) {
+TYPED_TEST(DeviceScalarTest, SetValue)
+{
   rmm::device_scalar<TypeParam> scalar{this->value, this->stream, this->mr};
   EXPECT_NE(nullptr, scalar.data());
 

--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -23,16 +23,17 @@
 
 class raii_restore_env {
  public:
-  raii_restore_env(char const* name)
-      : name_(name) {
+  raii_restore_env(char const* name) : name_(name)
+  {
     auto const value_or_null = getenv(name);
     if (value_or_null != nullptr) {
-      value_ = value_or_null;
+      value_  = value_or_null;
       is_set_ = true;
     }
   }
 
-  ~raii_restore_env() {
+  ~raii_restore_env()
+  {
     if (is_set_) {
       setenv(name_.c_str(), value_.c_str(), 1);
     } else {
@@ -46,17 +47,19 @@ class raii_restore_env {
   bool is_set_{false};
 };
 
-TEST(Adaptor, first) {
+TEST(Adaptor, first)
+{
   rmm::mr::cuda_memory_resource upstream;
 
-  rmm::mr::logging_resource_adaptor<rmm::mr::cuda_memory_resource> log_mr{
-      &upstream, "logs/test1.txt"};
+  rmm::mr::logging_resource_adaptor<rmm::mr::cuda_memory_resource> log_mr{&upstream,
+                                                                          "logs/test1.txt"};
 
   auto p = log_mr.allocate(100);
   log_mr.deallocate(p, 100);
 }
 
-TEST(Adaptor, factory) {
+TEST(Adaptor, factory)
+{
   rmm::mr::cuda_memory_resource upstream;
 
   auto log_mr = rmm::mr::make_logging_adaptor(&upstream, "logs/test2.txt");
@@ -65,7 +68,8 @@ TEST(Adaptor, factory) {
   log_mr.deallocate(p, 100);
 }
 
-TEST(Adaptor, EnviromentPath) {
+TEST(Adaptor, EnviromentPath)
+{
   rmm::mr::cuda_memory_resource upstream;
 
   // restore the original value (or unset) after test
@@ -85,7 +89,8 @@ TEST(Adaptor, EnviromentPath) {
   log_mr.deallocate(p, 100);
 }
 
-TEST(Adaptor, STDOUT) {
+TEST(Adaptor, STDOUT)
+{
   testing::internal::CaptureStdout();
 
   rmm::mr::cuda_memory_resource upstream;
@@ -100,7 +105,8 @@ TEST(Adaptor, STDOUT) {
   ASSERT_EQ(header, "Time,Action,Pointer,Size,Stream");
 }
 
-TEST(Adaptor, STDERR) {
+TEST(Adaptor, STDERR)
+{
   testing::internal::CaptureStderr();
 
   rmm::mr::cuda_memory_resource upstream;
@@ -114,4 +120,3 @@ TEST(Adaptor, STDERR) {
   std::string header = output.substr(0, output.find("\n"));
   ASSERT_EQ(header, "Time,Action,Pointer,Size,Stream");
 }
-

--- a/tests/memory_tests.cpp
+++ b/tests/memory_tests.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include "gtest/gtest.h"
-#include "test_fixtures.h"
 #include "rmm/rmm.h"
+#include "test_fixtures.h"
 
 #include <numeric>
 
@@ -27,166 +27,169 @@ cudaStream_t stream;
 
 // some useful allocation sizes
 constexpr size_t size_word{4};
-constexpr size_t size_kb {size_t{1}<<10};
-constexpr size_t size_mb {size_t{1}<<20};
-constexpr size_t size_gb {size_t{1}<<30};
-constexpr size_t size_tb {size_t{1}<<40};
-constexpr size_t size_pb {size_t{1}<<50};
+constexpr size_t size_kb{size_t{1} << 10};
+constexpr size_t size_mb{size_t{1} << 20};
+constexpr size_t size_gb{size_t{1} << 30};
+constexpr size_t size_tb{size_t{1} << 40};
+constexpr size_t size_pb{size_t{1} << 50};
 
 template <typename T>
-struct MemoryManagerUninitializedTest :
-    public ::testing::Test {};
-
-template <typename T>
-struct MemoryManagerTest :
-    public ::testing::Test
-{
-    static rmmAllocationMode_t allocationMode() { return T::alloc_mode; }
-
-    static void SetUpTestCase() {
-        ASSERT_FALSE(rmmIsInitialized(0));
-        ASSERT_EQ( cudaSuccess, cudaStreamCreate(&stream) );
-        rmmOptions_t options {};
-        options.allocation_mode = allocationMode();
-        ASSERT_SUCCESS(rmmInitialize(&options));
-        // verify initialized
-        rmmOptions_t options_set;
-        ASSERT_TRUE(rmmIsInitialized(&options_set));
-        // verify initialized options
-        ASSERT_EQ(options_set.allocation_mode, options.allocation_mode);
-        ASSERT_EQ(options_set.initial_pool_size, options.initial_pool_size);
-        ASSERT_EQ(options_set.enable_logging, options.enable_logging);
-    }
-
-    static void TearDownTestCase() {
-        ASSERT_SUCCESS( rmmFinalize() );
-        ASSERT_FALSE(rmmIsInitialized(0));
-        ASSERT_EQ( cudaSuccess, cudaStreamDestroy(stream) );
-    }
+struct MemoryManagerUninitializedTest : public ::testing::Test {
 };
 
+template <typename T>
+struct MemoryManagerTest : public ::testing::Test {
+  static rmmAllocationMode_t allocationMode() { return T::alloc_mode; }
+
+  static void SetUpTestCase()
+  {
+    ASSERT_FALSE(rmmIsInitialized(0));
+    ASSERT_EQ(cudaSuccess, cudaStreamCreate(&stream));
+    rmmOptions_t options{};
+    options.allocation_mode = allocationMode();
+    ASSERT_SUCCESS(rmmInitialize(&options));
+    // verify initialized
+    rmmOptions_t options_set;
+    ASSERT_TRUE(rmmIsInitialized(&options_set));
+    // verify initialized options
+    ASSERT_EQ(options_set.allocation_mode, options.allocation_mode);
+    ASSERT_EQ(options_set.initial_pool_size, options.initial_pool_size);
+    ASSERT_EQ(options_set.enable_logging, options.enable_logging);
+  }
+
+  static void TearDownTestCase()
+  {
+    ASSERT_SUCCESS(rmmFinalize());
+    ASSERT_FALSE(rmmIsInitialized(0));
+    ASSERT_EQ(cudaSuccess, cudaStreamDestroy(stream));
+  }
+};
 
 template <rmmAllocationMode_t mode>
 struct ModeType {
-    static constexpr rmmAllocationMode_t alloc_mode{mode};
+  static constexpr rmmAllocationMode_t alloc_mode{mode};
 };
 
-using allocation_modes = ::testing::Types< ModeType<CudaDefaultAllocation>,
-                                           ModeType<PoolAllocation>,
-                                           ModeType<CudaManagedMemory>,
-                                           ModeType<static_cast<rmmAllocationMode_t>(PoolAllocation | CudaManagedMemory)>
-                                         >;
+using allocation_modes =
+  ::testing::Types<ModeType<CudaDefaultAllocation>,
+                   ModeType<PoolAllocation>,
+                   ModeType<CudaManagedMemory>,
+                   ModeType<static_cast<rmmAllocationMode_t>(PoolAllocation | CudaManagedMemory)>>;
 TYPED_TEST_CASE(MemoryManagerUninitializedTest, allocation_modes);
 TYPED_TEST_CASE(MemoryManagerTest, allocation_modes);
 
 // non-fixture tests of non-initialized RMM
-TYPED_TEST(MemoryManagerUninitializedTest, UninitializedAllocateFree) {
-    char *a = nullptr;
-    ASSERT_FAILURE(RMM_ALLOC(&a, size_kb, stream));
-    ASSERT_FAILURE(RMM_FREE(a, stream));
+TYPED_TEST(MemoryManagerUninitializedTest, UninitializedAllocateFree)
+{
+  char *a = nullptr;
+  ASSERT_FAILURE(RMM_ALLOC(&a, size_kb, stream));
+  ASSERT_FAILURE(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MemoryManagerUninitializedTest, GetInfoUninitialized) {
-    size_t free, total;
-    ASSERT_FAILURE(rmmGetInfo(&free, &total, stream));
+TYPED_TEST(MemoryManagerUninitializedTest, GetInfoUninitialized)
+{
+  size_t free, total;
+  ASSERT_FAILURE(rmmGetInfo(&free, &total, stream));
 }
-
 
 // Init / Finalize tests
 
-TYPED_TEST(MemoryManagerTest, Initialize) {
+TYPED_TEST(MemoryManagerTest, Initialize)
+{
+  // Initialized in Fixture class.
+  rmmOptions_t options;
+  ASSERT_TRUE(rmmIsInitialized(&options));
 
-    // Initialized in Fixture class.
-    rmmOptions_t options;
-    ASSERT_TRUE(rmmIsInitialized(&options));
-
-    // second initialization is no-op
-    ASSERT_NO_THROW(rmmInitialize(&options));
-    ASSERT_TRUE(rmmIsInitialized(&options));
+  // second initialization is no-op
+  ASSERT_NO_THROW(rmmInitialize(&options));
+  ASSERT_TRUE(rmmIsInitialized(&options));
 }
 
-TYPED_TEST(MemoryManagerTest, Finalize) {
-    // Empty because handled in Fixture class.
+TYPED_TEST(MemoryManagerTest, Finalize)
+{
+  // Empty because handled in Fixture class.
 }
 
 // zero size tests
 
-TYPED_TEST(MemoryManagerTest, AllocateZeroBytes) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, 0, stream) );
+TYPED_TEST(MemoryManagerTest, AllocateZeroBytes)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, 0, stream));
 }
 
-TYPED_TEST(MemoryManagerTest, NullPtrAllocateZeroBytes) {
-    char ** p{nullptr};
-    ASSERT_SUCCESS( RMM_ALLOC(p, 0, stream) );
+TYPED_TEST(MemoryManagerTest, NullPtrAllocateZeroBytes)
+{
+  char **p{nullptr};
+  ASSERT_SUCCESS(RMM_ALLOC(p, 0, stream));
 }
 
-TYPED_TEST(MemoryManagerTest, FreeNullPtr) {
-    ASSERT_SUCCESS( RMM_FREE(nullptr, stream) );
-}
-
+TYPED_TEST(MemoryManagerTest, FreeNullPtr) { ASSERT_SUCCESS(RMM_FREE(nullptr, stream)); }
 
 // Bad argument tests
 
-TYPED_TEST(MemoryManagerTest, NullPtrInvalidArgument) {
-    char ** p{nullptr};
-    rmmError_t res = RMM_ALLOC(p, 4, stream);
-    ASSERT_FAILURE(res);
-    ASSERT_EQ(RMM_ERROR_INVALID_ARGUMENT, res);
+TYPED_TEST(MemoryManagerTest, NullPtrInvalidArgument)
+{
+  char **p{nullptr};
+  rmmError_t res = RMM_ALLOC(p, 4, stream);
+  ASSERT_FAILURE(res);
+  ASSERT_EQ(RMM_ERROR_INVALID_ARGUMENT, res);
 }
 
 // Simple allocation / free tests
 
-TYPED_TEST(MemoryManagerTest, AllocateWord) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_word, stream) );
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+TYPED_TEST(MemoryManagerTest, AllocateWord)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_word, stream));
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MemoryManagerTest, AllocateKB) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_kb, stream) );
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+TYPED_TEST(MemoryManagerTest, AllocateKB)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_kb, stream));
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MemoryManagerTest, AllocateMB) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_mb, stream) );
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+TYPED_TEST(MemoryManagerTest, AllocateMB)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_mb, stream));
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MemoryManagerTest, AllocateGB) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_gb, stream) );
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+TYPED_TEST(MemoryManagerTest, AllocateGB)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_gb, stream));
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MemoryManagerTest, AllocateTB) {
-    char *a = 0;
-    size_t freeBefore = 0, totalBefore = 0;
-    ASSERT_SUCCESS( rmmGetInfo(&freeBefore, &totalBefore, stream) );
+TYPED_TEST(MemoryManagerTest, AllocateTB)
+{
+  char *a           = 0;
+  size_t freeBefore = 0, totalBefore = 0;
+  ASSERT_SUCCESS(rmmGetInfo(&freeBefore, &totalBefore, stream));
 
-    if ((this->allocationMode() & CudaManagedMemory) ||
-        (size_tb < freeBefore)) {
-        // TODO investigate and fix this
-        //ASSERT_SUCCESS( RMM_ALLOC(&a, size_tb, stream) );
-        //ASSERT_FAILURE( RMM_FREE(a, stream) );
-    }
-    else {
-        ASSERT_FAILURE( RMM_ALLOC(&a, size_tb, stream) );
-        RMM_FREE(a, stream);
-    }
-}
-
-TYPED_TEST(MemoryManagerTest, AllocateTooMuch) {
-    char *a = 0;
-    ASSERT_FAILURE( RMM_ALLOC(&a, size_pb, stream) );
+  if ((this->allocationMode() & CudaManagedMemory) || (size_tb < freeBefore)) {
+    // TODO investigate and fix this
+    // ASSERT_SUCCESS( RMM_ALLOC(&a, size_tb, stream) );
+    // ASSERT_FAILURE( RMM_FREE(a, stream) );
+  } else {
+    ASSERT_FAILURE(RMM_ALLOC(&a, size_tb, stream));
     RMM_FREE(a, stream);
+  }
 }
 
-TYPED_TEST(MemoryManagerTest, FreeZero) {
-    ASSERT_SUCCESS( RMM_FREE(0, stream) );
+TYPED_TEST(MemoryManagerTest, AllocateTooMuch)
+{
+  char *a = 0;
+  ASSERT_FAILURE(RMM_ALLOC(&a, size_pb, stream));
+  RMM_FREE(a, stream);
 }
+
+TYPED_TEST(MemoryManagerTest, FreeZero) { ASSERT_SUCCESS(RMM_FREE(0, stream)); }
 
 // Reallocation tests
 /*
@@ -218,160 +221,170 @@ TYPED_TEST(MemoryManagerTest, ReallocateMuchLarger) {
     ASSERT_SUCCESS( RMM_FREE(a, stream) );
 }
 */
-TYPED_TEST(MemoryManagerTest, GetInfo) {
-    size_t freeBefore = 0, totalBefore = 0;
-    ASSERT_SUCCESS( rmmGetInfo(&freeBefore, &totalBefore, stream) );
-    ASSERT_GE(freeBefore, 0);
-    ASSERT_GE(totalBefore, 0);
+TYPED_TEST(MemoryManagerTest, GetInfo)
+{
+  size_t freeBefore = 0, totalBefore = 0;
+  ASSERT_SUCCESS(rmmGetInfo(&freeBefore, &totalBefore, stream));
+  ASSERT_GE(freeBefore, 0);
+  ASSERT_GE(totalBefore, 0);
 }
 
-TYPED_TEST(MemoryManagerTest, AllocationOffset) {
-    char *a = nullptr, *b = nullptr;
-    ptrdiff_t offset = -1;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_mb, stream) );
-    ASSERT_SUCCESS( RMM_ALLOC(&b, size_mb, stream) );
+TYPED_TEST(MemoryManagerTest, AllocationOffset)
+{
+  char *a = nullptr, *b = nullptr;
+  ptrdiff_t offset = -1;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_mb, stream));
+  ASSERT_SUCCESS(RMM_ALLOC(&b, size_mb, stream));
 
-    ASSERT_SUCCESS( rmmGetAllocationOffset(&offset, a, stream) );
-    ASSERT_GE(offset, 0);
+  ASSERT_SUCCESS(rmmGetAllocationOffset(&offset, a, stream));
+  ASSERT_GE(offset, 0);
 
-    ASSERT_SUCCESS( rmmGetAllocationOffset(&offset, b, stream) );
-    ASSERT_GE(offset, 0);
+  ASSERT_SUCCESS(rmmGetAllocationOffset(&offset, b, stream));
+  ASSERT_GE(offset, 0);
 
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
-    ASSERT_SUCCESS( RMM_FREE(b, stream) );
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
+  ASSERT_SUCCESS(RMM_FREE(b, stream));
 }
 
 template <typename T>
 struct MultiGPUMemoryManagerTest : public MemoryManagerTest<T> {
-    static void SetUpTestCase() {
-        ASSERT_FALSE(rmmIsInitialized(0));
-        ASSERT_EQ( cudaSuccess, cudaStreamCreate(&stream) );
-        int device_count{};
-        ASSERT_EQ(cudaSuccess, cudaGetDeviceCount(&device_count));
-        std::vector<int> devices(device_count);
-        std::iota(begin(devices), end(devices),0);
-        rmmOptions_t options{};
-        options.allocation_mode = T::alloc_mode;
-        options.devices = devices;
-        ASSERT_SUCCESS( rmmInitialize(&options) );
-        rmmOptions_t options_set;
-        // verify initialized
-        ASSERT_TRUE(rmmIsInitialized(&options_set));
-        // verify initialized options
-        ASSERT_EQ(options_set.allocation_mode, options.allocation_mode);
-        ASSERT_EQ(options_set.initial_pool_size, options.initial_pool_size);
-        ASSERT_EQ(options_set.enable_logging, options.enable_logging);
-    }
+  static void SetUpTestCase()
+  {
+    ASSERT_FALSE(rmmIsInitialized(0));
+    ASSERT_EQ(cudaSuccess, cudaStreamCreate(&stream));
+    int device_count{};
+    ASSERT_EQ(cudaSuccess, cudaGetDeviceCount(&device_count));
+    std::vector<int> devices(device_count);
+    std::iota(begin(devices), end(devices), 0);
+    rmmOptions_t options{};
+    options.allocation_mode = T::alloc_mode;
+    options.devices         = devices;
+    ASSERT_SUCCESS(rmmInitialize(&options));
+    rmmOptions_t options_set;
+    // verify initialized
+    ASSERT_TRUE(rmmIsInitialized(&options_set));
+    // verify initialized options
+    ASSERT_EQ(options_set.allocation_mode, options.allocation_mode);
+    ASSERT_EQ(options_set.initial_pool_size, options.initial_pool_size);
+    ASSERT_EQ(options_set.enable_logging, options.enable_logging);
+  }
 };
 
 TYPED_TEST_CASE(MultiGPUMemoryManagerTest, allocation_modes);
 
 // Init / Finalize tests
 
-TYPED_TEST(MultiGPUMemoryManagerTest, Initialize) {
-    
-    // Initialized in Fixture class.
-    rmmOptions_t options;
-    ASSERT_TRUE(rmmIsInitialized(&options));
+TYPED_TEST(MultiGPUMemoryManagerTest, Initialize)
+{
+  // Initialized in Fixture class.
+  rmmOptions_t options;
+  ASSERT_TRUE(rmmIsInitialized(&options));
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, Finalize) {
-    // Empty because handled in Fixture class.
+TYPED_TEST(MultiGPUMemoryManagerTest, Finalize)
+{
+  // Empty because handled in Fixture class.
 }
 
 // zero size tests
 
-TYPED_TEST(MultiGPUMemoryManagerTest, AllocateZeroBytes) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, 0, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, AllocateZeroBytes)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, 0, stream));
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, NullPtrAllocateZeroBytes) {
-    char ** p{nullptr};
-    ASSERT_SUCCESS( RMM_ALLOC(p, 0, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, NullPtrAllocateZeroBytes)
+{
+  char **p{nullptr};
+  ASSERT_SUCCESS(RMM_ALLOC(p, 0, stream));
 }
 
 // Bad argument tests
 
-TYPED_TEST(MultiGPUMemoryManagerTest, NullPtrInvalidArgument) {
-    char ** p{nullptr};
-    rmmError_t res = RMM_ALLOC(p, 4, stream);
-    ASSERT_FAILURE(res);
-    ASSERT_EQ(RMM_ERROR_INVALID_ARGUMENT, res);
+TYPED_TEST(MultiGPUMemoryManagerTest, NullPtrInvalidArgument)
+{
+  char **p{nullptr};
+  rmmError_t res = RMM_ALLOC(p, 4, stream);
+  ASSERT_FAILURE(res);
+  ASSERT_EQ(RMM_ERROR_INVALID_ARGUMENT, res);
 }
 
 // Simple allocation / free tests
 
-TYPED_TEST(MultiGPUMemoryManagerTest, AllocateWord) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_word, stream) );
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, AllocateWord)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_word, stream));
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, AllocateKB) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_kb, stream) );
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, AllocateKB)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_kb, stream));
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, AllocateMB) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_mb, stream) );
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, AllocateMB)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_mb, stream));
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, AllocateGB) {
-    char *a = 0;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_gb, stream) );
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, AllocateGB)
+{
+  char *a = 0;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_gb, stream));
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTB) {
-    char *a = 0;
-    size_t freeBefore = 0, totalBefore = 0;
-    ASSERT_SUCCESS( rmmGetInfo(&freeBefore, &totalBefore, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTB)
+{
+  char *a           = 0;
+  size_t freeBefore = 0, totalBefore = 0;
+  ASSERT_SUCCESS(rmmGetInfo(&freeBefore, &totalBefore, stream));
 
-    if ((this->allocationMode() & CudaManagedMemory) || 
-        (size_tb < freeBefore)) {
-        // TODO investigate and fix this
-        //ASSERT_SUCCESS( RMM_ALLOC(&a, size_tb, stream) );
-    }
-    else {
-        ASSERT_FAILURE( RMM_ALLOC(&a, size_tb, stream) );
-        RMM_FREE(a, stream);
-    }
-    
-}
-
-TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTooMuch) {
-    char *a = 0;
-    ASSERT_FAILURE( RMM_ALLOC(&a, size_pb, stream) );
+  if ((this->allocationMode() & CudaManagedMemory) || (size_tb < freeBefore)) {
+    // TODO investigate and fix this
+    // ASSERT_SUCCESS( RMM_ALLOC(&a, size_tb, stream) );
+  } else {
+    ASSERT_FAILURE(RMM_ALLOC(&a, size_tb, stream));
     RMM_FREE(a, stream);
+  }
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, FreeZero) {
-    ASSERT_SUCCESS( RMM_FREE(0, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, AllocateTooMuch)
+{
+  char *a = 0;
+  ASSERT_FAILURE(RMM_ALLOC(&a, size_pb, stream));
+  RMM_FREE(a, stream);
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, GetInfo) {
-    size_t freeBefore = 0, totalBefore = 0;
-    ASSERT_SUCCESS( rmmGetInfo(&freeBefore, &totalBefore, stream) );
-    ASSERT_GE(freeBefore, 0);
-    ASSERT_GE(totalBefore, 0);
+TYPED_TEST(MultiGPUMemoryManagerTest, FreeZero) { ASSERT_SUCCESS(RMM_FREE(0, stream)); }
+
+TYPED_TEST(MultiGPUMemoryManagerTest, GetInfo)
+{
+  size_t freeBefore = 0, totalBefore = 0;
+  ASSERT_SUCCESS(rmmGetInfo(&freeBefore, &totalBefore, stream));
+  ASSERT_GE(freeBefore, 0);
+  ASSERT_GE(totalBefore, 0);
 }
 
-TYPED_TEST(MultiGPUMemoryManagerTest, AllocationOffset) {
-    char *a = nullptr, *b = nullptr;
-    ptrdiff_t offset = -1;
-    ASSERT_SUCCESS( RMM_ALLOC(&a, size_mb, stream) );
-    ASSERT_SUCCESS( RMM_ALLOC(&b, size_mb, stream) );
+TYPED_TEST(MultiGPUMemoryManagerTest, AllocationOffset)
+{
+  char *a = nullptr, *b = nullptr;
+  ptrdiff_t offset = -1;
+  ASSERT_SUCCESS(RMM_ALLOC(&a, size_mb, stream));
+  ASSERT_SUCCESS(RMM_ALLOC(&b, size_mb, stream));
 
-    ASSERT_SUCCESS( rmmGetAllocationOffset(&offset, a, stream) );
-    ASSERT_GE(offset, 0);
+  ASSERT_SUCCESS(rmmGetAllocationOffset(&offset, a, stream));
+  ASSERT_GE(offset, 0);
 
-    ASSERT_SUCCESS( rmmGetAllocationOffset(&offset, b, stream) );
-    ASSERT_GE(offset, 0);
+  ASSERT_SUCCESS(rmmGetAllocationOffset(&offset, b, stream));
+  ASSERT_GE(offset, 0);
 
-    ASSERT_SUCCESS( RMM_FREE(a, stream) );
-    ASSERT_SUCCESS( RMM_FREE(b, stream) );
+  ASSERT_SUCCESS(RMM_FREE(a, stream));
+  ASSERT_SUCCESS(RMM_FREE(b, stream));
 }

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -16,17 +16,17 @@
 
 #include "gtest/gtest.h"
 
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
 #include <rmm/mr/device/cnmem_managed_memory_resource.hpp>
+#include <rmm/mr/device/cnmem_memory_resource.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/mr/device/managed_memory_resource.hpp>
-#include <rmm/mr/device/thread_safe_resource_adaptor.hpp>
-#include <rmm/mr/device/pool_memory_resource.hpp>
-#include <rmm/mr/device/fixed_size_memory_resource.hpp>
 #include <rmm/mr/device/fixed_multisize_memory_resource.hpp>
+#include <rmm/mr/device/fixed_size_memory_resource.hpp>
 #include <rmm/mr/device/hybrid_memory_resource.hpp>
+#include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/mr/device/thread_safe_resource_adaptor.hpp>
 
 #include <cuda_runtime_api.h>
 #include <cstddef>
@@ -35,7 +35,8 @@
 
 namespace {
 static constexpr std::size_t ALIGNMENT{256};
-inline bool is_aligned(void* p, std::size_t alignment = ALIGNMENT) {
+inline bool is_aligned(void* p, std::size_t alignment = ALIGNMENT)
+{
   return (0 == reinterpret_cast<uintptr_t>(p) % alignment);
 }
 
@@ -43,16 +44,14 @@ inline bool is_aligned(void* p, std::size_t alignment = ALIGNMENT) {
  * @brief Returns if a pointer points to a device memory or managed memory
  * allocation.
  */
-inline bool is_device_memory(void* p) {
+inline bool is_device_memory(void* p)
+{
   cudaPointerAttributes attributes{};
-  if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) {
-    return false;
-  }
+  if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) { return false; }
 #if CUDART_VERSION < 10000  // memoryType is deprecated in CUDA 10
   return attributes.memoryType == cudaMemoryTypeDevice;
 #else
-  return (attributes.type == cudaMemoryTypeDevice) or
-         (attributes.type == cudaMemoryTypeManaged);
+  return (attributes.type == cudaMemoryTypeDevice) or (attributes.type == cudaMemoryTypeManaged);
 #endif
 }
 
@@ -73,13 +72,12 @@ struct allocation {
 }  // namespace
 
 // nested MR type names can get long...
-using pool_mr = rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>;
+using pool_mr       = rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>;
 using fixed_size_mr = rmm::mr::fixed_size_memory_resource<rmm::mr::device_memory_resource>;
-using fixed_multisize_mr = rmm::mr::fixed_multisize_memory_resource<rmm::mr::device_memory_resource>;
-using fixed_multisize_pool_mr =
-    rmm::mr::fixed_multisize_memory_resource<pool_mr>;
-using hybrid_mr =
-    rmm::mr::hybrid_memory_resource<fixed_multisize_pool_mr, pool_mr>;
+using fixed_multisize_mr =
+  rmm::mr::fixed_multisize_memory_resource<rmm::mr::device_memory_resource>;
+using fixed_multisize_pool_mr = rmm::mr::fixed_multisize_memory_resource<pool_mr>;
+using hybrid_mr               = rmm::mr::hybrid_memory_resource<fixed_multisize_pool_mr, pool_mr>;
 
 using thread_safe_cuda_mr = rmm::mr::thread_safe_resource_adaptor<rmm::mr::cuda_memory_resource>;
 
@@ -92,49 +90,49 @@ struct MRTest : public ::testing::Test {
 
   void SetUp() override { EXPECT_EQ(cudaSuccess, cudaStreamCreate(&stream)); }
 
-  void TearDown() override {
-    EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream));
-  };
+  void TearDown() override { EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream)); };
 
   ~MRTest() {}
 
   void test_allocate(std::size_t bytes, cudaStream_t stream = 0);
   void test_random_allocations_base(std::size_t num_allocations = 100,
-                                    std::size_t max_size = 5 * size_mb,
-                                    cudaStream_t stream = 0);
-  void test_random_allocations(std::size_t num_allocations = 100,
-                                          cudaStream_t stream = 0);
+                                    std::size_t max_size        = 5 * size_mb,
+                                    cudaStream_t stream         = 0);
+  void test_random_allocations(std::size_t num_allocations = 100, cudaStream_t stream = 0);
   void test_mixed_random_allocation_free_base(std::size_t max_size = 5 * size_mb,
-                                              cudaStream_t stream = 0);
+                                              cudaStream_t stream  = 0);
   void test_mixed_random_allocation_free(cudaStream_t stream = 0);
 };
 
 // Specialize constructor to pass arguments
 template <>
-MRTest<fixed_size_mr>::MRTest() : 
-  mr{new fixed_size_mr{rmm::mr::get_default_resource()}} {}
+MRTest<fixed_size_mr>::MRTest() : mr{new fixed_size_mr{rmm::mr::get_default_resource()}}
+{
+}
 
 template <>
-MRTest<fixed_multisize_mr>::MRTest() : 
-  mr{new fixed_multisize_mr(rmm::mr::get_default_resource())}
-{}
+MRTest<fixed_multisize_mr>::MRTest() : mr{new fixed_multisize_mr(rmm::mr::get_default_resource())}
+{
+}
 
 template <>
-MRTest<pool_mr>::MRTest() {
-  rmm::mr::cuda_memory_resource *cuda = new rmm::mr::cuda_memory_resource{};
+MRTest<pool_mr>::MRTest()
+{
+  rmm::mr::cuda_memory_resource* cuda = new rmm::mr::cuda_memory_resource{};
   this->mr.reset(new pool_mr(cuda));
 }
 
 template <>
 MRTest<hybrid_mr>::MRTest()
 {
-  rmm::mr::cuda_memory_resource *cuda = new rmm::mr::cuda_memory_resource{};
-  pool_mr* pool = new pool_mr(cuda);
+  rmm::mr::cuda_memory_resource* cuda = new rmm::mr::cuda_memory_resource{};
+  pool_mr* pool                       = new pool_mr(cuda);
   this->mr.reset(new hybrid_mr(new fixed_multisize_pool_mr(pool), pool));
 }
 
 template <>
-MRTest<pool_mr>::~MRTest() {
+MRTest<pool_mr>::~MRTest()
+{
   auto upstream = this->mr->get_upstream();
   this->mr.reset();
   delete upstream;
@@ -152,92 +150,98 @@ MRTest<hybrid_mr>::~MRTest()
 
 template <>
 MRTest<thread_safe_cuda_mr>::MRTest()
-: mr{new thread_safe_cuda_mr(new rmm::mr::cuda_memory_resource)} {}
+  : mr{new thread_safe_cuda_mr(new rmm::mr::cuda_memory_resource)}
+{
+}
 
 template <>
-MRTest<thread_safe_cuda_mr>::~MRTest() {
+MRTest<thread_safe_cuda_mr>::~MRTest()
+{
   auto upstream = mr->get_upstream();
   delete upstream;
 }
 
-
 template <typename MemoryResourceType>
-std::size_t get_max_size(MemoryResourceType *mr) { return std::numeric_limits<std::size_t>::max(); }
+std::size_t get_max_size(MemoryResourceType* mr)
+{
+  return std::numeric_limits<std::size_t>::max();
+}
 
 template <>
-std::size_t get_max_size(fixed_size_mr *mr) {
+std::size_t get_max_size(fixed_size_mr* mr)
+{
   return mr->get_block_size();
 }
 
 template <>
-std::size_t get_max_size(fixed_multisize_mr *mr) {
+std::size_t get_max_size(fixed_multisize_mr* mr)
+{
   return mr->get_max_size();
 }
 
 template <typename MemoryResourceType>
-void MRTest<MemoryResourceType>::test_allocate(std::size_t bytes, cudaStream_t stream) {
+void MRTest<MemoryResourceType>::test_allocate(std::size_t bytes, cudaStream_t stream)
+{
   void* p{nullptr};
   if (bytes > get_max_size(this->mr.get())) {
     EXPECT_THROW(p = this->mr->allocate(bytes), std::bad_alloc);
-  }
-  else {
+  } else {
     EXPECT_NO_THROW(p = this->mr->allocate(bytes));
-    if (stream != 0)
-      EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(this->stream));
+    if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(this->stream));
     EXPECT_NE(nullptr, p);
     EXPECT_TRUE(is_aligned(p));
     EXPECT_TRUE(is_device_memory(p));
     EXPECT_NO_THROW(this->mr->deallocate(p, bytes));
-    if (stream != 0)
-      EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(this->stream));
+    if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(this->stream));
   }
 }
 
 template <typename MemoryResourceType>
 void MRTest<MemoryResourceType>::test_random_allocations_base(std::size_t num_allocations,
                                                               std::size_t max_size,
-                                                              cudaStream_t stream) {
+                                                              cudaStream_t stream)
+{
   std::vector<allocation> allocations(num_allocations);
 
   std::default_random_engine generator;
   std::uniform_int_distribution<std::size_t> distribution(1, max_size);
 
   // 100 allocations from [0,5MB)
-  std::for_each(
-      allocations.begin(), allocations.end(),
-      [&generator, &distribution, stream, this](allocation& a) {
-        a.size = distribution(generator);
-        EXPECT_NO_THROW(a.p = this->mr->allocate(a.size, stream));
-        if (stream != 0)
-          EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
-        EXPECT_NE(nullptr, a.p);
-        EXPECT_TRUE(is_aligned(a.p));
-      });
+  std::for_each(allocations.begin(),
+                allocations.end(),
+                [&generator, &distribution, stream, this](allocation& a) {
+                  a.size = distribution(generator);
+                  EXPECT_NO_THROW(a.p = this->mr->allocate(a.size, stream));
+                  if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
+                  EXPECT_NE(nullptr, a.p);
+                  EXPECT_TRUE(is_aligned(a.p));
+                });
 
   std::for_each(
-      allocations.begin(), allocations.end(),
-       [generator, distribution, stream, this](allocation& a) {
-        EXPECT_NO_THROW(this->mr->deallocate(a.p, a.size, stream));
-        if (stream != 0)
-          EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
-      });
+    allocations.begin(), allocations.end(), [generator, distribution, stream, this](allocation& a) {
+      EXPECT_NO_THROW(this->mr->deallocate(a.p, a.size, stream));
+      if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
+    });
 }
 
 template <typename MemoryResourceType>
 void MRTest<MemoryResourceType>::test_random_allocations(std::size_t num_allocations,
-                                                         cudaStream_t stream) {
+                                                         cudaStream_t stream)
+{
   return test_random_allocations_base(num_allocations, 5 * size_mb, stream);
 }
 
 template <>
 void MRTest<fixed_size_mr>::test_random_allocations(std::size_t num_allocations,
-                                                                          cudaStream_t stream) {
+                                                    cudaStream_t stream)
+{
   return test_random_allocations_base(num_allocations, 1 * size_mb, stream);
 }
 
 template <>
 void MRTest<fixed_multisize_mr>::test_random_allocations(std::size_t num_allocations,
-                                                         cudaStream_t stream) {
+                                                         cudaStream_t stream)
+{
   return test_random_allocations_base(num_allocations, 4 * size_mb, stream);
 }
 
@@ -250,9 +254,9 @@ void MRTest<MemoryResourceType>::test_mixed_random_allocation_free_base(std::siz
 
   std::uniform_int_distribution<std::size_t> size_distribution(1, max_size);
 
-  constexpr int allocation_probability = 53; // percent
+  constexpr int allocation_probability = 53;  // percent
   std::uniform_int_distribution<int> op_distribution(0, 99);
-  std::uniform_int_distribution<int> index_distribution(0, num_allocations-1);
+  std::uniform_int_distribution<int> index_distribution(0, num_allocations - 1);
 
   int active_allocations{0};
   int allocation_count{0};
@@ -263,8 +267,7 @@ void MRTest<MemoryResourceType>::test_mixed_random_allocation_free_base(std::siz
     bool do_alloc = true;
     if (active_allocations > 0) {
       int chance = op_distribution(generator);
-      do_alloc = (chance < allocation_probability) && 
-                 (allocation_count < num_allocations);
+      do_alloc   = (chance < allocation_probability) && (allocation_count < num_allocations);
     }
 
     if (do_alloc) {
@@ -275,8 +278,7 @@ void MRTest<MemoryResourceType>::test_mixed_random_allocation_free_base(std::siz
       auto new_allocation = allocations.back();
       EXPECT_NE(nullptr, new_allocation.p);
       EXPECT_TRUE(is_aligned(new_allocation.p));
-    }
-    else {
+    } else {
       size_t index = index_distribution(generator) % active_allocations;
       active_allocations--;
       allocation to_free = allocations[index];
@@ -290,17 +292,20 @@ void MRTest<MemoryResourceType>::test_mixed_random_allocation_free_base(std::siz
 }
 
 template <typename MemoryResourceType>
-void MRTest<MemoryResourceType>::test_mixed_random_allocation_free(cudaStream_t stream) {
-  test_mixed_random_allocation_free_base(5 * size_mb, stream); 
+void MRTest<MemoryResourceType>::test_mixed_random_allocation_free(cudaStream_t stream)
+{
+  test_mixed_random_allocation_free_base(5 * size_mb, stream);
 }
 
 template <>
-void MRTest<fixed_size_mr>::test_mixed_random_allocation_free(cudaStream_t stream) {
+void MRTest<fixed_size_mr>::test_mixed_random_allocation_free(cudaStream_t stream)
+{
   test_mixed_random_allocation_free_base(size_mb, stream);
 }
 
 template <>
-void MRTest<fixed_multisize_mr>::test_mixed_random_allocation_free(cudaStream_t stream) {
+void MRTest<fixed_multisize_mr>::test_mixed_random_allocation_free(cudaStream_t stream)
+{
   test_mixed_random_allocation_free_base(4 * size_mb, stream);
 }
 
@@ -317,7 +322,8 @@ using resources = ::testing::Types<rmm::mr::cuda_memory_resource,
 
 TYPED_TEST_CASE(MRTest, resources);
 
-TEST(DefaultTest, UseDefaultResource) {
+TEST(DefaultTest, UseDefaultResource)
+{
   EXPECT_NE(nullptr, rmm::mr::get_default_resource());
   void* p{nullptr};
   EXPECT_NO_THROW(p = rmm::mr::get_default_resource()->allocate(size_mb));
@@ -327,9 +333,10 @@ TEST(DefaultTest, UseDefaultResource) {
   EXPECT_NO_THROW(rmm::mr::get_default_resource()->deallocate(p, size_mb));
 }
 
-TYPED_TEST(MRTest, SetDefaultResource) {
+TYPED_TEST(MRTest, SetDefaultResource)
+{
   // Not necessarily false, since two cuda_memory_resources are always equal
-  //EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
+  // EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
   rmm::mr::device_memory_resource* old{nullptr};
   EXPECT_NO_THROW(old = rmm::mr::set_default_resource(this->mr.get()));
   EXPECT_NE(nullptr, old);
@@ -344,19 +351,21 @@ TYPED_TEST(MRTest, SetDefaultResource) {
   EXPECT_NO_THROW(rmm::mr::set_default_resource(nullptr));
   EXPECT_TRUE(old->is_equal(*rmm::mr::get_default_resource()));
   // Not necessarily false, since two cuda_memory_resources are always equal
-  //EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
+  // EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
 }
 
 TYPED_TEST(MRTest, SelfEquality) { EXPECT_TRUE(this->mr->is_equal(*this->mr)); }
 
-TYPED_TEST(MRTest, AllocateZeroBytes) {
+TYPED_TEST(MRTest, AllocateZeroBytes)
+{
   void* p{nullptr};
   EXPECT_NO_THROW(p = this->mr->allocate(0));
   EXPECT_EQ(nullptr, p);
   EXPECT_NO_THROW(this->mr->deallocate(p, 0));
 }
 
-TYPED_TEST(MRTest, AllocateZeroBytesStream) {
+TYPED_TEST(MRTest, AllocateZeroBytesStream)
+{
   void* p{nullptr};
   EXPECT_NO_THROW(p = this->mr->allocate(0, this->stream));
   EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(this->stream));
@@ -364,7 +373,8 @@ TYPED_TEST(MRTest, AllocateZeroBytesStream) {
   EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(this->stream));
 }
 
-TYPED_TEST(MRTest, Allocate) {
+TYPED_TEST(MRTest, Allocate)
+{
   this->test_allocate(size_word);
   this->test_allocate(size_kb);
   this->test_allocate(size_mb);
@@ -376,46 +386,40 @@ TYPED_TEST(MRTest, Allocate) {
   EXPECT_EQ(nullptr, p);
 }
 
-TYPED_TEST(MRTest, AllocateOnStream) {
+TYPED_TEST(MRTest, AllocateOnStream)
+{
   this->test_allocate(size_word, this->stream);
-  this->test_allocate(size_kb,   this->stream);
-  this->test_allocate(size_mb,   this->stream);
-  this->test_allocate(size_gb,   this->stream);
+  this->test_allocate(size_kb, this->stream);
+  this->test_allocate(size_mb, this->stream);
+  this->test_allocate(size_gb, this->stream);
 
   // should fail to allocate too much
   void* p{nullptr};
   EXPECT_THROW(p = this->mr->allocate(size_pb, this->stream), rmm::bad_alloc);
   EXPECT_EQ(nullptr, p);
-
 }
 
-TYPED_TEST(MRTest, RandomAllocations) {
-  this->test_random_allocations();
-}
+TYPED_TEST(MRTest, RandomAllocations) { this->test_random_allocations(); }
 
-TYPED_TEST(MRTest, RandomAllocationsStream) {
-  this->test_random_allocations(100, this->stream);
-}
+TYPED_TEST(MRTest, RandomAllocationsStream) { this->test_random_allocations(100, this->stream); }
 
-TYPED_TEST(MRTest, MixedRandomAllocationFree)
-{
-  this->test_mixed_random_allocation_free();
-}
-  
+TYPED_TEST(MRTest, MixedRandomAllocationFree) { this->test_mixed_random_allocation_free(); }
+
 TYPED_TEST(MRTest, MixedRandomAllocationFreeStream)
 {
   this->test_mixed_random_allocation_free(this->stream);
 }
 
-TYPED_TEST(MRTest, GetMemInfo) {
+TYPED_TEST(MRTest, GetMemInfo)
+{
   if (this->mr->supports_get_mem_info()) {
-    std::pair<std::size_t,std::size_t> mem_info;
+    std::pair<std::size_t, std::size_t> mem_info;
     EXPECT_NO_THROW(mem_info = this->mr->get_mem_info(0));
     std::size_t allocation_size = 16 * 256;
-    void * ptr;
+    void* ptr;
     EXPECT_NO_THROW(ptr = this->mr->allocate(allocation_size));
     EXPECT_NO_THROW(mem_info = this->mr->get_mem_info(0));
     EXPECT_TRUE(mem_info.first >= allocation_size);
-    EXPECT_NO_THROW(this->mr->deallocate(ptr,allocation_size));
+    EXPECT_NO_THROW(this->mr->deallocate(ptr, allocation_size));
   }
 }

--- a/tests/mr/device/thrust_allocator_tests.cu
+++ b/tests/mr/device/thrust_allocator_tests.cu
@@ -29,26 +29,25 @@
 
 using pool_mr = rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>;
 
-using resources =
-    ::testing::Types<rmm::mr::cuda_memory_resource,
-                     rmm::mr::managed_memory_resource,
-                     rmm::mr::cnmem_memory_resource,
-                     rmm::mr::cnmem_managed_memory_resource, pool_mr>;
+using resources = ::testing::Types<rmm::mr::cuda_memory_resource,
+                                   rmm::mr::managed_memory_resource,
+                                   rmm::mr::cnmem_memory_resource,
+                                   rmm::mr::cnmem_managed_memory_resource,
+                                   pool_mr>;
 
 template <typename MR>
 struct AllocatorTest : public ::testing::Test {
   std::vector<std::unique_ptr<rmm::mr::device_memory_resource>> upstreams;
   std::unique_ptr<MR> mr;
 
-  AllocatorTest() : mr{std::make_unique<MR>()} {
-    rmm::mr::set_default_resource(mr.get());
-  }
+  AllocatorTest() : mr{std::make_unique<MR>()} { rmm::mr::set_default_resource(mr.get()); }
 
   ~AllocatorTest() = default;
 };
 
 template <>
-AllocatorTest<pool_mr>::AllocatorTest() {
+AllocatorTest<pool_mr>::AllocatorTest()
+{
   upstreams.emplace_back(std::make_unique<rmm::mr::cuda_memory_resource>());
   auto& cuda_upstream = upstreams.front();
   mr.reset(new pool_mr(static_cast<rmm::mr::cuda_memory_resource*>(cuda_upstream.get())));
@@ -57,7 +56,8 @@ AllocatorTest<pool_mr>::AllocatorTest() {
 
 TYPED_TEST_CASE(AllocatorTest, resources);
 
-TYPED_TEST(AllocatorTest, first) {
+TYPED_TEST(AllocatorTest, first)
+{
   rmm::device_vector<int> ints(100, 1);
   EXPECT_EQ(100, thrust::reduce(ints.begin(), ints.end()));
 }

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -26,12 +26,13 @@
 #include <random>
 
 namespace {
-inline bool is_aligned(void* p,
-                       std::size_t alignment = alignof(std::max_align_t)) {
+inline bool is_aligned(void* p, std::size_t alignment = alignof(std::max_align_t))
+{
   return (0 == reinterpret_cast<uintptr_t>(p) % alignment);
 }
 
-inline void expect_aligned(void* p, std::size_t alignment) {
+inline void expect_aligned(void* p, std::size_t alignment)
+{
   EXPECT_EQ(0, reinterpret_cast<uintptr_t>(p) % alignment);
 }
 
@@ -39,27 +40,24 @@ inline void expect_aligned(void* p, std::size_t alignment) {
  * @brief Returns if a pointer points to a device memory or managed memory
  * allocation.
  *---------------------------------------------------------------------------**/
-inline bool is_device_memory(void* p) {
+inline bool is_device_memory(void* p)
+{
   cudaPointerAttributes attributes{};
-  if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) {
-    return false;
-  }
+  if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) { return false; }
 #if CUDART_VERSION < 10000  // memoryType is deprecated in CUDA 10
   return attributes.memoryType == cudaMemoryTypeDevice;
 #else
-  return (attributes.type == cudaMemoryTypeDevice) or
-         (attributes.type == cudaMemoryTypeManaged);
+  return (attributes.type == cudaMemoryTypeDevice) or (attributes.type == cudaMemoryTypeManaged);
 #endif
 }
 
 /**
  * @brief Returns if a pointer `p` points to pinned host memory.
  */
-inline bool is_pinned_memory(void* p) {
+inline bool is_pinned_memory(void* p)
+{
   cudaPointerAttributes attributes{};
-  if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) {
-    return false;
-  }
+  if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) { return false; }
   return attributes.type == cudaMemoryTypeHost;
 }
 
@@ -86,20 +84,21 @@ struct MRTest : public ::testing::Test {
   ~MRTest() = default;
 };
 
-using resources = ::testing::Types<rmm::mr::new_delete_resource,
-                                   rmm::mr::pinned_memory_resource>;
+using resources = ::testing::Types<rmm::mr::new_delete_resource, rmm::mr::pinned_memory_resource>;
 
 TYPED_TEST_CASE(MRTest, resources);
 
 TYPED_TEST(MRTest, SelfEquality) { EXPECT_TRUE(this->mr->is_equal(*this->mr)); }
 
-TYPED_TEST(MRTest, AllocateZeroBytes) {
+TYPED_TEST(MRTest, AllocateZeroBytes)
+{
   void* p{nullptr};
   EXPECT_NO_THROW(p = this->mr->allocate(0));
   EXPECT_NO_THROW(this->mr->deallocate(p, 0));
 }
 
-TYPED_TEST(MRTest, AllocateWord) {
+TYPED_TEST(MRTest, AllocateWord)
+{
   void* p{nullptr};
   EXPECT_NO_THROW(p = this->mr->allocate(size_word));
   EXPECT_NE(nullptr, p);
@@ -108,7 +107,8 @@ TYPED_TEST(MRTest, AllocateWord) {
   EXPECT_NO_THROW(this->mr->deallocate(p, size_word));
 }
 
-TYPED_TEST(MRTest, AllocateKB) {
+TYPED_TEST(MRTest, AllocateKB)
+{
   void* p{nullptr};
   EXPECT_NO_THROW(p = this->mr->allocate(size_kb));
   EXPECT_NE(nullptr, p);
@@ -117,7 +117,8 @@ TYPED_TEST(MRTest, AllocateKB) {
   EXPECT_NO_THROW(this->mr->deallocate(p, size_kb));
 }
 
-TYPED_TEST(MRTest, AllocateMB) {
+TYPED_TEST(MRTest, AllocateMB)
+{
   void* p{nullptr};
   EXPECT_NO_THROW(p = this->mr->allocate(size_mb));
   EXPECT_NE(nullptr, p);
@@ -126,7 +127,8 @@ TYPED_TEST(MRTest, AllocateMB) {
   EXPECT_NO_THROW(this->mr->deallocate(p, size_mb));
 }
 
-TYPED_TEST(MRTest, AllocateGB) {
+TYPED_TEST(MRTest, AllocateGB)
+{
   void* p{nullptr};
   EXPECT_NO_THROW(p = this->mr->allocate(size_gb));
   EXPECT_NE(nullptr, p);
@@ -135,43 +137,44 @@ TYPED_TEST(MRTest, AllocateGB) {
   EXPECT_NO_THROW(this->mr->deallocate(p, size_gb));
 }
 
-TYPED_TEST(MRTest, AllocateTooMuch) {
+TYPED_TEST(MRTest, AllocateTooMuch)
+{
   void* p{nullptr};
   EXPECT_THROW(p = this->mr->allocate(size_pb), std::bad_alloc);
   EXPECT_EQ(nullptr, p);
 }
 
-TYPED_TEST(MRTest, RandomAllocations) {
+TYPED_TEST(MRTest, RandomAllocations)
+{
   constexpr std::size_t num_allocations{100};
   std::vector<allocation> allocations(num_allocations);
 
   constexpr std::size_t MAX_ALLOCATION_SIZE{5 * size_mb};
 
   std::default_random_engine generator;
-  std::uniform_int_distribution<std::size_t> distribution(1,
-                                                          MAX_ALLOCATION_SIZE);
+  std::uniform_int_distribution<std::size_t> distribution(1, MAX_ALLOCATION_SIZE);
 
   // 100 allocations from [0,5MB)
-  std::for_each(allocations.begin(), allocations.end(),
-                [&generator, &distribution, this](allocation& a) {
-                  a.size = distribution(generator);
-                  EXPECT_NO_THROW(a.p = this->mr->allocate(a.size));
-                  EXPECT_NE(nullptr, a.p);
-                  EXPECT_TRUE(is_aligned(a.p));
-                });
+  std::for_each(
+    allocations.begin(), allocations.end(), [&generator, &distribution, this](allocation& a) {
+      a.size = distribution(generator);
+      EXPECT_NO_THROW(a.p = this->mr->allocate(a.size));
+      EXPECT_NE(nullptr, a.p);
+      EXPECT_TRUE(is_aligned(a.p));
+    });
 
-  std::for_each(allocations.begin(), allocations.end(),
-                [generator, distribution, this](allocation& a) {
-                  EXPECT_NO_THROW(this->mr->deallocate(a.p, a.size));
-                });
+  std::for_each(
+    allocations.begin(), allocations.end(), [generator, distribution, this](allocation& a) {
+      EXPECT_NO_THROW(this->mr->deallocate(a.p, a.size));
+    });
 }
 
-TYPED_TEST(MRTest, MixedRandomAllocationFree) {
+TYPED_TEST(MRTest, MixedRandomAllocationFree)
+{
   std::default_random_engine generator;
 
   constexpr std::size_t MAX_ALLOCATION_SIZE{10 * size_mb};
-  std::uniform_int_distribution<std::size_t> size_distribution(
-      1, MAX_ALLOCATION_SIZE);
+  std::uniform_int_distribution<std::size_t> size_distribution(1, MAX_ALLOCATION_SIZE);
 
   // How often a free will occur. For example, if `1`, then every allocation
   // will immediately be free'd. Or, if 4, on average, a free will occur after
@@ -184,14 +187,12 @@ TYPED_TEST(MRTest, MixedRandomAllocationFree) {
   constexpr std::size_t num_allocations{100};
   for (std::size_t i = 0; i < num_allocations; ++i) {
     std::size_t allocation_size = size_distribution(generator);
-    EXPECT_NO_THROW(allocations.emplace_back(
-        this->mr->allocate(allocation_size), allocation_size));
+    EXPECT_NO_THROW(allocations.emplace_back(this->mr->allocate(allocation_size), allocation_size));
     auto new_allocation = allocations.back();
     EXPECT_NE(nullptr, new_allocation.p);
     EXPECT_TRUE(is_aligned(new_allocation.p));
 
-    bool const free_front{free_distribution(generator) ==
-                          free_distribution.max()};
+    bool const free_front{free_distribution(generator) == free_distribution.max()};
 
     if (free_front) {
       auto front = allocations.front();
@@ -206,23 +207,22 @@ TYPED_TEST(MRTest, MixedRandomAllocationFree) {
   }
 }
 
-static constexpr std::size_t MinTestedSize = 32;
-static constexpr std::size_t MaxTestedSize = 8 * 1024;
-static constexpr std::size_t TestedSizeStep = 1;
-static constexpr std::size_t MinTestedAlignment = 16;
-static constexpr std::size_t MaxTestedAlignment = 4 * 1024;
+static constexpr std::size_t MinTestedSize             = 32;
+static constexpr std::size_t MaxTestedSize             = 8 * 1024;
+static constexpr std::size_t TestedSizeStep            = 1;
+static constexpr std::size_t MinTestedAlignment        = 16;
+static constexpr std::size_t MaxTestedAlignment        = 4 * 1024;
 static constexpr std::size_t TestedAlignmentMultiplier = 2;
 static constexpr std::size_t NUM_TRIALS{100};
 
-TYPED_TEST(MRTest, AlignmentTest) {
+TYPED_TEST(MRTest, AlignmentTest)
+{
   std::default_random_engine generator(0);
   constexpr std::size_t MAX_ALLOCATION_SIZE{10 * size_mb};
-  std::uniform_int_distribution<std::size_t> size_distribution(
-      1, MAX_ALLOCATION_SIZE);
+  std::uniform_int_distribution<std::size_t> size_distribution(1, MAX_ALLOCATION_SIZE);
 
   for (std::size_t num_trials = 0; num_trials < NUM_TRIALS; ++num_trials) {
-    for (std::size_t alignment = MinTestedAlignment;
-         alignment <= MaxTestedAlignment;
+    for (std::size_t alignment = MinTestedAlignment; alignment <= MaxTestedAlignment;
          alignment *= TestedAlignmentMultiplier) {
       auto allocation_size = size_distribution(generator);
       void* ptr{nullptr};
@@ -233,15 +233,14 @@ TYPED_TEST(MRTest, AlignmentTest) {
   }
 }
 
-TYPED_TEST(MRTest, UnsupportedAlignmentTest) {
+TYPED_TEST(MRTest, UnsupportedAlignmentTest)
+{
   std::default_random_engine generator(0);
   constexpr std::size_t MAX_ALLOCATION_SIZE{10 * size_mb};
-  std::uniform_int_distribution<std::size_t> size_distribution(
-      1, MAX_ALLOCATION_SIZE);
+  std::uniform_int_distribution<std::size_t> size_distribution(1, MAX_ALLOCATION_SIZE);
 
   for (std::size_t num_trials = 0; num_trials < NUM_TRIALS; ++num_trials) {
-    for (std::size_t alignment = MinTestedAlignment;
-         alignment <= MaxTestedAlignment;
+    for (std::size_t alignment = MinTestedAlignment; alignment <= MaxTestedAlignment;
          alignment *= TestedAlignmentMultiplier) {
       auto allocation_size = size_distribution(generator);
       void* ptr{nullptr};
@@ -250,13 +249,13 @@ TYPED_TEST(MRTest, UnsupportedAlignmentTest) {
       auto const bad_alignment = alignment + 1;
       EXPECT_NO_THROW(ptr = this->mr->allocate(allocation_size, bad_alignment));
       expect_aligned(ptr, alignof(std::max_align_t));
-      EXPECT_NO_THROW(
-          this->mr->deallocate(ptr, allocation_size, bad_alignment));
+      EXPECT_NO_THROW(this->mr->deallocate(ptr, allocation_size, bad_alignment));
     }
   }
 }
 
-TEST(PinnedResource, isPinned) {
+TEST(PinnedResource, isPinned)
+{
   rmm::mr::pinned_memory_resource mr;
   void* p{nullptr};
   EXPECT_NO_THROW(p = mr.allocate(100));

--- a/tests/performance/random_allocate.cpp
+++ b/tests/performance/random_allocate.cpp
@@ -15,91 +15,95 @@
  */
 #include <cuda_runtime_api.h>
 #include <rmm/rmm.h>
-#include <cstdio>
-#include <cstring>
 #include <cassert>
 #include <chrono>
+#include <cstdio>
+#include <cstring>
 
 using namespace std;
 
-#define cudaSucceeded(ans) { gpuAssert((ans), __FILE__, __LINE__); }
-inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true) {
-    if (code != cudaSuccess) {
-        fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
-        if (abort) exit(code);
-    }
+#define cudaSucceeded(ans)                \
+  {                                       \
+    gpuAssert((ans), __FILE__, __LINE__); \
+  }
+inline void gpuAssert(cudaError_t code, const char* file, int line, bool abort = true)
+{
+  if (code != cudaSuccess) {
+    fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
+    if (abort) exit(code);
+  }
 }
 
-#define rmmSucceeded(ans) { rmmAssert((ans), __FILE__, __LINE__); }
-inline void rmmAssert(rmmError_t code, const char *file, int line, bool abort=true) {
-    if (code != RMM_SUCCESS) {
-        fprintf(stderr, "RMMassert: %s %d\n", file, line);
-        if (abort) exit(code);
-    }
+#define rmmSucceeded(ans)                 \
+  {                                       \
+    rmmAssert((ans), __FILE__, __LINE__); \
+  }
+inline void rmmAssert(rmmError_t code, const char* file, int line, bool abort = true)
+{
+  if (code != RMM_SUCCESS) {
+    fprintf(stderr, "RMMassert: %s %d\n", file, line);
+    if (abort) exit(code);
+  }
 }
 
 cudaError_t (*gpuAlloc)(void** ptr, size_t sz) = cudaMalloc;
-cudaError_t (*gpuFree)(void* ptr) = cudaFree;
+cudaError_t (*gpuFree)(void* ptr)              = cudaFree;
 
-cudaError_t _rmmAlloc(void **ptr, size_t sz) {
-    rmmError_t res = RMM_ALLOC(ptr, sz, 0);
-    rmmSucceeded(res);
-    if (res != RMM_SUCCESS) return cudaErrorMemoryAllocation;
-    return cudaSuccess;
+cudaError_t _rmmAlloc(void** ptr, size_t sz)
+{
+  rmmError_t res = RMM_ALLOC(ptr, sz, 0);
+  rmmSucceeded(res);
+  if (res != RMM_SUCCESS) return cudaErrorMemoryAllocation;
+  return cudaSuccess;
 }
 
-cudaError_t _rmmFree(void *ptr) {
-    rmmError_t res = RMM_FREE(ptr, 0);
-    rmmSucceeded(res);
-    if (res != RMM_SUCCESS) return cudaErrorMemoryAllocation;
-    return cudaSuccess;
+cudaError_t _rmmFree(void* ptr)
+{
+  rmmError_t res = RMM_FREE(ptr, 0);
+  rmmSucceeded(res);
+  if (res != RMM_SUCCESS) return cudaErrorMemoryAllocation;
+  return cudaSuccess;
 }
 
-enum Allocator {
-    cudaDefault = 0,
-    rmmDefault,
-    rmmManaged,
-    rmmDefaultPool,
-    rmmManagedPool
-};
+enum Allocator { cudaDefault = 0, rmmDefault, rmmManaged, rmmDefaultPool, rmmManagedPool };
 
-void setAllocator(const std::string alloc) {
-    if (alloc == "cudaDefault") {
-        gpuAlloc = cudaMalloc;
-        gpuFree = cudaFree;
-        return;
-    }
-    else {
-        rmmOptions_t options{};
-        if (alloc == "rmmManaged")
-            options.allocation_mode = CudaManagedMemory;
-        else if (alloc == "rmmDefaultPool")
-            options.allocation_mode = PoolAllocation;
-        else if (alloc == "rmmManagedPool")
-            options.allocation_mode = 
-                static_cast<rmmAllocationMode_t>(PoolAllocation | 
-                                                 CudaManagedMemory);
-        else assert(alloc == "rmmDefault");
-        rmmInitialize(&options);
-        gpuAlloc = _rmmAlloc;
-        gpuFree = _rmmFree;
-        return;
-    }
+void setAllocator(const std::string alloc)
+{
+  if (alloc == "cudaDefault") {
+    gpuAlloc = cudaMalloc;
+    gpuFree  = cudaFree;
+    return;
+  } else {
+    rmmOptions_t options{};
+    if (alloc == "rmmManaged")
+      options.allocation_mode = CudaManagedMemory;
+    else if (alloc == "rmmDefaultPool")
+      options.allocation_mode = PoolAllocation;
+    else if (alloc == "rmmManagedPool")
+      options.allocation_mode =
+        static_cast<rmmAllocationMode_t>(PoolAllocation | CudaManagedMemory);
+    else
+      assert(alloc == "rmmDefault");
+    rmmInitialize(&options);
+    gpuAlloc = _rmmAlloc;
+    gpuFree  = _rmmFree;
+    return;
+  }
 }
 
 using timer = std::chrono::high_resolution_clock;
 
 // double precision time durations
 template <typename T>
-std::chrono::duration<double, std::micro>  microseconds(T&& t)
+std::chrono::duration<double, std::micro> microseconds(T&& t)
 {
-    return std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(t);
+  return std::chrono::duration_cast<std::chrono::duration<double, std::micro>>(t);
 }
 
 template <typename T>
-std::chrono::duration<double, std::milli>  milliseconds(T&& t)
+std::chrono::duration<double, std::milli> milliseconds(T&& t)
 {
-    return std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(t);
+  return std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(t);
 }
 
 #define ALLOC_PROBABILITY 53
@@ -118,190 +122,201 @@ std::chrono::duration<double, std::milli>  milliseconds(T&& t)
 
 #define SEED 123898464
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
+  if (argc < 5) {
+    printf(
+      "Usage: %s <allocator> <num allocations> <num unique sizes> <report average time every n "
+      "allocations>\n",
+      argv[0]);
+    printf(
+      "Allocator is one of: cudaDefault, rmmDefault, rmmManaged, rmmDefaultPool, or "
+      "rmmManagedPool\n");
+    return 1;
+  }
 
-    if (argc < 5) {
-        printf("Usage: %s <allocator> <num allocations> <num unique sizes> <report average time every n allocations>\n", argv[0]);
-        printf("Allocator is one of: cudaDefault, rmmDefault, rmmManaged, rmmDefaultPool, or rmmManagedPool\n");
-        return 1;
+  setAllocator(argv[1]);
+
+  int numAllocations = atoi(argv[2]);
+  int numSizes       = atoi(argv[3]);
+  int averagePerN    = atoi(argv[4]);
+  printf("allocator: %s, numAllocations: %d, numSize: %d, report average every %d allocations\n",
+         argv[1],
+         numAllocations,
+         numSizes,
+         averagePerN);
+
+  cudaStream_t st1;
+  cudaSucceeded(cudaStreamCreate(&st1));  // Not used in this version
+
+  //------------------------ creating some random sizes -------------------------//
+  unsigned* sizes = (unsigned*)malloc(numSizes * sizeof(unsigned));
+  srand(SEED);
+
+  printf("Randomizing sizes between %luKB and %luKB bytes\n",
+         MIN_BUFFER_SIZE_BYTE / KB,
+         MAX_BUFFER_SIZE_BYTE / KB);
+  for (int i = 0; i < numSizes; i++) {
+    sizes[i] = (rand() % (MAX_BUFFER_SIZE_BYTE - MIN_BUFFER_SIZE_BYTE)) + MIN_BUFFER_SIZE_BYTE;
+  }
+  //-----------------------------------------------------------------------------//
+
+  //----------------------- create a bunch of allocation sizes -----------------//
+  srand(SEED);
+  unsigned* allocations                 = (unsigned*)malloc(numAllocations * sizeof(unsigned));
+  void** buffers                        = (void**)malloc(numAllocations * sizeof(void*));
+  long long unsigned totalAllocatedSize = 0;
+  for (int i = 0; i < numAllocations; i++) {
+    allocations[i] = sizes[rand() % numSizes];
+    buffers[i]     = NULL;
+    totalAllocatedSize += allocations[i];
+  }
+  //----------------------------------------------------------------------------//
+
+  size_t totalMem, freeMem;
+  cudaSucceeded(cudaMemGetInfo(&freeMem, &totalMem));
+
+  //----------------- create the exact allocation-free plan --------------------//
+  const int numAllocFree = numAllocations * 2;
+  int* allocFrees        = (int*)malloc(numAllocFree * sizeof(int));
+
+  // This is the array the holds the valid allocations we currently have
+  int* existingAllocations = (int*)malloc(numAllocations * sizeof(int));
+  memset(existingAllocations, 0, numAllocations * sizeof(int));
+
+  int allocCounter    = 0;  // Ignore the first allocation index (so that we can negate the index)
+  size_t currentSize  = 0;
+  size_t maxSize      = (size_t)(((freeMem / MB) * MEM_USAGE_PERCENTAGE) / 10000) * MB;
+  int existingCounter = 0;
+
+  // Printing the bar for max size, so user knows how to measure the usage based on the bar length
+  printf("[                       max size: (%8luMB)               ]  [", freeMem / MB);
+  for (size_t j = 0; j < ((maxSize / KB) * BAR_UNIT) / (maxSize / KB); j++) {
+    printf("-");
+  }
+  printf("]100.0%%\n");
+
+  srand(SEED);
+  for (int i = 0; i < numAllocFree; i++) {
+    // Decide whether we want to allocate or free
+    int allocOrFree = 0;
+    int chance      = rand() % 100;
+    if (chance < ALLOC_PROBABILITY) {
+      allocOrFree = ALLOC;
+      if ((currentSize + allocations[allocCounter]) >= maxSize || allocCounter >= numAllocations) {
+        allocOrFree = FREE;
+      }
+    } else {
+      allocOrFree = FREE;
+      if (currentSize <= 0) { allocOrFree = ALLOC; }
     }
 
-    setAllocator(argv[1]);
+    if (allocOrFree == ALLOC) {
+      allocFrees[i] = allocCounter++;
 
-    int numAllocations = atoi(argv[2]);
-    int numSizes = atoi(argv[3]);
-    int averagePerN = atoi(argv[4]);
-    printf("allocator: %s, numAllocations: %d, numSize: %d, report average every %d allocations\n", argv[1], numAllocations, numSizes, averagePerN);
-    
-    cudaStream_t st1;
-    cudaSucceeded(cudaStreamCreate(&st1)); // Not used in this version
-
-    //------------------------ creating some random sizes -------------------------//
-    unsigned *sizes = (unsigned*) malloc(numSizes * sizeof(unsigned));
-    srand(SEED);
-
-    printf("Randomizing sizes between %luKB and %luKB bytes\n", MIN_BUFFER_SIZE_BYTE / KB, MAX_BUFFER_SIZE_BYTE / KB);
-    for (int i = 0; i < numSizes; i ++) {
-        sizes[i] = (rand() % (MAX_BUFFER_SIZE_BYTE - MIN_BUFFER_SIZE_BYTE)) + MIN_BUFFER_SIZE_BYTE;
-    }
-    //-----------------------------------------------------------------------------//
-
-
-    //----------------------- create a bunch of allocation sizes -----------------//
-    srand(SEED);
-    unsigned* allocations = (unsigned*) malloc(numAllocations * sizeof(unsigned));
-    void** buffers = (void**) malloc(numAllocations * sizeof(void*));
-    long long unsigned totalAllocatedSize = 0;
-    for (int i = 0; i < numAllocations; i ++) {
-        allocations[i] = sizes[rand() % numSizes];
-        buffers[i] = NULL;
-        totalAllocatedSize += allocations[i];
-    }
-    //----------------------------------------------------------------------------//
-
-    size_t totalMem, freeMem;
-    cudaSucceeded(cudaMemGetInfo(&freeMem, &totalMem));
-    
-    //----------------- create the exact allocation-free plan --------------------//
-    const int numAllocFree = numAllocations * 2;
-    int* allocFrees = (int*)malloc(numAllocFree * sizeof(int));
-
-    // This is the array the holds the valid allocations we currently have
-    int* existingAllocations = (int*) malloc(numAllocations * sizeof(int));
-    memset(existingAllocations, 0, numAllocations * sizeof(int));
-
-    int allocCounter = 0; // Ignore the first allocation index (so that we can negate the index)
-    size_t currentSize = 0;
-    size_t maxSize = (size_t)(((freeMem / MB) * MEM_USAGE_PERCENTAGE) / 10000) * MB;
-    int existingCounter = 0;
-
-    // Printing the bar for max size, so user knows how to measure the usage based on the bar length
-    printf("[                       max size: (%8luMB)               ]  [", freeMem / MB);
-    for (size_t j = 0; j < ((maxSize / KB) * BAR_UNIT) / (maxSize / KB); j ++) {
+      // Record this allocation and move on
+      existingAllocations[existingCounter++] = allocFrees[i];
+      currentSize += allocations[allocFrees[i]];
+      assert(currentSize < maxSize);
+      printf("[%3d] Alloc index %4d with size %7luKB (current sum: %7luMB)[",
+             i,
+             allocFrees[i],
+             allocations[allocFrees[i]] / KB,
+             currentSize / MB);
+      for (size_t j = 0; j < ((currentSize / KB) * BAR_UNIT) / (maxSize / KB); j++) {
         printf("-");
+      }
+      double usage = (double)((currentSize / KB) * 100) / (double)(maxSize / KB);
+      printf("]%3.1f%%\n", usage);
+    } else {
+      // Let's randomly pick one of the allocations that is not already free'd
+      int allocationToFreeIndex = rand() % existingCounter;
+      allocFrees[i]             = existingAllocations[allocationToFreeIndex] * (-1);
+
+      // Shift existingAllocations to remove the allocation
+      for (int j = allocationToFreeIndex + 1; j < existingCounter; j++) {
+        existingAllocations[j - 1] = existingAllocations[j];
+      }
+      existingCounter--;
+      currentSize -= allocations[allocFrees[i] * (-1)];
+      printf("[%3d] Free  index %4d with size %7luKB (current sum: %7luMB)[",
+             i,
+             allocFrees[i],
+             allocations[allocFrees[i] * (-1)] / KB,
+             currentSize / MB);
+      for (size_t j = 0; j < (currentSize * BAR_UNIT) / maxSize; j++) {
+        printf("-");
+      }
+      double usage = (double)((currentSize / KB) * 100) / (double)(maxSize / KB);
+      printf("]%3.1f%%\n", usage);
     }
-    printf("]100.0%%\n");
+  }
 
-    srand(SEED);
-    for (int i = 0; i < numAllocFree; i++) {
-        // Decide whether we want to allocate or free
-        int allocOrFree = 0;
-        int chance = rand() % 100;
-        if (chance < ALLOC_PROBABILITY) {
-            allocOrFree = ALLOC;
-            if ((currentSize + allocations[allocCounter]) >= maxSize || allocCounter >= numAllocations) {
-                allocOrFree = FREE;
-            }
-        }
-        else {
-            allocOrFree = FREE;
-            if (currentSize <= 0) {
-                allocOrFree = ALLOC;
-            }
-        }
+  printf("Allocation-free plan is created. Executing the plan.\n");
 
+  // int this_time_malloc, this_time_free, sum_time_malloc=0, sum_time_free=0, period_time_malloc=0,
+  // period_time_free=0;
+  auto sum_time_malloc    = std::chrono::duration<double>::zero();
+  auto sum_time_free      = std::chrono::duration<double>::zero();
+  auto period_time_malloc = std::chrono::duration<double>::zero();
+  auto period_time_free   = std::chrono::duration<double>::zero();
 
-        if (allocOrFree == ALLOC) {
-            allocFrees[i] = allocCounter ++;
+  int period_count_malloc = 0;
+  int period_count_free   = 0;
 
-            // Record this allocation and move on
-            existingAllocations[existingCounter++] = allocFrees[i];
-            currentSize += allocations[allocFrees[i]];
-            assert(currentSize < maxSize);
-            printf("[%3d] Alloc index %4d with size %7luKB (current sum: %7luMB)[", i, allocFrees[i], allocations[allocFrees[i]] / KB, currentSize / MB);
-            for (size_t j = 0; j < ((currentSize / KB) * BAR_UNIT) / (maxSize / KB); j ++) {
-                printf("-");
-            }
-            double usage = (double)((currentSize / KB) * 100) / (double)(maxSize / KB);
-            printf("]%3.1f%%\n", usage);
-        }
-        else {
-            // Let's randomly pick one of the allocations that is not already free'd
-            int allocationToFreeIndex = rand() % existingCounter;
-            allocFrees[i] = existingAllocations[allocationToFreeIndex] * (-1);
+  auto start = timer::now();
+  // Do the first allocation outside the for, since its index is 0
+  cudaSucceeded(gpuAlloc(&buffers[allocFrees[0]], allocations[allocFrees[0]]));
+  auto end = timer::now();
 
-            // Shift existingAllocations to remove the allocation
-            for (int j = allocationToFreeIndex + 1; j < existingCounter; j ++) {
-                existingAllocations[j - 1] = existingAllocations[j];
-            }
-            existingCounter --;
-            currentSize -= allocations[allocFrees[i] * (-1)];
-            printf("[%3d] Free  index %4d with size %7luKB (current sum: %7luMB)[", i, allocFrees[i], allocations[allocFrees[i] * (-1)] / KB, currentSize / MB);
-            for (size_t j = 0; j < (currentSize * BAR_UNIT) / maxSize; j ++) {
-                printf("-");
-            }
-            double usage = (double)((currentSize / KB) * 100) / (double)(maxSize / KB);
-            printf("]%3.1f%%\n", usage);
-        }
+  for (int i = 1; i < numAllocFree; i++) {
+    if (allocFrees[i] > 0) {
+      start = timer::now();
+      if (gpuAlloc(&buffers[allocFrees[i]], allocations[allocFrees[i]]) != cudaSuccess) {
+        printf("failed to allocate %dth allocation with size %luKB\n",
+               i,
+               allocations[allocFrees[i]] / KB);
+        exit(1);
+      }
+      end                                = timer::now();
+      std::chrono::duration<double> diff = end - start;
+      sum_time_malloc += diff;
 
+      period_count_malloc++;
+      period_time_malloc += diff;
+      if (period_count_malloc >= averagePerN) {
+        printf("Average malloc: %0.2f us\n",
+               (double)microseconds(period_time_malloc).count() / period_count_malloc);
+        period_count_malloc = 0;
+        period_time_malloc  = std::chrono::duration<double>::zero();
+      }
+    } else {
+      start = timer::now();
+      cudaSucceeded(gpuFree(buffers[allocFrees[i] * (-1)]));
+      end                                = timer::now();
+      std::chrono::duration<double> diff = end - start;
+      sum_time_free += diff;
+
+      period_count_free++;
+      period_time_free += diff;
+      if (period_count_free >= averagePerN) {
+        printf("Average free: %0.2f us\n",
+               (double)microseconds(period_time_free).count() / period_count_free);
+        period_count_free = 0;
+        period_time_free  = std::chrono::duration<double>::zero();
+      }
     }
+  }
 
-    printf("Allocation-free plan is created. Executing the plan.\n");
+  cudaSucceeded(cudaStreamSynchronize(st1));
+  printf("sum allocation size: %llu MB\n", totalAllocatedSize / MB);
+  printf("Average allocation size: %llu KB\n", (totalAllocatedSize / numAllocations) / KB);
+  printf("sum malloc: %f ms (average: %0.2f us)\n",
+         (double)milliseconds(sum_time_malloc).count(),
+         (double)microseconds(sum_time_malloc).count() / numAllocations);
+  printf("sum free: %f ms (average: %0.2f us)\n",
+         (double)milliseconds(sum_time_free).count(),
+         (double)microseconds(sum_time_free).count() / numAllocations);
 
-    //int this_time_malloc, this_time_free, sum_time_malloc=0, sum_time_free=0, period_time_malloc=0, period_time_free=0;
-    auto sum_time_malloc = std::chrono::duration<double>::zero();
-    auto sum_time_free = std::chrono::duration<double>::zero();
-    auto period_time_malloc = std::chrono::duration<double>::zero();
-    auto period_time_free = std::chrono::duration<double>::zero();
-
-    int period_count_malloc = 0;
-    int period_count_free = 0;
-
-    auto start = timer::now(); 
-    // Do the first allocation outside the for, since its index is 0
-    cudaSucceeded(gpuAlloc(&buffers[allocFrees[0]], allocations[allocFrees[0]]));
-    auto end = timer::now();
-
-    for (int i = 1; i < numAllocFree; i++) {
-        if (allocFrees[i] > 0) {
-            start = timer::now();
-            if (gpuAlloc(&buffers[allocFrees[i]], allocations[allocFrees[i]]) != cudaSuccess) {
-                printf("failed to allocate %dth allocation with size %luKB\n", i, allocations[allocFrees[i]] / KB);
-                exit(1);
-            }
-            end = timer::now();
-            std::chrono::duration<double> diff = end-start;
-            sum_time_malloc += diff;
-
-            period_count_malloc ++;
-            period_time_malloc += diff;
-            if (period_count_malloc >= averagePerN) {
-                printf("Average malloc: %0.2f us\n",
-                       (double)microseconds(period_time_malloc).count() / 
-                            period_count_malloc);
-                period_count_malloc = 0;
-                period_time_malloc = std::chrono::duration<double>::zero();
-            }
-        }
-        else {
-            start = timer::now();
-            cudaSucceeded(gpuFree(buffers[allocFrees[i] * (-1)]));
-            end = timer::now();
-            std::chrono::duration<double> diff = end-start;
-            sum_time_free += diff;
-
-            period_count_free ++;
-            period_time_free += diff;
-            if (period_count_free >= averagePerN) {
-                printf("Average free: %0.2f us\n",
-                       (double)microseconds(period_time_free).count() / 
-                            period_count_free);
-                period_count_free = 0;
-                period_time_free = std::chrono::duration<double>::zero();
-            }
-        }
-    }
-
-    cudaSucceeded(cudaStreamSynchronize(st1));
-    printf("sum allocation size: %llu MB\n", totalAllocatedSize / MB);
-    printf("Average allocation size: %llu KB\n", 
-           (totalAllocatedSize / numAllocations) / KB);
-    printf("sum malloc: %f ms (average: %0.2f us)\n",
-           (double)milliseconds(sum_time_malloc).count(),
-           (double)microseconds(sum_time_malloc).count() / numAllocations);
-    printf("sum free: %f ms (average: %0.2f us)\n",
-           (double)milliseconds(sum_time_free).count(),
-           (double)microseconds(sum_time_free).count() / numAllocations);
-
-    return 0;
+  return 0;
 }

--- a/tests/test_fixtures.h
+++ b/tests/test_fixtures.h
@@ -21,15 +21,10 @@
 #include "rmm/rmm.h"
 
 // Base class fixture for GDF google tests that initializes / finalizes the memory manager
-struct GdfTest : public ::testing::Test
-{
-    static void SetUpTestCase() {
-        ASSERT_EQ( RMM_SUCCESS, rmmInitialize(nullptr) );
-    }
+struct GdfTest : public ::testing::Test {
+  static void SetUpTestCase() { ASSERT_EQ(RMM_SUCCESS, rmmInitialize(nullptr)); }
 
-    static void TearDownTestCase() {
-        ASSERT_EQ( RMM_SUCCESS, rmmFinalize() );
-    }
+  static void TearDownTestCase() { ASSERT_EQ(RMM_SUCCESS, rmmFinalize()); }
 };
 
 #endif


### PR DESCRIPTION
Identical to a bug that happened in the `cuDF` `run-clang-format.py` file, a missing comma prevented certain directories from being formatted. The PR fixes that and formats the files. See: https://github.com/rapidsai/cudf/pull/5122 for the previous bug.