### PR TITLE
[REVIEW] Adding limiting adaptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PR #560 Remove deprecated `get/set_default_resource` APIs
 - PR #543 Add an arena-based memory resource
 - PR #580 Install CMake config with RMM
+- PR #594 Adding limiting adaptor
 
 ## Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - PR #560 Remove deprecated `get/set_default_resource` APIs
 - PR #543 Add an arena-based memory resource
 - PR #580 Install CMake config with RMM
-- PR #594 Adding limiting adaptor
+- PR #594 Adding limiting memory resource adaptor
 
 ## Improvements
 

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+namespace rmm {
+namespace mr {
+/**
+ * @brief Resource that uses `Upstream` to allocate memory and limits the total
+ * allocations possible.
+ *
+ * An instance of this resource can be constructed with an existing, upstream
+ * resource in order to satisfy allocation requests, but any existing allocations
+ * will be untracked.
+ *
+ * @tparam Upstream Type of the upstream resource used for
+ * allocation/deallocation.
+ */
+template <typename Upstream>
+class limiting_resource_adaptor final : public device_memory_resource {
+ public:
+  /**
+   * @brief Construct a new limiting resource adaptor using `upstream` to satisfy
+   * allocation requests and limiting the total allocation amount possible.
+   *
+   * @throws `rmm::logic_error` if `upstream == nullptr`
+   *
+   * @param upstream The resource used for allocating/deallocating device memory
+   * @param allocation_limit Maximum memory allowed for this allocator.
+   */
+  limiting_resource_adaptor(Upstream* upstream,
+                            std::size_t allocation_limit = std::numeric_limits<std::size_t>::max(),
+                            std::size_t allocation_alignment = 256)
+    : upstream_{upstream},
+      allocation_limit_{allocation_limit},
+      allocation_alignment_(allocation_alignment),
+      allocated_bytes_(0)
+  {
+    RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
+  }
+
+  limiting_resource_adaptor()                                 = delete;
+  ~limiting_resource_adaptor()                                = default;
+  limiting_resource_adaptor(limiting_resource_adaptor const&) = delete;
+  limiting_resource_adaptor(limiting_resource_adaptor&&)      = default;
+  limiting_resource_adaptor& operator=(limiting_resource_adaptor const&) = delete;
+  limiting_resource_adaptor& operator=(limiting_resource_adaptor&&) = default;
+
+  /**
+   * @brief Return pointer to the upstream resource.
+   *
+   * @return Upstream* Pointer to the upstream resource.
+   */
+  Upstream* get_upstream() const noexcept { return upstream_; }
+
+  /**
+   * @brief Checks whether the upstream resource supports streams.
+   *
+   * @return true The upstream resource supports streams
+   * @return false The upstream resource does not support streams.
+   */
+  bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
+
+  /**
+   * @brief Query whether the resource supports the get_mem_info API.
+   *
+   * @return bool true if the upstream resource supports get_mem_info, false otherwise.
+   */
+  bool supports_get_mem_info() const noexcept override
+  {
+    return upstream_->supports_get_mem_info();
+  }
+
+  /**
+   * @brief Query the number of bytes that have been allocated. Note that
+   * this can not be used to know how large of an allocation is possible due
+   * to both possible fragmentation and also internal page sizes and alignment
+   * that is not tracked by this allocator.
+   *
+   * @return std::size_t number of bytes that have been allocated through this
+   * allocator.
+   */
+  std::size_t allocated_bytes() const { return allocated_bytes_; }
+
+  /**
+   * @brief Query the maximum number of bytes that this allocator is allowed
+   * to allocate. This is the limit on the allocator and not a representation of
+   * the underlying device. The device may not be able to support this limit.
+   *
+   * @return std::size_t max number of bytes allowed for this allocator
+   */
+  std::size_t allocation_limit() const { return allocation_limit_; }
+
+ private:
+  /**
+   * @brief Allocates memory of size at least `bytes` using the upstream
+   * resource as long as it fits inside the allocation limit.
+   *
+   * The returned pointer has at least 256B alignment.
+   *
+   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   * by the upstream resource.
+   *
+   * @param bytes The size, in bytes, of the allocation
+   * @param stream Stream on which to perform the allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* do_allocate(std::size_t bytes, cudaStream_t stream) override
+  {
+    void* p = nullptr;
+
+    std::size_t proposed_size = rmm::detail::align_up(bytes, allocation_alignment_);
+    if (proposed_size + allocated_bytes_ <= allocation_limit_) {
+      p = upstream_->allocate(bytes, stream);
+      allocated_bytes_ += proposed_size;
+    } else {
+      throw rmm::bad_alloc{std::string{"CUDA error: Unable to allocate memory due to limit"}};
+    }
+
+    return p;
+  }
+
+  /**
+   * @brief Free allocation of size `bytes` pointed to by `p`
+   *
+   * @throws Nothing.
+   *
+   * @param p Pointer to be deallocated
+   * @param bytes Size of the allocation
+   * @param stream Stream on which to perform the deallocation
+   */
+  void do_deallocate(void* p, std::size_t bytes, cudaStream_t stream) override
+  {
+    std::size_t allocated_size = rmm::detail::align_up(bytes, allocation_alignment_);
+    upstream_->deallocate(p, bytes, stream);
+    allocated_bytes_ -= allocated_size;
+  }
+
+  /**
+   * @brief Compare the upstream resource to another.
+   *
+   * @throws Nothing.
+   *
+   * @param other The other resource to compare to
+   * @return true If the two resources are equivalent
+   * @return false If the two resources are not equal
+   */
+  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  {
+    if (this == &other)
+      return true;
+    else {
+      limiting_resource_adaptor<Upstream> const* cast =
+        dynamic_cast<limiting_resource_adaptor<Upstream> const*>(&other);
+      if (cast != nullptr)
+        return upstream_->is_equal(*cast->get_upstream());
+      else
+        return upstream_->is_equal(other);
+    }
+  }
+
+  /**
+   * @brief Get free and available memory from upstream resource.
+   *
+   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   *
+   * @param stream Stream on which to get the mem info.
+   * @return std::pair contaiing free_size and total_size of memory
+   */
+  std::pair<size_t, size_t> do_get_mem_info(cudaStream_t stream) const override
+  {
+    auto ret = upstream_->get_mem_info(stream);
+    return {std::min(ret.first, allocation_limit_ - allocated_bytes_),
+            std::max(ret.second, allocation_limit_)};
+  }
+
+  // maximum bytes this allocator is allowed to allocate.
+  std::size_t allocation_limit_;
+
+  // number of currently-allocated bytes
+  std::atomic<std::size_t> allocated_bytes_;
+
+  // todo: should be some way to ask the upstream...
+  std::size_t allocation_alignment_;
+
+  Upstream* upstream_;  ///< The upstream resource used for satisfying
+                        ///< allocation requests
+};
+
+/**
+ * @brief Convenience factory to return a `limiting_resource_adaptor` around the
+ * upstream resource `upstream`.
+ *
+ * @tparam Upstream Type of the upstream `device_memory_resource`.
+ * @param upstream Pointer to the upstream resource
+ * @param limit Maximum amount of memory to allocate
+ */
+template <typename Upstream>
+limiting_resource_adaptor<Upstream> make_limiting_adaptor(Upstream* upstream,
+                                                          size_t allocation_limit)
+{
+  return limiting_resource_adaptor<Upstream>{upstream, allocation_limit};
+}
+
+}  // namespace mr
+}  // namespace rmm

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -129,7 +129,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
       p = upstream_->allocate(bytes, stream);
       allocated_bytes_ += proposed_size;
     } else {
-      throw rmm::bad_alloc{std::string{"CUDA error: Unable to allocate memory due to limit"}};
+      throw rmm::bad_alloc{"Exceeded memory limit"};
     }
 
     return p;

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -95,7 +95,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @return std::size_t number of bytes that have been allocated through this
    * allocator.
    */
-  std::size_t allocated_bytes() const { return allocated_bytes_; }
+  std::size_t get_allocated_bytes() const { return allocated_bytes_; }
 
   /**
    * @brief Query the maximum number of bytes that this allocator is allowed

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -104,7 +104,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    *
    * @return std::size_t max number of bytes allowed for this allocator
    */
-  std::size_t allocation_limit() const { return allocation_limit_; }
+  std::size_t get_allocation_limit() const { return allocation_limit_; }
 
  private:
   /**

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -133,7 +133,10 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * @return bool true if the upstream resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override { return upstream_->supports_streams(); }
+  bool supports_get_mem_info() const noexcept override
+  {
+    return upstream_->supports_get_mem_info();
+  }
 
   /**
    * @brief Flush logger contents.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,13 +31,14 @@ function(ConfigureTest CMAKE_TEST_NAME CMAKE_TEST_SRC)
   set_target_properties(${CMAKE_TEST_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_include_directories(${CMAKE_TEST_NAME} PRIVATE "$<BUILD_INTERFACE:${RMM_SOURCE_DIR}>")
 
-  target_link_libraries(${CMAKE_TEST_NAME} gmock gtest gmock_main gtest_main pthread rmm)
+  target_link_libraries(${CMAKE_TEST_NAME} GTest::gmock GTest::gtest GTest::gmock_main GTest::gtest_main
+                        pthread rmm)
   
   set_target_properties(${CMAKE_TEST_NAME} PROPERTIES
                         RUNTIME_OUTPUT_DIRECTORY "${RMM_BINARY_DIR}/gtests")
 
   target_compile_definitions(${CMAKE_TEST_NAME} PUBLIC
-                             SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${LOGGING_LEVEL})
+                        "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM_LOGGING_LEVEL}")    
 
   add_test(NAME ${CMAKE_TEST_NAME} COMMAND ${CMAKE_TEST_NAME})
 endfunction(ConfigureTest)
@@ -85,6 +86,15 @@ set(THRUST_ALLOCATOR_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/mr/device/thrust_allocator_tests.cu")
     
 ConfigureTest(THRUST_ALLOCATOR_TEST "${THRUST_ALLOCATOR_TEST_SRC}")
+
+###################################################################################################
+# - limiting adaptor tests
+
+set(LIMITING_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/mr/device/limiting_mr_tests.cpp")
+
+ConfigureTest(LIMITING_TEST "${LIMITING_TEST_SRC}")
+target_compile_definitions(LIMITING_TEST PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
 
 ###################################################################################################
 # - host mr tests

--- a/tests/mr/device/limiting_mr_tests.cpp
+++ b/tests/mr/device/limiting_mr_tests.cpp
@@ -27,7 +27,7 @@ namespace {
 using Limiting_adaptor = rmm::mr::limiting_resource_adaptor<rmm::mr::device_memory_resource>;
 TEST(LimitingTest, ThrowOnNullUpstream)
 {
-  auto construct_nullptr = []() { Limiting_adaptor mr{nullptr}; };
+  auto construct_nullptr = []() { Limiting_adaptor mr{nullptr, 5_MiB}; };
   EXPECT_THROW(construct_nullptr(), rmm::logic_error);
 }
 

--- a/tests/mr/device/limiting_mr_tests.cpp
+++ b/tests/mr/device/limiting_mr_tests.cpp
@@ -41,33 +41,33 @@ TEST(LimitingTest, UnderLimitDueToFrees)
 {
   Limiting_adaptor mr{rmm::mr::get_current_device_resource(), 10_MiB};
   auto p1 = mr.allocate(4_MiB);
-  EXPECT_EQ(mr.allocated_bytes(), 4_MiB);
-  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 6_MiB);
+  EXPECT_EQ(mr.get_allocated_bytes(), 4_MiB);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 6_MiB);
   auto p2 = mr.allocate(4_MiB);
-  EXPECT_EQ(mr.allocated_bytes(), 8_MiB);
-  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 2_MiB);
+  EXPECT_EQ(mr.get_allocated_bytes(), 8_MiB);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 2_MiB);
   mr.deallocate(p1, 4_MiB);
-  EXPECT_EQ(mr.allocated_bytes(), 4_MiB);
-  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 6_MiB);
+  EXPECT_EQ(mr.get_allocated_bytes(), 4_MiB);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 6_MiB);
   // note that we don't keep track of fragmentation or things like page size
   // so this should fill 100% of the memory even though it is probably over.
   EXPECT_NO_THROW(mr.allocate(6_MiB));
-  EXPECT_EQ(mr.allocated_bytes(), 10_MiB);
-  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 0);
+  EXPECT_EQ(mr.get_allocated_bytes(), 10_MiB);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 0);
 }
 
 TEST(LimitingTest, OverLimit)
 {
   Limiting_adaptor mr{rmm::mr::get_current_device_resource(), 10_MiB};
   auto p1 = mr.allocate(4_MiB);
-  EXPECT_EQ(mr.allocated_bytes(), 4_MiB);
-  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 6_MiB);
+  EXPECT_EQ(mr.get_allocated_bytes(), 4_MiB);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 6_MiB);
   auto p2 = mr.allocate(4_MiB);
-  EXPECT_EQ(mr.allocated_bytes(), 8_MiB);
-  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 2_MiB);
+  EXPECT_EQ(mr.get_allocated_bytes(), 8_MiB);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 2_MiB);
   EXPECT_THROW(mr.allocate(3_MiB), rmm::bad_alloc);
-  EXPECT_EQ(mr.allocated_bytes(), 8_MiB);
-  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 2_MiB);
+  EXPECT_EQ(mr.get_allocated_bytes(), 8_MiB);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 2_MiB);
 }
 
 }  // namespace

--- a/tests/mr/device/limiting_mr_tests.cpp
+++ b/tests/mr/device/limiting_mr_tests.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rmm/detail/error.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/mr/device/limiting_resource_adaptor.hpp>
+
+#include <gtest/gtest.h>
+#include "mr_test.hpp"
+
+namespace rmm {
+namespace test {
+namespace {
+using Limiting_adaptor = rmm::mr::limiting_resource_adaptor<rmm::mr::device_memory_resource>;
+TEST(LimitingTest, ThrowOnNullUpstream)
+{
+  auto construct_nullptr = []() { Limiting_adaptor mr{nullptr}; };
+  EXPECT_THROW(construct_nullptr(), rmm::logic_error);
+}
+
+TEST(LimitingTest, TooBig)
+{
+  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), 1_MiB};
+  EXPECT_THROW(mr.allocate(5_MiB), rmm::bad_alloc);
+}
+
+TEST(LimitingTest, UnderLimitDueToFrees)
+{
+  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), 10_MiB};
+  auto p1 = mr.allocate(4_MiB);
+  EXPECT_EQ(mr.allocated_bytes(), 4_MiB);
+  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 6_MiB);
+  auto p2 = mr.allocate(4_MiB);
+  EXPECT_EQ(mr.allocated_bytes(), 8_MiB);
+  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 2_MiB);
+  mr.deallocate(p1, 4_MiB);
+  EXPECT_EQ(mr.allocated_bytes(), 4_MiB);
+  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 6_MiB);
+  // note that we don't keep track of fragmentation or things like page size
+  // so this should fill 100% of the memory even though it is probably over.
+  EXPECT_NO_THROW(mr.allocate(6_MiB));
+  EXPECT_EQ(mr.allocated_bytes(), 10_MiB);
+  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 0);
+}
+
+TEST(LimitingTest, OverLimit)
+{
+  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), 10_MiB};
+  auto p1 = mr.allocate(4_MiB);
+  EXPECT_EQ(mr.allocated_bytes(), 4_MiB);
+  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 6_MiB);
+  auto p2 = mr.allocate(4_MiB);
+  EXPECT_EQ(mr.allocated_bytes(), 8_MiB);
+  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 2_MiB);
+  EXPECT_THROW(mr.allocate(3_MiB), rmm::bad_alloc);
+  EXPECT_EQ(mr.allocated_bytes(), 8_MiB);
+  EXPECT_EQ(mr.allocation_limit() - mr.allocated_bytes(), 2_MiB);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace rmm


### PR DESCRIPTION
This PR creates a limiting adaptor, which allows limiting the amount of memory available. Fixes #442.

Also fixing a small copy/paste error in `logging_resource_adaptor` as well.