### PR TITLE
Drop old Numba `device_array*` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 - PR #599 Make the arena memory resource work better with the producer/consumer mode
+- PR #612 Drop old Python `device_array*` API
 - PR #603 Always test both legacy and per-thread default stream
 
 ## Bug Fixes

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -19,11 +19,7 @@ from rmm.rmm import (
     RMMError,
     RMMNumbaManager,
     _numba_memory_manager,
-    device_array,
-    device_array_from_ptr,
-    device_array_like,
     is_initialized,
     reinitialize,
     rmm_cupy_allocator,
-    to_device,
 )

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import ctypes
 
-import numpy as np
 from numba import cuda
 from numba.cuda import HostOnlyCUDAMemoryManager, IpcHandle, MemoryPointer
 
@@ -83,85 +82,6 @@ def is_initialized():
     Returns true if RMM has been initialized, false otherwise
     """
     return rmm.mr.is_initialized()
-
-
-def device_array_from_ptr(ptr, nelem, dtype=np.float, finalizer=None):
-    """
-    device_array_from_ptr(ptr, size, dtype=np.float, stream=0)
-
-    Create a Numba device array from a ptr, size, and dtype.
-    """
-    # Handle Datetime Column
-    if dtype == np.datetime64:
-        dtype = np.dtype("datetime64[ms]")
-    else:
-        dtype = np.dtype(dtype)
-
-    elemsize = dtype.itemsize
-    datasize = elemsize * nelem
-    shape = (nelem,)
-    strides = (elemsize,)
-    # note no finalizer -- freed externally!
-    ctx = cuda.current_context()
-    ptr = ctypes.c_uint64(int(ptr))
-    mem = MemoryPointer(ctx, ptr, datasize, finalizer=finalizer)
-    return cuda.cudadrv.devicearray.DeviceNDArray(
-        shape, strides, dtype, gpu_data=mem
-    )
-
-
-def device_array(shape, dtype=np.float, strides=None, order="C", stream=0):
-    """
-    device_array(shape, dtype=np.float, strides=None, order='C',
-                 stream=0)
-
-    Allocate an empty Numba device array. Clone of Numba `cuda.device_array`,
-    but uses RMM for device memory management.
-    """
-    shape, strides, dtype = cuda.api._prepare_shape_strides_dtype(
-        shape, strides, dtype, order
-    )
-    datasize = cuda.driver.memory_size_from_info(
-        shape, strides, dtype.itemsize
-    )
-
-    buf = librmm.DeviceBuffer(size=datasize, stream=stream)
-
-    ctx = cuda.current_context()
-    ptr = ctypes.c_uint64(int(buf.ptr))
-    mem = MemoryPointer(ctx, ptr, datasize, owner=buf)
-    return cuda.cudadrv.devicearray.DeviceNDArray(
-        shape, strides, dtype, gpu_data=mem
-    )
-
-
-def device_array_like(ary, stream=0):
-    """
-    device_array_like(ary, stream=0)
-
-    Call rmmlib.device_array with information from `ary`. Clone of Numba
-    `cuda.device_array_like`, but uses RMM for device memory management.
-    """
-    if ary.ndim == 0:
-        ary = ary.reshape(1)
-
-    return device_array(ary.shape, ary.dtype, ary.strides, stream=stream)
-
-
-def to_device(ary, stream=0, copy=True, to=None):
-    """
-    to_device(ary, stream=0, copy=True, to=None)
-
-    Allocate and transfer a numpy ndarray or structured scalar to the device.
-    Clone of Numba `cuda.to_device`, but uses RMM for device memory management.
-    """
-    if to is None:
-        to = device_array_like(ary, stream=stream)
-        to.copy_to_device(ary, stream=stream)
-        return to
-    if copy:
-        to.copy_to_device(ary, stream=stream)
-    return to
 
 
 class RMMNumbaManager(HostOnlyCUDAMemoryManager):

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -44,7 +44,7 @@ _dtypes = [
     np.bool_,
 ]
 _nelems = [1, 2, 7, 8, 9, 32, 128]
-_allocs = [cuda, rmm]
+_allocs = [cuda]
 
 
 @pytest.mark.parametrize("dtype", _dtypes)
@@ -233,7 +233,6 @@ def test_rmm_device_buffer_copy_from_host(hb):
     "cuda_ary",
     [
         lambda: rmm.DeviceBuffer.to_device(b"abc"),
-        lambda: rmm.to_device(np.array([97, 98, 99], dtype="u1")),
         lambda: cuda.to_device(np.array([97, 98, 99], dtype="u1")),
     ],
 )


### PR DESCRIPTION
Fixes https://github.com/rapidsai/rmm/issues/180

RAPIDS libraries have been encouraged to move away from the for a while. Most libraries have simply used `DeviceBuffer`s directly, which works well and handles simple CUDA memory allocations with RMM. For more complex array objects, it is possible to use CuPy with the RMM allocator. Similarly Numba External Memory Manager provides support with using RMM to back Numba objects. Thus there are many options that don't require this API and libraries have left it anyways, so just drop it.