### PR TITLE
[REVIEW] Fix stream and mr usage inside device_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #348 Fix unintentional use of pool-managed resource.
 - PR #367 Fix flake8 issues
 - PR #368 Fix `clang-format` missing comma bug
+- PR #370 Fix stream and mr use in `device_buffer` methods
 
 # RMM 0.13.0 (Date TBD)
 

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -202,7 +202,7 @@ class device_buffer {
       // compatible, just reuse the existing memory
       if ((capacity() > other.size()) and _mr->is_equal(*other._mr)) {
         set_stream(other.stream());
-        resize(other.size());
+        resize(other.size(), stream());
         copy(other.data(), other.size());
       } else {
         // Otherwise, need to deallocate and allocate new memory
@@ -323,7 +323,7 @@ class device_buffer {
       // Invoke copy ctor on self which only copies `[0, size())` and swap it
       // with self. The temporary `device_buffer` will hold the old contents
       // which will then be destroyed
-      auto tmp = device_buffer{*this, stream};
+      auto tmp = device_buffer{*this, stream, _mr};
       std::swap(tmp, *this);
     }
   }
@@ -418,7 +418,7 @@ class device_buffer {
    */
   void deallocate() noexcept
   {
-    if (capacity() > 0) { _mr->deallocate(data(), capacity()); }
+    if (capacity() > 0) { _mr->deallocate(data(), capacity(), stream()); }
     _size     = 0;
     _capacity = 0;
     _data     = nullptr;

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -201,8 +201,7 @@ class device_buffer {
       // If the current capacity is large enough and the resources are
       // compatible, just reuse the existing memory
       if ((capacity() > other.size()) and _mr->is_equal(*other._mr)) {
-        set_stream(other.stream());
-        resize(other.size(), stream());
+        resize(other.size(), other.stream());
         copy(other.data(), other.size());
       } else {
         // Otherwise, need to deallocate and allocate new memory


### PR DESCRIPTION
The `deallocate()` method isn't using the `_stream` member. In copy assignment the `_stream` member gets erased. In `shrink_to_fit()` the `_mr` member gets erased.