### PR TITLE
Add `get_default_resource_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - PR #375 Support out-of-band buffers in Python pickling
+- PR #391 Add `get_default_resource_type`
 
 ## Improvements
 

--- a/python/rmm/_lib/memory_resource.pxd
+++ b/python/rmm/_lib/memory_resource.pxd
@@ -113,4 +113,6 @@ cdef class HybridMemoryResource(MemoryResource):
 cdef class LoggingResourceAdaptor(MemoryResource):
     cpdef flush(self)
 
+cpdef get_default_resource_type()
+
 cpdef is_initialized()

--- a/python/rmm/_lib/memory_resource.pxd
+++ b/python/rmm/_lib/memory_resource.pxd
@@ -112,3 +112,5 @@ cdef class HybridMemoryResource(MemoryResource):
 
 cdef class LoggingResourceAdaptor(MemoryResource):
     cpdef flush(self)
+
+cpdef is_initialized()

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -349,6 +349,13 @@ cpdef _set_default_resource(MemoryResource mr):
     set_default_resource(_mr.c_obj)
 
 
+cpdef get_default_resource_type():
+    """
+    Get the default memory resource type used for RMM device allocations.
+    """
+    return type(_mr)
+
+
 cpdef is_initialized():
     global _mr
     return _mr.c_obj.get() is not NULL

--- a/python/rmm/mr.py
+++ b/python/rmm/mr.py
@@ -14,6 +14,7 @@ from rmm._lib.memory_resource import (
     _flush_logs,
     _initialize,
     _set_default_resource as set_default_resource,
+    get_default_resource_type,
     is_initialized,
 )
 
@@ -31,5 +32,6 @@ __all__ = [
     "_flush_logs",
     "_initialize",
     "set_default_resource",
+    "get_default_resource_type",
     "is_initialized",
 ]

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -274,13 +274,13 @@ def test_rmm_cupy_allocator():
 @pytest.mark.parametrize("nelem", _nelems)
 @pytest.mark.parametrize("alloc", _allocs)
 def test_pool_memory_resource(dtype, nelem, alloc):
-    rmm.mr.set_default_resource(
-        rmm.mr.PoolMemoryResource(
-            rmm.mr.CudaMemoryResource(),
-            initial_pool_size=1 << 22,
-            maximum_pool_size=1 << 23,
-        )
+    mr = rmm.mr.PoolMemoryResource(
+        rmm.mr.CudaMemoryResource(),
+        initial_pool_size=1 << 22,
+        maximum_pool_size=1 << 23,
     )
+    rmm.mr.set_default_resource(mr)
+    assert rmm.mr.get_default_resource_type() is type(mr)
     array_tester(dtype, nelem, alloc)
     rmm.reinitialize()
 
@@ -296,11 +296,11 @@ def test_pool_memory_resource(dtype, nelem, alloc):
     ],
 )
 def test_fixed_size_memory_resource(dtype, nelem, alloc, upstream):
-    rmm.mr.set_default_resource(
-        rmm.mr.FixedSizeMemoryResource(
-            upstream(), block_size=1 << 20, blocks_to_preallocate=128
-        )
+    mr = rmm.mr.FixedSizeMemoryResource(
+        upstream(), block_size=1 << 20, blocks_to_preallocate=128
     )
+    rmm.mr.set_default_resource(mr)
+    assert rmm.mr.get_default_resource_type() is type(mr)
     array_tester(dtype, nelem, alloc)
     rmm.reinitialize()
 
@@ -316,15 +316,15 @@ def test_fixed_size_memory_resource(dtype, nelem, alloc, upstream):
     ],
 )
 def test_fixed_multisize_memory_resource(dtype, nelem, alloc, upstream):
-    rmm.mr.set_default_resource(
-        rmm.mr.FixedMultiSizeMemoryResource(
-            upstream(),
-            size_base=2,
-            min_size_exponent=18,
-            max_size_exponent=22,
-            initial_blocks_per_size=128,
-        )
+    mr = rmm.mr.FixedMultiSizeMemoryResource(
+        upstream(),
+        size_base=2,
+        min_size_exponent=18,
+        max_size_exponent=22,
+        initial_blocks_per_size=128,
     )
+    rmm.mr.set_default_resource(mr)
+    assert rmm.mr.get_default_resource_type() is type(mr)
     array_tester(dtype, nelem, alloc)
     rmm.reinitialize()
 
@@ -352,10 +352,10 @@ def test_fixed_multisize_memory_resource(dtype, nelem, alloc, upstream):
 def test_hybrid_memory_resource(
     dtype, nelem, alloc, small_alloc_mr, large_alloc_mr
 ):
-    rmm.mr.set_default_resource(
-        rmm.mr.HybridMemoryResource(
-            small_alloc_mr(), large_alloc_mr(), threshold_size=32
-        )
+    mr = rmm.mr.HybridMemoryResource(
+        small_alloc_mr(), large_alloc_mr(), threshold_size=32
     )
+    rmm.mr.set_default_resource(mr)
+    assert rmm.mr.get_default_resource_type() is type(mr)
     array_tester(dtype, nelem, alloc)
     rmm.reinitialize()


### PR DESCRIPTION
Adds a new function, `get_default_resource_type`, to the Python/Cython interface to allow users to inspect the type of the default resource in use.

cc @pentschev @shwina @kkraus14 @jrhemstad