### PR TITLE
[REVIEW] fix `device_scalar` and its tests so that they use the correct CUDA stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bug Fixes
 
+- PR #602 Fix `device_scalar` and its tests 
+
 # RMM 0.16.0 (Date TBD)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes
 
-- PR #602 Fix `device_scalar` and its tests 
+- PR #602 Fix `device_scalar` and its tests so that they use the correct CUDA stream
 
 # RMM 0.16.0 (Date TBD)
 

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -83,6 +83,25 @@ class device_scalar {
   }
 
   /**
+   * @brief Construct a new `device_scalar` by deep copying the contents of
+   * another `device_scalar`, optionally using the specified stream and memory
+   * resource.
+   *
+   * @throws rmm::bad_alloc If creating the new allocation fails.
+   * @throws rmm::cuda_error if copying from `other` fails.
+   *
+   * @param other The `device_scalar` whose contents will be copied
+   * @param stream The stream to use for the allocation and copy
+   * @param mr The resource to use for allocating the new `device_scalar`
+   */
+  device_scalar(device_scalar const &other,
+                cudaStream_t stream                 = 0,
+                rmm::mr::device_memory_resource *mr = rmm::mr::get_current_device_resource())
+    : buffer{other.buffer, stream, mr}
+  {
+  }
+
+  /**
    * @brief Copies the value from device to host, synchronizes, and returns the value.
    *
    * Synchronizes `stream` after copying the data from device to host.
@@ -212,10 +231,9 @@ class device_scalar {
    */
   T const *data() const noexcept { return static_cast<T const *>(buffer.data()); }
 
-  device_scalar()                      = default;
-  ~device_scalar()                     = default;
-  device_scalar(device_scalar const &) = default;
-  device_scalar(device_scalar &&)      = default;
+  device_scalar()  = default;
+  ~device_scalar() = default;
+  device_scalar(device_scalar &&) = default;
   device_scalar &operator=(device_scalar const &) = delete;
   device_scalar &operator=(device_scalar &&) = delete;
 

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -231,8 +231,8 @@ class device_scalar {
    */
   T const *data() const noexcept { return static_cast<T const *>(buffer.data()); }
 
-  device_scalar()  = default;
-  ~device_scalar() = default;
+  device_scalar()                 = default;
+  ~device_scalar()                = default;
   device_scalar(device_scalar &&) = default;
   device_scalar &operator=(device_scalar const &) = delete;
   device_scalar &operator=(device_scalar &&) = delete;

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -84,7 +84,7 @@ class device_scalar {
 
   /**
    * @brief Construct a new `device_scalar` by deep copying the contents of
-   * another `device_scalar`, optionally using the specified stream and memory
+   * another `device_scalar`, using the specified stream and memory
    * resource.
    *
    * @throws rmm::bad_alloc If creating the new allocation fails.

--- a/tests/device_scalar_tests.cpp
+++ b/tests/device_scalar_tests.cpp
@@ -57,34 +57,34 @@ TYPED_TEST(DeviceScalarTest, InitialValue)
 {
   rmm::device_scalar<TypeParam> scalar{this->value, this->stream, this->mr};
   EXPECT_NE(nullptr, scalar.data());
-  EXPECT_EQ(this->value, scalar.value());
+  EXPECT_EQ(this->value, scalar.value(this->stream));
 }
 
 TYPED_TEST(DeviceScalarTest, CopyCtor)
 {
   rmm::device_scalar<TypeParam> scalar{this->value, this->stream, this->mr};
   EXPECT_NE(nullptr, scalar.data());
-  EXPECT_EQ(this->value, scalar.value());
+  EXPECT_EQ(this->value, scalar.value(this->stream));
 
-  rmm::device_scalar<TypeParam> copy{scalar};
+  rmm::device_scalar<TypeParam> copy{scalar, this->stream, this->mr};
   EXPECT_NE(nullptr, copy.data());
   EXPECT_NE(copy.data(), scalar.data());
-  EXPECT_EQ(copy.value(), scalar.value());
+  EXPECT_EQ(copy.value(this->stream), scalar.value(this->stream));
 }
 
 TYPED_TEST(DeviceScalarTest, MoveCtor)
 {
   rmm::device_scalar<TypeParam> scalar{this->value, this->stream, this->mr};
   EXPECT_NE(nullptr, scalar.data());
-  EXPECT_EQ(this->value, scalar.value());
+  EXPECT_EQ(this->value, scalar.value(this->stream));
 
   auto original_pointer = scalar.data();
-  auto original_value   = scalar.value();
+  auto original_value   = scalar.value(this->stream);
 
   rmm::device_scalar<TypeParam> moved_to{std::move(scalar)};
   EXPECT_NE(nullptr, moved_to.data());
   EXPECT_EQ(moved_to.data(), original_pointer);
-  EXPECT_EQ(moved_to.value(), original_value);
+  EXPECT_EQ(moved_to.value(this->stream), original_value);
   EXPECT_EQ(nullptr, scalar.data());
 }
 
@@ -95,6 +95,6 @@ TYPED_TEST(DeviceScalarTest, SetValue)
 
   auto expected = this->distribution(this->generator);
 
-  scalar.set_value(expected);
-  EXPECT_EQ(expected, scalar.value());
+  scalar.set_value(expected, this->stream);
+  EXPECT_EQ(expected, scalar.value(this->stream));
 }


### PR DESCRIPTION
While debugging #563, found a few issues with the `device_scalar` and its tests. But I don't think these fixes would help with the `cudaErrorIllegalAddress` problems in Spark.

The main thing is we need to use the correct CUDA stream for setting/getting the value, and copying the `device_scalar`. By default these methods use the null stream, but in the tests we create a new non-default stream when constructing the `device_scalar`. This is not a problem when using the legacy default stream which does implicit synchronization, but when running with per-thread default stream, the mismatched streams create race conditions that cause the tests to fail.

@jrhemstad @harrism 