### PR TITLE
Allow unlimited maximum pool size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PR #581 Improve logging documentation
 - PR #585 Update ci/local/README.md
 - PR #587 Replaced `move` with `std::move`
+- PR #601 Make maximum pool size truly optional (grow until failure)
 
 ## Bug Fixes
 

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -72,6 +72,20 @@ constexpr std::size_t align_down(std::size_t v, std::size_t align_bytes) noexcep
 }
 
 /**
+ * @brief Checks whether a value is aligned to a multiple of a specified power of 2
+ *
+ * @param[in] v value to check for alignment
+ * @param[in] alignment amount, in bytes, must be a power of 2
+ *
+ * @return true if aligned
+ */
+constexpr bool is_aligned(std::size_t v, std::size_t align_bytes) noexcept
+{
+  assert(is_supported_alignment(align_bytes));
+  return v == align_down(v, align_bytes);
+}
+
+/**
  * @brief Allocates sufficient memory to satisfy the requested size `bytes` with
  * alignment `alignment` using the unary callable `alloc` to allocate memory.
  *

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -161,7 +161,8 @@ class pool_memory_resource final
    * Attempts to allocate `try_size` bytes from upstream. If it fails, it iteratively reduces the
    * attempted size by half until `min_size`, returning the allocated block once it succeeds.
    *
-   * @throws rmm::bad_alloc if `min_size` bytes cannot be allocated from upstream.
+   * @throws rmm::bad_alloc if `min_size` bytes cannot be allocated from upstream or maximum pool
+   * size is exceeded.
    *
    * @param try_size The initial requested size to try allocating.
    * @param min_size The minimum requested size to try allocating.
@@ -170,7 +171,6 @@ class pool_memory_resource final
    */
   block_type try_to_expand(std::size_t try_size, std::size_t min_size, cudaStream_t stream)
   {
-    RMM_EXPECTS(try_size >= min_size, "try_size must be at least as big as min_size");
     while (try_size >= min_size) {
       auto b = block_from_upstream(try_size, stream);
       if (b.has_value()) {

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -178,7 +178,6 @@ class pool_memory_resource final
     auto try_size =
       maximum_pool_size_.has_value() ? size_to_grow(size) : std::max(size, pool_size());
     while (try_size >= size) {
-      std::cout << "Trying " << try_size << " B" << std::endl;
       try {
         auto b = block_from_upstream(try_size, stream);
         current_pool_size_ += try_size;

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -198,8 +198,11 @@ class pool_memory_resource final
   /**
    * @brief Given a minimum size, computes an appropriate size to grow the pool.
    *
-   * Strategy is to try to grow the pool by half the difference between
-   * the configured maximum pool size and the current pool size.
+   * Strategy is to try to grow the pool by half the difference between the configured maximum pool
+   * size and the current pool size, if the maximum pool size is set. If it is not set, try to
+   * double the current pool size.
+   *
+   * Returns 0 if the requested size cannot be satisfied.
    *
    * @param size The size of the minimum allocation immediately needed
    * @return size_t The computed size to grow the pool.

--- a/python/rmm/_lib/memory_resource_wrappers.hpp
+++ b/python/rmm/_lib/memory_resource_wrappers.hpp
@@ -10,9 +10,11 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 #include <rmm/mr/device/thread_safe_resource_adaptor.hpp>
+
+#include <thrust/optional.h>
+
 #include <string>
 #include <vector>
-#include "rmm/mr/device/per_device_resource.hpp"
 
 // These are "owning" versions of the memory_resource classes
 // that help lift the responsibility of managing memory resource
@@ -66,13 +68,15 @@ class pool_memory_resource_wrapper : public device_memory_resource_wrapper {
  public:
   pool_memory_resource_wrapper(
     std::shared_ptr<device_memory_resource_wrapper> upstream_mr,
-    std::size_t initial_pool_size =
-      rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>::default_initial_size,
-    std::size_t maximum_pool_size =
-      rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>::default_maximum_size)
+    std::size_t initial_pool_size = ~0,  // TODO use std::optional / thrust::optional when available
+    std::size_t maximum_pool_size = ~0)
     : upstream_mr(upstream_mr),
       mr(std::make_shared<rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>>(
-        upstream_mr->get_mr().get(), initial_pool_size, maximum_pool_size))
+        upstream_mr->get_mr().get(),
+        initial_pool_size == static_cast<size_t>(~0) ? thrust::nullopt
+                                                     : thrust::make_optional(initial_pool_size),
+        maximum_pool_size == static_cast<size_t>(~0) ? thrust::nullopt
+                                                     : thrust::make_optional(maximum_pool_size)))
   {
   }
 

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -38,7 +38,7 @@
 namespace rmm {
 namespace test {
 
-inline bool is_aligned(void* p, std::size_t alignment = 256)
+inline bool is_pointer_aligned(void* p, std::size_t alignment = 256)
 {
   return (0 == reinterpret_cast<uintptr_t>(p) % alignment);
 }
@@ -81,7 +81,7 @@ inline void test_get_current_device_resource()
   void* p{nullptr};
   EXPECT_NO_THROW(p = rmm::mr::get_current_device_resource()->allocate(1_MiB));
   EXPECT_NE(nullptr, p);
-  EXPECT_TRUE(is_aligned(p));
+  EXPECT_TRUE(is_pointer_aligned(p));
   EXPECT_TRUE(is_device_memory(p));
   EXPECT_NO_THROW(rmm::mr::get_current_device_resource()->deallocate(p, 1_MiB));
 }
@@ -94,7 +94,7 @@ inline void test_allocate(rmm::mr::device_memory_resource* mr,
   EXPECT_NO_THROW(p = mr->allocate(bytes));
   if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
   EXPECT_NE(nullptr, p);
-  EXPECT_TRUE(is_aligned(p));
+  EXPECT_TRUE(is_pointer_aligned(p));
   EXPECT_TRUE(is_device_memory(p));
   EXPECT_NO_THROW(mr->deallocate(p, bytes));
   if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
@@ -141,7 +141,7 @@ inline void test_random_allocations(rmm::mr::device_memory_resource* mr,
       EXPECT_NO_THROW(a.p = mr->allocate(a.size, stream));
       if (stream != 0) EXPECT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
       EXPECT_NE(nullptr, a.p);
-      EXPECT_TRUE(is_aligned(a.p));
+      EXPECT_TRUE(is_pointer_aligned(a.p));
     });
 
   std::for_each(
@@ -183,7 +183,7 @@ inline void test_mixed_random_allocation_free(rmm::mr::device_memory_resource* m
       EXPECT_NO_THROW(allocations.emplace_back(mr->allocate(size, stream), size));
       auto new_allocation = allocations.back();
       EXPECT_NE(nullptr, new_allocation.p);
-      EXPECT_TRUE(is_aligned(new_allocation.p));
+      EXPECT_TRUE(is_pointer_aligned(new_allocation.p));
     } else {
       size_t index = index_distribution(generator) % active_allocations;
       active_allocations--;

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -21,16 +21,20 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 #include "rmm/detail/aligned.hpp"
+#include "rmm/mr/device/limiting_resource_adaptor.hpp"
 
 #include <gtest/gtest.h>
 
 namespace rmm {
 namespace test {
 namespace {
-using Pool = rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>;
+using cuda_mr     = rmm::mr::cuda_memory_resource;
+using pool_mr     = rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource>;
+using limiting_mr = rmm::mr::limiting_resource_adaptor<rmm::mr::cuda_memory_resource>;
+
 TEST(PoolTest, ThrowOnNullUpstream)
 {
-  auto construct_nullptr = []() { Pool mr{nullptr}; };
+  auto construct_nullptr = []() { pool_mr mr{nullptr}; };
   EXPECT_THROW(construct_nullptr(), rmm::logic_error);
 }
 
@@ -38,7 +42,9 @@ TEST(PoolTest, ThrowMaxLessThanInitial)
 {
   // Make sure first argument is enough larger than the second that alignment rounding doesn't
   // make them equal
-  auto max_less_than_initial = []() { Pool mr{rmm::mr::get_current_device_resource(), 1024, 256}; };
+  auto max_less_than_initial = []() {
+    pool_mr mr{rmm::mr::get_current_device_resource(), 1024, 256};
+  };
   EXPECT_THROW(max_less_than_initial(), rmm::logic_error);
 }
 
@@ -48,8 +54,8 @@ TEST(PoolTest, AllocateNinetyPercent)
     std::size_t free{}, total{};
     std::tie(free, total) = rmm::mr::detail::available_device_memory();
     auto const ninety_percent_pool =
-      rmm::detail::align_up(static_cast<std::size_t>(free * 0.9), Pool::allocation_alignment);
-    Pool mr{rmm::mr::get_current_device_resource(), ninety_percent_pool};
+      rmm::detail::align_up(static_cast<std::size_t>(free * 0.9), pool_mr::allocation_alignment);
+    pool_mr mr{rmm::mr::get_current_device_resource(), ninety_percent_pool};
   };
   EXPECT_NO_THROW(allocate_ninety());
 }
@@ -59,7 +65,7 @@ TEST(PoolTest, TwoLargeBuffers)
   auto two_large = []() {
     std::size_t free{}, total{};
     std::tie(free, total) = rmm::mr::detail::available_device_memory();
-    Pool mr{rmm::mr::get_current_device_resource()};
+    pool_mr mr{rmm::mr::get_current_device_resource()};
     auto p1 = mr.allocate(free / 4);
     auto p2 = mr.allocate(free / 4);
     mr.deallocate(p1, free / 4);
@@ -70,13 +76,18 @@ TEST(PoolTest, TwoLargeBuffers)
 
 TEST(PoolTest, ForceGrowth)
 {
-  Pool mr{rmm::mr::get_current_device_resource(), 0};
+  cuda_mr cuda;
+  limiting_mr limiter{&cuda, 6000};
+  pool_mr mr{&limiter, 0};
   EXPECT_NO_THROW(mr.allocate(1000));
+  EXPECT_NO_THROW(mr.allocate(4000));
+  EXPECT_NO_THROW(mr.allocate(500));
+  EXPECT_THROW(mr.allocate(2000), rmm::bad_alloc);  // too much
 }
 
 TEST(PoolTest, DeletedStream)
 {
-  Pool mr{rmm::mr::get_current_device_resource(), 0};
+  pool_mr mr{rmm::mr::get_current_device_resource(), 0};
   cudaStream_t stream;
   const int size = 10000;
   cudaStreamCreate(&stream);
@@ -89,7 +100,7 @@ TEST(PoolTest, DeletedStream)
 TEST(PoolTest, InitialAndMaxPoolSizeEqual)
 {
   EXPECT_NO_THROW([]() {
-    Pool mr(rmm::mr::get_current_device_resource(), 1000192, 1000192);
+    pool_mr mr(rmm::mr::get_current_device_resource(), 1000192, 1000192);
     mr.allocate(1000);
   }());
 }
@@ -98,14 +109,14 @@ TEST(PoolTest, NonAlignedPoolSize)
 {
   EXPECT_THROW(
     []() {
-      Pool mr(rmm::mr::get_current_device_resource(), 1000031, 1000192);
+      pool_mr mr(rmm::mr::get_current_device_resource(), 1000031, 1000192);
       mr.allocate(1000);
     }(),
     rmm::logic_error);
 
   EXPECT_THROW(
     []() {
-      Pool mr(rmm::mr::get_current_device_resource(), 1000192, 1000200);
+      pool_mr mr(rmm::mr::get_current_device_resource(), 1000192, 1000200);
       mr.allocate(1000);
     }(),
     rmm::logic_error);


### PR DESCRIPTION
Fixes #600 

In some cases you want a pool with no maximum size -- e.g. when your upstream resource is managed memory. This PR allows a truly optional maximum pool size and improves the pool growth heuristic to grow exponentially in this case, with exponential backoff in case of failure. It will retry smaller allocations until either it succeeds or allocating the requested size from upstream fails.

Also changes to using `thrust::optional` for the initial and maximum pool size parameters to `pool_memory_resource`.  (std::optional can be used in the future when C++17 is our minimum)
