### PR TITLE
[REVIEW]  Fix segfault in RANDOM_ALLOCATIONS_BENCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 
 ## Bug Fixes
 
+- PR #400 Fix segfault in RANDOM_ALLOCATIONS_BENCH
 - PR #383 Explicitly require NumPy
+
 
 # RMM 0.14.0 (Date TBD)
 

--- a/benchmarks/random_allocations/random_allocations.cpp
+++ b/benchmarks/random_allocations/random_allocations.cpp
@@ -171,13 +171,13 @@ struct resource_wrapper {
   MemoryResource* mr{};
 };
 
-template<>
+template <>
 resource_wrapper<cnmem_mr>::resource_wrapper()
 {
   mr = new cnmem_mr();
 }
 
-template<>
+template <>
 resource_wrapper<cuda_mr>::resource_wrapper()
 {
   mr = new cuda_mr();
@@ -198,8 +198,8 @@ resource_wrapper<fixed_multisize_mr>::resource_wrapper()
 template <>
 resource_wrapper<safe_hybrid_mr>::resource_wrapper()
 {
-  auto pool    = new pool_mr(new cuda_mr());
-  mr           = new rmm::mr::thread_safe_resource_adaptor<hybrid_mr>(
+  auto pool = new pool_mr(new cuda_mr());
+  mr        = new rmm::mr::thread_safe_resource_adaptor<hybrid_mr>(
     new hybrid_mr(new fixed_multisize_mr(pool), pool));
 }
 


### PR DESCRIPTION
Allocate cnmem_memory_resource like we do for other resources in the test. Fixes #399.