### PR TITLE
[REVIEW] add a simulated memory resource to the replay bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #560 Remove deprecated `get/set_default_resource` APIs
 - PR #543 Add an arena-based memory resource
 - PR #580 Install CMake config with RMM
+- PR #591 Allow the replay bench to simulate different GPU memory sizes
 
 ## Improvements
 

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -151,10 +151,7 @@ struct replay_benchmark {
   replay_benchmark(replay_benchmark const&) = delete;
 
   /// Add an allocation to the map (NOT thread safe)
-  void set_allocation( uintptr_t ptr, allocation alloc)
-  {
-    allocation_map.insert({ptr, alloc});
-  }
+  void set_allocation(uintptr_t ptr, allocation alloc) { allocation_map.insert({ptr, alloc}); }
 
   /// Remove an allocation from the map (NOT thread safe)
   allocation remove_allocation(uintptr_t ptr)

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -151,16 +151,13 @@ struct replay_benchmark {
   replay_benchmark(replay_benchmark const&) = delete;
 
   /// Add an allocation to the map (NOT thread safe)
-  static void set_allocation(std::unordered_map<uintptr_t, allocation>& allocation_map,
-                             uintptr_t ptr,
-                             allocation alloc)
+  void set_allocation( uintptr_t ptr, allocation alloc)
   {
     allocation_map.insert({ptr, alloc});
   }
 
   /// Remove an allocation from the map (NOT thread safe)
-  static allocation remove_allocation(std::unordered_map<uintptr_t, allocation>& allocation_map,
-                                      uintptr_t ptr)
+  allocation remove_allocation(uintptr_t ptr)
   {
     auto iter = allocation_map.find(ptr);
     if (iter != allocation_map.end()) {
@@ -219,9 +216,9 @@ struct replay_benchmark {
 
         if (rmm::detail::action::ALLOCATE == e.act) {
           auto p = mr_->allocate(e.size);
-          set_allocation(allocation_map, e.pointer, allocation{p, e.size});
+          set_allocation(e.pointer, allocation{p, e.size});
         } else {
-          auto a = remove_allocation(allocation_map, e.pointer);
+          auto a = remove_allocation(e.pointer);
           mr_->deallocate(a.p, e.size);
         }
 

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -341,7 +341,7 @@ int main(int argc, char** argv)
     options.add_options()("s,size",
                           "Size of simulated GPU memory in GiB. Not supported for the cuda memory "
                           "resource.",
-                          cxxopts::value<std::size_t>()->default_value("0"));
+                          cxxopts::value<float>()->default_value("0"));
     options.add_options()("v,verbose",
                           "Enable verbose printing of log events",
                           cxxopts::value<bool>()->default_value("false"));
@@ -364,7 +364,8 @@ int main(int argc, char** argv)
   std::cout << "Using CUDA per-thread default stream.\n";
 #endif
 
-  auto const simulated_size = args["size"].as<std::size_t>() << 30;
+  auto const simulated_size =
+    static_cast<std::size_t>(args["size"].as<float>() * static_cast<float>(1u << 30u));
   if (simulated_size != 0 && args["resource"].as<std::string>() != "cuda") {
     std::cout << "Simulating GPU with memory size of " << simulated_size << " bytes.\n";
   }

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <benchmarks/utilities/cxxopts.hpp>
 #include <benchmarks/utilities/log_parser.hpp>
+#include <benchmarks/utilities/simulated_memory_resource.hpp>
 
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/arena_memory_resource.hpp>
@@ -43,21 +44,35 @@
 #include "spdlog/common.h"
 
 /// MR factory functions
-inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
-
-inline auto make_pool()
+std::shared_ptr<rmm::mr::device_memory_resource> make_cuda(std::size_t = 0)
 {
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda());
+  return std::make_shared<rmm::mr::cuda_memory_resource>();
 }
 
-inline auto make_arena()
+std::shared_ptr<rmm::mr::device_memory_resource> make_simulated(std::size_t simulated_size)
 {
-  return rmm::mr::make_owning_wrapper<rmm::mr::arena_memory_resource>(make_cuda());
+  return std::make_shared<rmm::mr::simulated_memory_resource>(simulated_size);
 }
 
-inline auto make_binning()
+inline auto make_pool(std::size_t simulated_size)
 {
-  auto pool = make_pool();
+  return simulated_size == 0
+           ? rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_cuda())
+           : rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
+               make_simulated(simulated_size), simulated_size, simulated_size);
+}
+
+inline auto make_arena(std::size_t simulated_size)
+{
+  return simulated_size == 0
+           ? rmm::mr::make_owning_wrapper<rmm::mr::arena_memory_resource>(make_cuda())
+           : rmm::mr::make_owning_wrapper<rmm::mr::arena_memory_resource>(
+               make_simulated(simulated_size), simulated_size, simulated_size);
+}
+
+inline auto make_binning(std::size_t simulated_size)
+{
+  auto pool = make_pool(simulated_size);
   auto mr   = rmm::mr::make_owning_wrapper<rmm::mr::binning_memory_resource>(pool);
   for (std::size_t i = 18; i <= 22; i++) {
     mr->wrapped().add_bin(1 << i);
@@ -65,7 +80,7 @@ inline auto make_binning()
   return mr;
 }
 
-using MRFactoryFunc = std::function<std::shared_ptr<rmm::mr::device_memory_resource>()>;
+using MRFactoryFunc = std::function<std::shared_ptr<rmm::mr::device_memory_resource>(std::size_t)>;
 
 /**
  * @brief Represents an allocation made during the replay
@@ -87,6 +102,7 @@ struct allocation {
  */
 struct replay_benchmark {
   MRFactoryFunc factory_;
+  std::size_t simulated_size_;
   std::shared_ptr<rmm::mr::device_memory_resource> mr_{};
   std::vector<std::vector<rmm::detail::event>> const& events_{};
 
@@ -106,8 +122,14 @@ struct replay_benchmark {
    * @param args Variable number of arguments forward to the constructor of MR
    */
   replay_benchmark(MRFactoryFunc factory,
+                   std::size_t simulated_size,
                    std::vector<std::vector<rmm::detail::event>> const& events)
-    : factory_{factory}, mr_{}, events_{events}, allocation_map{events.size()}, event_index{0}
+    : factory_{std::move(factory)},
+      simulated_size_{simulated_size},
+      mr_{},
+      events_{events},
+      allocation_map{events.size()},
+      event_index{0}
   {
   }
 
@@ -116,10 +138,11 @@ struct replay_benchmark {
    *
    * Does not copy the mutex or the map
    */
-  replay_benchmark(replay_benchmark&& other)
+  replay_benchmark(replay_benchmark&& other) noexcept
     : factory_{std::move(other.factory_)},
+      simulated_size_{other.simulated_size_},
       mr_{std::move(other.mr_)},
-      events_{std::move(other.events_)},
+      events_{other.events_},
       allocation_map{events_.size()},
       event_index{0}
   {
@@ -128,16 +151,16 @@ struct replay_benchmark {
   replay_benchmark(replay_benchmark const&) = delete;
 
   /// Add an allocation to the map (NOT thread safe)
-  void set_allocation(std::unordered_map<uintptr_t, allocation>& allocation_map,
-                      uintptr_t ptr,
-                      allocation alloc)
+  static void set_allocation(std::unordered_map<uintptr_t, allocation>& allocation_map,
+                             uintptr_t ptr,
+                             allocation alloc)
   {
     allocation_map.insert({ptr, alloc});
   }
 
   /// Remove an allocation from the map (NOT thread safe)
-  allocation remove_allocation(std::unordered_map<uintptr_t, allocation>& allocation_map,
-                               uintptr_t ptr)
+  static allocation remove_allocation(std::unordered_map<uintptr_t, allocation>& allocation_map,
+                                      uintptr_t ptr)
   {
     auto iter = allocation_map.find(ptr);
     if (iter != allocation_map.end()) {
@@ -153,7 +176,7 @@ struct replay_benchmark {
   {
     if (state.thread_index == 0) {
       rmm::logger().log(spdlog::level::info, "------ Start of Benchmark -----");
-      mr_ = factory_();
+      mr_ = factory_(simulated_size_);
     }
   }
 
@@ -169,7 +192,7 @@ struct replay_benchmark {
         auto alloc = ptr_alloc.second;
         num_leaked++;
         total_leaked += alloc.size;
-        mr_->deallocate(alloc.p, alloc.size, 0);
+        mr_->deallocate(alloc.p, alloc.size);
       }
       if (num_leaked > 0)
         std::cout << "LOG shows leak of " << num_leaked << " allocations of " << total_leaked
@@ -269,25 +292,29 @@ std::vector<std::vector<rmm::detail::event>> parse_per_thread_events(std::string
   return per_thread_events;
 }
 
-void declare_benchmark(std::string name,
+void declare_benchmark(std::string const& name,
+                       std::size_t simulated_size,
                        std::vector<std::vector<rmm::detail::event>> const& per_thread_events,
                        std::size_t num_threads)
 {
   if (name == "cuda")
-    benchmark::RegisterBenchmark("CUDA Resource", replay_benchmark(&make_cuda, per_thread_events))
+    benchmark::RegisterBenchmark("CUDA Resource",
+                                 replay_benchmark(&make_cuda, simulated_size, per_thread_events))
       ->Unit(benchmark::kMillisecond)
       ->Threads(num_threads);
   else if (name == "binning")
     benchmark::RegisterBenchmark("Binning Resource",
-                                 replay_benchmark(&make_binning, per_thread_events))
+                                 replay_benchmark(&make_binning, simulated_size, per_thread_events))
       ->Unit(benchmark::kMillisecond)
       ->Threads(num_threads);
   else if (name == "pool")
-    benchmark::RegisterBenchmark("Pool Resource", replay_benchmark(&make_pool, per_thread_events))
+    benchmark::RegisterBenchmark("Pool Resource",
+                                 replay_benchmark(&make_pool, simulated_size, per_thread_events))
       ->Unit(benchmark::kMillisecond)
       ->Threads(num_threads);
   else if (name == "arena")
-    benchmark::RegisterBenchmark("Arena Resource", replay_benchmark(&make_arena, per_thread_events))
+    benchmark::RegisterBenchmark("Arena Resource",
+                                 replay_benchmark(&make_arena, simulated_size, per_thread_events))
       ->Unit(benchmark::kMillisecond)
       ->Threads(num_threads);
   else
@@ -311,6 +338,10 @@ int main(int argc, char** argv)
     options.add_options()("r,resource",
                           "Type of device_memory_resource",
                           cxxopts::value<std::string>()->default_value("pool"));
+    options.add_options()("s,size",
+                          "Size of simulated GPU memory in GiB. Not supported for the cuda memory "
+                          "resource.",
+                          cxxopts::value<std::size_t>()->default_value("0"));
     options.add_options()("v,verbose",
                           "Enable verbose printing of log events",
                           cxxopts::value<bool>()->default_value("false"));
@@ -332,6 +363,11 @@ int main(int argc, char** argv)
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
   std::cout << "Using CUDA per-thread default stream.\n";
 #endif
+
+  auto const simulated_size = args["size"].as<std::size_t>() << 30;
+  if (simulated_size != 0 && args["resource"].as<std::string>() != "cuda") {
+    std::cout << "Simulating GPU with memory size of " << simulated_size << " bytes.\n";
+  }
 
   std::cout << "Total Events: "
             << std::accumulate(
@@ -357,13 +393,14 @@ int main(int argc, char** argv)
 
   if (args.count("resource") > 0) {
     std::string mr_name = args["resource"].as<std::string>();
-    declare_benchmark(mr_name, per_thread_events, num_threads);
+    declare_benchmark(mr_name, simulated_size, per_thread_events, num_threads);
   } else {
     std::array<std::string, 4> mrs{"pool", "arena", "binning", "cuda"};
-    std::for_each(
-      std::cbegin(mrs), std::cend(mrs), [&per_thread_events, &num_threads](auto const& s) {
-        declare_benchmark(s, per_thread_events, num_threads);
-      });
+    std::for_each(std::cbegin(mrs),
+                  std::cend(mrs),
+                  [&simulated_size, &per_thread_events, &num_threads](auto const& s) {
+                    declare_benchmark(s, simulated_size, per_thread_events, num_threads);
+                  });
   }
 
   ::benchmark::RunSpecifiedBenchmarks();

--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <cuda_runtime_api.h>
+
+namespace rmm {
+namespace mr {
+
+/**
+ * @brief A device memory resource that simulates a fix-sized GPU.
+ *
+ * Only allocation calls are simulated. New memory is allocated sequentially in monotonically
+ * increasing address based on the requested size, until the predetermined size is exceeded.
+ *
+ * Deallocation calls are ignored.
+ */
+class simulated_memory_resource final : public device_memory_resource {
+ public:
+  /**
+   * @brief Construct a `simulated_memory_resource`.
+   *
+   * @param memory_size_bytes The size of the memory to simulate.
+   */
+  explicit simulated_memory_resource(std::size_t memory_size_bytes)
+    : begin_{reinterpret_cast<char*>(0x100)},
+      end_{reinterpret_cast<char*>(begin_ + memory_size_bytes)}
+  {
+  }
+
+  // Disable copy (and move) semantics.
+  simulated_memory_resource(simulated_memory_resource const&) = delete;
+  simulated_memory_resource& operator=(simulated_memory_resource const&) = delete;
+
+  /**
+   * @brief Query whether the resource supports use of non-null CUDA streams for
+   * allocation/deallocation.
+   *
+   * @returns bool false
+   */
+  bool supports_streams() const noexcept override { return false; }
+
+  /**
+   * @brief Query whether the resource supports the get_mem_info API.
+   *
+   * @return false
+   */
+  bool supports_get_mem_info() const noexcept override { return false; }
+
+ private:
+  /**
+   * @brief Allocates memory of size at least `bytes`.
+   *
+   * @note Stream argument is ignored
+   *
+   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   *
+   * @param bytes The size, in bytes, of the allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* do_allocate(std::size_t bytes, cudaStream_t) override
+  {
+    RMM_EXPECTS(begin_ + bytes <= end_, rmm::bad_alloc, "Simulated memory size exceeded");
+    auto p = static_cast<void*>(begin_);
+    begin_ += bytes;
+    return p;
+  }
+
+  /**
+   * @brief Deallocate memory pointed to by \p p.
+   *
+   * @note This call is ignored.
+   *
+   * @throws Nothing.
+   *
+   * @param p Pointer to be deallocated
+   */
+  void do_deallocate(void* p, std::size_t, cudaStream_t) override {}
+
+  /**
+   * @brief Get free and available memory for memory resource.
+   *
+   * @param stream to execute on.
+   * @return std::pair containing free_size and total_size of memory.
+   */
+  std::pair<std::size_t, std::size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
+    return std::make_pair(0, 0);
+  }
+
+ private:
+  char* begin_;
+  char* end_;
+};
+}  // namespace mr
+}  // namespace rmm


### PR DESCRIPTION
This allows replaying rmm logs against different, simulated GPU memory sizes.
```console
$ ./gbenchmarks/REPLAY_BENCH -f ../rmm_debug -r arena -s 12
Using CUDA per-thread default stream.
Simulating GPU with memory size of 12884901888 bytes.
Total Events: 110250
...
terminate called after throwing an instance of 'rmm::bad_alloc'
  what():  std::bad_alloc: RMM failure at:/home/rou/src/rmm/include/rmm/mr/device/detail/arena.hpp:389: Maximum pool size exceeded
Aborted (core dumped)

$ ./gbenchmarks/REPLAY_BENCH -f ../rmm_debug -r arena -s 14
Using CUDA per-thread default stream.
Simulating GPU with memory size of 15032385536 bytes.
Total Events: 110250
...
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
Arena Resource/threads:16        178 ms          621 ms           16
```
@harrism @jlowe @abellina