### PR TITLE
[REVIEW] Silence deprecation warnings on tests for deprecated features

### DIFF
--- a/include/rmm/detail/diagnostic.hpp
+++ b/include/rmm/detail/diagnostic.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The code in this file has been adapted from the range-v3 library:
+ * https://github.com/ericniebler/range-v3/
+ * which contains the following copyright notice:
+ *
+ * Range v3 library
+ *
+ *  Copyright Eric Niebler 2013-present
+ *  Copyright Casey Carter 2016
+ *
+ *  Use, modification and distribution is subject to the
+ *  Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at
+ *  http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+#pragma once
+
+/**
+ * @brief This file defines macros for fine-grained compiler diagnostic control.
+ *
+ * Example usage:
+ * ```
+ * // A deprecated API:
+ * [[deprecated]] void foo() {}
+ *
+ * foo(); // calling it produces a "deprecated" warning
+ *
+ * RMM_DIAGNOSTIC_PUSH
+ * RMM_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+ * foo(); // no deprecation warning!
+ * RMM_DIAGNOSTIC_POP
+ * ```
+ */
+
+#if defined(_MSC_VER) && !defined(__clang__)
+
+#define RMM_DIAGNOSTIC_PUSH __pragma(warning(push))
+#define RMM_DIAGNOSTIC_POP __pragma(warning(pop))
+#define RMM_DIAGNOSTIC_IGNORE_PRAGMAS __pragma(warning(disable : 4068))
+#define RMM_DIAGNOSTIC_IGNORE(X)                               \
+  RMM_DIAGNOSTIC_IGNORE_PRAGMAS __pragma(warning(disable : X))
+#define RMM_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS RMM_DIAGNOSTIC_IGNORE(4996)
+
+#elif defined(__GNUC__) || defined(__clang__)
+
+#define RMM_PRAGMA(X) _Pragma(#X)
+#define RMM_DIAGNOSTIC_PUSH RMM_PRAGMA(GCC diagnostic push)
+#define RMM_DIAGNOSTIC_POP RMM_PRAGMA(GCC diagnostic pop)
+#define RMM_DIAGNOSTIC_IGNORE_PRAGMAS RMM_PRAGMA(GCC diagnostic ignored "-Wpragmas")
+#define RMM_DIAGNOSTIC_IGNORE(X)                                   \
+  RMM_DIAGNOSTIC_IGNORE_PRAGMAS                                    \
+  RMM_PRAGMA(GCC diagnostic ignored "-Wunknown-pragmas")           \
+    RMM_PRAGMA(GCC diagnostic ignored "-Wunknown-warning-option")  \
+    RMM_PRAGMA(GCC diagnostic ignored X)
+#define RMM_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS  \
+  RMM_DIAGNOSTIC_IGNORE("-Wdeprecated-declarations")
+
+#else
+
+#define RMM_DIAGNOSTIC_PUSH
+#define RMM_DIAGNOSTIC_POP
+#define RMM_DIAGNOSTIC_IGNORE_PRAGMAS
+#define RMM_DIAGNOSTIC_IGNORE(X)
+#define RMM_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+
+#endif

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -60,13 +60,13 @@ void spawn(Task task, Arguments&&... args)
   spawn_n(4, task, std::forward<Arguments>(args)...);
 }
 
-TEST(DefaultTest, UseDefaultResource_mt) { spawn(test_get_default_resource); }
+TEST(DefaultTest, UseDefaultResource_mt) { spawn(test_get_current_device_resource); }
 
 TEST(DefaultTest, DefaultResourceIsCUDA_mt)
 {
   spawn([]() {
-    EXPECT_NE(nullptr, rmm::mr::get_default_resource());
-    EXPECT_TRUE(rmm::mr::get_default_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
+    EXPECT_NE(nullptr, rmm::mr::get_current_device_resource());
+    EXPECT_TRUE(rmm::mr::get_current_device_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
   });
 }
 
@@ -89,8 +89,8 @@ TEST_P(mr_test_mt, SetDefaultResource_mt)
   EXPECT_NE(nullptr, old);
 
   spawn([mr = this->mr.get()]() {
-    EXPECT_EQ(mr, rmm::mr::get_default_resource());
-    test_get_default_resource();  // test allocating with the new default resource
+    EXPECT_EQ(mr, rmm::mr::get_current_device_resource());
+    test_get_current_device_resource();  // test allocating with the new default resource
   });
 
   // setting default resource w/ nullptr should reset to initial

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -27,6 +27,7 @@
 #include <rmm/mr/device/owning_wrapper.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/detail/diagnostic.hpp>
 
 #include <cuda_runtime_api.h>
 
@@ -76,6 +77,8 @@ struct allocation {
 // Various test functions, shared between single-threaded and multithreaded tests.
 inline void test_get_default_resource()
 {
+  RMM_DIAGNOSTIC_PUSH
+  RMM_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
   EXPECT_NE(nullptr, rmm::mr::get_default_resource());
   void* p{nullptr};
   EXPECT_NO_THROW(p = rmm::mr::get_default_resource()->allocate(1_MiB));
@@ -83,6 +86,7 @@ inline void test_get_default_resource()
   EXPECT_TRUE(is_aligned(p));
   EXPECT_TRUE(is_device_memory(p));
   EXPECT_NO_THROW(rmm::mr::get_default_resource()->deallocate(p, 1_MiB));
+  RMM_DIAGNOSTIC_POP
 }
 
 inline void test_get_current_device_resource()

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -33,8 +33,11 @@ INSTANTIATE_TEST_CASE_P(ResourceTests,
 
 TEST(DefaultTest, DefaultResourceIsCUDA)
 {
+  RMM_DIAGNOSTIC_PUSH
+  RMM_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
   EXPECT_NE(nullptr, rmm::mr::get_default_resource());
   EXPECT_TRUE(rmm::mr::get_default_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
+  RMM_DIAGNOSTIC_POP
 }
 
 TEST(DefaultTest, UseDefaultResource) { test_get_default_resource(); }
@@ -49,6 +52,8 @@ TEST(DefaultTest, GetCurrentDeviceResource)
 
 TEST_P(mr_test, SetDefaultResource)
 {
+  RMM_DIAGNOSTIC_PUSH
+  RMM_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
   rmm::mr::device_memory_resource* old{nullptr};
   EXPECT_NO_THROW(old = rmm::mr::set_default_resource(this->mr.get()));
   EXPECT_NE(nullptr, old);
@@ -58,6 +63,7 @@ TEST_P(mr_test, SetDefaultResource)
   // setting default resource w/ nullptr should reset to initial
   EXPECT_NO_THROW(rmm::mr::set_default_resource(nullptr));
   EXPECT_TRUE(old->is_equal(*rmm::mr::get_default_resource()));
+  RMM_DIAGNOSTIC_POP
 }
 
 TEST_P(mr_test, SetCurrentDeviceResource)


### PR DESCRIPTION
This PR adds macros to silence warnings; they are based on the macros from range-v3:

```c++
[[deprecated]] foo() {}

RMM_DIAGNOSTIC_PUSH
RMM_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
foo(); // no deprecation warning!
RMM_DIAGNOSTIC_POP
```

These macros are used on the tests for deprecated features that are still included in the library to avoid deprecation warnings while building.