### PR TITLE
[REVIEW] Enforce rule of 0 for memory resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PR #435 Update conda upload versions for new supported CUDA/Python
 - PR #437 Test with `pickle5` (for older Python versions)
 - PR #443 Remove thread safe adaptor from PoolMemoryResource
+- PR #445 Make all resource operators/ctors explicit
 
 ## Bug Fixes
 

--- a/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
@@ -51,7 +51,6 @@ class cnmem_managed_memory_resource final : public cnmem_memory_resource {
   {
   }
 
-  cnmem_managed_memory_resource()                                     = default;
   cnmem_managed_memory_resource(cnmem_managed_memory_resource const&) = delete;
   cnmem_managed_memory_resource(cnmem_managed_memory_resource&&)      = delete;
   cnmem_managed_memory_resource& operator=(cnmem_managed_memory_resource const&) = delete;

--- a/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
@@ -50,6 +50,13 @@ class cnmem_managed_memory_resource final : public cnmem_memory_resource {
     : cnmem_memory_resource(initial_pool_size, devices, memory_kind::MANAGED)
   {
   }
+
+  cnmem_managed_memory_resource()                                     = default;
+  cnmem_managed_memory_resource(cnmem_managed_memory_resource const&) = delete;
+  cnmem_managed_memory_resource(cnmem_managed_memory_resource&&)      = delete;
+  cnmem_managed_memory_resource& operator=(cnmem_managed_memory_resource const&) = delete;
+  cnmem_managed_memory_resource& operator=(cnmem_managed_memory_resource&&) = delete;
+  ~cnmem_managed_memory_resource()                                          = default;
 };
 
 }  // namespace mr

--- a/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_managed_memory_resource.hpp
@@ -19,14 +19,6 @@
 #include "cnmem_memory_resource.hpp"
 #include "device_memory_resource.hpp"
 
-#include <cuda_runtime_api.h>
-#include <cassert>
-#include <exception>
-#include <iostream>
-#include <mutex>
-#include <set>
-#include <vector>
-
 namespace rmm {
 namespace mr {
 /**

--- a/include/rmm/mr/device/cnmem_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_memory_resource.hpp
@@ -90,7 +90,6 @@ class cnmem_memory_resource : public device_memory_resource {
     assert(CNMEM_STATUS_SUCCESS == status);
   }
 
-  cnmem_memory_resource()                             = default;
   cnmem_memory_resource(cnmem_memory_resource const&) = delete;
   cnmem_memory_resource(cnmem_memory_resource&&)      = delete;
   cnmem_memory_resource& operator=(cnmem_memory_resource const&) = delete;

--- a/include/rmm/mr/device/cnmem_memory_resource.hpp
+++ b/include/rmm/mr/device/cnmem_memory_resource.hpp
@@ -90,6 +90,12 @@ class cnmem_memory_resource : public device_memory_resource {
     assert(CNMEM_STATUS_SUCCESS == status);
   }
 
+  cnmem_memory_resource()                             = default;
+  cnmem_memory_resource(cnmem_memory_resource const&) = delete;
+  cnmem_memory_resource(cnmem_memory_resource&&)      = delete;
+  cnmem_memory_resource& operator=(cnmem_memory_resource const&) = delete;
+  cnmem_memory_resource& operator=(cnmem_memory_resource&&) = delete;
+
   /**
    * @brief Query whether the resource supports use of non-null CUDA streams for
    * allocation/deallocation.

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -32,6 +32,12 @@ namespace mr {
  */
 class cuda_memory_resource final : public device_memory_resource {
  public:
+  cuda_memory_resource()                            = default;
+  cuda_memory_resource(cuda_memory_resource const&) = default;
+  cuda_memory_resource(cuda_memory_resource&&)      = default;
+  cuda_memory_resource& operator=(cuda_memory_resource const&) = default;
+  cuda_memory_resource& operator=(cuda_memory_resource&&) = default;
+
   /**
    * @brief Query whether the resource supports use of non-null CUDA streams for
    * allocation/deallocation. `cuda_memory_resource` does not support streams.

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -33,6 +33,7 @@ namespace mr {
 class cuda_memory_resource final : public device_memory_resource {
  public:
   cuda_memory_resource()                            = default;
+  ~cuda_memory_resource()                           = default;
   cuda_memory_resource(cuda_memory_resource const&) = default;
   cuda_memory_resource(cuda_memory_resource&&)      = default;
   cuda_memory_resource& operator=(cuda_memory_resource const&) = default;

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -45,7 +45,6 @@ namespace mr {
  */
 class device_memory_resource {
  public:
-  device_memory_resource()          = default;
   virtual ~device_memory_resource() = default;
 
   /**

--- a/include/rmm/mr/device/fixed_multisize_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_multisize_memory_resource.hpp
@@ -113,7 +113,13 @@ class fixed_multisize_memory_resource : public device_memory_resource {
    * @brief Destroy the fixed_multisize_memory_resource and free all memory allocated from the
    *        upstream resource.
    */
-  virtual ~fixed_multisize_memory_resource() {}
+  ~fixed_multisize_memory_resource() = default;
+
+  fixed_multisize_memory_resource()                                       = delete;
+  fixed_multisize_memory_resource(fixed_multisize_memory_resource const&) = delete;
+  fixed_multisize_memory_resource(fixed_multisize_memory_resource&&)      = delete;
+  fixed_multisize_memory_resource& operator=(fixed_multisize_memory_resource const&) = delete;
+  fixed_multisize_memory_resource& operator=(fixed_multisize_memory_resource&&) = delete;
 
   /**
    * @brief Query whether the resource supports use of non-null streams for

--- a/include/rmm/mr/device/fixed_multisize_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_multisize_memory_resource.hpp
@@ -39,13 +39,10 @@
 using cudaStream_t = struct CUstream_st*;
 
 namespace rmm {
-
 namespace mr {
-
-namespace {
-
+namespace detail {
 // Integer pow function
-std::size_t ipow(std::size_t base, std::size_t exp)
+constexpr std::size_t ipow(std::size_t base, std::size_t exp)
 {
   std::size_t ret = 1;
   while (exp > 0) {
@@ -55,8 +52,7 @@ std::size_t ipow(std::size_t base, std::size_t exp)
   }
   return ret;
 }
-
-}  // namespace
+}  // namespace detail
 
 /**
  * @brief Allocates fixed-size memory blocks of a range of sizes.
@@ -101,15 +97,15 @@ class fixed_multisize_memory_resource : public device_memory_resource {
       size_base_{size_base},
       min_size_exponent_{min_size_exponent},
       max_size_exponent_{max_size_exponent},
-      min_size_bytes_{ipow(size_base, min_size_exponent)},
-      max_size_bytes_{ipow(size_base, max_size_exponent)}
+      min_size_bytes_{detail::ipow(size_base, min_size_exponent)},
+      max_size_bytes_{detail::ipow(size_base, max_size_exponent)}
   {
     RMM_EXPECTS(rmm::detail::is_pow2(size_base), "size_base must be a power of two");
 
     // allocate initial blocks and insert into free list
     for (std::size_t i = min_size_exponent_; i <= max_size_exponent_; i++) {
       fixed_size_mr_.emplace_back(new fixed_size_memory_resource<Upstream>(
-        upstream_resource, ipow(size_base, i), initial_blocks_per_size));
+        upstream_resource, detail::ipow(size_base, i), initial_blocks_per_size));
     }
   }
 
@@ -170,7 +166,7 @@ class fixed_multisize_memory_resource : public device_memory_resource {
   {
     assert(bytes <= get_max_size());
 
-    auto exponentiate = [this](std::size_t const& k) { return ipow(size_base_, k); };
+    auto exponentiate = [this](std::size_t const& k) { return detail::ipow(size_base_, k); };
     auto min_exp      = thrust::make_transform_iterator(
       thrust::make_counting_iterator(min_size_exponent_), exponentiate);
 

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -77,7 +77,13 @@ class fixed_size_memory_resource : public device_memory_resource {
    * @brief Destroy the `fixed_size_memory_resource` and free all memory allocated from upstream.
    *
    */
-  virtual ~fixed_size_memory_resource() { release(); }
+  ~fixed_size_memory_resource() { release(); }
+
+  fixed_size_memory_resource()                                  = delete;
+  fixed_size_memory_resource(fixed_size_memory_resource const&) = delete;
+  fixed_size_memory_resource(fixed_size_memory_resource&&)      = delete;
+  fixed_size_memory_resource& operator=(fixed_size_memory_resource const&) = delete;
+  fixed_size_memory_resource& operator=(fixed_size_memory_resource&&) = delete;
 
   /**
    * @brief Query whether the resource supports use of non-null streams for

--- a/include/rmm/mr/device/hybrid_memory_resource.hpp
+++ b/include/rmm/mr/device/hybrid_memory_resource.hpp
@@ -15,25 +15,13 @@
  */
 #pragma once
 
-#include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-#include <cuda_runtime_api.h>
-
-#include <algorithm>
-#include <cassert>
 #include <cstddef>
-#include <list>
-#include <memory>
-#include <unordered_map>
 #include <utility>
 
-// forward decl
-using cudaStream_t = struct CUstream_st*;
-
 namespace rmm {
-
 namespace mr {
 
 /**

--- a/include/rmm/mr/device/hybrid_memory_resource.hpp
+++ b/include/rmm/mr/device/hybrid_memory_resource.hpp
@@ -64,7 +64,13 @@ class hybrid_memory_resource : public device_memory_resource {
    * @note since hybrid_memory_resource does not own its upstream memory_resources, this does not
    *       free any memory.
    */
-  virtual ~hybrid_memory_resource() = default;
+  ~hybrid_memory_resource() = default;
+
+  hybrid_memory_resource()                              = delete;
+  hybrid_memory_resource(hybrid_memory_resource const&) = delete;
+  hybrid_memory_resource(hybrid_memory_resource&&)      = delete;
+  hybrid_memory_resource& operator=(hybrid_memory_resource const&) = delete;
+  hybrid_memory_resource& operator=(hybrid_memory_resource&&) = delete;
 
   /**
    * @brief Query whether the resource supports use of non-null streams for

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -99,6 +99,13 @@ class logging_resource_adaptor final : public device_memory_resource {
     init_logger(auto_flush);
   }
 
+  logging_resource_adaptor()                                = delete;
+  ~logging_resource_adaptor()                               = default;
+  logging_resource_adaptor(logging_resource_adaptor const&) = delete;
+  logging_resource_adaptor(logging_resource_adaptor&&)      = default;
+  logging_resource_adaptor& operator=(logging_resource_adaptor const&) = delete;
+  logging_resource_adaptor& operator=(logging_resource_adaptor&&) = default;
+
   /**
    * @brief Return pointer to the upstream resource.
    *

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -32,6 +32,13 @@ namespace mr {
  */
 class managed_memory_resource final : public device_memory_resource {
  public:
+  managed_memory_resource()                               = default;
+  ~managed_memory_resource()                              = default;
+  managed_memory_resource(managed_memory_resource const&) = default;
+  managed_memory_resource(managed_memory_resource&&)      = default;
+  managed_memory_resource& operator=(managed_memory_resource const&) = default;
+  managed_memory_resource& operator=(managed_memory_resource&&) = default;
+
   /**
    * @brief Query whether the resource supports use of non-null streams for
    * allocation/deallocation.

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -22,11 +22,9 @@
 #include <cuda_runtime_api.h>
 
 #include <algorithm>
-#include <atomic>
 #include <cassert>
 #include <cstdint>
 #include <iostream>
-#include <list>
 #include <map>
 #include <mutex>
 #include <numeric>

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -100,6 +100,12 @@ class pool_memory_resource final : public device_memory_resource {
 #endif
   }
 
+  pool_memory_resource()                            = delete;
+  pool_memory_resource(pool_memory_resource const&) = delete;
+  pool_memory_resource(pool_memory_resource&&)      = delete;
+  pool_memory_resource& operator=(pool_memory_resource const&) = delete;
+  pool_memory_resource& operator=(pool_memory_resource&&) = delete;
+
   /**
    * @brief Queries whether the resource supports use of non-null CUDA streams for
    * allocation/deallocation.

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -51,6 +51,13 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
   }
 
+  thread_safe_resource_adaptor()                                    = delete;
+  ~thread_safe_resource_adaptor()                                   = default;
+  thread_safe_resource_adaptor(thread_safe_resource_adaptor const&) = delete;
+  thread_safe_resource_adaptor(thread_safe_resource_adaptor&&)      = delete;
+  thread_safe_resource_adaptor& operator=(thread_safe_resource_adaptor const&) = delete;
+  thread_safe_resource_adaptor& operator=(thread_safe_resource_adaptor&&) = delete;
+
   /**
    * @brief Get the upstream memory resource.
    *

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -46,7 +46,6 @@ namespace mr {
  *---------------------------------------------------------------------------**/
 class host_memory_resource {
  public:
-  host_memory_resource()          = default;
   virtual ~host_memory_resource() = default;
 
   /**---------------------------------------------------------------------------*

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -30,6 +30,14 @@ namespace mr {
  * `operator delete` to allocate host memory.
  *---------------------------------------------------------------------------**/
 class new_delete_resource final : public host_memory_resource {
+ public:
+  new_delete_resource()                            = default;
+  ~new_delete_resource()                           = default;
+  new_delete_resource(new_delete_resource const &) = default;
+  new_delete_resource(new_delete_resource &&)      = default;
+  new_delete_resource &operator=(new_delete_resource const &) = default;
+  new_delete_resource &operator=(new_delete_resource &&) = default;
+
  private:
   /**---------------------------------------------------------------------------*
    * @brief Allocates memory on the host of size at least `bytes` bytes.

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -31,6 +31,14 @@ namespace mr {
  * See https://devblogs.nvidia.com/how-optimize-data-transfers-cuda-cc/
  *---------------------------------------------------------------------------**/
 class pinned_memory_resource final : public host_memory_resource {
+ public:
+  pinned_memory_resource()                               = default;
+  ~pinned_memory_resource()                              = default;
+  pinned_memory_resource(pinned_memory_resource const &) = default;
+  pinned_memory_resource(pinned_memory_resource &&)      = default;
+  pinned_memory_resource &operator=(pinned_memory_resource const &) = default;
+  pinned_memory_resource &operator=(pinned_memory_resource &&) = default;
+
  private:
   /**---------------------------------------------------------------------------*
    * @brief Allocates pinned memory on the host of size at least `bytes` bytes.


### PR DESCRIPTION
In line with what [Scott Meyer's says](http://scottmeyers.blogspot.com/2014/03/a-concern-about-rule-of-zero.html), makes Rule of 0 explicit by explicitly defaulting or deleting ctors/assignment operators as appropriate for all resources. 

I also cleaned up a few minor things I noticed while I was going through all the files, like cleaning up unnecessary includes. 