### PR TITLE
Remove DeviceBuffer synchronization on default stream

### DIFF
--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -391,6 +391,8 @@ cpdef void copy_ptr_to_host(uintptr_t db,
         _copy_async(<const void*>db, <void*>&hb[0], len(hb),
                     cudaMemcpyDeviceToHost, stream.view())
 
+    if stream.c_is_default():
+        stream.c_synchronize()
 
 @cython.boundscheck(False)
 cpdef void copy_host_to_ptr(const unsigned char[::1] hb,

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -440,7 +440,7 @@ cpdef void copy_device_to_ptr(uintptr_t d_src,
                               uintptr_t d_dst,
                               size_t count,
                               Stream stream=DEFAULT_STREAM) except *:
-    """Copy from a host pointer to a device pointer
+    """Copy from a device pointer to a device pointer
 
     Parameters
     ----------

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -380,6 +380,7 @@ cpdef void copy_ptr_to_host(uintptr_t db,
     if stream.c_is_default():
         stream.c_synchronize()
 
+
 @cython.boundscheck(False)
 cpdef void copy_host_to_ptr(const unsigned char[::1] hb,
                             uintptr_t db,
@@ -391,6 +392,13 @@ cpdef void copy_host_to_ptr(const unsigned char[::1] hb,
     hb : ``bytes``-like host buffer to copy
     db : pointer to data on device to write into
     stream : CUDA stream to use for copying, default the default stream
+
+    Note
+    ----
+
+    If ``stream`` is the default stream, it is synchronized after the copy.
+    However if a non-default ``stream`` is provided, this function is fully
+    asynchronous.
 
     Examples
     --------
@@ -412,6 +420,9 @@ cpdef void copy_host_to_ptr(const unsigned char[::1] hb,
     with nogil:
         _copy_async(<const void*>&hb[0], <void*>db, len(hb),
                     cudaMemcpyHostToDevice, stream.view())
+
+    if stream.c_is_default():
+        stream.c_synchronize()
 
 
 @cython.boundscheck(False)

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -78,9 +78,6 @@ cdef class DeviceBuffer:
             else:
                 self.c_obj.reset(new device_buffer(c_ptr, size, stream.view()))
 
-            if stream.c_is_default():
-                stream.c_synchronize()
-
     def __len__(self):
         return self.size
 
@@ -353,9 +350,6 @@ cdef void _copy_async(const void* src,
 
     if err != cudaError.cudaSuccess:
         raise RuntimeError(f"Memcpy failed with error: {err}")
-
-    if stream.is_default():
-        stream.synchronize()
 
 
 @cython.boundscheck(False)

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -53,6 +53,13 @@ cdef class DeviceBuffer:
             CUDA stream to use for construction and/or copying,
             default the default stream
 
+        Note
+        ----
+
+        If the pointer passed is non-null and ``stream`` is the default stream,
+        it is synchronized after the copy. However if a non-default ``stream``
+        is provided, this function is fully asynchronous.
+
         Examples
         --------
         >>> import rmm
@@ -70,6 +77,9 @@ cdef class DeviceBuffer:
                 self.c_obj.reset(new device_buffer(size, stream.view()))
             else:
                 self.c_obj.reset(new device_buffer(c_ptr, size, stream.view()))
+
+                if stream.c_is_default():
+                    stream.c_synchronize()
 
     def __len__(self):
         return self.size

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -53,13 +53,6 @@ cdef class DeviceBuffer:
             CUDA stream to use for construction and/or copying,
             default the default stream
 
-        Note
-        ----
-
-        If ``stream`` is the default stream, it is synchronized after the copy.
-        However if a non-default ``stream`` is provided, this function is fully
-        asynchronous.
-
         Examples
         --------
         >>> import rmm
@@ -337,13 +330,6 @@ cdef void _copy_async(const void* src,
     dst : pointer to ``bytes``-like host buffer to or device data to copy into
     count : the size in bytes to copy
     stream : CUDA stream to use for copying, default the default stream
-
-    Note
-    ----
-
-    If ``stream`` is the default stream, it is synchronized after the copy.
-    However if a non-default ``stream`` is provided, this function is fully
-    asynchronous.
     """
     cdef cudaError_t err = cudaMemcpyAsync(dst, src, count, kind,
                                            <cudaStream_t>stream)
@@ -406,13 +392,6 @@ cpdef void copy_host_to_ptr(const unsigned char[::1] hb,
     db : pointer to data on device to write into
     stream : CUDA stream to use for copying, default the default stream
 
-    Note
-    ----
-
-    If ``stream`` is the default stream, it is synchronized after the copy.
-    However if a non-default ``stream`` is provided, this function is fully
-    asynchronous.
-
     Examples
     --------
     >>> import rmm
@@ -447,13 +426,6 @@ cpdef void copy_device_to_ptr(uintptr_t d_src,
     d_src : pointer to data on device to copy from
     d_dst : pointer to data on device to write into
     stream : CUDA stream to use for copying, default the default stream
-
-    Note
-    ----
-
-    If ``stream`` is the default stream, it is synchronized after the copy.
-    However if a non-default ``stream`` is provided, this function is fully
-    asynchronous.
 
     Examples
     --------


### PR DESCRIPTION
As discussed offline a couple weeks ago, RMM's Python binding synchronizes on the default stream and that was introduced mostly because of UCX-Py's usage with Dask. However, Distributed synchronizes the default stream when using UCX-Py in https://github.com/dask/distributed/blob/9f5426e030b5c4f7cd9db08d5c73f9aca3db4830/distributed/comm/ucx.py#L224-L230 and https://github.com/dask/distributed/blob/9f5426e030b5c4f7cd9db08d5c73f9aca3db4830/distributed/comm/ucx.py#L282-L285 .

I spent a good part of yesterday and today testing this PR as much as I could, including with TPCx-BB workflows, and I've experienced no regressions on simply getting rid of those two cases. Therefore, I'm reasonably confident we're safe in removing those synchronizations.