### PR TITLE
[REVIEW] Removing target-specific entries in CMake's link command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - PR #370 Fix stream and mr use in `device_buffer` methods
 - PR #379 Remove deprecated calls from synchronization.cpp
 - PR #381 Remove test_benchmark.cpp from cmakelists
+- PR #392 SPDLOG matches other header-only acquisition patterns
 
 
 # RMM 0.13.0 (Date TBD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,8 @@ endif(BUILD_BENCHMARKS)
 
 ###################################################################################################
 # - include paths ---------------------------------------------------------------------------------
-include_directories("${CUB_INCLUDE_DIR}"
+include_directories("${SPDLOG_INCLUDE_DIR}"
+                    "${CUB_INCLUDE_DIR}"
                     "${THRUST_INCLUDE_DIR}"
                     "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                     "${CMAKE_CURRENT_SOURCE_DIR}/include"
@@ -177,7 +178,7 @@ endif(USE_NVTX)
 ###################################################################################################
 # - link libraries --------------------------------------------------------------------------------
 
-target_link_libraries(rmm ${CUDART_LIBRARY} cuda spdlog::spdlog_header_only)
+target_link_libraries(rmm ${CUDART_LIBRARY} cuda)
 
 ###################################################################################################
 # - install targets -------------------------------------------------------------------------------

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -50,6 +50,7 @@ if(NOT spdlog_POPULATED)
   FetchContent_Populate(spdlog)
   add_subdirectory(${spdlog_SOURCE_DIR} ${spdlog_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
+set(SPDLOG_INCLUDE_DIR "${spdlog_SOURCE_DIR}/include" PARENT_SCOPE)
 
 ###################################################################################################
 # - thrust ----------------------------------------------------------------------------------------


### PR DESCRIPTION
Removed `spdlog::spdlog_header_only` from `target_link_libraries`, and added an appropriate `PARENT_SCOPE` `set`.

This creates properly scoped variable `SPDLOG_INCLUDE_DIR` that can be included at configure/compile time.