### PR TITLE
Rely on NumPy arrays for out-of-band pickling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Improvements
 
 - PR #372 Use CMake `FetchContent` to obtain `cnmem` instead of git submodule
+- PR #382 Rely on NumPy arrays for out-of-band pickling
 
 ## Bug Fixes
 

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -112,7 +112,7 @@ cdef class DeviceBuffer:
         return int(self.c_size())
 
     def __reduce_ex__(self, protocol):
-        host_data = self.tobytes()
+        host_data = self.copy_to_host()
         if protocol >= 5:
             host_data = pickle.PickleBuffer(host_data)
         return to_device, (host_data,)

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -18,8 +18,6 @@
 # cython: language_level = 3
 
 
-import pickle
-
 import numpy as np
 
 from libcpp.memory cimport unique_ptr
@@ -113,8 +111,6 @@ cdef class DeviceBuffer:
 
     def __reduce_ex__(self, protocol):
         host_data = self.copy_to_host()
-        if protocol >= 5:
-            host_data = pickle.PickleBuffer(host_data)
         return to_device, (host_data,)
 
     @property

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -109,7 +109,7 @@ cdef class DeviceBuffer:
     def size(self):
         return int(self.c_size())
 
-    def __reduce_ex__(self, protocol):
+    def __reduce__(self):
         return to_device, (self.copy_to_host(),)
 
     @property

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -110,8 +110,7 @@ cdef class DeviceBuffer:
         return int(self.c_size())
 
     def __reduce_ex__(self, protocol):
-        host_data = self.copy_to_host()
-        return to_device, (host_data,)
+        return to_device, (self.copy_to_host(),)
 
     @property
     def __cuda_array_interface__(self):


### PR DESCRIPTION
As NumPy arrays already support pickle protocol 5 and are pickleable themselves, just rely on NumPy arrays for all pickling protocols. This saves us the effort of needing to special case out-of-band pickling support.