### PR TITLE
[REVIEW] fix adding languages after version number in cmake in release script [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #625 Use `librmm` conda artifact when building `rmm` conda package
 - PR #634 Fix conda uploads
 - PR #639 Fix release script version updater based on CMake reformatting
+- PR #XXX Fix adding "LANGUAGES" after version number in CMake in release script
 
 
 # RMM 0.16.0 (21 Oct 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - PR #625 Use `librmm` conda artifact when building `rmm` conda package
 - PR #634 Fix conda uploads
 - PR #639 Fix release script version updater based on CMake reformatting
-- PR #XXX Fix adding "LANGUAGES" after version number in CMake in release script
+- PR #641 Fix adding "LANGUAGES" after version number in CMake in release script
 
 
 # RMM 0.16.0 (21 Oct 2020)

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -45,7 +45,7 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-sed_runner 's/'"  VERSION .*"'/'"  VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' CMakeLists.txt
+sed_runner 's/'"  VERSION .*"'/'"  VERSION ${NEXT_FULL_TAG}"'/g' CMakeLists.txt
 
 sed_runner 's/version=.*/version=\"'"${NEXT_FULL_TAG}"'\",/g' python/setup.py
 


### PR DESCRIPTION
Forgot to remove the `LANGUAGES` from the sed command which is now on a new line in the CMake.