### PR TITLE
[REVIEW] Sets a fixed version (v1.5.1) of Google Benchmark.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #383 Explicitly require NumPy
 - PR #398 Fix missing head flag in merge_blocks (pool_memory_resource) and improve block class
 - PR #403 Mark Cython `memory_resource_wrappers` `extern` as `nogil`
+- PR #406 Sets Google Benchmark to a fixed version, v1.5.1.
 
 
 # RMM 0.14.0 (Date TBD)

--- a/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -4,10 +4,10 @@ include(ExternalProject)
 
 ExternalProject_Add(GoogleBenchmark
                     GIT_REPOSITORY    https://github.com/google/benchmark.git
-                    GIT_TAG           master 
+                    GIT_TAG           v1.5.1
                     SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
                     BINARY_DIR        "${GBENCH_ROOT}/build"
-                    INSTALL_DIR		    "${GBENCH_ROOT}/install"
+                    INSTALL_DIR       "${GBENCH_ROOT}/install"
                     CMAKE_ARGS        ${GBENCH_CMAKE_ARGS} -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=${GBENCH_ROOT}/install)
                     # The flag BENCHMARK_ENABLE_TESTING=OFF prevents Google Benchmark from asking for Google Test.
 


### PR DESCRIPTION
A recent pull request https://github.com/google/benchmark/pull/965 to Google Benchmark throws a warning and causes builds to fail. This sets a fixed version of v1.5.1 instead of using the master branch.

Error output (warnings are treated as errors):
```cpp
.../googlebenchmark/src/timers.cc:215:23: error: '%02li' directive writing between 2 and 17 bytes into a region of size 6 [-Werror=format-overflow=]
     tz_len = ::sprintf(tz_offset, "%c%02li:%02li", tz_offset_sign,
              ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         offset_minutes / 100, offset_minutes % 100);
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../googlebenchmark/src/timers.cc:215:23: note: directive argument in the range [0, 92233720368547758]
.../googlebenchmark/src/timers.cc:215:23: note: directive argument in the range [0, 99]
```

Failing CI output: https://gpuci.gpuopenanalytics.com/blue/organizations/jenkins/rapidsai%2Fgpuci%2Fcudf%2Fprb%2Fcudf-gpu-build/detail/cudf-gpu-build/27496/pipeline