### PR TITLE
Make `rmm::cuda_stream_default` a `constexpr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - PR #592 Add `auto_flush` to `make_logging_adaptor`
 - PR #602 Fix `device_scalar` and its tests so that they use the correct CUDA stream
+- PR #621 Make `rmm::cuda_stream_default` a `constexpr`
 
 # RMM 0.16.0 (21 Oct 2020)
 

--- a/include/rmm/cuda_stream_view.hpp
+++ b/include/rmm/cuda_stream_view.hpp
@@ -112,7 +112,7 @@ class cuda_stream_view {
 /**
  * @brief Static cuda_stream_view of the default stream (stream 0), for convenience
  */
-static cuda_stream_view cuda_stream_default{};
+static constexpr cuda_stream_view cuda_stream_default{};
 
 /**
  * @brief Static cuda_stream_view of cudaStreamLegacy, for convenience


### PR DESCRIPTION
Makes `rmm::cuda_stream_default` a `constexpr`.

Also reverts unnecessary stream parsing added to replay benchmark in #608
