### PR TITLE
[REVIEW] Update docs to remove references to master [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/rmm/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/rmm/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/rmm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/rmm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The goal of the RAPIDS Memory Manager (RMM) is to provide:
 For information on the interface RMM provides and how to use RMM in your C++ code, see
 [below](#using-rmm-in-c++).
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/rmm/blob/master/README.md)
-ensure you are on the `master` branch.
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/rmm/blob/main/README.md)
+ensure you are on the `main` branch.
 
 ## Installation
 


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.