### PR TITLE
Remove cuda driver linking and fix NVTX usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ## Bug Fixes
 
 - PR #534 Fix `pool_memory_resource` failure when init and max pool sizes are equal
+- PR #546 Remove CUDA driver linking and correct NVTX macro.
 
 
 # RMM 0.15.0 (26 Aug 2020)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
 
 option(PER_THREAD_DEFAULT_STREAM "Build with per-thread default stream" OFF)
 
-option(USE_NVTX "Build with NVTX support" ON)
+option(USE_NVTX "Build with NVTX support" OFF)
 
 ###################################################################################################
 # - find packages we depend on --------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,6 @@ endif(CUDA_STATIC_RUNTIME)
 
 if(USE_NVTX)
   message(STATUS "Using Nvidia Tools Extension")
-  target_link_libraries(rmm PUBLIC CUDA::nvToolsExt)
   target_compile_definitions(rmm PUBLIC USE_NVTX)
 endif(USE_NVTX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,8 +167,6 @@ else()
   target_link_libraries(rmm PUBLIC CUDA::cudart)
 endif(CUDA_STATIC_RUNTIME)
 
-target_link_libraries(rmm PUBLIC CUDA::cuda_driver)
-
 if(USE_NVTX)
   message(STATUS "Using Nvidia Tools Extension")
   target_link_libraries(rmm PUBLIC CUDA::nvToolsExt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,8 @@ endif(CUDA_STATIC_RUNTIME)
 
 if(USE_NVTX)
   message(STATUS "Using Nvidia Tools Extension")
-  target_compile_definitions(rmm PUBLIC USE_NVTX)
+else()
+  target_compile_definitions(rmm PUBLIC NVTX_DISABLE)
 endif(USE_NVTX)
 
 # Set a default logging level if none was specified


### PR DESCRIPTION
- [x] Remove erroneous linking of CUDA driver

- [x] Remove unnecessary linking of NVTX (we use the header only version now)

- [x] Correctly set `NVTX_DISABLE` when `USE_NVTX` is off

- [x] Default `USE_NVTX` to off 