### PR TITLE
[REVIEW] Fix device_uvector copy constructor compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,8 @@
 - PR #298 Remove RMM_CUDA_TRY from cuda_event_timer destructor
 - PR #299 Fix assert condition blocking debug builds
 - PR #300 Fix host mr_tests compile error
-- PR #312 Fix libcudf compilation errors due to explicit defaulted device_buffer constructor.
+- PR #312 Fix libcudf compilation errors due to explicit defaulted device_buffer constructor
+- PR #484 Fix device_uvector copy constructor compilation error and add test
 
 
 # RMM 0.12.0 (04 Feb 2020)

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -128,7 +128,7 @@ class device_uvector {
     device_uvector const& other,
     cudaStream_t stream,
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource())
-    : _storage{other.storage, stream, mr}
+    : _storage{other._storage, stream, mr}
   {
   }
 

--- a/tests/device_uvector_tests.cu
+++ b/tests/device_uvector_tests.cu
@@ -49,6 +49,17 @@ TYPED_TEST(TypedUVectorTest, NonZeroSizeConstructor)
   EXPECT_NE(uv.element_ptr(0), nullptr);
 }
 
+TYPED_TEST(TypedUVectorTest, CopyConstructor)
+{
+  rmm::device_uvector<TypeParam> uv(12345, this->stream());
+  rmm::device_uvector<TypeParam> uv_copy(uv, this->stream());
+  EXPECT_EQ(uv_copy.size(), uv.size());
+  EXPECT_NE(uv_copy.data(), nullptr);
+  EXPECT_EQ(uv_copy.end(), uv_copy.begin() + uv_copy.size());
+  EXPECT_FALSE(uv_copy.is_empty());
+  EXPECT_NE(uv_copy.element_ptr(0), nullptr);
+}
+
 TYPED_TEST(TypedUVectorTest, ResizeSmaller)
 {
   auto original_size = 12345;


### PR DESCRIPTION
Fixes #483

`device_uvector` copy constructor refered to the member `storage` rather than `_storage`. Single-character fix, but I also added a copy constructor test to improve coverage.
