### PR TITLE
[REVIEW] Enable print function in non-debug builds and correct printing blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PR #463 Revert cmake change for cnmem header not being added to source directory
 - PR #464 More completely revert cnmem.h cmake changes
 - PR #473 Fix initialization logic in pool_memory_resource.
+- PR #479 Fix usage of block printing in pool_memory_resource.
 
 # RMM 0.14.0 (03 Jun 2020)
 

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -278,9 +278,10 @@ class pool_memory_resource final
     current_pool_size_ = 0;
   }
 
-#ifndef NDEBUG
   /**
    * @brief Print debugging information about all blocks in the pool.
+   *
+   * @note This function is intended only for use in debugging.
    *
    */
   void print()
@@ -295,18 +296,17 @@ class pool_memory_resource final
     std::size_t upstream_total{0};
 
     for (auto h : upstream_blocks_) {
-      detail::print(h);
+      h.print();
       upstream_total += h.size();
     }
     std::cout << "total upstream: " << upstream_total << " B\n";
 
     std::cout << "allocated_blocks: " << allocated_blocks_.size() << "\n";
     for (auto b : allocated_blocks_)
-      detail::print(b);
+      b.print();
 
     this->print_free_blocks();
   }
-#endif  // DEBUG
 
   /**
    * @brief Get free and available memory for memory resource


### PR DESCRIPTION
Usage of the `print` function for printing blocks changed from a free function to a member function, but was never updated in the `pool_memory_resource::print()` function. This wasn't caught because it was guarded with `ifndef NDEBUG` and we do not test debug builds. 

I updated the usage of `block::print`, and in order to avoid issues like this in the future (because a similar issue has occurred in the past), I removed the `NDEBUG` guard around `print()` and just documented that the function is only intended to be used for debugging purposes. 