### PR TITLE
Update prebuild.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #414 Add element-wise access for device_uvector
 - PR #421 Capture thread id in logging and improve logger testing
 - PR #426 Added multi-threaded support to replay benchmark.
+- PR #435 Update conda upload versions for new supported CUDA/Python
 
 ## Bug Fixes
 

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 #Build rmm once per PYTHON
-if [[ "$CUDA" == "10.0" ]]; then
+if [[ "$CUDA" == "10.1" ]]; then
     export UPLOAD_RMM=1
 else
     export UPLOAD_RMM=0
 fi
 
 #Build librmm once per CUDA
-if [[ "$PYTHON" == "3.6" ]]; then
+if [[ "$PYTHON" == "3.7" ]]; then
     export UPLOAD_LIBRMM=1
 else
     export UPLOAD_LIBRMM=0


### PR DESCRIPTION
Update conda upload versions for new supported CUDA/Python

Edited ci/cpu/prebuild.sh with CUDA 10.1 and python 3.7 as new defaults.