### PR TITLE
[WIP] Remove device buffer default ctor

### DIFF
--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -72,16 +72,9 @@ namespace rmm {
 class device_buffer {
  public:
   /**
-   * @brief Default constructor creates an empty `device_buffer`
+   * @brief Default constructor is deleted as there is no way to specify a stream.
    */
-  // Note: we cannot use `device_buffer() = default;` because nvcc implicitly adds
-  // `__host__ __device__` specifiers to the defaulted constructor when it is called within the
-  // context of both host and device functions. Specifically, the `cudf::type_dispatcher` is a host-
-  // device function. This causes warnings/errors because this ctor invokes host-only functions.
-  device_buffer()
-    : _data{nullptr}, _size{}, _capacity{}, _stream{}, _mr{rmm::mr::get_default_resource()}
-  {
-  }
+  device_buffer() = delete;
 
   /**
    * @brief Constructs a new device buffer of `size` uninitialized bytes

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -77,7 +77,7 @@ class device_uvector {
   using iterator        = pointer;
   using const_iterator  = const_pointer;
 
-  device_uvector()                 = default;
+  device_uvector()                 = delete;
   ~device_uvector()                = default;
   device_uvector(device_uvector&&) = default;
   device_uvector& operator=(device_uvector&&) = default;
@@ -255,7 +255,7 @@ class device_uvector {
   }
 
  private:
-  device_buffer _storage{};  ///< Device memory storage for vector elements
+  device_buffer _storage;  ///< Device memory storage for vector elements
 
   std::size_t constexpr elements_to_bytes(std::size_t num_elements) const noexcept
   {

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -262,21 +262,6 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
   //                  static_cast<signed char *>(buff_copy.data())));
 }
 
-TYPED_TEST(DeviceBufferTest, CopyAssignmentToDefault)
-{
-  rmm::device_buffer const from(this->size, 0, &this->mr);
-  rmm::device_buffer to{};
-  EXPECT_NO_THROW(to = from);
-  EXPECT_NE(nullptr, to.data());
-  EXPECT_NE(nullptr, from.data());
-  EXPECT_NE(from.data(), to.data());
-  EXPECT_EQ(from.size(), to.size());
-  EXPECT_EQ(from.capacity(), to.capacity());
-  EXPECT_EQ(from.stream(), to.stream());
-  EXPECT_EQ(from.memory_resource(), to.memory_resource());
-  // TODO Check contents of memory
-}
-
 TYPED_TEST(DeviceBufferTest, CopyAssignment)
 {
   rmm::device_buffer from(this->size, 0, &this->mr);
@@ -379,34 +364,6 @@ TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
   EXPECT_EQ(0, buff.capacity());
   EXPECT_EQ(0, buff.stream());
   EXPECT_NE(nullptr, buff.memory_resource());
-}
-
-TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
-{
-  rmm::device_buffer from(this->size, 0, &this->mr);
-  auto p        = from.data();
-  auto size     = from.size();
-  auto capacity = from.capacity();
-  auto mr       = from.memory_resource();
-  auto stream   = from.stream();
-
-  rmm::device_buffer to;
-  EXPECT_NO_THROW(to = std::move(from));
-
-  // contents of `from` should be in `to`
-  EXPECT_NE(nullptr, to.data());
-  EXPECT_EQ(p, to.data());
-  EXPECT_EQ(size, to.size());
-  EXPECT_EQ(capacity, to.capacity());
-  EXPECT_EQ(stream, to.stream());
-  EXPECT_EQ(mr, to.memory_resource());
-
-  // `from` should be empty
-  EXPECT_EQ(nullptr, from.data());
-  EXPECT_EQ(0, from.size());
-  EXPECT_EQ(0, from.capacity());
-  EXPECT_EQ(0, from.stream());
-  EXPECT_NE(nullptr, from.memory_resource());
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignment)

--- a/tests/device_uvector_tests.cu
+++ b/tests/device_uvector_tests.cu
@@ -30,15 +30,6 @@ using TestTypes = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
 
 TYPED_TEST_CASE(TypedUVectorTest, TestTypes);
 
-TYPED_TEST(TypedUVectorTest, DefaultConstructor)
-{
-  rmm::device_uvector<TypeParam> uv{};
-  EXPECT_EQ(uv.size(), 0);
-  EXPECT_EQ(uv.begin(), uv.end());
-  EXPECT_TRUE(uv.is_empty());
-  EXPECT_NE(uv.memory_resource(), nullptr);
-}
-
 TYPED_TEST(TypedUVectorTest, ZeroSizeConstructor)
 {
   rmm::device_uvector<TypeParam> uv(0, this->stream());


### PR DESCRIPTION
Closes https://github.com/rapidsai/rmm/issues/422

Deletes the default ctor for device_buffer and removes all uses. 