### PR TITLE
Document that Conda package requires GCC 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,10 @@ conda install -c nvidia -c rapidsai -c conda-forge -c defaults \
     rmm cudatoolkit=10.0
 ```
 
-We also provide [nightly conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD
+We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD
 of our latest development branch.
 
-Note: RMM is supported only on Linux, and with Python versions 3.6 or 3.7.
-
-Note: If you choose to install RMM using Conda, make sure to use GCC 7 or later. Otherwise, your application may fail to build.
+Note: The RMM package from Conda requires building with GCC 7 or later. Otherwise, your application may fail to build.
 
 See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info.
 
@@ -54,7 +52,7 @@ See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS an
 
 Compiler requirements:
 
-* `gcc`     version 4.8 or higher recommended
+* `gcc`     version 7.0 or higher required
 * `nvcc`    version 9.0 or higher recommended
 * `cmake`   version 3.12 or higher
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ conda install -c nvidia -c rapidsai -c conda-forge -c defaults \
 We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD
 of our latest development branch.
 
+Note: RMM is supported only on Linux, and with Python versions 3.7 and later.
+
 Note: The RMM package from Conda requires building with GCC 7 or later. Otherwise, your application may fail to build.
 
 See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ensure you are on the `main` branch.
 
 ### Conda
 
-RMM can be installed with conda ([miniconda](https://conda.io/miniconda.html), or the full
+RMM can be installed with Conda ([miniconda](https://conda.io/miniconda.html), or the full
 [Anaconda distribution](https://www.anaconda.com/download)) from the `rapidsai` channel:
 
 ```bash
@@ -43,6 +43,8 @@ We also provide [nightly conda packages](https://anaconda.org/rapidsai-nightly) 
 of our latest development branch.
 
 Note: RMM is supported only on Linux, and with Python versions 3.6 or 3.7.
+
+Note: If you choose to install RMM using Conda, make sure to use GCC 7 or later. Otherwise, your application may fail to build.
 
 See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS and version info.
 


### PR DESCRIPTION
Today I was working on upgrading XGBoost CI to use latest RMM (dmlc/xgboost#6157), and noticed that GCC 5.x no longer worked with latest RMM from `rapidsai-nightly` Conda channel. I got the following build error while building XGBoost with GCC 5.4.0:

> ...
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:936:68: error: invalid static_cast from type 'const char [17]' to type 'const char (&)[]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h: In instantiation of 'Char* fmt::v6::internal::format_uint(Char*, UInt, int, bool) [with unsigned int BASE_BITS = 3u; Char = char; UInt = long unsigned int]':
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:1547:36:   required from 'void fmt::v6::internal::basic_writer<Range>::int_writer<Int, Specs>::bin_writer<BITS>::operator()(It&&) const [with It = char*&; int BITS = 3; Int = long long int; Specs = fmt::v6::basic_format_specs<char>; Range = fmt::v6::buffer_range<char>]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:1441:1:   required from 'void fmt::v6::internal::basic_writer<Range>::padded_int_writer<F>::operator()(It&&) const [with It = char*; F = fmt::v6::internal::basic_writer<fmt::v6::buffer_range<char> >::int_writer<long long int, fmt::v6::basic_format_specs<char> >::bin_writer<3>; Range = fmt::v6::buffer_range<char>]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:1682:41:   required from 'void fmt::v6::internal::basic_writer<Range>::write_padded(const format_specs&, F&&) [with F = fmt::v6::internal::basic_writer<fmt::v6::buffer_range<char> >::padded_int_writer<fmt::v6::internal::basic_writer<fmt::v6::buffer_range<char> >::int_writer<long long int, fmt::v6::basic_format_specs<char> >::bin_writer<3> >; Range = fmt::v6::buffer_range<char>; fmt::v6::internal::basic_writer<Range>::format_specs = fmt::v6::basic_format_specs<char>; typename Range::value_type = char]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:1465:13:   required from 'void fmt::v6::internal::basic_writer<Range>::write_int(int, fmt::v6::string_view, fmt::v6::internal::basic_writer<Range>::format_specs, F) [with F = fmt::v6::internal::basic_writer<fmt::v6::buffer_range<char> >::int_writer<long long int, fmt::v6::basic_format_specs<char> >::bin_writer<3>; Range = fmt::v6::buffer_range<char>; fmt::v6::string_view = fmt::v6::basic_string_view<char>; fmt::v6::internal::basic_writer<Range>::format_specs = fmt::v6::basic_format_specs<char>; typename Range::value_type = char]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:1568:1:   required from 'void fmt::v6::internal::basic_writer<Range>::int_writer<Int, Specs>::on_oct() [with Int = long long int; Specs = fmt::v6::basic_format_specs<char>; Range = fmt::v6::buffer_range<char>]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:1236:1:   [ skipping 3 instantiation contexts, use -ftemplate-backtrace-limit=0 to disable ]
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/core.h:1109:11:   required from 'decltype (vis(0)) fmt::v6::visit_format_arg(Visitor&&, const fmt::v6::basic_format_arg<Context>&) [with Visitor = fmt::v6::arg_formatter<fmt::v6::buffer_range<char> >; Context = fmt::v6::basic_format_context<std::back_insert_iterator<fmt::v6::internal::buffer<char> >, char>; decltype (vis(0)) = std::back_insert_iterator<fmt::v6::internal::buffer<char> >]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:3170:39:   required from 'void fmt::v6::format_handler<ArgFormatter, Char, Context>::on_replacement_field(const Char*) [with ArgFormatter = fmt::v6::arg_formatter<fmt::v6::buffer_range<char> >; Char = char; Context = fmt::v6::basic_format_context<std::back_insert_iterator<fmt::v6::internal::buffer<char> >, char>]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:2606:1:   required from 'void fmt::v6::internal::parse_format_string(fmt::v6::basic_string_view<Char>, Handler&&) [with bool IS_CONSTEXPR = false; Char = char; Handler = fmt::v6::format_handler<fmt::v6::arg_formatter<fmt::v6::buffer_range<char> >, char, fmt::v6::basic_format_context<std::back_insert_iterator<fmt::v6::internal::buffer<char> >, char> >&]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:3204:39:   required from 'typename Context::iterator fmt::v6::vformat_to(typename ArgFormatter::range, fmt::v6::basic_string_view<Char>, fmt::v6::basic_format_args<Context>, fmt::v6::internal::locale_ref) [with ArgFormatter = fmt::v6::arg_formatter<fmt::v6::buffer_range<char> >; Char = char; Context = fmt::v6::basic_format_context<std::back_insert_iterator<fmt::v6::internal::buffer<char> >, char>; typename Context::iterator = std::back_insert_iterator<fmt::v6::internal::buffer<char> >; typename ArgFormatter::range = fmt::v6::buffer_range<char>]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:3359:59:   required from 'typename fmt::v6::basic_format_context<std::back_insert_iterator<fmt::v6::internal::buffer<Char> >, Char>::iterator fmt::v6::internal::vformat_to(fmt::v6::internal::buffer<Char>&, fmt::v6::basic_string_view<Char>, fmt::v6::basic_format_args<fmt::v6::basic_format_context<std::back_insert_iterator<fmt::v6::internal::buffer<typename fmt::v6::type_identity<T>::type> >, typename fmt::v6::type_identity<T>::type> >) [with Char = char; typename fmt::v6::basic_format_context<std::back_insert_iterator<fmt::v6::internal::buffer<Char> >, Char>::iterator = std::back_insert_iterator<fmt::v6::internal::buffer<char> >; typename fmt::v6::type_identity<T>::type = char]'
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format-inl.h:1364:156:   required from here
> /opt/python/envs/gpu_test/include/spdlog/fmt/bundled/format.h:936:68: error: invalid static_cast from type 'const char [17]' to type 'const char (&)[]'
> ninja: build stopped: subcommand failed.

The build error comes from `spdlog`, which is a dependency of `librmm`.

I had to upgrade to GCC 7.x to repair the build. AFAIK, all packages in conda-forge are built with GCC 7.x.