### PR TITLE
[gpuCI] Auto-merge branch-0.17 to branch-0.18 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PR #602 Fix `device_scalar` and its tests so that they use the correct CUDA stream
 - PR #621 Make `rmm::cuda_stream_default` a `constexpr`
 - PR #625 Use `librmm` conda artifact when building `rmm` conda package
+- PR #631 Force local conda artifact install
 - PR #634 Fix conda uploads
 - PR #639 Fix release script version updater based on CMake reformatting
 - PR #641 Fix adding "LANGUAGES" after version number in CMake in release script

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -106,8 +106,12 @@ else
 
     cd $WORKSPACE/python
     
-    gpuci_logger "Installing librmm"
-    gpuci_conda_retry install -c $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ librmm
+    CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*.tar.bz2"`
+    CONDA_FILE=`basename "$CONDA_FILE" .tar.bz2` #get filename without extension
+    CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install
+    gpuci_logger "Installing $CONDA_FILE"
+    gpuci_conda_retry install -c $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ "$CONDA_FILE"
+
     export LIBRMM_BUILD_DIR="$WORKSPACE/ci/artifacts/rmm/cpu/conda_work/build"
     
     gpuci_logger "Building rmm"


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.17` that creates a PR to keep `branch-0.18` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.