### PR TITLE
[REVIEW] Owning resource wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PR #396 Remove deprecated RMM APIs
 - PR #425 Add CUDA per-thread default stream support and thread safety to `pool_memory_resource`
 - PR #436 Always build and test with per-thread default stream enabled in the GPU CI build
+- PR #444 Add `owning_wrapper` to simplify lifetime management of resources and their upstreams
 
 ## Improvements
 

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -32,6 +32,13 @@ namespace mr {
  */
 class cuda_memory_resource final : public device_memory_resource {
  public:
+  cuda_memory_resource()                            = default;
+  ~cuda_memory_resource()                           = default;
+  cuda_memory_resource(cuda_memory_resource const&) = default;
+  cuda_memory_resource& operator=(cuda_memory_resource const&) = default;
+  cuda_memory_resource(cuda_memory_resource&&)                 = default;
+  cuda_memory_resource& operator=(cuda_memory_resource&&) = default;
+
   /**
    * @brief Query whether the resource supports use of non-null CUDA streams for
    * allocation/deallocation. `cuda_memory_resource` does not support streams.

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -48,8 +48,6 @@ class owning_wrapper final : public device_memory_resource {
     : upstreams_{std::move(upstreams)},
       wrapped_{detail::make_resource<Resource>(upstreams_, std::forward<Args>(args)...)}
   {
-    std::cout << "owning_wrapper. Number of args: " << sizeof...(args)
-              << " Number of upstreams: " << std::tuple_size<upstream_tuple>::value << std::endl;
   }
 
   Resource const& wrapped() const noexcept { return *wrapped_; }
@@ -97,7 +95,6 @@ class owning_wrapper final : public device_memory_resource {
 template <template <typename...> class Resource, typename... Upstreams, typename... Args>
 auto make_owning_wrapper(std::tuple<std::shared_ptr<Upstreams>...> upstreams, Args&&... args)
 {
-  std::cout << "make owning wrapper\n";
   return std::make_shared<owning_wrapper<Resource<Upstreams...>, Upstreams...>>(
     std::move(upstreams), std::forward<Args>(args)...);
 }

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -17,6 +17,7 @@
 
 #include "device_memory_resource.hpp"
 
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <utility>
@@ -24,6 +25,7 @@
 namespace rmm {
 namespace mr {
 namespace detail {
+/// Converts a tuple into a parameter pack
 template <typename Resource, typename UpstreamTuple, std::size_t... Indices, typename... Args>
 auto make_resource_impl(UpstreamTuple const& t, std::index_sequence<Indices...>, Args&&... args)
 {

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -102,7 +102,8 @@ auto make_owning_wrapper(std::tuple<std::shared_ptr<Upstreams>...> upstreams, Ar
 template <template <typename...> class Resource, typename Upstream, typename... Args>
 auto make_owning_wrapper(std::shared_ptr<Upstream> upstream, Args&&... args)
 {
-  return make_owning_wrapper(std::make_tuple(std::move(upstream)), std::forward<Args>(args)...);
+  return make_owning_wrapper<Resource>(std::make_tuple(std::move(upstream)),
+                                       std::forward<Args>(args)...);
 }
 
 }  // namespace mr

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -63,12 +63,12 @@ class owning_wrapper final : public device_memory_resource {
  private:
   void* do_allocate(std::size_t bytes, cudaStream_t stream) override
   {
-    return wrapped().do_allocate(bytes, stream);
+    return wrapped().allocate(bytes, stream);
   }
 
   void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
   {
-    wrapped().do_deallocate(p, bytes, stream);
+    wrapped().deallocate(p, bytes, stream);
   }
 
   bool do_is_equal(device_memory_resource const& other) const noexcept override

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -51,9 +51,9 @@ class owning_wrapper final : public device_memory_resource {
               << " Number of upstreams: " << std::tuple_size<upstream_tuple>::value << std::endl;
   }
 
-  Resource const& wrapped() const noexcept { return wrapped_; }
+  bool supports_streams() const noexcept override { return wrapped().supports_streams(); }
 
-  Resource& wrapped() noexcept { return wrapped_; }
+  bool supports_get_mem_info() const noexcept override { return wrapped().supports_get_mem_info(); }
 
  private:
   void* do_allocate(std::size_t bytes, cudaStream_t stream) override
@@ -78,6 +78,10 @@ class owning_wrapper final : public device_memory_resource {
         return wrapped_.is_equal(other);
       }
     }
+
+  std::pair<std::size_t, std::size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
+    return wrapped().get_mem_info(stream);
   }
 
   upstream_tuple upstreams_;

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -99,5 +99,11 @@ auto make_owning_wrapper(std::tuple<std::shared_ptr<Upstreams>...> upstreams, Ar
     std::move(upstreams), std::forward<Args>(args)...);
 }
 
+template <template <typename...> class Resource, typename Upstream, typename... Args>
+auto make_owning_wrapper(std::shared_ptr<Upstream> upstream, Args&&... args)
+{
+  return make_owning_wrapper(std::make_tuple(std::move(upstream)), std::forward<Args>(args)...);
+}
+
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -227,7 +227,7 @@ class owning_wrapper final : public device_memory_resource {
  * //`cuda_mr` and using it as both of `example_resource`s upstream resources. Forwards the
  * // arguments `42` and `3.14` to the additional `n` and `f` arguments of `example_resources`
  * // constructor.
- * auto wrapped_example = make_owning_wrapper<example_resource>(cuda_upstreams, 42, 3.14);
+ * auto wrapped_example = rmm::mr::make_owning_wrapper<example_resource>(cuda_upstreams, 42, 3.14);
  * \endcode
  *
  * @tparam Resource Template template parameter specifying the type of the wrapped resource to

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -38,11 +38,70 @@ auto make_resource(std::tuple<std::shared_ptr<Upstreams>...> const& t, Args&&...
 }
 }  // namespace detail
 
+/**
+ * @brief Resource adaptor that maintains the lifetime of upstream resources.
+ *
+ * Many `device_memory_resource` derived types allocate memory from another "upstream" resource.
+ * E.g., `pool_memory_resource` allocates its pool from an upstream resource. Typically, a resource
+ * does not own its upstream, and therefore it is the users responsibility to maintain the lifetime
+ * of the upstream resource. This can be inconvenient and error prone, especially for resources with
+ * complex upstreams who may themselves also have an upstream.
+ *
+ * `owning_wrapper` simplifies lifetime management of a resource, `wrapped`, by taking shared
+ * ownership of all upstream resources via a `std::shared_ptr`.
+ *
+ * For convenience, it is reccomended to use the `make_owning_wrapper` factory instead of
+ * constructing an `owning_wrapper` directly.
+ *
+ * Example:
+ * \code{.cpp}
+ * auto cuda = std::make_shared<rmm::mr::cuda_memory_resource>();
+ * auto pool = rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(cuda,initial_pool_size,
+ *                                                                         max_pool_size);
+ * // The `cuda` resource will be kept alive for the lifetime of `pool` and automatically be
+ * // destroyed after `pool` is destroyed
+ * \endcode
+ *
+ * @tparam Resource Type of the wrapped resource
+ * @tparam Upstreams Template parameter pack of the types of the upstream resources used by
+ * `Resource`
+ */
 template <typename Resource, typename... Upstreams>
 class owning_wrapper final : public device_memory_resource {
  public:
   using upstream_tuple = std::tuple<std::shared_ptr<Upstreams>...>;
 
+  /**
+   * @brief Constructs the wrapped resource using the provided upstreams and any additional
+   * arguments forwarded to the wrapped resources constructor.
+   *
+   * `Resource` is required to have a constructor whose first argument(s) are raw pointers to its
+   * upstream resources in the same order as `upstreams`, followed by any additional arguments in
+   * the same order as `args`.
+   *
+   * Example:
+   * \code{.cpp}
+   * template <typename Upstream1, typename Upstream2>
+   * class example_resource{
+   *   example_resource(Upstream1 * u1, Upstream2 * u2, int n, float f);
+   * };
+   *
+   * using cuda = rmm::mr::cuda_memory_resource;
+   * using example = example_resource<cuda,cuda>;
+   * using wrapped_example = rmm::mr::owning_wrapper<example, cuda, cuda>;
+   * auto cuda_mr = std::make_shared<cuda>();
+   *
+   * // Constructs an `example_resource` wrapped by an `owning_wrapper` taking shared ownership of
+   * //`cuda_mr` and using it as both of `example_resource`s upstream resources.
+   * wrapped_example w{std::make_tuple(cuda_mr,cuda_mr), 42, 3.14};
+   * \endcode
+   *
+   * @tparam Args Template parameter pack to forward to the wrapped resource's constructor
+   * @param upstreams Tuple of `std::shared_ptr`s to the upstreams used by the wrapped resource, in
+   * the same order as expected by `Resource`s constructor.
+   * @param args Function parameter pack of arguments to forward to the wrapped resource's
+   * constructor
+   */
   template <typename... Args>
   owning_wrapper(upstream_tuple upstreams, Args&&... args)
     : upstreams_{std::move(upstreams)},
@@ -50,25 +109,73 @@ class owning_wrapper final : public device_memory_resource {
   {
   }
 
+  /**
+   * @brief Returns a constant reference to the wrapped resource.
+   *
+   */
   Resource const& wrapped() const noexcept { return *wrapped_; }
 
+  /**
+   * @brief Returns reference to the wrapped resource.
+   *
+   */
   Resource& wrapped() noexcept { return *wrapped_; }
 
+  /**
+   * @copydoc rmm::mr::device_memory_resource::supports_streams()
+   */
   bool supports_streams() const noexcept override { return wrapped().supports_streams(); }
 
+  /**
+   * @brief Query whether the resource supports the get_mem_info API.
+   *
+   * @return true if the upstream resource supports get_mem_info, false otherwise.
+   */
   bool supports_get_mem_info() const noexcept override { return wrapped().supports_get_mem_info(); }
 
  private:
+  /**
+   * @brief Allocates memory using the wrapped resource.
+   *
+   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled by the wrapped
+   * resource.
+   *
+   * @param bytes The size, in bytes, of the allocation
+   * @param stream Stream on which to perform the allocation
+   * @return void* Pointer to the memory allocated by the wrapped resource
+   */
   void* do_allocate(std::size_t bytes, cudaStream_t stream) override
   {
     return wrapped().allocate(bytes, stream);
   }
 
+  /**
+   * @brief Returns an allocation to the wrapped resource.
+   *
+   * `p` must have been returned from a prior call to `do_allocate(bytes)`.
+   *
+   * @throws Nothing.
+   *
+   * @param p Pointer to the allocation to free.
+   * @param bytes Size of the allocation
+   * @param stream Stream on which to deallocate the memory
+   */
   void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
   {
     wrapped().deallocate(p, bytes, stream);
   }
 
+  /**
+   * @brief Compare if this resource is equal to another.
+   *
+   * Two resources are equal if memory allocated by one resource can be freed by the other.
+   *
+   * @throws Nothing.
+   *
+   * @param other The other resource to compare to
+   * @return true If the two resources are equal
+   * @return false If the two resources are not equal
+   */
   bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
     if (this == &other) {
@@ -83,15 +190,36 @@ class owning_wrapper final : public device_memory_resource {
     }
   }
 
+  /**
+   * @brief Get free and available memory from upstream resource.
+   *
+   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   *
+   * @param stream Stream on which to get the mem info.
+   * @return std::pair contaiing free_size and total_size of memory
+   */
   std::pair<std::size_t, std::size_t> do_get_mem_info(cudaStream_t stream) const override
   {
     return wrapped().get_mem_info(stream);
   }
 
-  upstream_tuple upstreams_;
-  std::unique_ptr<Resource> wrapped_;
+  upstream_tuple upstreams_;           ///< The owned upstream resources
+  std::unique_ptr<Resource> wrapped_;  ///< The wrapped resource that uses the upstreams
 };
 
+/**
+ * @brief Constructs a resource of type `Resource` wrapped in an `owning_wrapper` using `upstreams`
+ * as the upstream resources and `args` as the additional parameters for the constructor of
+ * `Resource`.
+ *
+ * @tparam Resource Template template parameter specifying the type of the wrapped resource to
+ * construct
+ * @tparam Upstreams Types of the upstream resources
+ * @tparam Args Types of the arguments used in `Resource`s constructor
+ * @param upstreams Tuple of
+ * @param args
+ * @return auto
+ */
 template <template <typename...> class Resource, typename... Upstreams, typename... Args>
 auto make_owning_wrapper(std::tuple<std::shared_ptr<Upstreams>...> upstreams, Args&&... args)
 {

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "device_memory_resource.hpp"
+
+#include <iostream>
+#include <memory>
+#include <utility>
+
+namespace rmm {
+namespace mr {
+
+template <typename Resource, typename UpstreamTuple, std::size_t... Indices, typename... Args>
+auto make_resource_impl(UpstreamTuple t, std::index_sequence<Indices...>, Args&&... args)
+{
+  return Resource{std::get<Indices>(t).get()..., std::forward<Args>(args)...};
+}
+
+template <typename Resource, typename... Upstreams, typename... Args>
+auto make_resource(std::tuple<std::shared_ptr<Upstreams>...> t, Args&&... args)
+{
+  return make_resource_impl<Resource>(
+    std::move(t), std::index_sequence_for<Upstreams...>{}, std::forward<Args>(args)...);
+}
+
+template <typename Resource, typename... Upstreams>
+class owning_wrapper final : public device_memory_resource {
+ public:
+  using upstream_tuple = std::tuple<std::shared_ptr<Upstreams>...>;
+
+  template <typename... Args>
+  owning_wrapper(upstream_tuple upstreams, Args&&... args)
+    : upstreams_{std::move(upstreams)},
+      wrapped_{make_resource<Resource>(std::move(upstreams), std::forward<Args>(args)...)}
+  {
+    std::cout << "owning_wrapper. Number of args: " << sizeof...(args)
+              << " Number of upstreams: " << std::tuple_size<upstream_tuple>::value << std::endl;
+  }
+
+  Resource const& wrapped() const noexcept { return wrapped_; }
+
+  Resource& wrapped() noexcept { return wrapped_; }
+
+ private:
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
+    return wrapped_.do_allocate(bytes, stream);
+  }
+
+  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
+  {
+    wrapped_.do_deallocate(p, bytes, stream);
+  }
+
+  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  {
+    if (this == &other) {
+      return true;
+    } else {
+      auto casted = dynamic_cast<owning_wrapper<Resource, Upstreams...> const*>(&other);
+      if (nullptr != casted) {
+        return wrapped().is_equal(casted->wrapped());
+      } else {
+        return wrapped_.is_equal(other);
+      }
+    }
+  }
+
+  upstream_tuple upstreams_;
+  Resource wrapped_;
+};
+
+template <typename Resource, typename... Upstreams, typename... Args>
+auto make_owning_wrapper(std::tuple<std::shared_ptr<Upstreams>...> upstreams, Args&&... args)
+{
+  return std::make_shared<owning_wrapper<Resource, Upstreams...>>(std::move(upstreams),
+                                                                  std::forward<Args>(args)...);
+}
+
+}  // namespace mr
+}  // namespace rmm

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -67,7 +67,7 @@ auto make_resource(std::tuple<std::shared_ptr<Upstreams>...> const& t, Args&&...
  * `Resource`
  */
 template <typename Resource, typename... Upstreams>
-class owning_wrapper final : public device_memory_resource {
+class owning_wrapper : public device_memory_resource {
  public:
   using upstream_tuple = std::tuple<std::shared_ptr<Upstreams>...>;
 

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -84,11 +84,11 @@ class owning_wrapper final : public device_memory_resource {
   Resource wrapped_;
 };
 
-template <typename Resource, typename... Upstreams, typename... Args>
+template <template <typename...> class Resource, typename... Upstreams, typename... Args>
 auto make_owning_wrapper(std::tuple<std::shared_ptr<Upstreams>...> upstreams, Args&&... args)
 {
-  return std::make_shared<owning_wrapper<Resource, Upstreams...>>(std::move(upstreams),
-                                                                  std::forward<Args>(args)...);
+  return std::make_shared<owning_wrapper<Resource<Upstreams...>, Upstreams...>>(
+    std::move(upstreams), std::forward<Args>(args)...);
 }
 
 }  // namespace mr

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -223,10 +223,10 @@ class owning_wrapper final : public device_memory_resource {
  * auto cuda_mr = std::make_shared<rmm::mr::cuda_memory_resource>();
  * auto cuda_upstreams = std::make_tuple(cuda_mr, cuda_mr);
  *
- * // Constructs an `example_resource` wrapped by an `owning_wrapper` taking shared ownership of
- * //`cuda_mr` and using it as both of `example_resource`s upstream resources. Forwards the
- * // arguments `42` and `3.14` to the additional `n` and `f` arguments of `example_resources`
- * // constructor.
+ * // Constructs an `example_resource<rmm::mr::cuda_memory_resource, rmm::mr::cuda_memory_resource>`
+ * // wrapped by an `owning_wrapper` taking shared ownership of `cuda_mr` and using it as both of
+ * // `example_resource`s upstream resources. Forwards the  arguments `42` and `3.14` to the
+ * // additional `n` and `f` arguments of `example_resource` constructor.
  * auto wrapped_example = rmm::mr::make_owning_wrapper<example_resource>(cuda_upstreams, 42, 3.14);
  * \endcode
  *

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -45,14 +45,14 @@ auto make_resource(std::tuple<std::shared_ptr<Upstreams>...> const& t, Args&&...
  *
  * Many `device_memory_resource` derived types allocate memory from another "upstream" resource.
  * E.g., `pool_memory_resource` allocates its pool from an upstream resource. Typically, a resource
- * does not own its upstream, and therefore it is the users responsibility to maintain the lifetime
+ * does not own its upstream, and therefore it is the user's responsibility to maintain the lifetime
  * of the upstream resource. This can be inconvenient and error prone, especially for resources with
- * complex upstreams who may themselves also have an upstream.
+ * complex upstreams that may themselves also have an upstream.
  *
  * `owning_wrapper` simplifies lifetime management of a resource, `wrapped`, by taking shared
  * ownership of all upstream resources via a `std::shared_ptr`.
  *
- * For convenience, it is reccomended to use the `make_owning_wrapper` factory instead of
+ * For convenience, it is recommended to use the `make_owning_wrapper` factory instead of
  * constructing an `owning_wrapper` directly.
  *
  * Example:

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -91,8 +91,9 @@ class pool_memory_resource final : public device_memory_resource {
   }
 
   pool_memory_resource(pool_memory_resource const&) = delete;
-
-  pool_memory_resource(pool_memory_resource&&) = delete;
+  pool_memory_resource(pool_memory_resource&&)      = delete;
+  pool_memory_resource& operator=(pool_memory_resource const&) = delete;
+  pool_memory_resource& operator=(pool_memory_resource&&) = delete;
 
   /**
    * @brief Destroy the `pool_memory_resource` and deallocate all memory it allocated using

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -60,6 +60,8 @@ class pool_memory_resource final : public device_memory_resource {
    * @brief Construct a `pool_memory_resource` and allocate the initial
    * device memory pool using `upstream_mr`.
    *
+   * @throws rmm::logic_error if `upstream_mr == nullptr`
+   *
    * @param upstream_mr The memory_resource from which to allocate blocks for the pool.
    * @param initial_pool_size Size, in bytes, of the initial pool. When
    * zero, an implementation-defined pool size is used.
@@ -70,6 +72,8 @@ class pool_memory_resource final : public device_memory_resource {
                                 std::size_t maximum_pool_size = default_maximum_size)
     : upstream_mr_{upstream_mr}, maximum_pool_size_{maximum_pool_size}
   {
+    RMM_EXPECTS(nullptr != upstream_mr, "Unexpected null upstream pointer.");
+
     cudaDeviceProp props;
     int device{0};
     RMM_CUDA_TRY(cudaGetDevice(&device));

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -86,6 +86,10 @@ class pool_memory_resource final : public device_memory_resource {
       block_from_upstream(initial_pool_size, 0));
   }
 
+  pool_memory_resource(pool_memory_resource const&) = delete;
+
+  pool_memory_resource(pool_memory_resource&&) = delete;
+
   /**
    * @brief Destroy the `pool_memory_resource` and deallocate all memory it allocated using
    * the upstream resource.

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -88,11 +88,6 @@ class pool_memory_resource final : public device_memory_resource {
       block_from_upstream(initial_pool_size, 0));
   }
 
-  pool_memory_resource(pool_memory_resource const&) = delete;
-  pool_memory_resource(pool_memory_resource&&)      = delete;
-  pool_memory_resource& operator=(pool_memory_resource const&) = delete;
-  pool_memory_resource& operator=(pool_memory_resource&&) = delete;
-
   /**
    * @brief Destroy the `pool_memory_resource` and deallocate all memory it allocated using
    * the upstream resource.

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -17,194 +17,48 @@
 #include "gtest/gtest.h"
 #include "mr/device/cuda_memory_resource.hpp"
 #include "mr/device/default_memory_resource.hpp"
+#include "mr/device/device_memory_resource.hpp"
 #include "mr/device/pool_memory_resource.hpp"
 #include "mr_test.hpp"
 
 #include <thread>
 #include <vector>
 
+namespace rmm {
+namespace test {
 namespace {
 
-using thread_safe_fixed_size_mr      = rmm::mr::thread_safe_resource_adaptor<fixed_size_mr>;
-using thread_safe_fixed_multisize_mr = rmm::mr::thread_safe_resource_adaptor<fixed_multisize_mr>;
-using thread_safe_fixed_multisize_pool_mr =
-  rmm::mr::thread_safe_resource_adaptor<fixed_multisize_pool_mr>;
-using thread_safe_hybrid_mr = rmm::mr::thread_safe_resource_adaptor<hybrid_mr>;
+struct mr_test_mt : public mr_test {
+};
+
+INSTANTIATE_TEST_CASE_P(MultiThreadResourceTests,
+                        mr_test_mt,
+                        ::testing::Values(mr_factory{"CUDA", &make_cuda},
+                                          mr_factory{"Managed", &make_managed},
+                                          mr_factory{"Pool", &make_pool},
+                                          mr_factory{"SyncHybrid", &make_sync_hybrid}),
+                        [](auto const& info) { return info.param.name; });
 
 constexpr std::size_t num_threads{4};
 
 template <typename Task, typename... Arguments>
-void spawn(Task task, Arguments... args)
+void spawn(Task task, Arguments&&... args)
 {
   std::vector<std::thread> threads;
   threads.reserve(num_threads);
   for (int i = 0; i < num_threads; ++i)
-    threads.emplace_back(std::thread(task, args...));
+    threads.emplace_back(std::thread(task, std::forward<Arguments>(args)...));
 
   for (auto& t : threads)
     t.join();
 }
 
-}  // namespace
-
-// specialize test constructor for thread-safe types
-
-template <>
-inline MRTest<thread_safe_fixed_size_mr>::MRTest()
-  : mr{new thread_safe_fixed_size_mr(new fixed_size_mr(rmm::mr::get_default_resource()))}
-{
-}
-
-template <>
-inline MRTest<thread_safe_fixed_size_mr>::~MRTest()
-{
-  auto fixed = mr->get_upstream();
-  this->mr.reset();
-  delete fixed;
-}
-
-template <>
-inline MRTest<thread_safe_fixed_multisize_mr>::MRTest()
-  : mr{new thread_safe_fixed_multisize_mr(new fixed_multisize_mr(rmm::mr::get_default_resource()))}
-{
-}
-
-template <>
-inline MRTest<thread_safe_fixed_multisize_mr>::~MRTest()
-{
-  auto fixed = mr->get_upstream();
-  this->mr.reset();
-  delete fixed;
-}
-
-template <>
-inline MRTest<thread_safe_fixed_multisize_pool_mr>::MRTest()
-  : mr{new thread_safe_fixed_multisize_pool_mr(
-      new fixed_multisize_pool_mr(new pool_mr(new rmm::mr::cuda_memory_resource)))}
-{
-}
-
-template <>
-inline MRTest<thread_safe_fixed_multisize_pool_mr>::~MRTest()
-{
-  auto fixed = mr->get_upstream();
-  auto pool  = fixed->get_upstream();
-  auto cuda  = pool->get_upstream();
-  this->mr.reset();
-  delete fixed;
-  delete pool;
-  delete cuda;
-}
-
-template <>
-inline MRTest<thread_safe_hybrid_mr>::MRTest()
-{
-  rmm::mr::cuda_memory_resource* cuda = new rmm::mr::cuda_memory_resource{};
-  pool_mr* pool                       = new pool_mr(cuda);
-  this->mr.reset(new thread_safe_hybrid_mr(new hybrid_mr(new fixed_multisize_pool_mr(pool), pool)));
-}
-
-template <>
-inline MRTest<thread_safe_hybrid_mr>::~MRTest()
-{
-  auto hybrid = mr->get_upstream();
-  auto fixed  = hybrid->get_small_mr();
-  auto pool   = hybrid->get_large_mr();
-  auto cuda   = pool->get_upstream();
-  this->mr.reset();
-  delete hybrid;
-  delete fixed;
-  delete pool;
-  delete cuda;
-}
-
-// specialize get_max_size for thread-safe MRs
-template <>
-std::size_t get_max_size(thread_safe_fixed_size_mr* mr)
-{
-  return mr->get_upstream()->get_block_size();
-}
-
-template <>
-std::size_t get_max_size(thread_safe_fixed_multisize_mr* mr)
-{
-  return mr->get_upstream()->get_max_size();
-}
-
-template <>
-std::size_t get_max_size(thread_safe_fixed_multisize_pool_mr* mr)
-{
-  return mr->get_upstream()->get_max_size();
-}
-
-// specialize random allocations to not allocate too large
-template <>
-inline void test_random_allocations<thread_safe_fixed_size_mr>(thread_safe_fixed_size_mr* mr,
-                                                               std::size_t num_allocations,
-                                                               cudaStream_t stream)
-{
-  return test_random_allocations_base(mr, num_allocations, 1_MiB, stream);
-}
-
-template <>
-inline void test_random_allocations<thread_safe_fixed_multisize_mr>(
-  thread_safe_fixed_multisize_mr* mr, std::size_t num_allocations, cudaStream_t stream)
-{
-  return test_random_allocations_base(mr, num_allocations, 1_MiB, stream);
-}
-
-template <>
-inline void test_random_allocations<thread_safe_fixed_multisize_pool_mr>(
-  thread_safe_fixed_multisize_pool_mr* mr, std::size_t num_allocations, cudaStream_t stream)
-{
-  return test_random_allocations_base(mr, num_allocations, 1_MiB, stream);
-}
-
-template <>
-inline void test_mixed_random_allocation_free<thread_safe_fixed_size_mr>(
-  thread_safe_fixed_size_mr* mr, cudaStream_t stream)
-{
-  test_mixed_random_allocation_free_base(mr, 1_MiB, stream);
-}
-
-template <>
-inline void test_mixed_random_allocation_free<thread_safe_fixed_multisize_mr>(
-  thread_safe_fixed_multisize_mr* mr, cudaStream_t stream)
-{
-  test_mixed_random_allocation_free_base(mr, 4_MiB, stream);
-}
-
-template <>
-inline void test_mixed_random_allocation_free<thread_safe_fixed_multisize_pool_mr>(
-  thread_safe_fixed_multisize_pool_mr* mr, cudaStream_t stream)
-{
-  test_mixed_random_allocation_free_base(mr, 4_MiB, stream);
-}
-
-// Test on all memory resource classes
-using resources = ::testing::Types<rmm::mr::cuda_memory_resource,
-                                   rmm::mr::managed_memory_resource,
-                                   rmm::mr::cnmem_memory_resource,
-                                   rmm::mr::cnmem_managed_memory_resource,
-                                   pool_mr,
-                                   thread_safe_fixed_size_mr,
-                                   thread_safe_fixed_multisize_mr,
-                                   thread_safe_fixed_multisize_pool_mr,
-                                   thread_safe_hybrid_mr>;
-
-template <typename MemoryResourceType>
-using MRTest_mt = MRTest<MemoryResourceType>;
-
-TYPED_TEST_CASE(MRTest_mt, resources);
-
 TEST(DefaultTest, UseDefaultResource_mt) { spawn(test_get_default_resource); }
 
-TYPED_TEST(MRTest_mt, SetDefaultResource_mt)
+TEST_P(mr_test_mt, SetDefaultResource_mt)
 {
   // single thread changes default resource, then multiple threads use it
 
-  // Not necessarily false, since two cuda_memory_resources are always equal
-  // EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
   rmm::mr::device_memory_resource* old{nullptr};
   EXPECT_NO_THROW(old = rmm::mr::set_default_resource(this->mr.get()));
   EXPECT_NE(nullptr, old);
@@ -217,39 +71,39 @@ TYPED_TEST(MRTest_mt, SetDefaultResource_mt)
   // setting default resource w/ nullptr should reset to initial
   EXPECT_NO_THROW(rmm::mr::set_default_resource(nullptr));
   EXPECT_TRUE(old->is_equal(*rmm::mr::get_default_resource()));
-  // Not necessarily false, since two cuda_memory_resources are always equal
-  // EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
 }
 
-TYPED_TEST(MRTest_mt, Allocate) { spawn(test_various_allocations<TypeParam>, this->mr.get()); }
-
-TYPED_TEST(MRTest_mt, AllocateOnStream)
+TEST_P(mr_test_mt, AllocateDefaultStream)
 {
-  spawn(test_various_allocations_on_stream<TypeParam>, this->mr.get(), this->stream);
+  spawn(test_various_allocations, this->mr.get(), cudaStream_t{cudaStreamDefault});
 }
 
-TYPED_TEST(MRTest_mt, RandomAllocations)
+TEST_P(mr_test_mt, AllocateOnStream)
 {
-  spawn(test_random_allocations<TypeParam>, this->mr.get(), 100, nullptr);
+  spawn(test_various_allocations, this->mr.get(), this->stream);
 }
 
-TYPED_TEST(MRTest_mt, RandomAllocationsStream)
+TEST_P(mr_test_mt, RandomAllocationsDefaultStream)
 {
-  spawn(test_random_allocations<TypeParam>, this->mr.get(), 100, this->stream);
+  spawn(test_random_allocations, this->mr.get(), 100, 5_MiB, cudaStream_t{cudaStreamDefault});
 }
 
-TYPED_TEST(MRTest_mt, MixedRandomAllocationFree)
+TEST_P(mr_test_mt, RandomAllocationsStream)
 {
-  spawn(test_mixed_random_allocation_free<TypeParam>, this->mr.get(), nullptr);
+  spawn(test_random_allocations, this->mr.get(), 100, 5_MiB, this->stream);
 }
 
-TYPED_TEST(MRTest_mt, MixedRandomAllocationFreeStream)
+TEST_P(mr_test_mt, MixedRandomAllocationFreeDefaultStream)
 {
-  spawn(test_mixed_random_allocation_free<TypeParam>, this->mr.get(), this->stream);
+  spawn(test_mixed_random_allocation_free, this->mr.get(), 5_MiB, cudaStream_t{cudaStreamDefault});
 }
 
-template <typename MemoryResourceType>
-void allocate_loop(MemoryResourceType* mr,
+TEST_P(mr_test_mt, MixedRandomAllocationFreeStream)
+{
+  spawn(test_mixed_random_allocation_free, this->mr.get(), 5_MiB, this->stream);
+}
+
+void allocate_loop(rmm::mr::device_memory_resource* mr,
                    std::size_t num_allocations,
                    std::list<allocation>& allocations,
                    std::mutex& mtx,
@@ -271,88 +125,64 @@ void allocate_loop(MemoryResourceType* mr,
   }
 }
 
-template <typename MemoryResourceType>
-void deallocate_loop(MemoryResourceType* mr,
+void deallocate_loop(rmm::mr::device_memory_resource* mr,
                      std::size_t num_allocations,
                      std::list<allocation>& allocations,
                      std::mutex& mtx,
                      cudaStream_t stream)
 {
   for (std::size_t i = 0; i < num_allocations;) {
-    {
-      std::lock_guard<std::mutex> lock(mtx);
-      if (allocations.empty())
-        continue;
-      else {
-        i++;
-        allocation alloc = allocations.front();
-        allocations.pop_front();
-        EXPECT_NO_THROW(mr->deallocate(alloc.p, alloc.size, stream));
-      }
+    std::lock_guard<std::mutex> lock(mtx);
+    if (allocations.empty())
+      continue;
+    else {
+      i++;
+      allocation alloc = allocations.front();
+      allocations.pop_front();
+      EXPECT_NO_THROW(mr->deallocate(alloc.p, alloc.size, stream));
     }
   }
 }
 
-template <typename MemoryResourceType>
-void test_allocate_free_different_threads(MemoryResourceType* mr,
+void test_allocate_free_different_threads(rmm::mr::device_memory_resource* mr,
                                           cudaStream_t streamA,
                                           cudaStream_t streamB)
 {
-  std::default_random_engine generator;
   constexpr std::size_t num_allocations{100};
-  constexpr std::size_t max_size{1_MiB};
-
-  std::uniform_int_distribution<std::size_t> size_distribution(1, max_size);
 
   std::mutex mtx;
   std::list<allocation> allocations;
 
-  std::thread producer(allocate_loop<MemoryResourceType>,
-                       mr,
-                       num_allocations,
-                       std::ref(allocations),
-                       std::ref(mtx),
-                       streamA);
-  std::thread consumer(deallocate_loop<MemoryResourceType>,
-                       mr,
-                       num_allocations,
-                       std::ref(allocations),
-                       std::ref(mtx),
-                       streamB);
+  std::thread producer(
+    allocate_loop, mr, num_allocations, std::ref(allocations), std::ref(mtx), streamA);
+
+  std::thread consumer(
+    deallocate_loop, mr, num_allocations, std::ref(allocations), std::ref(mtx), streamB);
 
   producer.join();
   consumer.join();
 }
 
-TYPED_TEST(MRTest_mt, AllocFreeDifferentThreadsDefaultStream)
+TEST_P(mr_test_mt, AllocFreeDifferentThreadsDefaultStream)
 {
-  test_allocate_free_different_threads<TypeParam>(this->mr.get(), nullptr, nullptr);
+  test_allocate_free_different_threads(
+    this->mr.get(), cudaStream_t{cudaStreamDefault}, cudaStream_t{cudaStreamDefault});
 }
 
-TYPED_TEST(MRTest_mt, AllocFreeDifferentThreadsSameStream)
+TEST_P(mr_test_mt, AllocFreeDifferentThreadsSameStream)
 {
-  test_allocate_free_different_threads<TypeParam>(this->mr.get(), this->stream, this->stream);
+  test_allocate_free_different_threads(this->mr.get(), this->stream, this->stream);
 }
 
-// cnmem does not allow freeing on a different stream than allocating
-using resources_different_stream = ::testing::Types<rmm::mr::cuda_memory_resource,
-                                                    rmm::mr::managed_memory_resource,
-                                                    pool_mr,
-                                                    thread_safe_fixed_size_mr,
-                                                    thread_safe_fixed_multisize_mr,
-                                                    thread_safe_fixed_multisize_pool_mr,
-                                                    thread_safe_hybrid_mr>;
-
-template <typename MemoryResourceType>
-using MRTestDifferentStream_mt = MRTest<MemoryResourceType>;
-
-TYPED_TEST_CASE(MRTestDifferentStream_mt, resources_different_stream);
-
-TYPED_TEST(MRTestDifferentStream_mt, AllocFreeDifferentThreadsDifferentStream)
+TEST_P(mr_test_mt, AllocFreeDifferentThreadsDifferentStream)
 {
   cudaStream_t streamB{};
   EXPECT_EQ(cudaSuccess, cudaStreamCreate(&streamB));
-  test_allocate_free_different_threads<TypeParam>(this->mr.get(), this->stream, streamB);
+  test_allocate_free_different_threads(this->mr.get(), this->stream, streamB);
   EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(streamB));
   EXPECT_EQ(cudaSuccess, cudaStreamDestroy(streamB));
 }
+
+}  // namespace
+}  // namespace test
+}  // namespace rmm

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -36,7 +36,8 @@
 #include <cstdint>
 #include <random>
 
-namespace {
+namespace rmm {
+namespace test {
 
 inline bool is_aligned(void* p, std::size_t alignment = 256)
 {
@@ -80,8 +81,6 @@ using fixed_multisize_mr =
   rmm::mr::fixed_multisize_memory_resource<rmm::mr::device_memory_resource>;
 using fixed_multisize_pool_mr = rmm::mr::fixed_multisize_memory_resource<pool_mr>;
 using hybrid_mr               = rmm::mr::hybrid_memory_resource<fixed_multisize_pool_mr, pool_mr>;
-
-}  // namespace
 
 // Various test functions, shared between single-threaded and multithreaded tests.
 
@@ -268,3 +267,6 @@ inline MRTest<hybrid_mr>::~MRTest()
   delete pool;
   delete cuda;
 }
+
+}  // namespace test
+}  // namespace rmm

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -109,32 +109,7 @@ void test_allocate(MemoryResourceType* mr, std::size_t bytes, cudaStream_t strea
   if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
 }
 
-template <typename MemoryResourceType>
-void test_various_allocations(MemoryResourceType* mr)
-{
-  // test allocating zero bytes
-  {
-    void* p{nullptr};
-    EXPECT_NO_THROW(p = mr->allocate(0));
-    EXPECT_EQ(nullptr, p);
-    EXPECT_NO_THROW(mr->deallocate(p, 0));
-  }
-
-  test_allocate(mr, 4_B);
-  test_allocate(mr, 1_KiB);
-  test_allocate(mr, 1_MiB);
-  test_allocate(mr, 1_GiB);
-
-  // should fail to allocate too much
-  {
-    void* p{nullptr};
-    EXPECT_THROW(p = mr->allocate(1_PiB), rmm::bad_alloc);
-    EXPECT_EQ(nullptr, p);
-  }
-}
-
-template <typename MemoryResourceType>
-void test_various_allocations_on_stream(MemoryResourceType* mr, cudaStream_t stream = 0)
+void test_various_allocations(rmm::mr::device_memory_resource* mr, cudaStream_t stream)
 {
   // test allocating zero bytes on non-default stream
   {

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -133,11 +133,10 @@ void test_various_allocations(rmm::mr::device_memory_resource* mr, cudaStream_t 
   }
 }
 
-template <typename MemoryResourceType>
-void test_random_allocations_base(MemoryResourceType* mr,
-                                  std::size_t num_allocations = 100,
-                                  std::size_t max_size        = 5_MiB,
-                                  cudaStream_t stream         = 0)
+void test_random_allocations(rmm::mr::device_memory_resource* mr,
+                             std::size_t num_allocations = 100,
+                             std::size_t max_size        = 5_MiB,
+                             cudaStream_t stream         = 0)
 {
   std::vector<allocation> allocations(num_allocations);
 
@@ -159,30 +158,6 @@ void test_random_allocations_base(MemoryResourceType* mr,
       EXPECT_NO_THROW(mr->deallocate(a.p, a.size, stream));
       if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
     });
-}
-
-template <typename MemoryResourceType>
-void test_random_allocations(MemoryResourceType* mr,
-                             std::size_t num_allocations = 100,
-                             cudaStream_t stream         = 0)
-{
-  return test_random_allocations_base<MemoryResourceType>(mr, num_allocations, 5_MiB, stream);
-}
-
-template <>
-inline void test_random_allocations<fixed_size_mr>(fixed_size_mr* mr,
-                                                   std::size_t num_allocations,
-                                                   cudaStream_t stream)
-{
-  return test_random_allocations_base(mr, num_allocations, 1_MiB, stream);
-}
-
-template <>
-inline void test_random_allocations<fixed_multisize_mr>(fixed_multisize_mr* mr,
-                                                        std::size_t num_allocations,
-                                                        cudaStream_t stream)
-{
-  return test_random_allocations_base(mr, num_allocations, 1_MiB, stream);
 }
 
 template <typename MemoryResourceType>

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -161,9 +161,9 @@ void test_random_allocations(rmm::mr::device_memory_resource* mr,
 }
 
 template <typename MemoryResourceType>
-void test_mixed_random_allocation_free_base(MemoryResourceType* mr,
-                                            std::size_t max_size = 5_MiB,
-                                            cudaStream_t stream  = 0)
+void test_mixed_random_allocation_free(MemoryResourceType* mr,
+                                       std::size_t max_size = 5_MiB,
+                                       cudaStream_t stream  = 0)
 {
   std::default_random_engine generator;
   constexpr std::size_t num_allocations{100};
@@ -205,25 +205,6 @@ void test_mixed_random_allocation_free_base(MemoryResourceType* mr,
 
   EXPECT_EQ(active_allocations, 0);
   EXPECT_EQ(allocations.size(), active_allocations);
-}
-
-template <typename MemoryResourceType>
-void test_mixed_random_allocation_free(MemoryResourceType* mr, cudaStream_t stream)
-{
-  test_mixed_random_allocation_free_base(mr, 5_MiB, stream);
-}
-
-template <>
-inline void test_mixed_random_allocation_free<fixed_size_mr>(fixed_size_mr* mr, cudaStream_t stream)
-{
-  test_mixed_random_allocation_free_base(mr, 1_MiB, stream);
-}
-
-template <>
-inline void test_mixed_random_allocation_free<fixed_multisize_mr>(fixed_multisize_mr* mr,
-                                                                  cudaStream_t stream)
-{
-  test_mixed_random_allocation_free_base(mr, 4_MiB, stream);
 }
 
 // The test fixture

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -74,7 +74,7 @@ auto make_hybrid()
     std::make_tuple(make_multisize(), make_pool()));
 }
 
-INSTANTIATE_TEST_CASE_P(name,
+INSTANTIATE_TEST_CASE_P(ResourceTests,
                         mr_test,
                         ::testing::Values(mr_factory{"CUDA", &make_cuda},
                                           mr_factory{"Managed", &make_managed},

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -88,8 +88,6 @@ TEST(DefaultTest, UseDefaultResource) { test_get_default_resource(); }
 
 TEST_P(mr_test, SetDefaultResource)
 {
-  // Not necessarily false, since two cuda_memory_resources are always equal
-  // EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
   rmm::mr::device_memory_resource* old{nullptr};
   EXPECT_NO_THROW(old = rmm::mr::set_default_resource(this->mr.get()));
   EXPECT_NE(nullptr, old);
@@ -99,8 +97,6 @@ TEST_P(mr_test, SetDefaultResource)
   // setting default resource w/ nullptr should reset to initial
   EXPECT_NO_THROW(rmm::mr::set_default_resource(nullptr));
   EXPECT_TRUE(old->is_equal(*rmm::mr::get_default_resource()));
-  // Not necessarily false, since two cuda_memory_resources are always equal
-  // EXPECT_FALSE(this->mr->is_equal(*rmm::mr::get_default_resource()));
 }
 
 TEST_P(mr_test, SelfEquality) { EXPECT_TRUE(this->mr->is_equal(*this->mr)); }

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -81,8 +81,6 @@ INSTANTIATE_TEST_CASE_P(ResourceTests,
                                           mr_factory{"CNMEM", &make_cnmem},
                                           mr_factory{"CNMEM_Managed", &make_cnmem_managed},
                                           mr_factory{"Pool", &make_pool},
-                                          mr_factory{"FixedSize", &make_fixed_size},
-                                          mr_factory{"MultiSize", &make_multisize},
                                           mr_factory{"Hybrid", &make_hybrid}),
                         [](auto const& info) { return info.param.name; });
 

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -14,70 +14,12 @@
  * limitations under the License.
  */
 
-#include <rmm/mr/device/owning_wrapper.hpp>
-#include "mr/device/cuda_memory_resource.hpp"
-#include "mr/device/device_memory_resource.hpp"
+#include <gtest/gtest.h>
 #include "mr_test.hpp"
 
 namespace rmm {
 namespace test {
 namespace {
-
-using MRFactoryFunc = std::function<std::shared_ptr<rmm::mr::device_memory_resource>()>;
-
-/// Encapsulates a `device_memory_resource` factory function and associated name
-struct mr_factory {
-  mr_factory(std::string const& name, MRFactoryFunc f) : name{name}, f{f} {}
-
-  std::string name;  ///< Name to associate with tests that use this factory
-  MRFactoryFunc f;   ///< Factory function that returns shared_ptr to `device_memory_resource`
-                     ///< instance to use in test
-};
-
-/// Test fixture class value-parameterized on different `mr_factory`s
-struct mr_test : public ::testing::TestWithParam<mr_factory> {
-  void SetUp() override
-  {
-    auto factory = GetParam().f;
-    mr           = factory();
-    EXPECT_EQ(cudaSuccess, cudaStreamCreate(&stream));
-  }
-
-  void TearDown() override { EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream)); };
-
-  std::shared_ptr<rmm::mr::device_memory_resource> mr;  ///< Pointer to resource to use in tests
-  cudaStream_t stream;
-};
-
-/// MR factory functions
-auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
-
-auto make_managed() { return std::make_shared<rmm::mr::managed_memory_resource>(); }
-
-auto make_cnmem() { return std::make_shared<rmm::mr::cnmem_memory_resource>(); }
-
-auto make_cnmem_managed() { return std::make_shared<rmm::mr::cnmem_managed_memory_resource>(); }
-
-auto make_pool()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
-}
-
-auto make_fixed_size()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::fixed_size_memory_resource>(make_cuda());
-}
-
-auto make_multisize()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::fixed_multisize_memory_resource>(make_cuda());
-}
-
-auto make_hybrid()
-{
-  return rmm::mr::make_owning_wrapper<rmm::mr::hybrid_memory_resource>(
-    std::make_tuple(make_multisize(), make_pool()));
-}
 
 INSTANTIATE_TEST_CASE_P(ResourceTests,
                         mr_test,

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -25,6 +25,8 @@ using MRFactoryFunc = std::function<std::shared_ptr<rmm::mr::device_memory_resou
 
 /// Encapsulates a `device_memory_resource` factory function and associated name
 struct mr_factory {
+  mr_factory(std::string const& name, MRFactoryFunc f) : name{name}, f{f} {}
+
   std::string name;  ///< Name to associate with tests that use this factory
   MRFactoryFunc f;   ///< Factory function that returns shared_ptr to `device_memory_resource`
                      ///< instance to use in test
@@ -45,6 +47,7 @@ struct mr_test : public ::testing::TestWithParam<mr_factory> {
   cudaStream_t stream;
 };
 
+/// MR factory functions
 auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
 
 auto make_managed() { return std::make_shared<rmm::mr::managed_memory_resource>(); }

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -104,18 +104,18 @@ TEST_P(mr_test, SetDefaultResource)
 
 TEST_P(mr_test, SelfEquality) { EXPECT_TRUE(this->mr->is_equal(*this->mr)); }
 
-TEST_P(mr_test, Allocate) { test_various_allocations(this->mr.get()); }
-
-TEST_P(mr_test, AllocateOnStream)
+TEST_P(mr_test, AllocateDefaultStream)
 {
-  test_various_allocations_on_stream(this->mr.get(), this->stream);
+  test_various_allocations(this->mr.get(), cudaStreamDefault);
 }
+
+TEST_P(mr_test, AllocateOnStream) { test_various_allocations(this->mr.get(), this->stream); }
 
 TEST_P(mr_test, RandomAllocations) { test_random_allocations(this->mr.get()); }
 
 TEST_P(mr_test, RandomAllocationsStream)
 {
-  test_random_allocations(this->mr.get(), 100, this->stream);
+  test_random_allocations(this->mr.get(), 100, 5_MiB, this->stream);
 }
 
 TEST_P(mr_test, MixedRandomAllocationFree)

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -120,12 +120,12 @@ TEST_P(mr_test, RandomAllocationsStream)
 
 TEST_P(mr_test, MixedRandomAllocationFree)
 {
-  test_mixed_random_allocation_free(this->mr.get(), nullptr);
+  test_mixed_random_allocation_free(this->mr.get(), 5_MiB, cudaStreamDefault);
 }
 
 TEST_P(mr_test, MixedRandomAllocationFreeStream)
 {
-  test_mixed_random_allocation_free(this->mr.get(), this->stream);
+  test_mixed_random_allocation_free(this->mr.get(), 5_MiB, this->stream);
 }
 
 TEST_P(mr_test, GetMemInfo)

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -19,6 +19,8 @@
 #include "mr/device/device_memory_resource.hpp"
 #include "mr_test.hpp"
 
+namespace rmm {
+namespace test {
 namespace {
 
 using MRFactoryFunc = std::function<std::shared_ptr<rmm::mr::device_memory_resource>()>;
@@ -141,5 +143,6 @@ TEST_P(mr_test, GetMemInfo)
     EXPECT_NO_THROW(this->mr->deallocate(ptr, allocation_size));
   }
 }
-
 }  // namespace
+}  // namespace test
+}  // namespace rmm


### PR DESCRIPTION
As an alternative to https://github.com/rapidsai/rmm/pull/439, introduces `rmm::mr::owning_wrapper` to allow constructing an object that owns both a `device_memory_resource` and any Upstream resources it may need. This approach doesn't require any modification of existing `device_memory_resource`s. 

This is to simplify and automate lifetime management of a resource and its upstreams. 

- [x] `owning_wrapper` implementation
- [x] Documentation
- [x] Update tests to use `owning_wrapper`

I needed to modify how tests were structured to avoid explicit template specialization due to how the `owning_wrapper` works. Instead of using type-parameterized tests, I am instead using value-parameterized tests where the list of value parameters are factory functions for constructing a MR. This allowed me to simplify the tests quite a bit. 