### PR TITLE
[REVIEW] Install rapids-build-env for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PR #382 Rely on NumPy arrays for out-of-band pickling
 - PR #386 Add short commit to conda package name
 - PR #401 Update `get_ipc_handle()` to use cuda driver API
+- PR #402 Install dependencies via rapids-build-env
 
 ## Bug Fixes
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -30,6 +30,7 @@ cd $WORKSPACE
 # Get latest tag and number of commits since tag
 export GIT_DESCRIBE_TAG=`git describe --abbrev=0 --tags`
 export GIT_DESCRIBE_NUMBER=`git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count`
+export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
 ################################################################################
 # SETUP - Check environment
@@ -41,8 +42,8 @@ env
 logger "Activate conda env..."
 source activate gdf
 
-# Install spdlog
-conda install spdlog">=1.4.2"
+# Install build env
+conda install rapids-build-env=${MINOR_VERSION}.*
 
 logger "Check versions..."
 python --version

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -45,6 +45,10 @@ source activate gdf
 # Install build env
 conda install rapids-build-env=${MINOR_VERSION}.*
 
+# https://docs.rapids.ai/maintainers/depmgmt/ 
+# conda remove -f rapids-build-env
+# conda install "your-pkg=1.0.0"
+
 logger "Check versions..."
 python --version
 gcc --version


### PR DESCRIPTION
Install dependencies via `rapids-build-env` (which is pre-installed in the containers).

This brings the repo in line with https://docs.rapids.ai/maintainers/depmgmt/