### PR TITLE
[REVIEW] a better way to fetch spdlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Improvements
 
+- PR #377 A better way to fetch `spdlog`
 - PR #372 Use CMake `FetchContent` to obtain `cnmem` instead of git submodule
 
 ## Bug Fixes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,7 @@ include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                     "${CMAKE_CURRENT_SOURCE_DIR}/include"
                     "${CMAKE_CURRENT_SOURCE_DIR}/include/rmm"
                     "${CMAKE_CURRENT_SOURCE_DIR}/src"
-                    "${CNMEM_INCLUDE_DIR}"
-                    "${SPDLOG_INCLUDE_DIR}")
+                    "${CNMEM_INCLUDE_DIR}")
 
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------
@@ -176,7 +175,7 @@ endif(USE_NVTX)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(rmm ${CUDART_LIBRARY} cuda)
+target_link_libraries(rmm ${CUDART_LIBRARY} cuda spdlog::spdlog_header_only)
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,8 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
     add_executable(${CMAKE_TEST_NAME} ${CMAKE_TEST_SRC})
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-    target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread cudart rmm)
+    target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread cudart rmm
+                            spdlog::spdlog_header_only)
     set_target_properties(${CMAKE_TEST_NAME} PROPERTIES
                             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/gtests")
     add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
@@ -43,8 +44,7 @@ include_directories("${GTEST_INCLUDE_DIR}"
                     "${CMAKE_SOURCE_DIR}/include"
                     "${CMAKE_SOURCE_DIR}/include/rmm"
                     "${CMAKE_SOURCE_DIR}/src"
-                    "${CMAKE_CURRENT_SOURCE_DIR}/../include"
-                    "${SPDLOG_INCLUDE_DIR}")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
 ###################################################################################################
 # - library paths ---------------------------------------------------------------------------------

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -31,6 +31,5 @@ FetchContent_Declare(
 FetchContent_GetProperties(spdlog)
 if(NOT spdlog_POPULATED)
   FetchContent_Populate(spdlog)
-  # We are not using the spdlog CMake targets, so no need to call `add_subdirectory()`.
+  add_subdirectory(${spdlog_SOURCE_DIR} ${spdlog_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
-set(SPDLOG_INCLUDE_DIR "${spdlog_SOURCE_DIR}/include" PARENT_SCOPE)


### PR DESCRIPTION
@kkraus14 @harrism figured out a slightly better way to fetch spdlog without having to build their static lib. This relies on target links instead of hard coding the include directory. I think it's a slight more modular approach, but if you think it's not worth the trouble I can live with that. :)