### PR TITLE
[REVIEW] Fix align_down so it only changes the value if not already aligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #545 Fix build to support using `clang` as the host compiler
 - PR #534 Fix `pool_memory_resource` failure when init and max pool sizes are equal
 - PR #546 Remove CUDA driver linking and correct NVTX macro.
+- PR #559 Fix align_down to only change unaligned values.
 
 
 # RMM 0.15.0 (26 Aug 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - PR #545 Fix build to support using `clang` as the host compiler
 - PR #534 Fix `pool_memory_resource` failure when init and max pool sizes are equal
 - PR #546 Remove CUDA driver linking and correct NVTX macro.
-- PR #559 Fix align_down to only change unaligned values.
+- PR #559 Fix `align_down` to only change unaligned values.
 
 
 # RMM 0.15.0 (26 Aug 2020)

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -58,20 +58,6 @@ constexpr std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept
 }
 
 /**
- * @brief Check whether `v` is aligned to a multiple of `align_bytes`
- *
- * @param v The value to check
- * @param align_bytes alignment amount, in bytes, must be a power of 2
- * @return true
- * @return false
- */
-constexpr bool is_aligned(std::size_t v, std::size_t align_bytes) noexcept
-{
-  assert(is_supported_alignment(align_bytes));
-  return v & ~(align_bytes - 1);
-}
-
-/**
  * @brief Align down to the nearest multiple of specified power of 2
  *
  * @param[in] v value to align
@@ -82,7 +68,7 @@ constexpr bool is_aligned(std::size_t v, std::size_t align_bytes) noexcept
 constexpr std::size_t align_down(std::size_t v, std::size_t align_bytes) noexcept
 {
   assert(is_supported_alignment(align_bytes));
-  return is_aligned(v, align_bytes) ? v : align_up(v, align_bytes) - align_bytes;
+  return v & ~(align_bytes - 1);
 }
 
 /**

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -44,7 +44,7 @@ constexpr bool is_pow2(std::size_t n) { return (0 == (n & (n - 1))); }
 constexpr bool is_supported_alignment(std::size_t alignment) { return is_pow2(alignment); }
 
 /**
- * @brief Align up to a power of 2
+ * @brief Align up to nearest multiple of specified power of 2
  *
  * @param[in] v value to align
  * @param[in] alignment amount, in bytes, must be a power of 2
@@ -58,7 +58,21 @@ constexpr std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept
 }
 
 /**
- * @brief Align down to a power of 2
+ * @brief Check whether `v` is aligned to a multiple of `align_bytes`
+ *
+ * @param v The value to check
+ * @param align_bytes alignment amount, in bytes, must be a power of 2
+ * @return true
+ * @return false
+ */
+constexpr bool is_aligned(std::size_t v, std::size_t align_bytes) noexcept
+{
+  assert(is_supported_alignment(align_bytes));
+  return v & ~(align_bytes - 1);
+}
+
+/**
+ * @brief Align down to the nearest multiple of specified power of 2
  *
  * @param[in] v value to align
  * @param[in] alignment amount, in bytes, must be a power of 2
@@ -68,7 +82,7 @@ constexpr std::size_t align_up(std::size_t v, std::size_t align_bytes) noexcept
 constexpr std::size_t align_down(std::size_t v, std::size_t align_bytes) noexcept
 {
   assert(is_supported_alignment(align_bytes));
-  return align_up(v, align_bytes) - align_bytes;
+  return is_aligned(v, align_bytes) ? v : align_up(v, align_bytes) - align_bytes;
 }
 
 /**


### PR DESCRIPTION
RMM's `align_down` function would align down to the next lower multiple of align_bytes even if the value was already aligned. THis could cause problems when using align_down on the available free memory, since it could make the maximum pool size smaller than the initial pool size in some cases.

This PR fixes this function to check if the value is already aligned.