### PR TITLE
Fix Cmake LOGGING_LEVEL so that default logging is not verbose and expensive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PR #546 Remove CUDA driver linking and correct NVTX macro.
 - PR #569 Correct `device_scalar::set_value` to pass host value by reference to avoid copying from invalid value
 - PR #559 Fix `align_down` to only change unaligned values.
+- PR #577 Fix CMake `LOGGING_LEVEL` issue which caused verbose logging / performance regression.
 
 
 # RMM 0.15.0 (26 Aug 2020)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,18 +117,11 @@ target_link_libraries(rmm INTERFACE spdlog::spdlog_header_only)
 # Set a default logging level if none was specified
 # Must go before including gtests and benchmarks. 
 
-
-set(DEFAULT_LOGGING_LEVEL "LEVEL_INFO")
-
-if(NOT LOGGING_LEVEL)
-  message(STATUS "Setting logging level to '${DEFAULT_LOGGING_LEVEL}' since none specified.")
-  set(LOGGING_LEVEL "${DEFAULT_LOGGING_LEVEL}" CACHE STRING "Choose the logging level." FORCE)
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS
-               "LEVEL_TRACE" "LEVEL_DEBUG" "LEVEL_INFO" "LEVEL_WARN" "LEVEL_ERROR" "LEVEL_CRITICAL" "LEVEL_OFF")
-else()
-    message(STATUS "Setting logging level to '${LOGGING_LEVEL}'")
-endif(NOT LOGGING_LEVEL)
+set(RMM_LOGGING_LEVEL "INFO" CACHE STRING "Choose the logging level.")
+# Set the possible values of build type for cmake-gui
+set_property(CACHE RMM_LOGGING_LEVEL PROPERTY STRINGS
+    "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
+message(STATUS "RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'.")
 
 ###################################################################################################
 # add gtest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,7 @@ endif(CUDA_STATIC_RUNTIME)
 target_link_libraries(rmm INTERFACE spdlog::spdlog_header_only)
 
 ###################################################################################################
-# Set a default logging level if none was specified
-# Must go before including gtests and benchmarks. 
+# Set logging level. Must go before including gtests and benchmarks. 
 
 set(RMM_LOGGING_LEVEL "INFO" CACHE STRING "Choose the logging level.")
 # Set the possible values of build type for cmake-gui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,21 +88,6 @@ if(PER_THREAD_DEFAULT_STREAM)
 endif(PER_THREAD_DEFAULT_STREAM)
 
 ###################################################################################################
-# add gtest
-
-if(BUILD_TESTS)
-    include(CTest)
-    add_subdirectory(tests)
-endif(BUILD_TESTS)
-
-###################################################################################################
-# add google benchmark
-
-if(BUILD_BENCHMARKS)
-  add_subdirectory(benchmarks)
-endif(BUILD_BENCHMARKS)
-
-###################################################################################################
 # library targets
 
 add_library(rmm INTERFACE)
@@ -130,19 +115,35 @@ target_link_libraries(rmm INTERFACE spdlog::spdlog_header_only)
 
 ###################################################################################################
 # Set a default logging level if none was specified
+# Must go before including gtests and benchmarks. 
 
-set(DEFAULT_LOGGING_LEVEL "INFO")
+
+set(DEFAULT_LOGGING_LEVEL "LEVEL_INFO")
 
 if(NOT LOGGING_LEVEL)
-    message(STATUS "Setting logging level to '${DEFAULT_LOGGING_LEVEL}' since none specified.")
-    set(LOGGING_LEVEL "${DEFAULT_LOGGING_LEVEL}" CACHE
-      STRING "Choose the logging level." FORCE)
-    # Set the possible values of build type for cmake-gui
-    set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS
-        "TRACE" "DEBUG" "INFO" "WARN" "ERROR" "CRITICAL" "OFF")
+  message(STATUS "Setting logging level to '${DEFAULT_LOGGING_LEVEL}' since none specified.")
+  set(LOGGING_LEVEL "${DEFAULT_LOGGING_LEVEL}" CACHE STRING "Choose the logging level." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE LOGGING_LEVEL PROPERTY STRINGS
+               "LEVEL_TRACE" "LEVEL_DEBUG" "LEVEL_INFO" "LEVEL_WARN" "LEVEL_ERROR" "LEVEL_CRITICAL" "LEVEL_OFF")
 else()
     message(STATUS "Setting logging level to '${LOGGING_LEVEL}'")
 endif(NOT LOGGING_LEVEL)
+
+###################################################################################################
+# add gtest
+
+if(BUILD_TESTS)
+    include(CTest)
+    add_subdirectory(tests)
+endif(BUILD_TESTS)
+
+###################################################################################################
+# add google benchmark
+
+if(BUILD_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif(BUILD_BENCHMARKS)
 
 ###################################################################################################
 # install targets

--- a/README.md
+++ b/README.md
@@ -407,18 +407,15 @@ information can show when errors occur, when additional memory is allocated from
 etc. The default log file is `rmm_log.txt` in the current working directory, but the environment
 variable `RMM_DEBUG_LOG_FILE` can be set to specify the path and file name.
 
-There is a CMake configuration variable `LOGGING_LEVEL`, which can be set to enable compilation of
-more detailed logging. The default is `LEVEL_INFO`. Available levels are `LEVEL_TRACE`,
-`LEVEL_DEBUG`, `LEVEL_INFO`, `LEVEL_WARN`, `LEVEL_ERROR`, `LEVEL_CRITICAL` and `LEVEL_OFF`. Note
-that to completely disable logging at compile time you need to use
-`cmake .. -DLOGGING_LEVEL=LEVEL_OFF`. Using `-DLOGGING_LEVEL=OFF` will not work because cmake treats
-`OFF` the same as undefined.
+There is a CMake configuration variable `RMM_LOGGING_LEVEL`, which can be set to enable compilation
+of more detailed logging. The default is `INFO`. Available levels are `TRACE`, `DEBUG`, `INFO`,
+`WARN`, `ERROR`, `CRITICAL` and `OFF`.
 
 The log relies on the [spdlog](https://github.com/gabime/spdlog.git) library.
 
 Note that to see logging below the `INFO` level, the C++ application must also call
 `rmm::logger().set_level()`, e.g. to enable all levels of logging down to `TRACE`, call 
-`rmm::logger().set_level(spdlog::level::trace)` (and compile with `-DLOGGING_LEVEL=LEVEL_TRACE`).
+`rmm::logger().set_level(spdlog::level::trace)` (and compile with `-DRMM_LOGGING_LEVEL=TRACE`).
 
 Note that debug logging is different from the CSV memory allocation logging provided by 
 `rmm::mr::logging_resource_adapter`. The latter is for logging a history of allocation /

--- a/README.md
+++ b/README.md
@@ -408,14 +408,17 @@ etc. The default log file is `rmm_log.txt` in the current working directory, but
 variable `RMM_DEBUG_LOG_FILE` can be set to specify the path and file name.
 
 There is a CMake configuration variable `LOGGING_LEVEL`, which can be set to enable compilation of
-more detailed logging. The default is `INFO`. Available levels are `TRACE`, `DEBUG`, `INFO`, `WARN`,
-`ERROR`, `CRITICAL`.
+more detailed logging. The default is `LEVEL_INFO`. Available levels are `LEVEL_TRACE`,
+`LEVEL_DEBUG`, `LEVEL_INFO`, `LEVEL_WARN`, `LEVEL_ERROR`, `LEVEL_CRITICAL` and `LEVEL_OFF`. Note
+that to completely disable logging at compile time you need to use
+`cmake .. -DLOGGING_LEVEL=LEVEL_OFF`. Using `-DLOGGING_LEVEL=OFF` will not work because cmake treats
+`OFF` the same as undefined.
 
 The log relies on the [spdlog](https://github.com/gabime/spdlog.git) library.
 
 Note that to see logging below the `INFO` level, the C++ application must also call
 `rmm::logger().set_level()`, e.g. to enable all levels of logging down to `TRACE`, call 
-`rmm::logger().set_level(spdlog::level::trace)`.
+`rmm::logger().set_level(spdlog::level::trace)` (and compile with `-DLOGGING_LEVEL=LEVEL_TRACE`).
 
 Note that debug logging is different from the CSV memory allocation logging provided by 
 `rmm::mr::logging_resource_adapter`. The latter is for logging a history of allocation /

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -33,7 +33,7 @@ function(ConfigureBench CMAKE_BENCH_NAME CMAKE_BENCH_SRC)
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gbenchmarks")
   
   target_compile_definitions(${CMAKE_BENCH_NAME} PUBLIC
-                             SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL})    
+                             "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL}")    
 endfunction(ConfigureBench)
 
 ###################################################################################################

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -33,7 +33,7 @@ function(ConfigureBench CMAKE_BENCH_NAME CMAKE_BENCH_SRC)
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gbenchmarks")
   
   target_compile_definitions(${CMAKE_BENCH_NAME} PUBLIC
-                             "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL}")    
+                             "SPDLOG_ACTIVE_LEVEL=SPDLOG_${LOGGING_LEVEL}")    
 endfunction(ConfigureBench)
 
 ###################################################################################################

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -33,7 +33,7 @@ function(ConfigureBench CMAKE_BENCH_NAME CMAKE_BENCH_SRC)
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gbenchmarks")
   
   target_compile_definitions(${CMAKE_BENCH_NAME} PUBLIC
-                             "SPDLOG_ACTIVE_LEVEL=SPDLOG_${LOGGING_LEVEL}")    
+                             "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM_LOGGING_LEVEL}")    
 endfunction(ConfigureBench)
 
 ###################################################################################################

--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -58,12 +58,14 @@ struct logger_wrapper {
   {
     logger_.set_pattern("[%6t][%H:%M:%S:%f][%-6l] %v");
     logger_.flush_on(spdlog::level::warn);
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
     logger_.info("----- RMM LOG BEGIN [PTDS ENABLED] -----");
 #else
     logger_.info("----- RMM LOG BEGIN [PTDS DISABLED] -----");
 #endif
     logger_.flush();
+#endif
   }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gtests")
 
   target_compile_definitions(${CMAKE_TEST_NAME} PUBLIC
-                             SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL})
+                             "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL}")    
 
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
 endfunction(ConfigureTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gtests")
 
   target_compile_definitions(${CMAKE_TEST_NAME} PUBLIC
-                        "SPDLOG_ACTIVE_LEVEL=SPDLOG_${LOGGING_LEVEL}")    
+                        "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM_LOGGING_LEVEL}")    
 
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
 endfunction(ConfigureTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gtests")
 
   target_compile_definitions(${CMAKE_TEST_NAME} PUBLIC
-                             "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL}")    
+                        "SPDLOG_ACTIVE_LEVEL=SPDLOG_${LOGGING_LEVEL}")    
 
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
 endfunction(ConfigureTest)


### PR DESCRIPTION
Fixes the cmake for LOGGING_LEVEL so that it's actually possible to turn it OFF. Also renames to RMM_LOGGING_LEVEL.

Also, the LOGGING_LEVEL variable handling was being done *After* `add_subdirectory(benchmark)` which meant that the variable was not set the first time benchmarks were built after a clean. This resulted in logging being compiled at trace level, causing benchmark regressions. This PR reorders the cmake.

This fixes a performance regression (on initial builds) reported in #543 
