### PR TITLE
[FEA] Add a reflection interface to query type of device resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  - PR #529 Add debug logging and fix multithreaded replay benchmark
  - PR #560 Remove deprecated `get/set_default_resource` APIs
+ - PR #573 Add a reflection interface to query type of device resource
 
 ## Improvements
 

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -150,6 +150,17 @@ class binning_memory_resource final : public device_memory_resource {
     }
   }
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  std::string get_device_resource_type_str() const override
+  {
+    return std::string("rmm::mr::binning_memory_resource<")
+           + upstream_mr_->get_device_resource_type_str() + ">";
+  }
+
  private:
   /**
    * @brief Get the memory resource for the requested size

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -49,6 +49,16 @@ class cuda_memory_resource final : public device_memory_resource {
    */
   bool supports_get_mem_info() const noexcept override { return true; }
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  std::string get_device_resource_type_str() const override
+  {
+    return "rmm::mr::cuda_memory_resource";
+  }
+
  private:
   /**
    * @brief Allocates memory of size at least `bytes` using cudaMalloc.

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -85,6 +85,16 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
   stream_ordered_memory_resource& operator=(stream_ordered_memory_resource const&) = delete;
   stream_ordered_memory_resource& operator=(stream_ordered_memory_resource&&) = delete;
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  std::string get_device_resource_type_str() const override
+  {
+    return "rmm::mr::detail::stream_ordered_memory_resource";
+  }
+
  protected:
   using free_list  = FreeListType;
   using block_type = typename free_list::block_type;

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -171,6 +171,13 @@ class device_memory_resource {
     return do_get_mem_info(stream);
   }
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  virtual std::string get_device_resource_type_str() const = 0;
+
  private:
   /**
    * @brief Allocates memory of size at least \p bytes.

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -120,6 +120,17 @@ class fixed_size_memory_resource
    */
   std::size_t get_block_size() const noexcept { return block_size_; }
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  std::string get_device_resource_type_str() const override
+  {
+    return std::string("rmm::mr::fixed_size_memory_resource<")
+           + upstream_mr_->get_device_resource_type_str() + ">";
+  }
+
  protected:
   using free_list  = detail::fixed_size_free_list;
   using block_type = free_list::block_type;

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -147,6 +147,17 @@ class logging_resource_adaptor final : public device_memory_resource {
    */
   std::string header() const { return std::string{"Thread,Time,Action,Pointer,Size,Stream"}; }
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  std::string get_device_resource_type_str() const override
+  {
+    return std::string("rmm::mr::logging_resource_adaptor<")
+           + upstream_->get_device_resource_type_str() + ">";
+  }
+
  private:
   // make_logging_adaptor needs access to private get_default_filename
   template <typename T>

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -49,6 +49,16 @@ class managed_memory_resource final : public device_memory_resource {
    */
   bool supports_get_mem_info() const noexcept override { return true; }
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  std::string get_device_resource_type_str() const override
+  {
+    return "rmm::mr::managed_memory_resource";
+  }
+
  private:
   /**
    * @brief Allocates memory of size at least \p bytes using cudaMallocManaged.

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -153,6 +153,17 @@ class pool_memory_resource final
    */
   Upstream* get_upstream() const noexcept { return upstream_mr_; }
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  std::string get_device_resource_type_str() const override
+  {
+    return std::string("rmm::mr::pool_memory_resource<")
+           + upstream_mr_->get_device_resource_type_str() + ">";
+  }
+
  protected:
   using free_list  = detail::coalescing_free_list;
   using block_type = free_list::block_type;

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -77,6 +77,17 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    */
   bool supports_get_mem_info() const noexcept override { return upstream_->supports_streams(); }
 
+  /**
+   * @brief Query the type of the underlying device resource
+   *
+   * @return std::string containing human-readable representation of the device resource's type
+   */
+  std::string get_device_resource_type_str() const override
+  {
+    return std::string("rmm::mr::thread_safe_resource_adaptor<")
+           + upstream_->get_device_resource_type_str() + ">";
+  }
+
  private:
   /**
    * @brief Allocates memory of size at least `bytes` using the upstream


### PR DESCRIPTION
Add a convenience function `get_device_resource_type_str()` to every device resource so that a downstream application can determine the type of a device resource at runtime.

Example output from `get_device_resource_type_str()`:
```
rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>
```