### PR TITLE
[gpuCI] Auto-merge branch-0.17 to branch-0.18 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #603 Always test both legacy and per-thread default stream
 - PR #611 Add a note to the contribution guide about requiring 2 C++ reviewers
 - PR #615 Improve gpuCI Scripts
+- PR #635 Add Python docs build to gpuCI
 
 ## Bug Fixes
 

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -16,7 +16,7 @@ export HOME=$WORKSPACE
 export PROJECT_WORKSPACE=/rapids/rmm
 export LIBCUDF_KERNEL_CACHE_PATH="$HOME/.jitify-cache"
 export NIGHTLY_VERSION=$(echo $BRANCH_VERSION | awk -F. '{print $2}')
-export PROJECTS=(rmm)
+export PROJECTS=(librmm rmm)
 
 gpuci_logger "Check environment"
 env
@@ -43,6 +43,11 @@ gpuci_logger "Build Doxygen docs"
 cd $PROJECT_WORKSPACE/doxygen
 doxygen Doxyfile
 
+# Build Python docs
+gpuci_logger "Build Python docs"
+cd $PROJECT_WORKSPACE/python/docs
+make html
+
 #Commit to Website
 cd $DOCS_WORKSPACE
 
@@ -54,5 +59,6 @@ for PROJECT in ${PROJECTS[@]}; do
 done
 
 
-mv $PROJECT_WORKSPACE/doxygen/html/* $DOCS_WORKSPACE/api/rmm/$BRANCH_VERSION
+mv $PROJECT_WORKSPACE/doxygen/html/* $DOCS_WORKSPACE/api/librmm/$BRANCH_VERSION
+mv $PROJECT_WORKSPACE/python/docs/_build/html/* $DOCS_WORKSPACE/api/rmm/$BRANCH_VERSION
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.17` that creates a PR to keep `branch-0.18` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.