### PR TITLE
[REVIEW] use installed C++ RMM in python build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PR #579 CMake: handle thrust via target
 - PR #581 Improve logging documentation
 - PR #585 Update ci/local/README.md
+- PR #588 Use installed C++ RMM in python build
 
 ## Bug Fixes
 

--- a/build.sh
+++ b/build.sh
@@ -45,9 +45,9 @@ PER_THREAD_DEFAULT_STREAM=OFF
 RAN_CMAKE=0
 
 # Set defaults for vars that may not have been defined externally
-#  FIXME: if INSTALL_PREFIX is not set, check PREFIX, then check
-#         CONDA_PREFIX, but there is no fallback from there!
-INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX}}}
+# If INSTALL_PREFIX is not set, check PREFIX, then check
+# CONDA_PREFIX, then fall back to install inside of $LIBRMM_BUILD_DIR
+INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX:=$LIBRMM_BUILD_DIR/install}}}
 PARALLEL_LEVEL=${PARALLEL_LEVEL:=""}
 
 function hasArg {

--- a/build.sh
+++ b/build.sh
@@ -133,12 +133,12 @@ if (( NUMARGS == 0 )) || hasArg rmm; then
     cd "${REPODIR}/python"
     if [[ ${INSTALL_TARGET} != "" ]]; then
         echo "building rmm..."
-        python setup.py build_ext --inplace --library-dir="${LIBRMM_BUILD_DIR}"
+        python setup.py build_ext --inplace
         echo "installing rmm..."
         python setup.py install --single-version-externally-managed --record=record.txt
     else
         echo "building rmm..."
-        python setup.py build_ext --inplace --library-dir="${LIBRMM_BUILD_DIR}"
+        python setup.py build_ext --inplace
     fi
 
 fi

--- a/build.sh
+++ b/build.sh
@@ -131,6 +131,7 @@ fi
 # Build and install the rmm Python package
 if (( NUMARGS == 0 )) || hasArg rmm; then
     cd "${REPODIR}/python"
+    export INSTALL_PREFIX
     if [[ ${INSTALL_TARGET} != "" ]]; then
         echo "building rmm..."
         python setup.py build_ext --inplace

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -202,7 +202,8 @@ class RMMNumbaManager(HostOnlyCUDAMemoryManager):
         start, end = cuda.cudadrv.driver.device_extents(memory)
         ipchandle = (ctypes.c_byte * 64)()  # IPC handle is 64 bytes
         cuda.cudadrv.driver.driver.cuIpcGetMemHandle(
-            ctypes.byref(ipchandle), start,
+            ctypes.byref(ipchandle),
+            start,
         )
         source_info = cuda.current_context().device.get_device_identity()
         offset = memory.handle.value - start

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -202,8 +202,7 @@ class RMMNumbaManager(HostOnlyCUDAMemoryManager):
         start, end = cuda.cudadrv.driver.device_extents(memory)
         ipchandle = (ctypes.c_byte * 64)()  # IPC handle is 64 bytes
         cuda.cudadrv.driver.driver.cuIpcGetMemHandle(
-            ctypes.byref(ipchandle),
-            start,
+            ctypes.byref(ipchandle), start,
         )
         source_info = cuda.current_context().device.get_device_identity()
         offset = memory.handle.value - start

--- a/python/setup.py
+++ b/python/setup.py
@@ -53,11 +53,11 @@ cuda_lib_dir = os.path.join(CUDA_HOME, "lib64")
 CUDA_VERSION = get_cuda_version_from_header(cuda_include_dir)
 
 INSTALL_PREFIX = os.environ.get("INSTALL_PREFIX", False)
-if not os.path.isdir(INSTALL_PREFIX):
-    raise OSError(
-        f"Invalid INSTALL_PREFIX: directory does not exist: {INSTALL_PREFIX}"
-    )
-rmm_include_dir = os.path.join(INSTALL_PREFIX, "include")
+if os.path.isdir(INSTALL_PREFIX):
+    rmm_include_dir = os.path.join(INSTALL_PREFIX, "include")
+else:
+    # use uninstalled headers in source tree
+    rmm_include_dir = "../include"
 
 # Preprocessor step to specify correct pxd file with
 # valid symbols for specific version of CUDA.

--- a/python/setup.py
+++ b/python/setup.py
@@ -111,9 +111,7 @@ extensions = cythonize(
     ],
     nthreads=nthreads,
     compiler_directives=dict(
-        profile=False,
-        language_level=3,
-        embedsignature=True,
+        profile=False, language_level=3, embedsignature=True,
     ),
 )
 
@@ -137,9 +135,7 @@ extensions += cythonize(
     ],
     nthreads=nthreads,
     compiler_directives=dict(
-        profile=False,
-        language_level=3,
-        embedsignature=True,
+        profile=False, language_level=3, embedsignature=True,
     ),
 )
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -54,7 +54,8 @@ CUDA_VERSION = get_cuda_version_from_header(cuda_include_dir)
 
 INSTALL_PREFIX = os.environ.get("INSTALL_PREFIX", False)
 if not os.path.isdir(INSTALL_PREFIX):
-    raise OSError(f"Invalid INSTALL_PREFIX: directory does not exist: {INSTALL_PREFIX}")
+    raise OSError(
+        f"Invalid INSTALL_PREFIX: directory does not exist: {INSTALL_PREFIX}")
 rmm_include_dir = os.path.join(INSTALL_PREFIX, "include")
 
 # Preprocessor step to specify correct pxd file with

--- a/python/setup.py
+++ b/python/setup.py
@@ -52,6 +52,11 @@ cuda_include_dir = os.path.join(CUDA_HOME, "include")
 cuda_lib_dir = os.path.join(CUDA_HOME, "lib64")
 CUDA_VERSION = get_cuda_version_from_header(cuda_include_dir)
 
+INSTALL_PREFIX = os.environ.get("INSTALL_PREFIX", False)
+if not os.path.isdir(INSTALL_PREFIX):
+    raise OSError(f"Invalid INSTALL_PREFIX: directory does not exist: {INSTALL_PREFIX}")
+rmm_include_dir = os.path.join(INSTALL_PREFIX, "include")
+
 # Preprocessor step to specify correct pxd file with
 # valid symbols for specific version of CUDA.
 
@@ -78,9 +83,7 @@ except Exception:
     nthreads = 0
 
 include_dirs = [
-    "../include/rmm",
-    "../include",
-    "../build/include",
+    rmm_include_dir,
     os.path.dirname(sysconfig.get_path("include")),
     cuda_include_dir,
 ]

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,7 +55,8 @@ CUDA_VERSION = get_cuda_version_from_header(cuda_include_dir)
 INSTALL_PREFIX = os.environ.get("INSTALL_PREFIX", False)
 if not os.path.isdir(INSTALL_PREFIX):
     raise OSError(
-        f"Invalid INSTALL_PREFIX: directory does not exist: {INSTALL_PREFIX}")
+        f"Invalid INSTALL_PREFIX: directory does not exist: {INSTALL_PREFIX}"
+    )
 rmm_include_dir = os.path.join(INSTALL_PREFIX, "include")
 
 # Preprocessor step to specify correct pxd file with
@@ -110,7 +111,9 @@ extensions = cythonize(
     ],
     nthreads=nthreads,
     compiler_directives=dict(
-        profile=False, language_level=3, embedsignature=True,
+        profile=False,
+        language_level=3,
+        embedsignature=True,
     ),
 )
 
@@ -134,7 +137,9 @@ extensions += cythonize(
     ],
     nthreads=nthreads,
     compiler_directives=dict(
-        profile=False, language_level=3, embedsignature=True,
+        profile=False,
+        language_level=3,
+        embedsignature=True,
     ),
 )
 


### PR DESCRIPTION
This PR switches the build of the python rmm to use the installed C++ RMM.

For the most part, this is just a cleanup, since the installed header-only RMM is the same as the one in the source tree.

But combined with PR #580, it will address issues like #584, where there is no spdlog preinstalled on the system. Currently, cmake will pull in its own spdlog in this case, but that spdlog won't be available to build the python modules. #580 will install spdlog together with RMM in this case, and with this PR, the python rmm build will use it.

Also, on a side note, for all I can tell, right now the build of the python modules will not use the downloaded Thrust 1.10.0, either, but whatever Thrust will be found on the Python side (ie., probably the one from the CUDA toolkit).
