### PR TITLE
[REVIEW] revert the remainder of the cnmem.h move into the build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Debug
 build/
 RelWithDebInfo/
 thirdparty/googletest/
+include/rmm/detail/cnmem.h
 
 ## Eclipse IDE
 .project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PR #406 Sets Google Benchmark to a fixed version, v1.5.1.
 - PR #434 Fix issue with incorrect docker image being used in local build script
 - PR #463 Revert cmake change for cnmem header not being added to source directory
+- PR #464 More completely revert cnmem.h cmake changes
 
 # RMM 0.14.0 (Date TBD)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,6 @@ add_subdirectory(thirdparty)
 
 ###################################################################################################
 # - cnmem ---------------------------------------------------------------------------------
-# include cnmem.h in the include/detail directory
-configure_file("${CNMEM_INCLUDE_DIR}/cnmem.h"
-               "${CMAKE_CURRENT_BINARY_DIR}/include/rmm/detail/cnmem.h" COPYONLY)
 
 # Temporarily needed to have all RMM includes under a single directory
 configure_file("${CNMEM_INCLUDE_DIR}/cnmem.h"
@@ -189,9 +186,6 @@ install(TARGETS rmm
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/rmm
         DESTINATION include)
 
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/rmm
-        DESTINATION include)
-      
 ###################################################################################################
 # - make documentation ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Now that `cnmem.h` is back in the source dir, we should definitely also `.gitignore` it again, and we don't really need it in the build directory, too.

(With `cnmem.h` scheduled to go away, I think the hassles introduced by my previous move to the build dir are probably not worth it at all, but in any case, I think it should be either done completely or not at all, and this restores it to the "not at all" state.)
 