### PR TITLE
Support out-of-band buffers in Python pickling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## New Features
 
+- PR #375 Support out-of-band buffers in Python pickling
+
 ## Improvements
 
 ## Bug Fixes

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -110,7 +110,8 @@ cdef class DeviceBuffer:
         return int(self.c_size())
 
     def __getstate__(self):
-        return self.tobytes()
+        host_data = self.tobytes()
+        return host_data
 
     def __setstate__(self, state):
         cdef DeviceBuffer other = DeviceBuffer.c_to_device(state)

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -109,7 +109,7 @@ cdef class DeviceBuffer:
     def size(self):
         return int(self.c_size())
 
-    def __reduce__(self):
+    def __reduce_ex__(self, protocol):
         host_data = self.tobytes()
         return to_device, (host_data,)
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -109,13 +109,9 @@ cdef class DeviceBuffer:
     def size(self):
         return int(self.c_size())
 
-    def __getstate__(self):
+    def __reduce__(self):
         host_data = self.tobytes()
-        return host_data
-
-    def __setstate__(self, state):
-        cdef DeviceBuffer other = to_device(state)
-        self.c_obj = move(other.c_obj)
+        return to_device, (host_data,)
 
     @property
     def __cuda_array_interface__(self):

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -114,7 +114,7 @@ cdef class DeviceBuffer:
         return host_data
 
     def __setstate__(self, state):
-        cdef DeviceBuffer other = DeviceBuffer.c_to_device(state)
+        cdef DeviceBuffer other = to_device(state)
         self.c_obj = move(other.c_obj)
 
     @property

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -18,6 +18,8 @@
 # cython: language_level = 3
 
 
+import pickle
+
 import numpy as np
 
 from libcpp.memory cimport unique_ptr
@@ -111,6 +113,8 @@ cdef class DeviceBuffer:
 
     def __reduce_ex__(self, protocol):
         host_data = self.tobytes()
+        if protocol >= 5:
+            host_data = pickle.PickleBuffer(host_data)
         return to_device, (host_data,)
 
     @property

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -250,6 +250,18 @@ def test_rmm_device_buffer_pickle_roundtrip(hb):
     db2 = pickle.loads(pb)
     hb2 = db2.tobytes()
     assert hb == hb2
+    # out-of-band
+    if pickle.HIGHEST_PROTOCOL >= 5:
+        db = rmm.DeviceBuffer.to_device(hb)
+        buffers = []
+        pb2 = pickle.dumps(db, protocol=5, buffer_callback=buffers.append)
+        del db
+        assert len(buffers) == 1
+        assert isinstance(buffers[0], pickle.PickleBuffer)
+        assert bytes(buffers[0]) == hb
+        db3 = pickle.loads(pb2, buffers=buffers)
+        hb3 = db3.tobytes()
+        assert hb3 == hb
 
 
 def test_rmm_cupy_allocator():


### PR DESCRIPTION
When Python pickle's protocol 5 or greater is used, this change will support more efficient serialization of out-of-band buffers. This is analogous to Dask's custom serialization except for pickling. As such this is helpful in any Python serialization case where pickling is used. If an older pickling protocol is used, we simply proceed as before.

Also as we have switched from `__getstate__`/`__setstate__` to `__reduce_ex__`, we no longer need to build a `DeviceBuffer` and then steal its `unique_ptr` for our own `DeviceBuffer` (which pickle also constructs). Instead we can just build a `DeviceBuffer` once and return it. So this is a bit more efficient.

Note this is analogous to the change made to `Buffer` ( https://github.com/rapidsai/cudf/pull/5132 ) except for `DeviceBuffer`.