### PR TITLE
[REVIEW] Add RMM_ASSERT_CUDA_SUCCESS utility macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #414 Add element-wise access for device_uvector
 - PR #421 Capture thread id in logging and improve logger testing
 - PR #426 Added multi-threaded support to replay benchmark.
+- PR #429 Fix debug build and add new CUDA assert utility.
 
 ## Bug Fixes
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <cuda_runtime_api.h>
+#include <cassert>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -162,3 +164,45 @@ class out_of_range : public std::out_of_range {
     }                                                                                             \
   } while (0);
 #define RMM_CUDA_TRY_1(_call) RMM_CUDA_TRY_2(_call, rmm::cuda_error)
+
+/**
+ * @brief Error checking macro similar to `assert` for CUDA runtime API calls
+ *
+ * This utility should be used in situations where extra error checking is desired in "Debug"
+ * builds, or in situations where an error case cannot throw an exception (such as a class
+ * destructor).
+ *
+ * In "Release" builds, simply invokes the `_call`.
+ *
+ * In "Debug" builds, invokes `_call` and uses `assert` to verify the returned `cudaError_t` is
+ * equal to `cudaSuccess`.
+ *
+ *
+ * Replaces usecases such as:
+ * ```
+ * auto status = cudaRuntimeApi(...);
+ * assert(status == cudaSuccess);
+ * ```
+ *
+ * Example:
+ * ```
+ * RMM_ASSERT_CUDA_SUCCESS(cudaRuntimeApi(...));
+ * ```
+ *
+ */
+#ifdef NDEBUG
+#define RMM_ASSERT_CUDA_SUCCESS(_call) \
+  do {                                 \
+    (_call);                           \
+  } while (0);
+#else
+#define RMM_ASSERT_CUDA_SUCCESS(_call)                                          \
+  do {                                                                          \
+    cudaError_t const status__ = (_call);                                       \
+    if (status__ != cudaSuccess) {                                              \
+      std::cerr << "CUDA Error detected. " << cudaGetErrorName(status__) << " " \
+                << cudaGetErrorString(status__) << std::endl;                   \
+    }                                                                           \
+    assert(status__ == cudaSuccess);                                            \
+  } while (0);
+#endif

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -19,11 +19,6 @@
 
 #include <rmm/detail/error.hpp>
 
-#include <cuda_runtime_api.h>
-#include <cassert>
-#include <exception>
-#include <iostream>
-
 namespace rmm {
 namespace mr {
 /**
@@ -78,8 +73,7 @@ class cuda_memory_resource final : public device_memory_resource {
    */
   void do_deallocate(void* p, std::size_t, cudaStream_t) override
   {
-    cudaError_t const status = cudaFree(p);
-    assert(cudaSuccess == status);
+    RMM_ASSERT_CUDA_SUCCESS(cudaFree(p));
   }
 
   /**

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -19,11 +19,6 @@
 
 #include <rmm/detail/error.hpp>
 
-#include <cuda_runtime_api.h>
-#include <cassert>
-#include <exception>
-#include <iostream>
-
 namespace rmm {
 namespace mr {
 /**
@@ -82,8 +77,7 @@ class managed_memory_resource final : public device_memory_resource {
    */
   void do_deallocate(void* p, std::size_t, cudaStream_t) override
   {
-    cudaError_t const status = cudaFree(p);
-    assert(cudaSuccess == status);
+    RMM_ASSERT_CUDA_SUCCESS(cudaFree(p));
   }
 
   /**

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -224,7 +224,7 @@ class pool_memory_resource final : public device_memory_resource {
 
     auto const i = allocated_blocks_.find(static_cast<char*>(p));
     assert(i != allocated_blocks_.end());
-    assert(i->size == rmm::detail::align_up(size, allocation_alignment));
+    assert(i->size() == rmm::detail::align_up(size, allocation_alignment));
 
     stream_free_blocks_[stream].insert(*i);
     allocated_blocks_.erase(i);
@@ -306,7 +306,7 @@ class pool_memory_resource final : public device_memory_resource {
 
     for (auto h : upstream_blocks_) {
       h.print();
-      upstream_total += h.size;
+      upstream_total += h.size();
     }
     std::cout << "total upstream: " << upstream_total << " B\n";
 

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -15,9 +15,9 @@
  */
 #pragma once
 
+#include "detail/error.hpp"
 #include "host_memory_resource.hpp"
 
-#include <cuda_runtime_api.h>
 #include <cstddef>
 #include <utility>
 
@@ -86,10 +86,8 @@ class pinned_memory_resource final : public host_memory_resource {
   {
     (void)alignment;
     if (nullptr == p) { return; }
-    detail::aligned_deallocate(p, bytes, alignment, [](void *p) {
-      auto status = cudaFreeHost(p);
-      assert(status == cudaSuccess);
-    });
+    detail::aligned_deallocate(
+      p, bytes, alignment, [](void *p) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeHost(p)); });
   }
 };
 }  // namespace mr


### PR DESCRIPTION
Adds `RMM_ASSERT_CUDA_SUCCESS` to provide more error information when an `assert` is triggered on a CUDA runtime API 