### PR TITLE
Prefer artifact of librmm during conda build of rmm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #592 Add `auto_flush` to `make_logging_adaptor`
 - PR #602 Fix `device_scalar` and its tests so that they use the correct CUDA stream
 - PR #621 Make `rmm::cuda_stream_default` a `constexpr`
+- PR #625 Use `librmm` conda artifact when building `rmm` conda package
 
 # RMM 0.16.0 (21 Oct 2020)
 

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -66,7 +66,8 @@ if [[ "$BUILD_RMM" == "1" ]]; then
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     conda build conda/recipes/rmm --python=$PYTHON
   else
-    conda build --dirty --no-remove-work-dir conda/recipes/rmm
+    conda build --dirty --no-remove-work-dir \
+      -c $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ conda/recipes/rmm
   fi
 fi
 


### PR DESCRIPTION
We want to ensure that the Project Flash downloaded conda artifact of `librmm` is used when building `rmm`. This prevents two problems: 1) using `rapidsai-nightly` builds and 2) building `librmm` from source.

The directory referenced is guaranteed to exist in the context of Project Flash.