### PR TITLE
[REVIEW] Removed `move` from self-defined and replaced with standard library `move`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PR #579 CMake: handle thrust via target
 - PR #581 Improve logging documentation
 - PR #585 Update ci/local/README.md
+- PR #586 Replaced `move` with `std::move`
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - PR #579 CMake: handle thrust via target
 - PR #581 Improve logging documentation
 - PR #585 Update ci/local/README.md
-- PR #586 Replaced `move` with `std::move`
+- PR #587 Replaced `move` with `std::move`
 
 ## Bug Fixes
 

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -67,8 +67,3 @@ cpdef void copy_device_to_ptr(uintptr_t d_src,
                               uintptr_t d_dst,
                               size_t count,
                               uintptr_t stream=*) nogil except *
-
-
-cdef extern from "<utility>" namespace "std" nogil:
-    cdef unique_ptr[device_buffer] move(unique_ptr[device_buffer])
-    cdef device_buffer move(device_buffer)

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -17,6 +17,7 @@ cimport cython
 from cpython.bytes cimport PyBytes_AS_STRING, PyBytes_FromStringAndSize
 from libc.stdint cimport uintptr_t
 from libcpp.memory cimport unique_ptr
+from libcpp.utility cimport move
 
 from rmm._cuda.gpu cimport cudaError, cudaError_t
 from rmm._lib.lib cimport (

--- a/python/rmm/tests/test_device_buffer.pyx
+++ b/python/rmm/tests/test_device_buffer.pyx
@@ -16,8 +16,9 @@ import cython
 import numpy as np
 
 from libcpp.memory cimport make_unique
+from libcpp.utility cimport move
 
-from rmm._lib.device_buffer cimport DeviceBuffer, device_buffer, move
+from rmm._lib.device_buffer cimport DeviceBuffer, device_buffer
 
 
 def test_release():


### PR DESCRIPTION
Closes #586 