### PR TITLE
[REVIEW][DOC] Clarify relationship between active devices and resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - PR #456 Minor cleanup: always use rmm/-prefixed includes
 - PR #461 cmake improvements to be more target-based
 - PR #468 update past release dates in changelog
-- PR #485 Document relationship between active CUDA devices and resources
+- PR #486 Document relationship between active CUDA devices and resources
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PR #456 Minor cleanup: always use rmm/-prefixed includes
 - PR #461 cmake improvements to be more target-based
 - PR #468 update past release dates in changelog
+- PR #485 Document relationship between active CUDA devices and resources
 
 ## Bug Fixes
 
@@ -55,6 +56,7 @@
 - PR #464 More completely revert cnmem.h cmake changes
 - PR #473 Fix initialization logic in pool_memory_resource.
 - PR #479 Fix usage of block printing in pool_memory_resource.
+- PR #484 Fix device_uvector copy constructor compilation error and add test
 
 # RMM 0.14.0 (03 Jun 2020)
 
@@ -137,7 +139,6 @@
 - PR #308 Fix typo in README
 - PR #334 Replace `rmm_allocator` for Thrust allocations
 - PR #345 Remove stream synchronization from `device_scalar` constructor and `set_value`
-- PR #485 Document relationship between active CUDA devices and resources
 
 ## Bug Fixes
 
@@ -145,7 +146,6 @@
 - PR #299 Fix assert condition blocking debug builds
 - PR #300 Fix host mr_tests compile error
 - PR #312 Fix libcudf compilation errors due to explicit defaulted device_buffer constructor
-- PR #484 Fix device_uvector copy constructor compilation error and add test
 
 
 # RMM 0.12.0 (04 Feb 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@
 - PR #308 Fix typo in README
 - PR #334 Replace `rmm_allocator` for Thrust allocations
 - PR #345 Remove stream synchronization from `device_scalar` constructor and `set_value`
+- PR #485 Document relationship between active CUDA devices and resources
 
 ## Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,27 @@ rmm::mr::set_current_device_resource(&pool_mr); // Updates the current device re
 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(); // Points to `pool_mr`
 ```
 
+#### Multiple Devices
+
+A `device_memory_resource` should only be used when the active CUDA device is the same device
+that was active when the `device_memory_resource` was created. Otherwise behavior is undefined.
+ 
+Creating a `device_memory_resource` for each device requires care to set the current device before
+creating each resource, and to maintain the lifetime of the resources as long as they are set as
+per-device resources. Here is an example loop that creates `unique_ptr`s to `pool_memory_resource`
+objects for each device and sets them as the per-device resource for that device.
+
+```c++ 
+std::vector<unique_ptr<pool_memory_resource>> per_device_pools;
+for(int i = 0; i < N; ++i) {
+    cudaSetDevice(i); // set device i before creating MR
+    // Use a vector of unique_ptr to maintain the lifetime of the MRs
+    per_device_pools.push_back(std::make_unique<pool_memory_resource>());
+    // Set the per-device resource for device i
+    set_per_device_resource(cuda_device_id{i}, &per_device_pools.back());
+}
+```
+
 ## Device Data Structures
 
 ### `device_buffer`
@@ -395,7 +416,7 @@ example, enabling the `ManagedMemoryResource` tells RMM to use
 > :warning: The default resource must be set for any device **before**
 > allocating any device memory on that device.  Setting or changing the
 > resource after device allocations have been made can lead to unexpected
-> behaviour or crashes.
+> behaviour or crashes. See [Multiple Devices](#multiple-devices)
 
 As another example, `PoolMemoryResource` allows you to allocate a
 large "pool" of device memory up-front. Subsequent allocations will

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Configurable to use multiple upstream memory resources for allocations that fall
 bin sizes. Often configured with multiple bins backed by `fixed_size_memory_resource`s and a single
 `pool_memory_resource` for allocations larger than the largest bin size.
 
-### Default Resource
+### Default Resources and Per-device Resources
 
 RMM users commonly need to configure a `device_memory_resource` object to use for all allocations 
 where another resource has not explicitly been provided. A common example is configuring a
@@ -208,7 +208,7 @@ Accessing and modifying the default resource is done through two functions:
 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(); // Points to `cuda_memory_resource`
 // Construct a resource that uses a coalescing best-fit pool allocator
 rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>> pool_mr{mr}; 
-rmm::mr::set_default_resource(&pool_mr); // Updates the default resource pointer to `pool_mr`
+rmm::mr::set_current_device_resource(&pool_mr); // Updates the current device resource pointer to `pool_mr`
 rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource(); // Points to `pool_mr`
 ```
 

--- a/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/benchmarks/device_uvector/device_uvector_bench.cu
@@ -19,10 +19,9 @@
 #include <cuda_runtime_api.h>
 #include <rmm/thrust_rmm_allocator.h>
 #include <rmm/device_uvector.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
-#include "rmm/mr/device/cuda_memory_resource.hpp"
-#include "rmm/mr/device/per_device_resource.hpp"
 
 static void BM_UvectorSizeConstruction(benchmark::State& state)
 {

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -19,6 +19,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include <type_traits>
 

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -20,6 +20,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include <vector>
 

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -31,17 +31,17 @@ namespace mr {
  * This class serves as the interface that all custom device memory
  * implementations must satisfy.
  *
- * There are two private, pure virtual functions that all derived classes must
- *implement: `do_allocate` and `do_deallocate`. Optionally, derived classes may
- *also override `is_equal`. By default, `is_equal` simply performs an identity
- *comparison.
+ * There are two private, pure virtual functions that all derived classes must implement:
+ *`do_allocate` and `do_deallocate`. Optionally, derived classes may also override `is_equal`. By
+ * default, `is_equal` simply performs an identity comparison.
  *
- * The public, non-virtual functions `allocate`, `deallocate`, and `is_equal`
- * simply call the private virtual functions. The reason for this is to allow
- * implementing shared, default behavior in the base class. For example, the
- * base class' `allocate` function may log every allocation, no matter what
- * derived class implementation is used.
+ * The public, non-virtual functions `allocate`, `deallocate`, and `is_equal` simply call the
+ * private virtual functions. The reason for this is to allow implementing shared, default behavior
+ * in the base class. For example, the base class' `allocate` function may log every allocation, no
+ * matter what derived class implementation is used.
  *
+ * @note A device_memory_resource should only be used when the active CUDA device is the same device
+ * that was active when the device_memory_resource was created. Otherwise behavior is undefined.
  */
 class device_memory_resource {
  public:

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -40,8 +40,23 @@ namespace mr {
  * in the base class. For example, the base class' `allocate` function may log every allocation, no
  * matter what derived class implementation is used.
  *
- * @note A device_memory_resource should only be used when the active CUDA device is the same device
+ * A device_memory_resource should only be used when the active CUDA device is the same device
  * that was active when the device_memory_resource was created. Otherwise behavior is undefined.
+ *
+ * Creating a device_memory_resource for each device requires care to set the current device
+ * before creating each resource, and to maintain the lifetime of the resources as long as they
+ * are set as per-device resources. Here is an example loop that creates `unique_ptr`s to
+ * pool_memory_resource objects for each device and sets them as the per-device resource for that
+ * device.
+ *
+ * @code{c++}
+ * std::vector<unique_ptr<pool_memory_resource>> per_device_pools;
+ * for(int i = 0; i < N; ++i) {
+ *   cudaSetDevice(i);
+ *   per_device_pools.push_back(std::make_unique<pool_memory_resource>());
+ *   set_per_device_resource(cuda_device_id{i}, &per_device_pools.back());
+ * }
+ * @endcode
  */
 class device_memory_resource {
  public:

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -134,6 +134,11 @@ inline cuda_device_id current_device()
  * Concurrent calls to any of these functions will result in a valid state, but the order of
  * execution is undefined.
  *
+ * @note The returned `device_memory_resource` should only be used when CUDA device `id` is the
+ * current device  (e.g. set using `cudaSetDevice()`). The behavior of a device_memory_resource is
+ * undefined if used while the active CUDA device is a different device from the one that was active
+ * when the device_memory_resource was created.
+ *
  * @param id The id of the target device
  * @return Pointer to the current `device_memory_resource` for device `id`
  */
@@ -162,6 +167,11 @@ inline device_memory_resource* get_per_device_resource(cuda_device_id id)
  * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.
  * Concurrent calls to any of these functions will result in a valid state, but the order of
  * execution is undefined.
+ *
+ * @note The resource passed in `new_mr` must have been created when device `id` was the current
+ * CUDA device (e.g. set using `cudaSetDevice()`). The behavior of a device_memory_resource is
+ * undefined if used while the active CUDA device is a different device from the one that was active
+ * when the device_memory_resource was created.
  *
  * @param id The id of the target device
  * @param new_mr If not `nullptr`, pointer to new `device_memory_resource` to use as new resource
@@ -193,6 +203,12 @@ inline device_memory_resource* set_per_device_resource(cuda_device_id id,
  * Concurrent calls to any of these functions will result in a valid state, but the order of
  * execution is undefined.
  *
+ * @note The returned `device_memory_resource` should only be used with the current CUDA device.
+ * Changing the current device (e.g. using `cudaSetDevice()`) and then using the returned resource
+ * can result in undefined behavior. The behavior of a device_memory_resource is undefined if used
+ * while the active CUDA device is a different device from the one that was active when the
+ * device_memory_resource was created.
+ *
  * @return Pointer to the resource for the current device
  */
 inline device_memory_resource* get_current_device_resource()
@@ -216,6 +232,10 @@ inline device_memory_resource* get_current_device_resource()
  * `get_per_device_resource`, `get_current_device_resource`, and `set_current_device_resource`.
  * Concurrent calls to any of these functions will result in a valid state, but the order of
  * execution is undefined.
+ *
+ * @note The resource passed in `new_mr` must have been created for the current CUDA device. The
+ * behavior of a device_memory_resource is undefined if used while the active CUDA device is a
+ * different device from the one that was active when the device_memory_resource was created.
  *
  * @param new_mr If not `nullptr`, pointer to new resource to use for the current device
  * @return Pointer to the previous resource for the current device

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -41,6 +41,11 @@
  * the same pointer, `mr`. In this way, all places that use the resource returned from
  * `get_per_device_resource` for (de)allocation will use the user provided resource, `mr`.
  *
+ * @note `device_memory_resource` make CUDA API calls without setting the current CUDA device.
+ * Therefore a memory resource should only be used with the current CUDA device set to the device
+ * that was active when the memory resource was created. Calling `set_per_device_resource(id, mr)`
+ * is only valid if `id` refers to the CUDA device that was active when `mr` was created.
+ *
  * If no resource was explicitly set for a given device specified by `id`, then
  * `get_per_device_resource(id)` will return a pointer to a `cuda_memory_resource`.
  *

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -41,7 +41,7 @@
  * the same pointer, `mr`. In this way, all places that use the resource returned from
  * `get_per_device_resource` for (de)allocation will use the user provided resource, `mr`.
  *
- * @note `device_memory_resource` make CUDA API calls without setting the current CUDA device.
+ * @note `device_memory_resource`s make CUDA API calls without setting the current CUDA device.
  * Therefore a memory resource should only be used with the current CUDA device set to the device
  * that was active when the memory resource was created. Calling `set_per_device_resource(id, mr)`
  * is only valid if `id` refers to the CUDA device that was active when `mr` was created.
@@ -52,6 +52,21 @@
  * To fetch and modify the resource for the current CUDA device, `get_current_device_resource()` and
  * `set_current_device_resource()` will automatically use the current CUDA device id from
  * `cudaGetDevice()`.
+ *
+ * Creating a device_memory_resource for each device requires care to set the current device
+ * before creating each resource, and to maintain the lifetime of the resources as long as they
+ * are set as per-device resources. Here is an example loop that creates `unique_ptr`s to
+ * pool_memory_resource objects for each device and sets them as the per-device resource for that
+ * device.
+ *
+ * @code{c++}
+ * std::vector<unique_ptr<pool_memory_resource>> per_device_pools;
+ * for(int i = 0; i < N; ++i) {
+ *   cudaSetDevice(i);
+ *   per_device_pools.push_back(std::make_unique<pool_memory_resource>());
+ *   set_per_device_resource(cuda_device_id{i}, &per_device_pools.back());
+ * }
+ * @endcode
  */
 
 namespace rmm {

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -21,6 +21,7 @@
 
 #include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 namespace rmm {
 namespace mr {

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -360,6 +360,9 @@ cpdef get_per_device_resource(int device):
     """
     Get the default memory resource for the specified device.
 
+    If the returned memory resource is used when a different device is the
+    active CUDA device, behavior is undefined.
+
     Parameters
     ----------
     device : int
@@ -378,7 +381,8 @@ cpdef _set_per_device_resource(int device, MemoryResource mr):
     device : int
         The ID of the device for which to get the memory resource.
     mr : MemoryResource
-        The memory resource to set.
+        The memory resource to set.  Must have been created while device was
+        the active CUDA device.
     """
     global _per_device_mrs
     _per_device_mrs[device] = mr
@@ -393,7 +397,8 @@ cpdef set_current_device_resource(MemoryResource mr):
     Parameters
     ----------
     mr : MemoryResource
-        The memory resource to set.
+        The memory resource to set. Must have been created while the current
+        device is the active CUDA device.
     """
     _set_per_device_resource(get_current_device(), mr)
 
@@ -415,6 +420,9 @@ cpdef get_current_device_resource():
     """
     Get the memory resource used for RMM device allocations on the current
     device.
+
+    If the returned memory resource is used when a different device is the
+    active CUDA device, behavior is undefined.
     """
     return get_per_device_resource(get_current_device())
 

--- a/python/rmm/_lib/memory_resource_wrappers.hpp
+++ b/python/rmm/_lib/memory_resource_wrappers.hpp
@@ -3,11 +3,11 @@
 #include <memory>
 #include <rmm/mr/device/binning_memory_resource.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/fixed_size_memory_resource.hpp>
 #include <rmm/mr/device/logging_resource_adaptor.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 #include <rmm/mr/device/thread_safe_resource_adaptor.hpp>
 #include <string>

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -19,9 +19,9 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include <cuda_runtime_api.h>

--- a/tests/device_scalar_tests.cpp
+++ b/tests/device_scalar_tests.cpp
@@ -17,8 +17,8 @@
 #include <gtest/gtest.h>
 
 #include <rmm/device_scalar.hpp>
-#include <rmm/mr/device/default_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 #include <cuda_runtime_api.h>
 #include <chrono>

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -25,6 +25,7 @@
 #include <rmm/mr/device/fixed_size_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
 #include <rmm/mr/device/owning_wrapper.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include <cuda_runtime_api.h>

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
-#include "rmm/detail/error.hpp"
-#include "rmm/mr/device/cuda_memory_resource.hpp"
-#include "rmm/mr/device/default_memory_resource.hpp"
-#include "rmm/mr/device/device_memory_resource.hpp"
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Fixes #476 and closes #459 (finishes docs for deprecation)

Updates README and docs for `device_memory_resource`, `set_per_device_resource`, `get_per_device_resource`
and Python API equivalents to make clear that memory resources are only valid to use
on the device that was active when they were created, and that otherwise behavior
is undefined. Also demonstrates correct usages of `set_per_device_resource`.

Also cleans up some remaining includes.