### PR TITLE
Explicitly require NumPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Bug Fixes
 
+- PR #383 Explicitly require NumPy
+
 # RMM 0.14.0 (Date TBD)
 
 ## New Features

--- a/conda/environments/rmm_dev_cuda10.0.yml
+++ b/conda/environments/rmm_dev_cuda10.0.yml
@@ -8,6 +8,7 @@ dependencies:
 - cmake>=3.14
 - python>=3.6,<3.8
 - numba>=0.49
+- numpy
 - cffi>=1.10.0
 - pytest
 - cudatoolkit=10.0

--- a/conda/environments/rmm_dev_cuda9.2.yml
+++ b/conda/environments/rmm_dev_cuda9.2.yml
@@ -8,6 +8,7 @@ dependencies:
 - cmake>=3.14
 - python>=3.6,<3.8
 - numba>=0.49
+- numpy
 - cffi>=1.10.0
 - pytest
 - cudatoolkit=9.2

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -28,6 +28,7 @@ requirements:
   run:
     - python
     - numba >=0.49
+    - numpy
 
 test:
   commands:


### PR DESCRIPTION
Already we are using NumPy in the code. Thus far this has worked because Numba requires NumPy. So we have depended on NumPy implicitly. This makes the NumPy requirement explicit.