### PR TITLE
Just use `None` for `strides` in `DeviceBuffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Improvements
 
+- PR #477 Just use `None` for `strides` in `DeviceBuffer`
+
 ## Bug Fixes
 
 # RMM 0.15.0 (Date TBD)

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -108,7 +108,7 @@ cdef class DeviceBuffer:
         cdef dict intf = {
             "data": (self.ptr, False),
             "shape": (self.size,),
-            "strides": (1,),
+            "strides": None,
             "typestr": "|u1",
             "version": 0
         }

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -106,7 +106,7 @@ def test_rmm_device_buffer(size):
     assert set(b.__cuda_array_interface__) == keyset
     assert b.__cuda_array_interface__["data"] == (b.ptr, False)
     assert b.__cuda_array_interface__["shape"] == (b.size,)
-    assert b.__cuda_array_interface__["strides"] == (1,)
+    assert b.__cuda_array_interface__["strides"] is None
     assert b.__cuda_array_interface__["typestr"] == "|u1"
     assert b.__cuda_array_interface__["version"] == 0
 


### PR DESCRIPTION
Originally there were some issues in CuPy and Numba with how they implemented `__cuda_array_interface__` and handled other objects that supported it where they couldn't handle `strides` of `None` cleanly. So we added `strides` here with what it should be. However both libraries have since cleaned this up ( CuPy 6.6.0+, https://github.com/cupy/cupy/pull/2669 and Numba 0.46.0+, https://github.com/numba/numba/pull/4609 ) and we require newer versions of both. As some code contains fast paths when `strides` is `None`, switch to using `None` here as we ensure contiguous data in `DeviceBuffer`s. This should allow us to take advantage of those fast paths where possible.