### PR TITLE
[REVIEW] enable per-thread default stream in gpu ci build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PR #391 Add `get_default_resource_type`
 - PR #396 Remove deprecated RMM APIs
 - PR #425 Add CUDA per-thread default stream support and thread safety to `pool_memory_resource`
+- PR #436 Always build and test with per-thread default stream enabled in the GPU CI build
 
 ## Improvements
 

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,8 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean librmm rmm -v -g -n -s -h"
-HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [-h]
+VALIDARGS="clean librmm rmm -v -g -n -s -p -h"
+HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [-p] [-h]
    clean  - remove all existing build artifacts and configuration (start over)
    librmm - build and install the librmm C++ code
    rmm    - build and install the rmm Python package
@@ -27,6 +27,7 @@ HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [-h]
    -g     - build for debug
    -n     - no install step
    -s     - statically link against cudart
+   -p     - enable per-thread default stream
    -h     - print this text
 
    default action (no args) is to build and install 'librmm' and 'rmm' targets
@@ -40,6 +41,7 @@ VERBOSE=""
 BUILD_TYPE=Release
 INSTALL_TARGET=install
 CUDA_STATIC_RUNTIME=OFF
+PER_THREAD_DEFAULT_STREAM=OFF
 RAN_CMAKE=0
 
 # Set defaults for vars that may not have been defined externally
@@ -61,6 +63,7 @@ function ensureCMakeRan {
         echo "Executing cmake for librmm..."
         cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
               -DCUDA_STATIC_RUNTIME="${CUDA_STATIC_RUNTIME}" \
+              -DPER_THREAD_DEFAULT_STREAM="${PER_THREAD_DEFAULT_STREAM}" \
               -DCMAKE_CXX11_ABI=ON \
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
         RAN_CMAKE=1
@@ -95,6 +98,9 @@ if hasArg -n; then
 fi
 if hasArg -s; then
     CUDA_STATIC_RUNTIME=ON
+fi
+if hasArg -p; then
+    PER_THREAD_DEFAULT_STREAM=ON
 fi
 
 # If clean given, run it prior to any other steps

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,8 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean librmm rmm -v -g -n -s -p -h"
-HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [-p] [-h]
+VALIDARGS="clean librmm rmm -v -g -n -s --ptds -h"
+HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [--ptds] [-h]
    clean  - remove all existing build artifacts and configuration (start over)
    librmm - build and install the librmm C++ code
    rmm    - build and install the rmm Python package
@@ -27,7 +27,7 @@ HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [-p] [-h]
    -g     - build for debug
    -n     - no install step
    -s     - statically link against cudart
-   -p     - enable per-thread default stream
+   --ptds - enable per-thread default stream
    -h     - print this text
 
    default action (no args) is to build and install 'librmm' and 'rmm' targets
@@ -99,7 +99,7 @@ fi
 if hasArg -s; then
     CUDA_STATIC_RUNTIME=ON
 fi
-if hasArg -p; then
+if hasArg --ptds; then
     PER_THREAD_DEFAULT_STREAM=ON
 fi
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -60,7 +60,7 @@ conda list
 ################################################################################
 
 logger "Build and install librmm and rmm..."
-"$WORKSPACE/build.sh" -v -p clean librmm rmm
+"$WORKSPACE/build.sh" -v --ptds clean librmm rmm
 
 ################################################################################
 # Test - librmm

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -60,7 +60,7 @@ conda list
 ################################################################################
 
 logger "Build and install librmm and rmm..."
-"$WORKSPACE/build.sh" -v clean librmm rmm
+"$WORKSPACE/build.sh" -v -p clean librmm rmm
 
 ################################################################################
 # Test - librmm


### PR DESCRIPTION
Always build and test with per-thread default stream enabled, as discussed in https://github.com/rapidsai/cudf/issues/5614.

@harrism @jrhemstad @kkraus14 