### PR TITLE
[REVIEW] cmake: prefer locally installed thirdparty packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PR #565 CMake: Simplify gtest/gbench handling
 - PR #566 CMake: use CPM for thirdparty dependencies
 - PR #568 Upgrade googletest to v1.10.0
+- PR #572 CMake: prefer locally installed thirdparty packages
 
 ## Bug Fixes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,12 +71,12 @@ find_package(CUDAToolkit REQUIRED)
 ###################################################################################################
 # cmake modules
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 ###################################################################################################
 # third-party dependencies
 
-add_subdirectory(thirdparty)
+include(RMM_thirdparty)
 
 ###################################################################################################
 # per-thread default stream option

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -27,7 +27,7 @@ function(ConfigureBench CMAKE_BENCH_NAME CMAKE_BENCH_SRC)
   set_target_properties(${CMAKE_BENCH_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_include_directories(${CMAKE_BENCH_NAME} PRIVATE "$<BUILD_INTERFACE:${RMM_SOURCE_DIR}>")
   
-  target_link_libraries(${CMAKE_BENCH_NAME} benchmark pthread rmm)
+  target_link_libraries(${CMAKE_BENCH_NAME} benchmark::benchmark pthread rmm)
 
   set_target_properties(${CMAKE_BENCH_NAME} PROPERTIES
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gbenchmarks")

--- a/cmake/RMM_thirdparty.cmake
+++ b/cmake/RMM_thirdparty.cmake
@@ -52,7 +52,7 @@ endif()
 # - googlebenchmark -------------------------------------------------------------------------------
 
 if (BUILD_BENCHMARKS)
-  CPMAddPackage(
+  CPMFindPackage(
     NAME benchmark
     GITHUB_REPOSITORY google/benchmark
     VERSION 1.5.2

--- a/cmake/RMM_thirdparty.cmake
+++ b/cmake/RMM_thirdparty.cmake
@@ -28,15 +28,24 @@ set(THRUST_INCLUDE_DIR "${thrust_SOURCE_DIR}")
 # - googletest ------------------------------------------------------------------------------------
 
 if (BUILD_TESTS)
-  CPMAddPackage(
-    NAME googletest
+  CPMFindPackage(
+    NAME GTest
     GITHUB_REPOSITORY google/googletest
     GIT_TAG release-1.10.0
     VERSION 1.10.0
     GIT_SHALLOW TRUE
     OPTIONS
       "INSTALL_GTEST OFF"
+    # googletest >= 1.10.0 provides a cmake config file -- use it if it exists
+    FIND_PACKAGE_ARGUMENTS "CONFIG"
     )
+
+  if (GTest_ADDED)
+    add_library(GTest::gtest ALIAS gtest)
+    add_library(GTest::gmock ALIAS gmock)
+    add_library(GTest::gtest_main ALIAS gtest_main)
+    add_library(GTest::gmock_main ALIAS gmock_main)
+  endif()
 endif()
 
 ###################################################################################################

--- a/cmake/RMM_thirdparty.cmake
+++ b/cmake/RMM_thirdparty.cmake
@@ -22,7 +22,7 @@ CPMAddPackage(
   DOWNLOAD_ONLY TRUE
 )
 
-set(THRUST_INCLUDE_DIR "${thrust_SOURCE_DIR}" PARENT_SCOPE)
+set(THRUST_INCLUDE_DIR "${thrust_SOURCE_DIR}")
 
 ###################################################################################################
 # - googletest ------------------------------------------------------------------------------------

--- a/cmake/RMM_thirdparty.cmake
+++ b/cmake/RMM_thirdparty.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 ###################################################################################################
 # - spdlog ----------------------------------------------------------------------------------------
 
-CPMAddPackage(
+CPMFindPackage(
   NAME spdlog
   GITHUB_REPOSITORY gabime/spdlog
   VERSION 1.7.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,8 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
   set_target_properties(${CMAKE_TEST_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_include_directories(${CMAKE_TEST_NAME} PRIVATE "$<BUILD_INTERFACE:${RMM_SOURCE_DIR}>")
 
-  target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread rmm)
+  target_link_libraries(${CMAKE_TEST_NAME} GTest::gmock GTest::gtest GTest::gmock_main GTest::gtest_main
+                        pthread rmm)
   
   set_target_properties(${CMAKE_TEST_NAME} PROPERTIES
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gtests")


### PR DESCRIPTION
This PR essentially just changes `CPMAddPackage` to `CPMFindPackage`, except for thrust , which is currently still handled in a separate fashion (`DOWNLOAD_ONLY`). This makes CMake search for existing locally installed packages (at proper compatible versions) first, and if those don't exist, it falls back to fetching the packages, ie., to current behavior.

In theory, this shouldn't break anyone's workflow, since it falls back to current behavior. It does reduce the amount of duplicated libraries and potential resulting conflicts, and also should shorten build times when pre-installed local libraries can be used. In practice, I wouldn't be surprised to find some hiccups, though.

This is a step towards my goal to make RMM more easily packagable in a cmake-compatible fashion -- when using a package manager, RMM should use, e.g., the spdlog provided by the package manager, not pull in its own. This also applies to integration with conda -- currently the conda environment prescribes `spdlog=1.7.0`, but RMM will download and use its own (which is also 1.7.0).

Nevertheless, this PR isn't the only way to support locally installed packages -- one can also stick with the current default by keeping `CPMAddPackage` and setting a CMake variable to prefer locally installed packages when desired (e.g., when packaging).