### PR TITLE
Specify `--basetemp` for `py.test` run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - PR #484 Fix device_uvector copy constructor compilation error and add test
 - PR #498 Max pool growth less greedy
 - PR #500 Use tempfile rather than hardcoded path in `test_rmm_csv_log`
+- PR #511 Specify `--basetemp` for `py.test` run
 
 
 # RMM 0.14.0 (03 Jun 2020)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -80,7 +80,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
 
         logger "Python py.test for librmm_cffi..."
         cd $WORKSPACE/python
-        py.test --cache-clear --junitxml=${WORKSPACE}/test-results/junit-rmm.xml -v --cov-config=.coveragerc --cov=rmm --cov-report=xml:${WORKSPACE}/python/rmm-coverage.xml --cov-report term
+        py.test --cache-clear --basetemp=${WORKSPACE}/rmm-cuda-tmp --junitxml=${WORKSPACE}/test-results/junit-rmm.xml -v --cov-config=.coveragerc --cov=rmm --cov-report=xml:${WORKSPACE}/python/rmm-coverage.xml --cov-report term
     fi
 else
     export LD_LIBRARY_PATH="$WORKSPACE/ci/artifacts/rmm/cpu/conda_work/build:$LD_LIBRARY_PATH"


### PR DESCRIPTION
Fixes A100 builds showing this error:

```python
E           OSError: could not create numbered dir with prefix pytest- in /tmp/pytest-of-jenkins after 10 tries
```

cc @harrism @rapidsai/ops