### PR TITLE
[REVIEW] Temporary fix for cnmem to have all headers in the same directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@
 - PR #398 Fix missing head flag in merge_blocks (pool_memory_resource) and improve block class
 - PR #403 Mark Cython `memory_resource_wrappers` `extern` as `nogil`
 - PR #406 Sets Google Benchmark to a fixed version, v1.5.1.
-- PR #434: Fix issue with incorrect docker image being used in local build script
+- PR #434 Fix issue with incorrect docker image being used in local build script
+- PR #463 Revert cmake change for cnmem header not being added to source directory
 
 # RMM 0.14.0 (Date TBD)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,10 @@ add_subdirectory(thirdparty)
 configure_file("${CNMEM_INCLUDE_DIR}/cnmem.h"
                "${CMAKE_CURRENT_BINARY_DIR}/include/rmm/detail/cnmem.h" COPYONLY)
 
+# Temporarily needed to have all RMM includes under a single directory
+configure_file("${CNMEM_INCLUDE_DIR}/cnmem.h"
+	       "${CMAKE_CURRENT_SOURCE_DIR}/include/rmm/detail/cnmem.h" COPYONLY)
+
 ###################################################################################################
 # - per-thread default stream option --------------------------------------------------------------
 # This needs to be defined first so tests and benchmarks can inherit it.


### PR DESCRIPTION
We have a group of developers who do not run the `install` command after building, but just set environment variables to point to the source directory to grab RMM includes. Changes in #461 removed the cnmem headers from this which broke their workflow. Given cnmem will be removed in the near future, temporarily reverting the change of `cnmem.h` not being pulled into the source directory.

cc @trxcllnt @harrism 