### PR TITLE
[REVIEW] upgrade googletest to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #556 By default, don't create a debug log file unless there are warnings/errors
 - PR #561 Remove CNMeM and make RMM header-only
 - PR #565 CMake: Simplify gtest/gbench handling
+- PR #568 Upgrade googletest to v1.10.0
 
 ## Bug Fixes
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -44,7 +44,7 @@ if (BUILD_TESTS)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           release-1.8.0
+    GIT_TAG           release-1.10.0
     GIT_SHALLOW       true
     )
 


### PR DESCRIPTION
The current fetched version, 1.8.0, doesn't build under gcc-9:
```bash
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3957:23:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >::StrEqualityMatcher(const testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::StrEqualityMatcher<StringType>::operator=(const testing::internal::StrEqualityMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1180:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1180 |   GTEST_DISALLOW_ASSIGN_(StrEqualityMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3986:17:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >::HasSubstrMatcher(const testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::HasSubstrMatcher<StringType>::operator=(const testing::internal::HasSubstrMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1227:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1227 |   GTEST_DISALLOW_ASSIGN_(HasSubstrMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3993:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >::StartsWithMatcher(const testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::StartsWithMatcher<StringType>::operator=(const testing::internal::StartsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1274:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1274 |   GTEST_DISALLOW_ASSIGN_(StartsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4000:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >::EndsWithMatcher(const testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::EndsWithMatcher<StringType>::operator=(const testing::internal::EndsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1320:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1320 |   GTEST_DISALLOW_ASSIGN_(EndsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::MatchesRegexMatcher]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::MatchesRegexMatcher]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4007:75:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::MatchesRegexMatcher::MatchesRegexMatcher(const testing::internal::MatchesRegexMatcher&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::MatchesRegexMatcher’ has user-provided ‘void testing::internal::MatchesRegexMatcher::operator=(const testing::internal::MatchesRegexMatcher&)’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1369:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1369 |   GTEST_DISALLOW_ASSIGN_(MatchesRegexMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4032:23:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >::StrEqualityMatcher(const testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::StrEqualityMatcher<StringType>::operator=(const testing::internal::StrEqualityMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1180:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1180 |   GTEST_DISALLOW_ASSIGN_(StrEqualityMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4061:17:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >::HasSubstrMatcher(const testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::HasSubstrMatcher<StringType>::operator=(const testing::internal::HasSubstrMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1227:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1227 |   GTEST_DISALLOW_ASSIGN_(HasSubstrMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4068:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >::StartsWithMatcher(const testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::StartsWithMatcher<StringType>::operator=(const testing::internal::StartsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1274:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1274 |   GTEST_DISALLOW_ASSIGN_(StartsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4075:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >::EndsWithMatcher(const testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock_main.cc:33:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::EndsWithMatcher<StringType>::operator=(const testing::internal::EndsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1320:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1320 |   GTEST_DISALLOW_ASSIGN_(EndsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
_deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/build.make:107: recipe for target '_deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o' failed
make[2]: *** [_deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock_main.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3957:23:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >::StrEqualityMatcher(const testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::StrEqualityMatcher<StringType>::operator=(const testing::internal::StrEqualityMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1180:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1180 |   GTEST_DISALLOW_ASSIGN_(StrEqualityMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3986:17:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >::HasSubstrMatcher(const testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::HasSubstrMatcher<StringType>::operator=(const testing::internal::HasSubstrMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1227:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1227 |   GTEST_DISALLOW_ASSIGN_(HasSubstrMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3993:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >::StartsWithMatcher(const testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::StartsWithMatcher<StringType>::operator=(const testing::internal::StartsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1274:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1274 |   GTEST_DISALLOW_ASSIGN_(StartsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4000:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >::EndsWithMatcher(const testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::EndsWithMatcher<StringType>::operator=(const testing::internal::EndsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1320:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1320 |   GTEST_DISALLOW_ASSIGN_(EndsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::MatchesRegexMatcher]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::MatchesRegexMatcher]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4007:75:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::MatchesRegexMatcher::MatchesRegexMatcher(const testing::internal::MatchesRegexMatcher&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::MatchesRegexMatcher’ has user-provided ‘void testing::internal::MatchesRegexMatcher::operator=(const testing::internal::MatchesRegexMatcher&)’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1369:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1369 |   GTEST_DISALLOW_ASSIGN_(MatchesRegexMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4032:23:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >::StrEqualityMatcher(const testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::StrEqualityMatcher<StringType>::operator=(const testing::internal::StrEqualityMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1180:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1180 |   GTEST_DISALLOW_ASSIGN_(StrEqualityMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4061:17:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >::HasSubstrMatcher(const testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::HasSubstrMatcher<StringType>::operator=(const testing::internal::HasSubstrMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1227:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1227 |   GTEST_DISALLOW_ASSIGN_(HasSubstrMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4068:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >::StartsWithMatcher(const testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::StartsWithMatcher<StringType>::operator=(const testing::internal::StartsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1274:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1274 |   GTEST_DISALLOW_ASSIGN_(StartsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4075:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >::EndsWithMatcher(const testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::EndsWithMatcher<StringType>::operator=(const testing::internal::EndsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1320:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1320 |   GTEST_DISALLOW_ASSIGN_(EndsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
_deps/googletest-build/googlemock/CMakeFiles/gmock.dir/build.make:94: recipe for target '_deps/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o' failed
make[2]: *** [_deps/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o] Error 1
CMakeFiles/Makefile2:1160: recipe for target '_deps/googletest-build/googlemock/CMakeFiles/gmock.dir/all' failed
make[1]: *** [_deps/googletest-build/googlemock/CMakeFiles/gmock.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3957:23:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >::StrEqualityMatcher(const testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::StrEqualityMatcher<StringType>::operator=(const testing::internal::StrEqualityMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1180:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1180 |   GTEST_DISALLOW_ASSIGN_(StrEqualityMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3986:17:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >::HasSubstrMatcher(const testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::HasSubstrMatcher<StringType>::operator=(const testing::internal::HasSubstrMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1227:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1227 |   GTEST_DISALLOW_ASSIGN_(HasSubstrMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:3993:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >::StartsWithMatcher(const testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::StartsWithMatcher<StringType>::operator=(const testing::internal::StartsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1274:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1274 |   GTEST_DISALLOW_ASSIGN_(StartsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4000:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >::EndsWithMatcher(const testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<char> >’ has user-provided ‘void testing::internal::EndsWithMatcher<StringType>::operator=(const testing::internal::EndsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<char>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1320:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1320 |   GTEST_DISALLOW_ASSIGN_(EndsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::MatchesRegexMatcher]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::MatchesRegexMatcher]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4007:75:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::MatchesRegexMatcher::MatchesRegexMatcher(const testing::internal::MatchesRegexMatcher&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::MatchesRegexMatcher’ has user-provided ‘void testing::internal::MatchesRegexMatcher::operator=(const testing::internal::MatchesRegexMatcher&)’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1369:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1369 |   GTEST_DISALLOW_ASSIGN_(MatchesRegexMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4032:23:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >::StrEqualityMatcher(const testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StrEqualityMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::StrEqualityMatcher<StringType>::operator=(const testing::internal::StrEqualityMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1180:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1180 |   GTEST_DISALLOW_ASSIGN_(StrEqualityMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4061:17:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >::HasSubstrMatcher(const testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::HasSubstrMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::HasSubstrMatcher<StringType>::operator=(const testing::internal::HasSubstrMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1227:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1227 |   GTEST_DISALLOW_ASSIGN_(HasSubstrMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4068:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >::StartsWithMatcher(const testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::StartsWithMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::StartsWithMatcher<StringType>::operator=(const testing::internal::StartsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1274:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1274 |   GTEST_DISALLOW_ASSIGN_(StartsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:75,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-generated-function-mockers.h:43,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:61,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h: In instantiation of ‘testing::PolymorphicMatcher<Impl>::PolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’:
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:497:10:   required from ‘testing::PolymorphicMatcher<Impl> testing::MakePolymorphicMatcher(const Impl&) [with Impl = testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >]’
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:4075:14:   required from here
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:432:67: error: implicitly-declared ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >::EndsWithMatcher(const testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >&)’ is deprecated [-Werror=deprecated-copy]
  432 |   explicit PolymorphicMatcher(const Impl& an_impl) : impl_(an_impl) {}
      |                                                                   ^
In file included from /home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-linked_ptr.h:74,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-port.h:53,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-generated-internal-utils.h:44,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:45,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:46,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:58,
                 from /home/rou/src/rmm/build/_deps/googletest-src/googlemock/src/gmock-all.cc:40:
/home/rou/src/rmm/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:870:8: note: because ‘testing::internal::EndsWithMatcher<std::__cxx11::basic_string<wchar_t> >’ has user-provided ‘void testing::internal::EndsWithMatcher<StringType>::operator=(const testing::internal::EndsWithMatcher<StringType>&) [with StringType = std::__cxx11::basic_string<wchar_t>]’
  870 |   void operator=(type const &)
      |        ^~~~~~~~
/home/rou/src/rmm/build/_deps/googletest-src/googlemock/include/gmock/gmock-matchers.h:1320:3: note: in expansion of macro ‘GTEST_DISALLOW_ASSIGN_’
 1320 |   GTEST_DISALLOW_ASSIGN_(EndsWithMatcher);
      |   ^~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
_deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/build.make:94: recipe for target '_deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock-all.cc.o' failed
make[2]: *** [_deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/src/gmock-all.cc.o] Error 1
CMakeFiles/Makefile2:1133: recipe for target '_deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/all' failed
make[1]: *** [_deps/googletest-build/googlemock/CMakeFiles/gmock_main.dir/all] Error 2
Makefile:159: recipe for target 'all' failed
make: *** [all] Error 2
```