### PR TITLE
[REVIEW] add option to auto flush logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Improvements
 
+- PR #428 Add the option to automatically flush memory allocate/free logs
 - PR #378 Use CMake `FetchContent` to obtain latest release of `cub` and `thrust`
 - PR #377 A better way to fetch `spdlog`
 - PR #372 Use CMake `FetchContent` to obtain `cnmem` instead of git submodule

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -59,7 +59,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param upstream The resource used for allocating/deallocating device memory
    * @param filename Name of file to write log info. If not specified, retrieves
    * the file name from the environment variable "RMM_LOG_FILE".
-   * @param auto_flush If true, automatically flushes the log.
+   * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade performance. 
    */
   logging_resource_adaptor(Upstream* upstream,
                            std::string const& filename = get_default_filename(),

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -86,7 +86,8 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param stream The ostream to write log info.
-   * @param auto_flush If true, automatically flushes the log.
+   * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade
+   * performance.
    */
   logging_resource_adaptor(Upstream* upstream, std::ostream& stream, bool auto_flush = false)
     : upstream_{upstream},

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -59,7 +59,8 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param upstream The resource used for allocating/deallocating device memory
    * @param filename Name of file to write log info. If not specified, retrieves
    * the file name from the environment variable "RMM_LOG_FILE".
-   * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade performance. 
+   * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade
+   * performance.
    */
   logging_resource_adaptor(Upstream* upstream,
                            std::string const& filename = get_default_filename(),
@@ -156,9 +157,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    */
   void init_logger(bool auto_flush)
   {
-    if (auto_flush) {
-      logger_->flush_on(spdlog::level::info);
-    }
+    if (auto_flush) { logger_->flush_on(spdlog::level::info); }
     logger_->set_pattern("%v");
     logger_->info(header());
     logger_->set_pattern("%t,%H:%M:%S:%f,%v");

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -59,8 +59,11 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param upstream The resource used for allocating/deallocating device memory
    * @param filename Name of file to write log info. If not specified, retrieves
    * the file name from the environment variable "RMM_LOG_FILE".
+   * @param auto_flush If true, automatically flushes the log.
    */
-  logging_resource_adaptor(Upstream* upstream, std::string const& filename = get_default_filename())
+  logging_resource_adaptor(Upstream* upstream,
+                           std::string const& filename = get_default_filename(),
+                           bool auto_flush             = false)
     : upstream_{upstream},
       logger_{std::make_shared<spdlog::logger>(
         "RMM",
@@ -68,7 +71,7 @@ class logging_resource_adaptor final : public device_memory_resource {
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
 
-    init_logger();
+    init_logger(auto_flush);
   }
 
   /**
@@ -82,15 +85,16 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param stream The ostream to write log info.
+   * @param auto_flush If true, automatically flushes the log.
    */
-  logging_resource_adaptor(Upstream* upstream, std::ostream& stream)
+  logging_resource_adaptor(Upstream* upstream, std::ostream& stream, bool auto_flush = false)
     : upstream_{upstream},
       logger_{std::make_shared<spdlog::logger>(
         "RMM", std::make_shared<spdlog::sinks::ostream_sink_mt>(stream))}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
 
-    init_logger();
+    init_logger(auto_flush);
   }
 
   /**
@@ -150,8 +154,11 @@ class logging_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Initialize the logger.
    */
-  void init_logger()
+  void init_logger(bool auto_flush)
   {
+    if (auto_flush) {
+      logger_->flush_on(spdlog::level::info);
+    }
     logger_->set_pattern("%v");
     logger_->info(header());
     logger_->set_pattern("%t,%H:%M:%S:%f,%v");


### PR DESCRIPTION
In the Spark environment, RMM is loaded through JNI. When the JVM exits, it doesn't always have the chance to clean up the native objects, resulting in truncated logs. This PR adds an option to auto flush the logs at `info` level, which the JNI code can enable to get more complete logs.

@harrism @jrhemstad @revans2 