### PR TITLE
[REVIEW] Per device resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - PR #436 Always build and test with per-thread default stream enabled in the GPU CI build
 - PR #444 Add `owning_wrapper` to simplify lifetime management of resources and their upstreams
 - PR #450 Add support for new build process (Project Flash)
+- PR #458 Add `get/set_per_device_resource` to better support multi-GPU per process applications
 
 ## Improvements
 

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -80,7 +80,7 @@ inline cuda_device_id current_device()
  * Returns a pointer to the `device_memory_resource` for the specified device. The initial resource
  * is a `cuda_memory_resource`.
  *
- * `id.value()` must be in the range `[0, cudaGetDevicecount())`, otherwise behavior is undefined.
+ * `id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is undefined.
  *
  * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
  * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.
@@ -105,7 +105,7 @@ inline device_memory_resource* get_per_device_resource(cuda_device_id id)
  * If `new_mr` is not `nullptr`, sets the memory resource pointer for the device specified by `id`
  * to `new_mr`. Otherwise, resets `id`s resource to the initial `cuda_memory_resource`.
  *
- * `id.value()` must be in the range `[0, cudaGetDevicecount())`, otherwise behavior is undefined.
+ * `id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is undefined.
  *
  * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior
  * is undefined. It is the caller's responsibility to maintain the lifetime of the resource object.

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -26,16 +26,20 @@
  * @file per_device_resource.hpp
  * @brief Management of per-device `device_memory_resource`s
  *
- * It is common to construct a `device_memory_resource` and use it as a default for all allocations
- * where another resource has not been explicitly specified. In applications with multiple GPUs in
- * the same process, it may also be necessary to maintain independent "default" resources for each
- * device. To this end, the `set_per_device_resource` and `get_per_device_resource` functions enable
- * a mapping between a CUDA device id and a pointer to a `device_memory_resource`.
+ * One might wish to construct a `device_memory_resource` and use it for (de)allocation
+ * without explicit dependency injection, i.e., passing a reference to that object to all places it
+ * is to be used. Instead, one might want to set their resource as a "default" and have it be used
+ * in all places where another resource has not been explicitly specified.  In applications with
+ * multiple GPUs in the same process, it may also be necessary to maintain independent default
+ * resources for each device. To this end, the `set_per_device_resource` and
+ * `get_per_device_resource` functions enable mapping a CUDA device id to a `device_memory_resource`
+ * pointer.
  *
  * For example, given a pointer, `mr`, to a `device_memory_resource` object, calling
  * `set_per_device_resource(cuda_device_id{0}, mr)` will establish a mapping between CUDA device 0
  * and `mr` such that all future calls to `get_per_device_resource(cuda_device_id{0})` will return
- * the same pointer `mr`.
+ * the same pointer, `mr`. In this way, all places that use the resource returned from
+ * `get_per_device_resource` for (de)allocation will use the user provided resource, `mr`.
  *
  * If no resource was explicitly set for a given device specified by `id`, then
  * `get_per_device_resource(id)` will return a pointer to a `cuda_memory_resource`.
@@ -43,7 +47,6 @@
  * To fetch and modify the resource for the current CUDA device, `get_current_device_resource()` and
  * `set_current_device_resource()` will automatically use the current CUDA device id from
  * `cudaGetDevice()`.
- *
  */
 
 namespace rmm {

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -19,8 +19,8 @@
 #include "default_memory_resource.hpp"
 #include "device_memory_resource.hpp"
 
+#include <map>
 #include <mutex>
-#include <unordered_map>
 
 namespace rmm {
 namespace mr {
@@ -57,8 +57,7 @@ inline std::mutex& map_lock()
 
 inline auto& get_map()
 {
-  static std::unordered_map<cuda_device_id::value_type, device_memory_resource*>
-    device_id_to_resource;
+  static std::map<cuda_device_id::value_type, device_memory_resource*> device_id_to_resource;
   return device_id_to_resource;
 }
 

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -80,8 +80,8 @@ inline cuda_device_id current_device()
 /**
  * @brief Get the resource for the specified device.
  *
- * Returns a pointer to the `device_memory_resource` for the specified device. The initial resource is a
- * `cuda_memory_resource`.
+ * Returns a pointer to the `device_memory_resource` for the specified device. The initial resource
+ * is a `cuda_memory_resource`.
  *
  * This function is thread-safe.
  *
@@ -93,18 +93,18 @@ inline device_memory_resource* get_per_device_resource(cuda_device_id id)
   std::lock_guard<std::mutex> lock{detail::map_lock()};
   auto& map = detail::get_map();
   // If a resource was never set for `id`, set to the initial resource
-  return (map.find(id.value()) == map.end()) ? (map[id.value()] = detail::initial_resource())
-                                             : map[id.value()];
+  auto found = map.find(id.value());
+  return (found == map.end()) ? (map[id.value()] = detail::initial_resource()) : found->second;
 }
 
 /**
  * @brief Set the `device_memory_resource` for the specified device.
  *
- * If `new_mr` is not `nullptr`, sets the memory resource pointer for the device specified by `id` to
- * `new_mr`. Otherwise, resets `id`s resource to the initial `cuda_memory_resource`.
+ * If `new_mr` is not `nullptr`, sets the memory resource pointer for the device specified by `id`
+ * to `new_mr`. Otherwise, resets `id`s resource to the initial `cuda_memory_resource`.
  *
- * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior is
- * undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
+ * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior
+ * is undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
  *
  * This function is thread-safe.
  *
@@ -149,7 +149,8 @@ inline device_memory_resource* get_current_device_resource()
 
  * The "current device" is the device returned by `cudaGetDevice`.
  *
- * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior is
+ * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior
+ is
  * undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
  *
  * This function is thread-safe.

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "default_memory_resource.hpp"
+#include "device_memory_resource.hpp"
+
+#include <mutex>
+
+namespace rmm {
+namespace mr {
+
+/**
+ * @brief Strong type for a CUDA device identifier.
+ *
+ */
+enum class cuda_device_id : int {};
+
+namespace detail {
+std::mutex& map_lock()
+{
+  static std::mutex map_lock;
+  return map_lock;
+}
+
+auto& get_map()
+{
+  static std::unordered_map<cuda_device_id, device_memory_resource*> device_id_to_resource;
+  return device_id_to_resource;
+}
+
+/**
+ * @brief Returns a `cuda_device_id` for the current device
+ *
+ * The current device is the device on which the calling thread executes device code.
+ *
+ * @return `cuda_device_id` for the current device
+ */
+cuda_device_id current_device()
+{
+  int dev_id;
+  RMM_CUDA_TRY(cudaGetDevice(&dev_id));
+  return cuda_device_id{dev_id};
+}
+}  // namespace detail
+
+/**
+ * @brief Get the resource for the specified device
+ *
+ * Returns a pointer to the resource set for the specified device. The initial resource is a
+ * `cuda_memory_resource`.
+ *
+ * This function is thread-safe.
+ *
+ * @param id The id of the target device
+ * @return Pointer to the current resource for `id`
+ */
+inline device_memory_resource* get_per_device_resource(cuda_device_id id)
+{
+  std::lock_guard<std::mutex> lock{map_lock()};
+  auto& map        = get_map();
+  auto const found = map.find(id);
+  // If a resource was never set for `id`, set to the initial resource
+  return (found == map.end()) ? (map[id] = initial_resource()) : map[id];
+}
+
+/**
+ * @brief Update the resource for the specified device
+ *
+ * If `new_mr` is not `nullptr`, sets the resource pointer for the device specified by `id` to
+ * `new_mr`. Otherwise, resets `id`s resource to the initial `cuda_memory_resource`.
+ *
+ * The object pointed to by `new_mr` must outlive the last use of the resource, else behavior is
+ * undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
+ *
+ * This function is thread-safe.
+ *
+ * @param new_mr If not `nullptr`, pointer to new `device_memory_resource` to use as new resource
+ * for `id`
+ * @return Pointer to the previous the resource for `id`
+ */
+inline device_memory_resource* set_per_device_resource(cuda_device_id,
+                                                       devicce_memory_resource* new_mr)
+{
+  std::lock_guard<std::mutex> lock{map_lock()};
+  auto& map          = get_map();
+  auto const old_itr = map.find(id);
+  // If a resource didn't previously exist for `id`, return pointer to initial_resource
+  auto old_mr = (old_itr == map.end()) ? detail::initial_resource() : old_itr->second;
+  map[id]     = (new_mr == nullptr) ? detail::initial_resource() : new_mr;
+  return old_mr;
+}
+
+/**
+ * @brief Get the resource for the current device
+ *
+ * Returns a pointer to the resource set for the current device. The initial resource is a
+ * `cuda_memory_resource`.
+ *
+ * The "current device" is the device returned by `cudaGetDevice`.
+ *
+ * This function is thread-safe
+ *
+ * @return Pointer to the resource for the current device
+ */
+inline device_memory_resource* get_current_device_resource()
+{
+  return get_per_device_resource(current_device());
+}
+
+/**
+ * @brief Update the resource for the current device
+ *
+ * If `new_mr` is not `nullptr`, sets the resource pointer for the current device to
+ * `new_mr`. Otherwise, resets the resource to the initial `cuda_memory_resource`.
+
+ * The "current device" is the device returned by `cudaGetDevice`.
+ *
+ * The object pointed to by `new_mr` must outlive the last use of the resource, else behavior is
+ * undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
+ *
+ * This function is thread-safe.
+ *
+ * @param new_mr If not `nullptr`, pointer to new resource to use for the current device
+ * @return Pointer to the previous resource for the current device
+ */
+inline device_memory_resource* set_current_device_resource(device_memory_resource* new_mr)
+{
+  return set_per_device_resource(current_device(), new_mr);
+}
+}  // namespace mr
+}  // namespace rmm

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -80,6 +80,8 @@ inline cuda_device_id current_device()
  * Returns a pointer to the `device_memory_resource` for the specified device. The initial resource
  * is a `cuda_memory_resource`.
  *
+ * `id.value()` must be in the range `[0, cudaGetDevicecount())`, otherwise behavior is undefined.
+ *
  * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
  * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.
  * Concurrent calls to any of these functions will result in a valid state, but the order of
@@ -102,6 +104,8 @@ inline device_memory_resource* get_per_device_resource(cuda_device_id id)
  *
  * If `new_mr` is not `nullptr`, sets the memory resource pointer for the device specified by `id`
  * to `new_mr`. Otherwise, resets `id`s resource to the initial `cuda_memory_resource`.
+ *
+ * `id.value()` must be in the range `[0, cudaGetDevicecount())`, otherwise behavior is undefined.
  *
  * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior
  * is undefined. It is the caller's responsibility to maintain the lifetime of the resource object.

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -22,6 +22,30 @@
 #include <map>
 #include <mutex>
 
+/**
+ * @file per_device_resource.hpp
+ * @brief Management of per-device `device_memory_resource`s
+ *
+ * It is common to construct a `device_memory_resource` and use it as a default for all allocations
+ * where another resource has not been explicitly specified. In applications with multiple GPUs in
+ * the same process, it may also be necessary to maintain independent "default" resources for each
+ * device. To this end, the `set_per_device_resource` and `get_per_device_resource` functions enable
+ * a mapping between a CUDA device id and a pointer to a `device_memory_resource`.
+ *
+ * For example, given a pointer, `mr`, to a `device_memory_resource` object, calling
+ * `set_per_device_resource(cuda_device_id{0}, mr)` will establish a mapping between CUDA device 0
+ * and `mr` such that all future calls to `get_per_device_resource(cuda_device_id{0})` will return
+ * the same pointer `mr`.
+ *
+ * If no resource was explicitly set for a given device specified by `id`, then
+ * `get_per_device_resource(id)` will return a pointer to a `cuda_memory_resource`.
+ *
+ * To fetch and modify the resource for the current CUDA device, `get_current_device_resource()` and
+ * `set_current_device_resource()` will automatically use the current CUDA device id from
+ * `cudaGetDevice()`.
+ *
+ */
+
 namespace rmm {
 namespace mr {
 
@@ -77,8 +101,8 @@ inline cuda_device_id current_device()
 /**
  * @brief Get the resource for the specified device.
  *
- * Returns a pointer to the `device_memory_resource` for the specified device. The initial resource
- * is a `cuda_memory_resource`.
+ * Returns a pointer to the `device_memory_resource` for the specified device. The initial
+ * resource is a `cuda_memory_resource`.
  *
  * `id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is undefined.
  *
@@ -108,7 +132,8 @@ inline device_memory_resource* get_per_device_resource(cuda_device_id id)
  * `id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is undefined.
  *
  * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior
- * is undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
+ * is undefined. It is the caller's responsibility to maintain the lifetime of the resource
+ * object.
  *
  * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
  * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -80,7 +80,9 @@ inline cuda_device_id current_device()
  * Returns a pointer to the `device_memory_resource` for the specified device. The initial resource
  * is a `cuda_memory_resource`.
  *
- * This function is thread-safe.
+ * This function is thread-safe with respect to `set_per_device_resource`,
+ * `get_current_device_resource`, and `set_current_device_resource`. Concurrent calls to any of
+ * these functions will result in a valid state, but the order of execution is undefined.
  *
  * @param id The id of the target device
  * @return Pointer to the current `device_memory_resource` for device `id`
@@ -103,7 +105,10 @@ inline device_memory_resource* get_per_device_resource(cuda_device_id id)
  * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior
  * is undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
  *
- * This function is thread-safe.
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.
+ * Concurrent calls to any of these functions will result in a valid state, but the order of
+ * execution is undefined.
  *
  * @param new_mr If not `nullptr`, pointer to new `device_memory_resource` to use as new resource
  * for `id`
@@ -129,7 +134,10 @@ inline device_memory_resource* set_per_device_resource(cuda_device_id id,
  *
  * The "current device" is the device returned by `cudaGetDevice`.
  *
- * This function is thread-safe
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.
+ * Concurrent calls to any of these functions will result in a valid state, but the order of
+ * execution is undefined.
  *
  * @return Pointer to the resource for the current device
  */
@@ -150,7 +158,10 @@ inline device_memory_resource* get_current_device_resource()
  * is  undefined. It is the caller's responsibility to maintain the lifetime of the resource
  * object.
  *
- * This function is thread-safe.
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.
+ * Concurrent calls to any of these functions will result in a valid state, but the order of
+ * execution is undefined.
  *
  * @param new_mr If not `nullptr`, pointer to new resource to use for the current device
  * @return Pointer to the previous resource for the current device

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -47,7 +47,6 @@
  */
 
 namespace rmm {
-namespace mr {
 
 /**
  * @brief Strong type for a CUDA device identifier.
@@ -69,6 +68,8 @@ struct cuda_device_id {
  private:
   value_type id_;
 };
+
+namespace mr {
 
 namespace detail {
 inline std::mutex& map_lock()

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -80,9 +80,10 @@ inline cuda_device_id current_device()
  * Returns a pointer to the `device_memory_resource` for the specified device. The initial resource
  * is a `cuda_memory_resource`.
  *
- * This function is thread-safe with respect to `set_per_device_resource`,
- * `get_current_device_resource`, and `set_current_device_resource`. Concurrent calls to any of
- * these functions will result in a valid state, but the order of execution is undefined.
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.
+ * Concurrent calls to any of these functions will result in a valid state, but the order of
+ * execution is undefined.
  *
  * @param id The id of the target device
  * @return Pointer to the current `device_memory_resource` for device `id`

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -20,6 +20,7 @@
 #include "device_memory_resource.hpp"
 
 #include <mutex>
+#include <unordered_map>
 
 namespace rmm {
 namespace mr {

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -93,7 +93,7 @@ inline device_memory_resource* get_per_device_resource(cuda_device_id id)
   std::lock_guard<std::mutex> lock{detail::map_lock()};
   auto& map = detail::get_map();
   // If a resource was never set for `id`, set to the initial resource
-  auto found = map.find(id.value());
+  auto const found = map.find(id.value());
   return (found == map.end()) ? (map[id.value()] = detail::initial_resource()) : found->second;
 }
 

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -29,7 +29,7 @@
  * One might wish to construct a `device_memory_resource` and use it for (de)allocation
  * without explicit dependency injection, i.e., passing a reference to that object to all places it
  * is to be used. Instead, one might want to set their resource as a "default" and have it be used
- * in all places where another resource has not been explicitly specified.  In applications with
+ * in all places where another resource has not been explicitly specified. In applications with
  * multiple GPUs in the same process, it may also be necessary to maintain independent default
  * resources for each device. To this end, the `set_per_device_resource` and
  * `get_per_device_resource` functions enable mapping a CUDA device id to a `device_memory_resource`
@@ -144,6 +144,7 @@ inline device_memory_resource* get_per_device_resource(cuda_device_id id)
  * Concurrent calls to any of these functions will result in a valid state, but the order of
  * execution is undefined.
  *
+ * @param id The id of the target device
  * @param new_mr If not `nullptr`, pointer to new `device_memory_resource` to use as new resource
  * for `id`
  * @return Pointer to the previous memory resource for `id`
@@ -189,7 +190,7 @@ inline device_memory_resource* get_current_device_resource()
  * The "current device" is the device returned by `cudaGetDevice`.
  *
  * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior
- * is  undefined. It is the caller's responsibility to maintain the lifetime of the resource
+ * is undefined. It is the caller's responsibility to maintain the lifetime of the resource
  * object.
  *
  * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -35,13 +35,11 @@ struct cuda_device_id {
   /**
    * @brief Construct a `cuda_device_id` from the specified integer value
    *
+   * @param id The device's integer identifier
    */
   explicit constexpr cuda_device_id(value_type id) noexcept : id_{id} {}
 
-  /**
-   * @brief Returns the wrapped value
-   *
-   */
+  /// Returns the wrapped integer value
   constexpr value_type value() const noexcept { return id_; }
 
  private:
@@ -145,12 +143,12 @@ inline device_memory_resource* get_current_device_resource()
  *
  * If `new_mr` is not `nullptr`, sets the resource pointer for the current device to
  * `new_mr`. Otherwise, resets the resource to the initial `cuda_memory_resource`.
-
+ *
  * The "current device" is the device returned by `cudaGetDevice`.
  *
  * The object pointed to by `new_mr` must outlive the last use of the resource, otherwise behavior
- is
- * undefined. It is the caller's responsibility to maintain the lifetime of the resource object.
+ * is  undefined. It is the caller's responsibility to maintain the lifetime of the resource
+ * object.
  *
  * This function is thread-safe.
  *

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -32,13 +32,13 @@ namespace mr {
 enum class cuda_device_id : int {};
 
 namespace detail {
-std::mutex& map_lock()
+inline std::mutex& map_lock()
 {
   static std::mutex map_lock;
   return map_lock;
 }
 
-auto& get_map()
+inline auto& get_map()
 {
   static std::unordered_map<cuda_device_id, device_memory_resource*> device_id_to_resource;
   return device_id_to_resource;
@@ -51,7 +51,7 @@ auto& get_map()
  *
  * @return `cuda_device_id` for the current device
  */
-cuda_device_id current_device()
+inline cuda_device_id current_device()
 {
   int dev_id;
   RMM_CUDA_TRY(cudaGetDevice(&dev_id));

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -73,10 +73,9 @@ inline cuda_device_id current_device()
 inline device_memory_resource* get_per_device_resource(cuda_device_id id)
 {
   std::lock_guard<std::mutex> lock{map_lock()};
-  auto& map        = get_map();
-  auto const found = map.find(id);
+  auto& map = get_map();
   // If a resource was never set for `id`, set to the initial resource
-  return (found == map.end()) ? (map[id] = initial_resource()) : map[id];
+  return (map.find(id) == map.end()) ? (map[id] = initial_resource()) : map[id];
 }
 
 /**

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -63,6 +63,13 @@ void spawn(Task task, Arguments&&... args)
 
 TEST(DefaultTest, UseDefaultResource_mt) { spawn(test_get_default_resource); }
 
+TEST(DefaultTest, DefaultResourceIsCUDA_mt)
+{
+  spawn([]() {
+    EXPECT_NE(nullptr, rmm::mr::get_default_resource());
+    EXPECT_TRUE(rmm::mr::get_default_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
+  });
+}
 TEST_P(mr_test_mt, SetDefaultResource_mt)
 {
   // single thread changes default resource, then multiple threads use it

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -21,6 +21,7 @@
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include <thread>
@@ -70,6 +71,17 @@ TEST(DefaultTest, DefaultResourceIsCUDA_mt)
     EXPECT_TRUE(rmm::mr::get_default_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
   });
 }
+
+TEST(DefaultTest, GetCurrentDeviceResource_mt)
+{
+  spawn([]() {
+    rmm::mr::device_memory_resource* mr;
+    EXPECT_NO_THROW(mr = rmm::mr::get_current_device_resource());
+    EXPECT_NE(nullptr, mr);
+    EXPECT_TRUE(mr->is_equal(rmm::mr::cuda_memory_resource{}));
+  });
+}
+
 TEST_P(mr_test_mt, SetDefaultResource_mt)
 {
   // single thread changes default resource, then multiple threads use it

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -43,10 +43,8 @@ INSTANTIATE_TEST_CASE_P(MultiThreadResourceTests,
                                           mr_factory{"SyncHybrid", &make_sync_hybrid}),
                         [](auto const& info) { return info.param.name; });
 
-constexpr std::size_t num_threads{4};
-
 template <typename Task, typename... Arguments>
-void spawn(Task task, Arguments&&... args)
+void spawn_n(std::size_t num_threads, Task task, Arguments&&... args)
 {
   std::vector<std::thread> threads;
   threads.reserve(num_threads);
@@ -55,6 +53,12 @@ void spawn(Task task, Arguments&&... args)
 
   for (auto& t : threads)
     t.join();
+}
+
+template <typename Task, typename... Arguments>
+void spawn(Task task, Arguments&&... args)
+{
+  spawn_n(4, task, std::forward<Arguments>(args)...);
 }
 
 TEST(DefaultTest, UseDefaultResource_mt) { spawn(test_get_default_resource); }

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -79,7 +79,6 @@ struct allocation {
 inline void test_get_default_resource()
 {
   EXPECT_NE(nullptr, rmm::mr::get_default_resource());
-  EXPECT_TRUE(rmm::mr::get_default_resource->is_equal(rmm::mr::cuda_memory_resource{}));
   void* p{nullptr};
   EXPECT_NO_THROW(p = rmm::mr::get_default_resource()->allocate(1_MiB));
   EXPECT_NE(nullptr, p);

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -79,6 +79,7 @@ struct allocation {
 inline void test_get_default_resource()
 {
   EXPECT_NE(nullptr, rmm::mr::get_default_resource());
+  EXPECT_TRUE(rmm::mr::get_default_resource->is_equal(rmm::mr::cuda_memory_resource{}));
   void* p{nullptr};
   EXPECT_NO_THROW(p = rmm::mr::get_default_resource()->allocate(1_MiB));
   EXPECT_NE(nullptr, p);

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <rmm/mr/device/per_device_resource.hpp>
 #include "mr_test.hpp"
 
 #include <gtest/gtest.h>
@@ -32,7 +33,21 @@ INSTANTIATE_TEST_CASE_P(ResourceTests,
                                           mr_factory{"Hybrid", &make_hybrid}),
                         [](auto const& info) { return info.param.name; });
 
+TEST(DefaultTest, DefaultResourceIsCUDA)
+{
+  EXPECT_NE(nullptr, rmm::mr::get_default_resource());
+  EXPECT_TRUE(rmm::mr::get_default_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
+}
+
 TEST(DefaultTest, UseDefaultResource) { test_get_default_resource(); }
+
+TEST(DefaultTest, GetCurrentDeviceResource)
+{
+  rmm::mr::device_memory_resource* mr;
+  EXPECT_NO_THROW(mr = rmm::mr::get_current_device_resource());
+  EXPECT_NE(nullptr, mr);
+  EXPECT_TRUE(mr->is_equal(rmm::mr::cuda_memory_resource{}));
+}
 
 TEST_P(mr_test, SetDefaultResource)
 {

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -62,6 +62,23 @@ TEST_P(mr_test, SetDefaultResource)
   EXPECT_TRUE(old->is_equal(*rmm::mr::get_default_resource()));
 }
 
+TEST_P(mr_test, SetCurentDeviceResource)
+{
+  rmm::mr::device_memory_resource* old{};
+  EXPECT_NO_THROW(old = rmm::mr::set_current_device_resource(this->mr.get()));
+  EXPECT_NE(nullptr, old);
+
+  // old mr should equal a cuda mr
+  EXPECT_TRUE(old->is_equal(rmm::mr::cuda_memory_resource{}));
+
+  // current dev resource should equal this resource
+  EXPECT_TRUE(this->mr->is_equal(*rmm::mr::get_current_device_resource()));
+
+  // setting to `nullptr` should reset to initial cuda resource
+  EXPECT_NO_THROW(rmm::mr::set_current_device_resource(nullptr));
+  EXPECT_TRUE(rmm::mr::get_current_device_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
+}
+
 TEST_P(mr_test, SelfEquality) { EXPECT_TRUE(this->mr->is_equal(*this->mr)); }
 
 TEST_P(mr_test, AllocateDefaultStream)


### PR DESCRIPTION
Adds the concept of a "per-device" resource. This is similar to the "default resource" today, but is device specific.

This allows getting/setting a resource per device in usecases that use multiple GPUs per process. 