### PR TITLE
[REVIEW] add cmake option to disable deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - PR #477 Just use `None` for `strides` in `DeviceBuffer`
 - PR #528 Add maximum_pool_size parameter to reinitialize API
+- PR #537 Add CMake option to disable deprecation warnings
 
 ## Bug Fixes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 
+option(DISABLE_DEPRECATION_WARNING "Disable warnings generated from deprecated declarations." OFF)
+if(DISABLE_DEPRECATION_WARNING)
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-deprecated-declarations")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif(DISABLE_DEPRECATION_WARNING)
+
 ###################################################################################################
 # - cudart options --------------------------------------------------------------------------------
 # cudart can be statically linked or dynamically linked the python ecosystem wants dynamic linking


### PR DESCRIPTION
This is the same as the option in cuDF: https://github.com/rapidsai/cudf/blob/branch-0.16/cpp/CMakeLists.txt#L135, mainly to make it easier to see compilation errors.

@jrhemstad @harrism 