### PR TITLE
[gpuCI] Auto-merge branch-0.17 to branch-0.18 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #625 Use `librmm` conda artifact when building `rmm` conda package
 - PR #634 Fix conda uploads
 - PR #639 Fix release script version updater based on CMake reformatting
+- PR #641 Fix adding "LANGUAGES" after version number in CMake in release script
 
 
 # RMM 0.16.0 (21 Oct 2020)

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -45,7 +45,7 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-sed_runner 's/'"  VERSION .*"'/'"  VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' CMakeLists.txt
+sed_runner 's/'"  VERSION .*"'/'"  VERSION ${NEXT_FULL_TAG}"'/g' CMakeLists.txt
 
 sed_runner 's/version=.*/version=\"'"${NEXT_FULL_TAG}"'\",/g' python/setup.py
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.17` that creates a PR to keep `branch-0.18` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.