### PR TITLE
Fix pool_memory_resource failure when init and max pool sizes are equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Bug Fixes
 
+- PR #534 Fix pool_memory_resource failure when init and max pool sizes are equal
+
 
 # RMM 0.15.0 (26 Aug 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
 ## Improvements
 
 - PR #477 Just use `None` for `strides` in `DeviceBuffer`
-- PR #528 Add maximum_pool_size parameter to reinitialize API
+- PR #528 Add `maximum_pool_size` parameter to reinitialize API
 - PR #537 Add CMake option to disable deprecation warnings
 
 ## Bug Fixes
 
-- PR #534 Fix pool_memory_resource failure when init and max pool sizes are equal
+- PR #534 Fix `pool_memory_resource` failure when init and max pool sizes are equal
 
 
 # RMM 0.15.0 (26 Aug 2020)

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -44,8 +44,7 @@ constexpr bool is_pow2(std::size_t n) { return (0 == (n & (n - 1))); }
 constexpr bool is_supported_alignment(std::size_t alignment) { return is_pow2(alignment); }
 
 /**
- * @brief Align up to a power of 2, align_bytes is expected to be a nonzero
- * power of 2
+ * @brief Align up to a power of 2
  *
  * @param[in] v value to align
  * @param[in] alignment amount, in bytes, must be a power of 2
@@ -54,7 +53,22 @@ constexpr bool is_supported_alignment(std::size_t alignment) { return is_pow2(al
  */
 constexpr std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept
 {
+  assert(is_supported_alignment(align_bytes));
   return (v + (align_bytes - 1)) & ~(align_bytes - 1);
+}
+
+/**
+ * @brief Align down to a power of 2
+ *
+ * @param[in] v value to align
+ * @param[in] alignment amount, in bytes, must be a power of 2
+ *
+ * @return Return the aligned value, as one would expect
+ */
+constexpr std::size_t align_down(std::size_t v, std::size_t align_bytes) noexcept
+{
+  assert(is_supported_alignment(align_bytes));
+  return align_up(v, align_bytes) - align_bytes;
 }
 
 /**

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -103,10 +103,11 @@ class out_of_range : public std::out_of_range {
   GET_RMM_EXPECTS_MACRO(__VA_ARGS__, RMM_EXPECTS_3, RMM_EXPECTS_2) \
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
-#define RMM_EXPECTS_3(_condition, _exception_type, _what) \
-  (!!(_condition))                                        \
-    ? static_cast<void>(0)                                \
-    : throw _exception_type("RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what)
+#define RMM_EXPECTS_3(_condition, _exception_type, _reason)              \
+  (!!(_condition)) ? static_cast<void>(0) : throw _exception_type        \
+  {                                                                      \
+    "RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason \
+  }
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, rmm::logic_error, _reason)
 
 /**

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -33,6 +33,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include "rmm/detail/aligned.hpp"
 
 namespace rmm {
 namespace mr {
@@ -89,13 +90,25 @@ class pool_memory_resource final
         return upstream_mr;
       }()}
   {
+    RMM_EXPECTS(
+      initial_pool_size == default_initial_size ||
+        (initial_pool_size == rmm::detail::align_up(initial_pool_size, allocation_alignment)),
+      "Error, Initial pool size required to be a multiple of 256 bytes");
+    RMM_EXPECTS(
+      maximum_pool_size == default_maximum_size ||
+        (maximum_pool_size == rmm::detail::align_up(maximum_pool_size, allocation_alignment)),
+      "Error, Maximum pool size required to be a multiple of 256 bytes");
+
     std::size_t free{}, total{};
     std::tie(free, total) = detail::available_device_memory();
-    initial_pool_size =
-      (initial_pool_size == default_initial_size) ? std::min(free, total / 2) : initial_pool_size;
-    current_pool_size_ = rmm::detail::align_up(initial_pool_size, allocation_alignment);
-    maximum_pool_size_ = rmm::detail::align_up(
-      (maximum_pool_size == default_maximum_size) ? free : maximum_pool_size, allocation_alignment);
+
+    initial_pool_size = (initial_pool_size == default_initial_size)
+                          ? rmm::detail::align_up(std::min(free, total / 2), allocation_alignment)
+                          : initial_pool_size;
+    current_pool_size_ = initial_pool_size;
+    maximum_pool_size_ = (maximum_pool_size == default_maximum_size)
+                           ? rmm::detail::align_up(free, allocation_alignment)
+                           : maximum_pool_size;
 
     RMM_EXPECTS(pool_size() <= maximum_pool_size_,
                 "Initial pool size exceeds the maximum pool size!");

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -75,6 +75,10 @@ class pool_memory_resource final
    * `upstream_mr`.
    *
    * @throws rmm::logic_error if `upstream_mr == nullptr`
+   * @throws rmm::logic_error if `initial_pool_size` is neither the default nor aligned to a
+   * multiple of 256 bytes.
+   * @throws rmm::logic_error if `maximum_pool_size` is neither the default nor aligned to a
+   * multiple of 256 bytes.
    *
    * @param upstream_mr The memory_resource from which to allocate blocks for the pool.
    * @param initial_pool_size Minimum size, in bytes, of the initial pool. Defaults to half of the

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -94,7 +94,8 @@ class pool_memory_resource final
     initial_pool_size =
       (initial_pool_size == default_initial_size) ? std::min(free, total / 2) : initial_pool_size;
     current_pool_size_ = rmm::detail::align_up(initial_pool_size, allocation_alignment);
-    maximum_pool_size_ = (maximum_pool_size == default_maximum_size) ? free : maximum_pool_size;
+    maximum_pool_size_ = rmm::detail::align_up(
+      (maximum_pool_size == default_maximum_size) ? free : maximum_pool_size, allocation_alignment);
 
     RMM_EXPECTS(pool_size() <= maximum_pool_size_,
                 "Initial pool size exceeds the maximum pool size!");

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -76,9 +76,9 @@ class pool_memory_resource final
    *
    * @throws rmm::logic_error if `upstream_mr == nullptr`
    * @throws rmm::logic_error if `initial_pool_size` is neither the default nor aligned to a
-   * multiple of 256 bytes.
+   * multiple of pool_memory_resource::allocation_alignment bytes.
    * @throws rmm::logic_error if `maximum_pool_size` is neither the default nor aligned to a
-   * multiple of 256 bytes.
+   * multiple of pool_memory_resource::allocation_alignment bytes.
    *
    * @param upstream_mr The memory_resource from which to allocate blocks for the pool.
    * @param initial_pool_size Minimum size, in bytes, of the initial pool. Defaults to half of the

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -107,7 +107,7 @@ class pool_memory_resource final
                           : initial_pool_size;
     current_pool_size_ = initial_pool_size;
     maximum_pool_size_ = (maximum_pool_size == default_maximum_size)
-                           ? rmm::detail::align_up(free, allocation_alignment)
+                           ? rmm::detail::align_down(free, allocation_alignment)
                            : maximum_pool_size;
 
     RMM_EXPECTS(pool_size() <= maximum_pool_size_,

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -38,7 +38,7 @@ TEST(PoolTest, ThrowMaxLessThanInitial)
 {
   // Make sure first argument is enough larger than the second that alignment rounding doesn't
   // make them equal
-  auto max_less_than_initial = []() { Pool mr{rmm::mr::get_current_device_resource(), 1000, 99}; };
+  auto max_less_than_initial = []() { Pool mr{rmm::mr::get_current_device_resource(), 1024, 256}; };
   EXPECT_THROW(max_less_than_initial(), rmm::logic_error);
 }
 


### PR DESCRIPTION
Fixes #527 

Adds a simple alignment call on the max pool size to ensure setting the initial size and the maximum size the same will not cause a failure. Previously some values would fail because init was aligned up and max was not, so it would end up smaller than the initial pool size.

Also adds a test.
