### PR TITLE
[REVIEW] Make pool growth a bit less greedy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@
 - PR #427 Add DeviceBuffer.release() cdef method
 - PR #414 Add element-wise access for device_uvector
 - PR #421 Capture thread id in logging and improve logger testing
-- PR #426 Added multi-threaded support to replay benchmark.
-- PR #429 Fix debug build and add new CUDA assert utility.
+- PR #426 Added multi-threaded support to replay benchmark
+- PR #429 Fix debug build and add new CUDA assert utility
 - PR #435 Update conda upload versions for new supported CUDA/Python
 - PR #437 Test with `pickle5` (for older Python versions)
 - PR #443 Remove thread safe adaptor from PoolMemoryResource
@@ -55,10 +55,11 @@
 - PR #434 Fix issue with incorrect docker image being used in local build script
 - PR #463 Revert cmake change for cnmem header not being added to source directory
 - PR #464 More completely revert cnmem.h cmake changes
-- PR #473 Fix initialization logic in pool_memory_resource.
-- PR #479 Fix usage of block printing in pool_memory_resource.
+- PR #473 Fix initialization logic in pool_memory_resource
+- PR #479 Fix usage of block printing in pool_memory_resource
 - PR #490 Allow importing RMM without initializing CUDA driver
 - PR #484 Fix device_uvector copy constructor compilation error and add test
+- PR #498 Max pool growth less greedy
 
 
 # RMM 0.14.0 (03 Jun 2020)

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -341,7 +341,7 @@ cpdef void _initialize(
             args = (upstream(),)
         else:
             args = (upstream(), initial_pool_size)
-            
+
     else:
         typ = upstream
         args = ()

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -336,11 +336,12 @@ cpdef void _initialize(
         upstream = CudaMemoryResource
 
     if pool_allocator:
-        if initial_pool_size is None:
-            initial_pool_size = 0
-
         typ = PoolMemoryResource
-        args = (upstream(), initial_pool_size)
+        if initial_pool_size is None:
+            args = (upstream(),)
+        else:
+            args = (upstream(), initial_pool_size)
+            
     else:
         typ = upstream
         args = ()

--- a/python/rmm/_lib/memory_resource_wrappers.hpp
+++ b/python/rmm/_lib/memory_resource_wrappers.hpp
@@ -64,9 +64,12 @@ class managed_memory_resource_wrapper : public device_memory_resource_wrapper {
 
 class pool_memory_resource_wrapper : public device_memory_resource_wrapper {
  public:
-  pool_memory_resource_wrapper(std::shared_ptr<device_memory_resource_wrapper> upstream_mr,
-                               std::size_t initial_pool_size,
-                               std::size_t maximum_pool_size)
+  pool_memory_resource_wrapper(
+    std::shared_ptr<device_memory_resource_wrapper> upstream_mr,
+    std::size_t initial_pool_size =
+      rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>::default_initial_size,
+    std::size_t maximum_pool_size =
+      rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>::default_maximum_size)
     : upstream_mr(upstream_mr),
       mr(std::make_shared<rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>>(
         upstream_mr->get_mr().get(), initial_pool_size, maximum_pool_size))


### PR DESCRIPTION
Fixes #496

Pool growth was a bit too greedy -- when the requested size exceeded half the remaining side, it tried to allocate *all* of the remaining which sometimes failed. So now we just allocate the requested size from upstream in that situation.

Also fixes some default parameter passing from Python.
