### PR TITLE
[REVIEW] allow memory resources to own upstream resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PR #396 Remove deprecated RMM APIs
 - PR #425 Add CUDA per-thread default stream support and thread safety to `pool_memory_resource`
 - PR #436 Always build and test with per-thread default stream enabled in the GPU CI build
+- PR #439 Allow memory resources to own upstream resources
 
 ## Improvements
 

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -39,7 +39,7 @@ namespace mr {
  *
  * Supports only allocations of size smaller than the configured block_size.
  */
-template <typename Upstream>
+template <typename Upstream, typename Upstream_ptr = Upstream*>
 class fixed_size_memory_resource : public device_memory_resource {
  public:
   // A block is the fixed size this resource alloates
@@ -62,7 +62,7 @@ class fixed_size_memory_resource : public device_memory_resource {
    * @param blocks_to_preallocate The number of blocks to allocate to initialize the pool.
    */
   explicit fixed_size_memory_resource(
-    Upstream* upstream_mr,
+    Upstream_ptr upstream_mr,
     std::size_t block_size            = default_block_size,
     std::size_t blocks_to_preallocate = default_blocks_to_preallocate)
     : upstream_mr_{upstream_mr},
@@ -99,7 +99,7 @@ class fixed_size_memory_resource : public device_memory_resource {
    *
    * @return UpstreamResource* the upstream memory resource.
    */
-  Upstream* get_upstream() const noexcept { return upstream_mr_; }
+  Upstream_ptr get_upstream() const noexcept { return upstream_mr_; }
 
   /**
    * @brief Get the size of blocks allocated by this memory resource.
@@ -273,7 +273,7 @@ class fixed_size_memory_resource : public device_memory_resource {
     stream_blocks_.clear();
   }
 
-  Upstream* upstream_mr_;  // The resource from which to allocate new blocks
+  Upstream_ptr upstream_mr_;  // The resource from which to allocate new blocks
 
   std::size_t const block_size_;           // size of blocks this MR allocates
   std::size_t const upstream_chunk_size_;  // size of chunks allocated from heap MR

--- a/include/rmm/mr/device/hybrid_memory_resource.hpp
+++ b/include/rmm/mr/device/hybrid_memory_resource.hpp
@@ -173,8 +173,9 @@ class hybrid_memory_resource : public device_memory_resource {
    *
    * @return SmallAllocMemoryResource* the upstream resource used for small allocations.
    */
-  template <typename P = SmallAllocMemoryResource_ptr>
-  typename std::enable_if_t<std::is_pointer<P>::value> get_small_mr()
+  template <typename P                                            = SmallAllocMemoryResource_ptr,
+            typename std::enable_if_t<std::is_pointer<P>::value>* = nullptr>
+  P get_small_mr()
   {
     return small_mr_;
   }
@@ -184,8 +185,9 @@ class hybrid_memory_resource : public device_memory_resource {
    *
    * @return SmallAllocMemoryResource* the upstream resource used for small allocations.
    */
-  template <typename P = SmallAllocMemoryResource_ptr>
-  typename std::enable_if_t<!std::is_pointer<P>::value, SmallAllocMemoryResource>* get_small_mr()
+  template <typename P                                             = SmallAllocMemoryResource_ptr,
+            typename std::enable_if_t<!std::is_pointer<P>::value>* = nullptr>
+  SmallAllocMemoryResource* get_small_mr()
   {
     return small_mr_.get();
   }
@@ -195,8 +197,9 @@ class hybrid_memory_resource : public device_memory_resource {
    *
    * @return LargeAllocMemoryResource* the upstream resource used for large allocations.
    */
-  template <typename P = LargeAllocMemoryResource_ptr>
-  typename std::enable_if_t<std::is_pointer<P>::value> get_large_mr()
+  template <typename P                                            = LargeAllocMemoryResource_ptr,
+            typename std::enable_if_t<std::is_pointer<P>::value>* = nullptr>
+  P get_large_mr()
   {
     return large_mr_;
   }
@@ -206,8 +209,9 @@ class hybrid_memory_resource : public device_memory_resource {
    *
    * @return LargeAllocMemoryResource* the upstream resource used for large allocations.
    */
-  template <typename P = LargeAllocMemoryResource_ptr>
-  typename std::enable_if_t<!std::is_pointer<P>::value, LargeAllocMemoryResource>* get_large_mr()
+  template <typename P                                             = LargeAllocMemoryResource_ptr,
+            typename std::enable_if_t<!std::is_pointer<P>::value>* = nullptr>
+  LargeAllocMemoryResource* get_large_mr()
   {
     return large_mr_.get();
   }

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -31,7 +31,7 @@ namespace mr {
  *
  * @tparam Upstream Type of the upstream resource used for allocation/deallocation.
  */
-template <typename Upstream>
+template <typename Upstream, typename Upstream_ptr = Upstream*>
 class thread_safe_resource_adaptor final : public device_memory_resource {
  public:
   using lock_t = std::lock_guard<std::mutex>;
@@ -46,7 +46,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    *
    * @param upstream The resource used for allocating/deallocating device memory.
    */
-  thread_safe_resource_adaptor(Upstream* upstream) : upstream_{upstream}
+  thread_safe_resource_adaptor(Upstream_ptr upstream) : upstream_{upstream}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
   }
@@ -54,9 +54,9 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Get the upstream memory resource.
    *
-   * @return Upstream* pointer to a memory resource object.
+   * @return Upstream_ptr pointer to a memory resource object.
    */
-  Upstream* get_upstream() const noexcept { return upstream_; }
+  Upstream_ptr get_upstream() const noexcept { return upstream_; }
 
   /**
    * @copydoc rmm::mr::device_memory_resource::supports_streams()
@@ -141,7 +141,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
   }
 
   std::mutex mutable mtx;  // mutex for thread safe access to upstream
-  Upstream* upstream_;     ///< The upstream resource used for satisfying allocation requests
+  Upstream_ptr upstream_;  ///< The upstream resource used for satisfying allocation requests
 };
 
 }  // namespace mr


### PR DESCRIPTION
It seems that for both the python and java users of RMM, there is a need to separately maintain lifetimes of various memory resources. For example, creating a new `cuda_memory_resource` and passing it to `pool_memory_resource`. When the `pool_memory_resource` is destroyed, the user needs to manually delete the corresponding `cuda_memory_resource`. Rather than requiring additional wrappers for this type of usage, this PR adds lifetime management capability to the memory resources themselves.

Without ownership:
```cpp
using cuda_mr = rmm::mr::cuda_memory_resource;
using pool_mr = rmm::mr::pool_memory_resource<cuda_mr>;
auto mr = std::make_unique<pool_mr>(new cuda_mr());
```
which causes a leak with the `cuda_mr`.

With ownership:
```cpp
using cuda_mr = rmm::mr::cuda_memory_resource;
using pool_mr = rmm::mr::pool_memory_resource<cuda_mr, std::shared_ptr<cuda_mr>>;
auto mr = std::make_unique<pool_mr>(std::make_shared<cuda_mr>());
```
now the lifetime of `cuda_mr` is tied to the pool.

The good thing is this is backwards compatible with the existing code. The bad part is the types get pretty complicated with nested MR types. Let me know what you think.

@harrism @jrhemstad @kkraus14 @shwina 


 