### PR TITLE
[REVIEW] Add docs build.sh [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #358 Fix typo in `rmm_cupy_allocator` docstring
 - PR #357 Add Docker 19 support to local gpuci build
 - PR #365 Make .clang-format consistent with cuGRAPH and cuDF
+- PR #371 Add docs build script to repository
 
 ## Bug Fixes
 

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -52,7 +52,7 @@ for PROJECT in ${PROJECTS[@]}; do
 done
 
 
-mv $PROJECT_WORKSPACE/doxygen/html/* $DOCS_WORKSPACE/api/libcuml/$BRANCH_VERSION
+mv $PROJECT_WORKSPACE/doxygen/html/* $DOCS_WORKSPACE/api/rmm/$BRANCH_VERSION
 
 # Customize HTML documentation
 ./update_symlinks.sh $NIGHTLY_VERSION


### PR DESCRIPTION
Moving the docs build script used in our Jenkins job into the repository itself to streamline docs building pipeline and to push possible docs build changes to developer view for editing.

This script is written to run in a devel docker image for RAPIDS, which assumes the project is already built from source in PROJECT_WORKSPACE (this variable is defined inside the jenkins job as /rapids/$PROJECT).

The script also assumes that the docs repo is cloned and located in $DOCS_WORKSPACE. After building all the docs, it will move all html files into the proper api folders in this repo, then add the relevant folders for a git commit and git push to be executed inside the Jenkins job.