### PR TITLE
[REVIEW] Add multi-threaded support to replay benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - PR #405 Move doc customization scripts to Jenkins
 - PR #414 Add element-wise access for device_uvector
 - PR #421 Capture thread id in logging and improve logger testing
+- PR #426 Added multi-threaded support to replay benchmark.
 
 ## Bug Fixes
 

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -20,6 +20,7 @@
 #include "thrust/iterator/constant_iterator.h"
 
 #include <benchmarks/utilities/log_parser.hpp>
+#include <rmm/detail/error.hpp>
 #include <rmm/mr/device/cnmem_memory_resource.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 
@@ -157,6 +158,9 @@ int main(int argc, char** argv)
                            "Replays and benchmarks allocation activity captured from RMM logging.");
 
   options.add_options()("f,file", "Name of RMM log file.", cxxopts::value<std::string>());
+  options.add_options()("v,verbose",
+                        "Enable verbose printing of log events",
+                        cxxopts::value<bool>()->default_value("false"));
 
   auto result = options.parse(argc, argv);
 
@@ -165,6 +169,15 @@ int main(int argc, char** argv)
     auto filename = result["file"].as<std::string>();
 
     auto per_thread_events = parse_per_thread_events(filename);
+
+    if (result["verbose"].as<bool>()) {
+      for (auto const& events : per_thread_events) {
+        std::cout << "Thread Events:\n";
+        for (auto const& e : events) {
+          std::cout << e << std::endl;
+        }
+      }
+    }
 
     auto const num_threads = per_thread_events.size();
 

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -162,15 +162,15 @@ int main(int argc, char** argv)
                         "Enable verbose printing of log events",
                         cxxopts::value<bool>()->default_value("false"));
 
-  auto result = options.parse(argc, argv);
+  auto args = options.parse(argc, argv);
 
   // Parse the log file
-  if (result.count("file")) {
-    auto filename = result["file"].as<std::string>();
+  if (args.count("file")) {
+    auto filename = args["file"].as<std::string>();
 
     auto per_thread_events = parse_per_thread_events(filename);
 
-    if (result["verbose"].as<bool>()) {
+    if (args["verbose"].as<bool>()) {
       for (auto const& events : per_thread_events) {
         std::cout << "Thread Events:\n";
         for (auto const& e : events) {

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -92,7 +92,7 @@ struct replay_benchmark {
  * @param filename Name of log file
  * @return A vector of events for each thread in the log
  */
-std::vector<std::vector<rmm::detail::event>> process_log(std::string const& filename)
+std::vector<std::vector<rmm::detail::event>> parse_per_thread_events(std::string const& filename)
 {
   using rmm::detail::event;
   std::vector<event> all_events = rmm::detail::parse_csv(filename);
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
   if (result.count("file")) {
     auto filename = result["file"].as<std::string>();
 
-    auto per_thread_events = process_log(filename);
+    auto per_thread_events = parse_per_thread_events(filename);
 
     auto const num_threads = per_thread_events.size();
 

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -129,7 +129,7 @@ std::vector<std::vector<rmm::detail::event>> parse_per_thread_events(std::string
   std::vector<std::vector<event>> per_thread_events(num_threads);
   std::transform(events_per_thread.begin(),
                  events_per_thread.end(),
-                 std::back_inserter(per_thread_events),
+                 per_thread_events.begin(),
                  [&all_events, offset = 0](auto num_events) mutable {
                    auto begin = offset;
                    offset += num_events;

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -159,7 +159,10 @@ int main(int argc, char** argv)
 
   auto args = options.parse(argc, argv);
 
-  RMM_EXPECTS(args.count("file") > 0, "No log filename specified.");
+  if (args.count("file") == 0) {
+    std::cout << options.help() << std::endl;
+    exit(0);
+  }
 
   auto filename = args["file"].as<std::string>();
 

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -97,6 +97,14 @@ std::vector<std::vector<rmm::detail::event>> parse_per_thread_events(std::string
   using rmm::detail::event;
   std::vector<event> all_events = rmm::detail::parse_csv(filename);
 
+  RMM_EXPECTS(std::all_of(all_events.begin(),
+                          all_events.end(),
+                          [](auto const& e) {
+                            return (e.stream == cudaStreamDefault) or
+                                   (e.stream == reinterpret_cast<uintptr_t>(cudaStreamPerThread));
+                          }),
+              "Non-default streams not currently supported.");
+
   // Sort events by thread id
   std::stable_sort(all_events.begin(), all_events.end(), [](auto lhs, auto rhs) {
     return lhs.thread_id < rhs.thread_id;

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -86,6 +86,12 @@ struct replay_benchmark {
   }
 };
 
+/**
+ * @brief Processes a log file into a set of per-thread vectors of events
+ *
+ * @param filename Name of log file
+ * @return A vector of events for each thread in the log
+ */
 std::vector<std::vector<rmm::detail::event>> process_log(std::string const& filename)
 {
   using rmm::detail::event;

--- a/benchmarks/utilities/log_parser.hpp
+++ b/benchmarks/utilities/log_parser.hpp
@@ -43,12 +43,12 @@ struct event {
 
   event(action a, std::size_t s, uintptr_t p) : act{a}, size{s}, pointer{p} {}
 
-  event(std::string const& tid, action a, std::size_t sz, uintptr_t p, uintptr_t s)
+  event(std::size_t tid, action a, std::size_t sz, uintptr_t p, uintptr_t s)
     : thread_id{tid}, act{a}, size{sz}, pointer{p}, stream{s}
   {
   }
 
-  event(std::string const& tid, action a, std::size_t sz, void* p, uintptr_t s)
+  event(std::size_t tid, action a, std::size_t sz, void* p, uintptr_t s)
     : event{tid, a, sz, reinterpret_cast<uintptr_t>(p), s}
   {
   }
@@ -57,7 +57,7 @@ struct event {
   std::size_t size{};     ///< The size of the memory allocated or freed
   uintptr_t pointer{};    ///< The pointer returned from an allocation, or the
                           ///< pointer freed
-  std::string thread_id;  ///< ID of the thread that initiated the event
+  std::size_t thread_id;  ///< ID of the thread that initiated the event
   uintptr_t stream;       ///< Numeric representation of the CUDA stream on which the event occurred
 };
 
@@ -76,7 +76,7 @@ std::vector<event> parse_csv(std::string const& filename)
 {
   rapidcsv::Document csv(filename, rapidcsv::LabelParams(0, -1));
 
-  std::vector<std::string> tids     = csv.GetColumn<std::string>("Thread");
+  std::vector<std::size_t> tids     = csv.GetColumn<std::size_t>("Thread");
   std::vector<std::string> actions  = csv.GetColumn<std::string>("Action");
   std::vector<std::size_t> sizes    = csv.GetColumn<std::size_t>("Size");
   std::vector<std::string> pointers = csv.GetColumn<std::string>("Pointer");

--- a/benchmarks/utilities/log_parser.hpp
+++ b/benchmarks/utilities/log_parser.hpp
@@ -17,8 +17,11 @@
 #pragma once
 
 #include <cstdint>
+#include <iomanip>
+#include <limits>
 #include <memory>
 #include <rmm/detail/error.hpp>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include "rapidcsv.h"
@@ -53,6 +56,8 @@ struct event {
   {
   }
 
+  friend std::ostream& operator<<(std::ostream& os, event const& e);
+
   action act{};           ///< Indicates if the event is an allocation or a free
   std::size_t size{};     ///< The size of the memory allocated or freed
   uintptr_t pointer{};    ///< The pointer returned from an allocation, or the
@@ -60,6 +65,16 @@ struct event {
   std::size_t thread_id;  ///< ID of the thread that initiated the event
   uintptr_t stream;       ///< Numeric representation of the CUDA stream on which the event occurred
 };
+
+std::ostream& operator<<(std::ostream& os, event const& e)
+{
+  auto act_string = (e.act == action::ALLOCATE) ? "allocate" : "free";
+
+  os << "Thread: " << e.thread_id << std::setw(9) << act_string
+     << " Size: " << std::setw(std::numeric_limits<std::size_t>::digits10) << e.size << " Pointer: "
+     << "0x" << std::hex << e.pointer << std::dec << " Stream: " << e.stream;
+  return os;
+}
 
 uintptr_t hex_string_to_int(std::string const& s) { return std::stoll(s, nullptr, 16); }
 


### PR DESCRIPTION
Add support for replaying logs that contain events from multiple threads.

Parses the CSV log of events into a per-thread list of events, one for each of the `n` threads present in the log file. 

Uses Google Benchmark's multi-threaded benchmarking capabilities to launch `n` threads, each of which will execute the benchmark for its list of events.