### PR TITLE
[WIP] Support enabling PTDS via CUDA_PTDS environment variable

### DIFF
--- a/python/rmm/_lib/cuda_stream_view.pyx
+++ b/python/rmm/_lib/cuda_stream_view.pyx
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from libc.stdint cimport uintptr_t
 
 
@@ -26,7 +28,10 @@ cdef class CudaStreamView:
             CUDA stream to wrap, default 0
         """
         if (stream == 0):
-            self.c_obj.reset(new cuda_stream_view())
+            if int(os.environ.get("CUDA_PTDS", "0")) != 0:
+                self.c_obj.reset(new cuda_stream_view(<cudaStream_t>2))
+            else:
+                self.c_obj.reset(new cuda_stream_view())
         else:
             self.c_obj.reset(new cuda_stream_view(<cudaStream_t>stream))
 


### PR DESCRIPTION
Following up on a conversation with @harrism @jakirkham @rongou yesterday, I did a small change to the Cython bindings where we can enable PTDS via a `CUDA_PTDS` runtime environment variable, which is different from https://github.com/rapidsai/rmm/pull/480 where rebuilding the Python package is necessary. This allows us to test RMM together with other Python libraries in a non-intrusive fashion, requiring users to explicitly enable PTDS.

It's important to notice that this only works for the RMM API, for example `rmm.DeviceBuffer`, but using Numba to do the copying will still result on using the default stream only. To add Numba support, we may do a similar change there. Tagging @gmarkall for awareness too.

I currently used stream `2` because I didn't find an existing definition in RMM, I'm happy to change that appropriately to a definition, but I'm not sure where that should live yet.