### PR TITLE
[REVIEW] Remove thread safe adaptor from PoolMemoryResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PR #426 Added multi-threaded support to replay benchmark.
 - PR #435 Update conda upload versions for new supported CUDA/Python
 - PR #437 Test with `pickle5` (for older Python versions)
+- PR #443 Remove thread safe adaptor from PoolMemoryResource
 
 ## Bug Fixes
 

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -92,14 +92,10 @@ cdef class PoolMemoryResource(MemoryResource):
             size_t maximum_pool_size=~0
     ):
         self.c_obj.reset(
-            new thread_safe_resource_adaptor_wrapper(
-                shared_ptr[device_memory_resource_wrapper](
-                    new pool_memory_resource_wrapper(
-                        upstream.c_obj,
-                        initial_pool_size,
-                        maximum_pool_size
-                    )
-                )
+            new pool_memory_resource_wrapper(
+                upstream.c_obj,
+                initial_pool_size,
+                maximum_pool_size
             )
         )
 


### PR DESCRIPTION
`pool_memory_resource` is now thread safe by default.

cc: @jrhemstad 