### PR TITLE
fix release script version updater based on cmake reformatting [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - PR #621 Make `rmm::cuda_stream_default` a `constexpr`
 - PR #625 Use `librmm` conda artifact when building `rmm` conda package
 - PR #634 Fix conda uploads
-- PR #XXX Fix release script version updater based on CMake reformatting
+- PR #639 Fix release script version updater based on CMake reformatting
 
 # RMM 0.16.0 (21 Oct 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PR #634 Fix conda uploads
 - PR #639 Fix release script version updater based on CMake reformatting
 
+
 # RMM 0.16.0 (21 Oct 2020)
 
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #621 Make `rmm::cuda_stream_default` a `constexpr`
 - PR #625 Use `librmm` conda artifact when building `rmm` conda package
 - PR #634 Fix conda uploads
+- PR #XXX Fix release script version updater based on CMake reformatting
 
 # RMM 0.16.0 (21 Oct 2020)
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -45,7 +45,7 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-sed_runner 's/'"RMM VERSION .* LANGUAGES"'/'"RMM VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' CMakeLists.txt
+sed_runner 's/'"  VERSION .*"'/'"  VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' CMakeLists.txt
 
 sed_runner 's/version=.*/version=\"'"${NEXT_FULL_TAG}"'\",/g' python/setup.py
 


### PR DESCRIPTION
There was a cmake formatting change in #604 and the ci script that bumps versions at release time was not updated to account for it properly. This fixes the script.