### PR TITLE
[REVIEW] Move customization scripts to Jenkins build [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #386 Add short commit to conda package name
 - PR #401 Update `get_ipc_handle()` to use cuda driver API
 - PR #402 Install dependencies via rapids-build-env
+- PR #405 Move doc customization scripts to Jenkins
 
 ## Bug Fixes
 

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -54,15 +54,3 @@ done
 
 mv $PROJECT_WORKSPACE/doxygen/html/* $DOCS_WORKSPACE/api/rmm/$BRANCH_VERSION
 
-# Customize HTML documentation
-./update_symlinks.sh $NIGHTLY_VERSION
-./customization/lib_map.sh
-
-
-for PROJECT in ${PROJECTS[@]}; do
-    echo ""
-    echo "Customizing: $PROJECT"
-    ./customization/customize_docs_in_folder.sh api/$PROJECT/ $NIGHTLY_VERSION
-    git add $DOCS_WORKSPACE/api/$PROJECT/*
-done
-


### PR DESCRIPTION
This section is being moved to the Jenkins job as its not important to developers and allows easier editing to these scripts for OPS.