### PR TITLE
Mark Cython `memory_resource_wrappers` `extern` as `nogil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - PR #400 Fix segfault in RANDOM_ALLOCATIONS_BENCH
 - PR #383 Explicitly require NumPy
+- PR #403 Mark Cython `memory_resource_wrappers` `extern` as `nogil`
 
 
 # RMM 0.14.0 (Date TBD)

--- a/python/rmm/_lib/memory_resource.pxd
+++ b/python/rmm/_lib/memory_resource.pxd
@@ -5,7 +5,7 @@ from libcpp.string cimport string
 from libcpp.memory cimport shared_ptr
 
 
-cdef extern from "memory_resource_wrappers.hpp":
+cdef extern from "memory_resource_wrappers.hpp" nogil:
     cdef cppclass device_memory_resource_wrapper:
         shared_ptr[device_memory_resource_wrapper] get_mr() except +
 


### PR DESCRIPTION
Makes sure `memory_resource_wrappers` `extern` in Cython is marked as `nogil` so the functions can be used in sections where the GIL is released.