### PR TITLE
[REVIEW] logging: add auto_flush to make_logging_adaptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PR #577 Fix CMake `LOGGING_LEVEL` issue which caused verbose logging / performance regression.
 - PR #582 Fix handling of per-thread default stream when not compiled for PTDS
 - PR #590 Add missing `CODE_OF_CONDUCT.md`
+- PR #592 Add `auto_flush` to `make_logging_adaptor`
 
 
 # RMM 0.15.0 (26 Aug 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Bug Fixes
 
+- PR #592 Add `auto_flush` to `make_logging_adaptor`
+
+
 # RMM 0.16.0 (Date TBD)
 
 ## New Features
@@ -49,7 +52,6 @@
 - PR #577 Fix CMake `LOGGING_LEVEL` issue which caused verbose logging / performance regression.
 - PR #582 Fix handling of per-thread default stream when not compiled for PTDS
 - PR #590 Add missing `CODE_OF_CONDUCT.md`
-- PR #592 Add `auto_flush` to `make_logging_adaptor`
 
 
 # RMM 0.15.0 (26 Aug 2020)

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -150,7 +150,9 @@ class logging_resource_adaptor final : public device_memory_resource {
  private:
   // make_logging_adaptor needs access to private get_default_filename
   template <typename T>
-  friend logging_resource_adaptor<T> make_logging_adaptor(T* upstream, std::string const& filename);
+  friend logging_resource_adaptor<T> make_logging_adaptor(T* upstream,
+                                                          std::string const& filename,
+                                                          bool auto_flush);
 
   /**
    * @brief Return the value of the environment variable RMM_LOG_FILE.
@@ -296,9 +298,10 @@ class logging_resource_adaptor final : public device_memory_resource {
 template <typename Upstream>
 logging_resource_adaptor<Upstream> make_logging_adaptor(
   Upstream* upstream,
-  std::string const& filename = logging_resource_adaptor<Upstream>::get_default_filename())
+  std::string const& filename = logging_resource_adaptor<Upstream>::get_default_filename(),
+  bool auto_flush             = false)
 {
-  return logging_resource_adaptor<Upstream>{upstream, filename};
+  return logging_resource_adaptor<Upstream>{upstream, filename, auto_flush};
 }
 
 /**
@@ -310,9 +313,11 @@ logging_resource_adaptor<Upstream> make_logging_adaptor(
  * @param stream The ostream to write log info.
  */
 template <typename Upstream>
-logging_resource_adaptor<Upstream> make_logging_adaptor(Upstream* upstream, std::ostream& stream)
+logging_resource_adaptor<Upstream> make_logging_adaptor(Upstream* upstream,
+                                                        std::ostream& stream,
+                                                        bool auto_flush = false)
 {
-  return logging_resource_adaptor<Upstream>{upstream, stream};
+  return logging_resource_adaptor<Upstream>{upstream, stream, auto_flush};
 }
 
 }  // namespace mr


### PR DESCRIPTION
This does duplicate the defaults, but well, I don't want to wait for C++17... This is to make the make_ helpers match the constructors.

I know it's late for 0.16, but the `make_logging_adaptors` are missing the (defaulted) `auto_flush` argument, which I happen
to need. It's a rather straightforward and small change.
