### PR TITLE
[REVIEW] Fix segfault when stealing from destroyed event's free list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - PR #484 Fix device_uvector copy constructor compilation error and add test
 - PR #498 Max pool growth less greedy
 - PR #500 Use tempfile rather than hardcoded path in `test_rmm_csv_log`
+- PR #510 Fix segfault in pool_memory_resource when a CUDA stream is destroyed
 
 
 # RMM 0.14.0 (03 Jun 2020)

--- a/README.md
+++ b/README.md
@@ -3,22 +3,29 @@
 [![Build Status](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/rmm/job/branches/job/rmm-branch-pipeline/badge/icon)](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/rmm/job/branches/job/rmm-branch-pipeline/)
 
 
-Achieving optimal performance in GPU-centric workflows frequently requires customizing how host and device memory are allocated. For example, using "pinned" host memory for asynchronous host <-> device memory transfers, or using a device memory pool sub-allocator to reduce the cost of dynamic device memory allocation. 
+Achieving optimal performance in GPU-centric workflows frequently requires customizing how host and
+device memory are allocated. For example, using "pinned" host memory for asynchronous
+host <-> device memory transfers, or using a device memory pool sub-allocator to reduce the cost of
+dynamic device memory allocation. 
 
 The goal of the RAPIDS Memory Manager (RMM) is to provide:
-- A common interface that allows customizing [device](#device_memory_resource) and [host](#host_memory_resource) memory allocation
+- A common interface that allows customizing [device](#device_memory_resource) and
+  [host](#host_memory_resource) memory allocation
 - A collection of [implementations](#available-resources) of the interface
 - A collection of [data structures](#data-structures) that use the interface for memory allocation
 
-For information on the interface RMM provides and how to use RMM in your C++ code, see [below](#using-rmm-in-c++).
+For information on the interface RMM provides and how to use RMM in your C++ code, see
+[below](#using-rmm-in-c++).
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/rmm/blob/master/README.md) ensure you are on the `master` branch.
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/rmm/blob/master/README.md)
+ensure you are on the `master` branch.
 
 ## Installation
 
 ### Conda
 
-RMM can be installed with conda ([miniconda](https://conda.io/miniconda.html), or the full [Anaconda distribution](https://www.anaconda.com/download)) from the `rapidsai` channel:
+RMM can be installed with conda ([miniconda](https://conda.io/miniconda.html), or the full
+[Anaconda distribution](https://www.anaconda.com/download)) from the `rapidsai` channel:
 
 ```bash
 # for CUDA 10.2
@@ -32,7 +39,8 @@ conda install -c nvidia -c rapidsai -c conda-forge -c defaults \
     rmm cudatoolkit=10.0
 ```
 
-We also provide [nightly conda packages](https://anaconda.org/rapidsai-nightly) built from the tip of our latest development branch.
+We also provide [nightly conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD
+of our latest development branch.
 
 Note: RMM is supported only on Linux, and with Python versions 3.6 or 3.7.
 
@@ -66,7 +74,8 @@ $ git clone --recurse-submodules https://github.com/rapidsai/rmm.git
 $ cd rmm
 ```
 
-Follow the instructions under "Create the conda development environment `cudf_dev`" in the [cuDF README](https://github.com/rapidsai/cudf#build-from-source).
+Follow the instructions under "Create the conda development environment `cudf_dev`" in the
+[cuDF README](https://github.com/rapidsai/cudf#build-from-source).
 
 - Create the conda development environment `cudf_dev`
 ```bash
@@ -76,7 +85,9 @@ $ conda env create --name cudf_dev --file conda/environments/dev_py35.yml
 $ source activate cudf_dev
 ```
 
-- Build and install `librmm` using cmake & make. CMake depends on the `nvcc` executable being on your path or defined in `$CUDACXX`.
+- Build and install `librmm` using cmake & make. CMake depends on the `nvcc` executable being on
+  your path or defined in `$CUDACXX`.
+
 ```bash
 
 $ mkdir build                                       # make a build directory
@@ -86,7 +97,10 @@ $ make -j                                           # compile the library librmm
 $ make install                                      # install the library librmm.so to '/install/path'
 ```
 
-- Building and installing `librmm` and `rmm` using build.sh. Build.sh creates build dir at root of git repository. build.sh depends on the `nvcc` executable being on your path or defined in `$CUDACXX`.
+- Building and installing `librmm` and `rmm` using build.sh. Build.sh creates build dir at root of
+  git repository. build.sh depends on the `nvcc` executable being on your path or defined in
+  `$CUDACXX`.
+
 ```bash
 
 $ ./build.sh -h                                     # Display help and exit
@@ -114,17 +128,21 @@ Done! You are ready to develop for the RMM OSS project.
 # Using RMM in C++
 
 The first goal of RMM is to provide a common interface for device and host memory allocation. 
-This allows both _users_ and _implementers_ of custom allocation logic to program to a single interface.
+This allows both _users_ and _implementers_ of custom allocation logic to program to a single
+interface.
 
 To this end, RMM defines two abstract interface classes:
 - [`rmm::mr::device_memory_resource`](#device_memory_resource) for device memory allocation
 - [`rmm::mr::host_memory_resource`](#host_memory_resource) for host memory allocation
 
-These classes are based on the [`std::pmr::memory_resource`](https://en.cppreference.com/w/cpp/memory/memory_resource) interface class introduced in C++17 for polymorphic memory allocation.
+These classes are based on the
+[`std::pmr::memory_resource`](https://en.cppreference.com/w/cpp/memory/memory_resource) interface
+class introduced in C++17 for polymorphic memory allocation.
 
 ## `device_memory_resource`
 
-`rmm::mr::device_memory_resource` is the base class that defines the interface for allocating and freeing device memory.
+`rmm::mr::device_memory_resource` is the base class that defines the interface for allocating and
+freeing device memory.
 
 It has two key functions:
 
@@ -133,20 +151,22 @@ It has two key functions:
 
 2. `void device_memory_resource::deallocate(void* p, std::size_t bytes, cudaStream_t s)`
    - Reclaims a previous allocation of size `bytes` pointed to by `p`. 
-   - `p` *must* have been returned by a previous call to `allocate(bytes)`, otherwise behavior is undefined
+   - `p` *must* have been returned by a previous call to `allocate(bytes)`, otherwise behavior is
+     undefined
 
-It is up to a derived class to provide implementations of these functions. 
-See [available resources](#available-resources) for example `device_memory_resource` derived classes. 
+It is up to a derived class to provide implementations of these functions. See
+[available resources](#available-resources) for example `device_memory_resource` derived classes. 
 
-Unlike `std::pmr::memory_resource`, `rmm::mr::device_memory_resource` does not allow specifying an alignment argument. 
-All allocations are required to be aligned to at least 256B. 
-Furthermore, `device_memory_resource` adds an additional `cudaStream_t` argument to allow specifying the stream on which to perform the (de)allocation.
+Unlike `std::pmr::memory_resource`, `rmm::mr::device_memory_resource` does not allow specifying an 
+alignment argument. All allocations are required to be aligned to at least 256B. Furthermore, 
+`device_memory_resource` adds an additional `cudaStream_t` argument to allow specifying the stream
+on which to perform the (de)allocation.
 
 ### Stream-ordered Memory Allocation
 
 `rmm::mr::device_memory_resource` is a base class that provides stream-ordered memory allocation.
-This allows optimizations such as re-using memory deallocated on the same stream without the overhead
-of synchronization.
+This allows optimizations such as re-using memory deallocated on the same stream without the
+overhead of synchronization.
 
 A call to `device_memory_resource::allocate(bytes, stream_a)` returns a pointer that is valid to use
 on `stream_a`. Using the memory on a different stream (say `stream_b`) is Undefined Behavior unless
@@ -156,8 +176,9 @@ recording a CUDA event on `stream_a` and then calling `cudaStreamWaitEvent(strea
 The stream specified to `device_memory_resource::deallocate` should be a stream on which it is valid
 to use the deallocated memory immediately for another allocation. Typically this is the stream
 on which the allocation was *last* used before the call to `deallocate`. The passed stream may be
-used internally by a memory_resource for managing available memory with minimal synchronization, and
-it may also be synchronized at a later time, for example using a call to `cudaStreamSynchronize()`.
+used internally by a `device_memory_resource` for managing available memory with minimal
+synchronization, and it may also be synchronized at a later time, for example using a call to
+`cudaStreamSynchronize()`.
 
 For this reason, it is Undefined Behavior to destroy a CUDA stream that is passed to 
 `device_memory_resource::deallocate`. If the stream on which the allocation was last used has been
@@ -280,8 +301,8 @@ rmm::device_buffer b2{100, s, mr}; // Allocates at least 100 bytes on stream `s`
 
 ### `device_uvector<T>`
 A typed, unintialized RAII class for allocation of a contiguous set of elements in device memory.
-Similar to a `thrust::device_vector`, but as an optimization, does not default initialize the contained elements.
-This optimization restricts the types `T` to trivially copyable types.
+Similar to a `thrust::device_vector`, but as an optimization, does not default initialize the
+contained elements. This optimization restricts the types `T` to trivially copyable types.
 
 #### Example
 
@@ -296,7 +317,8 @@ rmm::device_vector<int32_t> v2{100, s, mr}; // Allocates uninitialized storage f
 
 ### `device_scalar`
 A typed, RAII class for allocation of a single element in device memory.
-This is similar to a `device_uvector` with a single element, but provides convenience functions like modifying the value in device memory from the host, or retrieving the value from device to host.
+This is similar to a `device_uvector` with a single element, but provides convenience functions like
+modifying the value in device memory from the host, or retrieving the value from device to host.
 
 #### Example
 ```c++
@@ -317,14 +339,17 @@ situations:
  1. As the backing store for `thrust::device_vector`, and
  2. As temporary storage inside some algorithms, such as `thrust::sort`.
 
-RMM provides `rmm::mr::thrust_allocator` as a conforming Thrust allocator that uses `device_memory_resource`s.
+RMM provides `rmm::mr::thrust_allocator` as a conforming Thrust allocator that uses
+`device_memory_resource`s.
 
 ### Thrust Algorithms
 
-To instruct a Thrust algorithm to use `rmm::mr::thrust_allocator` to allocate temporary storage, you can use the custom Thrust CUDA device execution policy: `rmm::exec_policy(stream)`.
+To instruct a Thrust algorithm to use `rmm::mr::thrust_allocator` to allocate temporary storage, you
+can use the custom Thrust CUDA device execution policy: `rmm::exec_policy(stream)`.
 
-`rmm::exec_policy(stream)` returns a `std::unique_ptr` to a Thrust execution policy that uses `rmm::mr::thrust_allocator` for temporary allocations.
-In order to specify that the Thrust algorithm be executed on a specific stream, the usage is:
+`rmm::exec_policy(stream)` returns a `std::unique_ptr` to a Thrust execution policy that uses
+`rmm::mr::thrust_allocator` for temporary allocations. In order to specify that the Thrust algorithm
+be executed on a specific stream, the usage is:
 
 ```c++
 thrust::sort(rmm::exec_policy(stream)->on(stream), ...);
@@ -336,18 +361,21 @@ These two arguments must be identical.
 
 ## `host_memory_resource`
 
-`rmm::mr::host_memory_resource` is the base class that defines the interface for allocating and freeing host memory.
+`rmm::mr::host_memory_resource` is the base class that defines the interface for allocating and
+freeing host memory.
 
 Similar to `device_memory_resource`, it has two key functions for (de)allocation:
 
 1. `void* device_memory_resource::allocate(std::size_t bytes, std::size_t alignment)`
-   - Returns a pointer to an allocation of at least `bytes` bytes aligned to the specified `alignment`
+   - Returns a pointer to an allocation of at least `bytes` bytes aligned to the specified
+     `alignment`
 
 2. `void device_memory_resource::deallocate(void* p, std::size_t bytes, std::size_t alignment)`
    - Reclaims a previous allocation of size `bytes` pointed to by `p`. 
 
 
-Unlike `device_memory_resource`, the `host_memory_resource` interface and behavior is identical to `std::pmr::memory_resource`. 
+Unlike `device_memory_resource`, the `host_memory_resource` interface and behavior is identical to
+`std::pmr::memory_resource`. 
 
 ### Available Resources
 
@@ -362,7 +390,8 @@ Allocates "pinned" host memory using `cuda(Malloc/Free)Host`.
 ## Host Data Structures
 
 RMM does not currently provide any data structures that interface with `host_memory_resource`.
-In the future, RMM will provide a similar host-side structure like `device_buffer` and an allocator that can be used with STL containers.
+In the future, RMM will provide a similar host-side structure like `device_buffer` and an allocator
+that can be used with STL containers.
 
 
 ## Using RMM in Python Code

--- a/benchmarks/utilities/log_parser.hpp
+++ b/benchmarks/utilities/log_parser.hpp
@@ -68,7 +68,7 @@ struct event {
   uintptr_t stream;       ///< Numeric representation of the CUDA stream on which the event occurred
 };
 
-std::ostream& operator<<(std::ostream& os, event const& e)
+inline std::ostream& operator<<(std::ostream& os, event const& e)
 {
   auto act_string = (e.act == action::ALLOCATE) ? "allocate" : "free";
 
@@ -78,7 +78,7 @@ std::ostream& operator<<(std::ostream& os, event const& e)
   return os;
 }
 
-uintptr_t hex_string_to_int(std::string const& s) { return std::stoll(s, nullptr, 16); }
+inline uintptr_t hex_string_to_int(std::string const& s) { return std::stoll(s, nullptr, 16); }
 
 /**
  * @brief Parses a RMM log file into a vector of events
@@ -89,7 +89,7 @@ uintptr_t hex_string_to_int(std::string const& s) { return std::stoll(s, nullptr
  * @param filename Name of the RMM log file
  * @return Vector of events from the contents of the log file
  */
-std::vector<event> parse_csv(std::string const& filename)
+inline std::vector<event> parse_csv(std::string const& filename)
 {
   rapidcsv::Document csv(filename, rapidcsv::LabelParams(0, -1));
 

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -53,15 +53,15 @@ namespace mr {
  * The stream specified to deallocate() should be a stream on which it is valid to use the
  * deallocated memory immediately for another allocation. Typically this is the stream on which the
  * allocation was *last* used before the call to deallocate(). The passed stream may be used
- * internally by a memory_resource for managing available memory with minimal synchronization, and
- * it may also be synchronized at a later time, for example using a call to
+ * internally by a device_memory_resource for managing available memory with minimal
+ * synchronization, and it may also be synchronized at a later time, for example using a call to
  * `cudaStreamSynchronize()`.
  *
  * For this reason, it is Undefined Behavior to destroy a CUDA stream that is passed to
- * `device_memory_resource::deallocate`. If the stream on which the allocation was last used has
- * been destroyed before calling deallocate() or it is known that it will be destroyed, it is likely
- * better to synchronize the stream (before destroying it) and then pass a different stream to
- * deallocate() (e.g. the default stream).
+ * deallocate(). If the stream on which the allocation was last used has been destroyed before
+ * calling deallocate() or it is known that it will be destroyed, it is likely better to synchronize
+ * the stream (before destroying it) and then pass a different stream to deallocate() (e.g. the
+ * default stream).
  *
  * A device_memory_resource should only be used when the active CUDA device is the same device
  * that was active when the device_memory_resource was created. Otherwise behavior is undefined.

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <rmm/detail/error.hpp>
+#include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
@@ -67,6 +68,17 @@ TEST(PoolTest, ForceGrowth)
 {
   Pool mr{rmm::mr::get_current_device_resource(), 0};
   EXPECT_NO_THROW(mr.allocate(1000));
+}
+
+TEST(PoolTest, DeletedStream)
+{
+  Pool mr{rmm::mr::get_current_device_resource(), 0};
+  cudaStream_t stream;
+  const int size = 10000;
+  cudaStreamCreate(&stream);
+  EXPECT_NO_THROW(rmm::device_buffer buff(size, stream, &mr));
+  EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream));
+  EXPECT_NO_THROW(mr.allocate(size));
 }
 
 }  // namespace


### PR DESCRIPTION
Should fix failure in rapidsai/cuml#2632 (although that failure demonstrates reliance on UB).
CC @JohnZed @dantegd @Salonijain27 @beckernick 

In non-PTDS mode, previously we avoided cudaEventRecord and instead just
synchronized the stream. With explicit non-default streams, this could 
result in a segfault when stealing from the free list of `cudaStreamDestroy`ed
stream.

This PR switches to always recording a CUDA event on deallocate, and always
waiting on the event (rather than the stream) when stealing. Since events 
are owned by the MR, this is safe, even if the event is recorded on a stream
that is destroyed before waiting on the event.

However, there is significant cost to recording an event on every deallocate,
so this makes the non-PTDS mode as expensive as PTDS mode. Future work is to 
optimize this -- we can track the most recent stream that was deallocated on
and only record an event when the stream switches. So then cases with 
frequent deallocation on the same stream can reduce calls to cudaEventDestroy.

[Note: Also adds some missing `inline` specifiers to header-only functions in log_parser.hpp, but that is independent of the fix.]

UPDATE:

Here is a comparison of benchmarks before and after this change.

```
(rapids) rapids@compose:~/rmm/build/release$ googlebenchmark/googlebenchmark/tools/compare.py benchmarks stream_sync.json ~/rmm/build/cuda-10.2/fix-always-record-event/release/always_event.json 
Comparing stream_sync.json to /home/mharris/rapids/rmm/build/cuda-10.2/fix-always-record-event/release/always_event.json
Benchmark                                                     Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------------------
BM_RandomAllocations/pool_mr/1000/1                        +0.6649         +0.6648             0             1             0             1
BM_RandomAllocations/pool_mr/1000/4                        +0.6328         +0.6327             1             1             1             1
BM_RandomAllocations/pool_mr/1000/64                       +0.6107         +0.6108             1             1             1             1
BM_RandomAllocations/pool_mr/1000/256                      +0.7066         +0.7072             0             1             0             1
BM_RandomAllocations/pool_mr/1000/1024                     +0.9272         +0.9274             0             1             0             1
BM_RandomAllocations/pool_mr/1000/4096                     +1.1587         +1.1045             0             1             0             1
BM_RandomAllocations/pool_mr/10000/1                       +0.0536         +0.0536            71            75            71            75
BM_RandomAllocations/pool_mr/10000/4                       +0.0223         +0.0224            76            77            76            77
BM_RandomAllocations/pool_mr/10000/64                      +0.3076         +0.3074            12            15            12            15
BM_RandomAllocations/pool_mr/10000/256                     +0.6128         +0.6118             5             7             5             7
BM_RandomAllocations/pool_mr/10000/1024                    +0.8940         +0.8935             3             6             3             6
BM_RandomAllocations/pool_mr/10000/4096                    +1.0186         +1.0377             3             7             3             5
BM_RandomAllocations/pool_mr/100000/1                      +0.0103         +0.0097         10580         10689         10577         10680
BM_RandomAllocations/pool_mr/100000/4                      +0.0293         +0.0292          3387          3486          3386          3485
BM_RandomAllocations/pool_mr/100000/64                     +0.2642         +0.2642           131           165           131           165
BM_RandomAllocations/pool_mr/100000/256                    +0.5977         +0.5977            47            75            47            75
BM_RandomAllocations/pool_mr/100000/1024                   +0.8870         +0.8870            31            59            31            59
BM_RandomAllocations/pool_mr/100000/4096                   +1.1914         +1.1227            32            70            26            54
BM_RandomAllocations/binning_mr/1000/1                     +2.2625         +2.2624             0             0             0             0
BM_RandomAllocations/binning_mr/1000/4                     +2.2886         +2.2886             0             0             0             0
BM_RandomAllocations/binning_mr/1000/64                    +0.6255         +0.6254             0             1             0             1
BM_RandomAllocations/binning_mr/1000/256                   +0.7030         +0.7044             0             1             0             1
BM_RandomAllocations/binning_mr/1000/1024                  +0.8727         +0.8725             0             1             0             1
BM_RandomAllocations/binning_mr/1000/4096                  +1.1512         +1.0486             0             1             0             1
BM_RandomAllocations/binning_mr/10000/1                    +2.1331         +2.1330             1             4             1             4
BM_RandomAllocations/binning_mr/10000/4                    +2.1909         +2.1892             1             4             1             4
BM_RandomAllocations/binning_mr/10000/64                   +0.3366         +0.3365            11            15            11            15
BM_RandomAllocations/binning_mr/10000/256                  +0.7341         +0.7340             5             8             5             8
BM_RandomAllocations/binning_mr/10000/1024                 +0.8784         +0.8768             3             6             3             6
BM_RandomAllocations/binning_mr/10000/4096                 +0.8983         +1.0589             3             6             3             6
BM_RandomAllocations/binning_mr/100000/1                   +2.1709         +2.1655            13            42            12            39
BM_RandomAllocations/binning_mr/100000/4                   +2.0626         +2.0996            13            41            12            38
BM_RandomAllocations/binning_mr/100000/64                  +0.3046         +0.3043           114           149           114           148
BM_RandomAllocations/binning_mr/100000/256                 +0.6093         +0.6102            46            75            46            75
BM_RandomAllocations/binning_mr/100000/1024                +0.9042         +0.9037            32            60            32            60
BM_RandomAllocations/binning_mr/100000/4096                +1.0847         +1.1133            33            69            27            57
```
The "Time" column is `(Time new / Time old) - 1`. So multiply by 100 to get the slowdown in percent. Or Add 1 to get the slowdown factor. Basically, slowdown is up to 2.2x for pool_memory_resource and up to 3.3x for binning_memory_resource (especially for cases where the latter is much faster than the former).

This is a random allocation / free benchmark where the first number (1000, 10000, 100000) is the number of allocations (and frees) and the second number is the maximum allocation size in MiB. So when there are lots of small allocations (e.g. 100000/1) the impact of `cudaEventRecord on every call to deallocate is significant.
