### PR TITLE
[WIP] Interface rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Achieving optimal performance in GPU-centric workflows frequently requires customizing how host and
 device memory are allocated. For example, using "pinned" host memory for asynchronous
 host <-> device memory transfers, or using a device memory pool sub-allocator to reduce the cost of
-dynamic device memory allocation. 
+dynamic device memory allocation.
 
 The goal of the RAPIDS Memory Manager (RMM) is to provide:
 - A common interface that allows customizing [device](#device_memory_resource) and
@@ -162,7 +162,7 @@ Thrust. If you want to customize it, you can set the variables
 
 # Using RMM in C++
 
-The first goal of RMM is to provide a common interface for device and host memory allocation. 
+The first goal of RMM is to provide a common interface for device and host memory allocation.
 This allows both _users_ and _implementers_ of custom allocation logic to program to a single
 interface.
 
@@ -181,19 +181,19 @@ freeing device memory.
 
 It has two key functions:
 
-1. `void* device_memory_resource::allocate(std::size_t bytes, cuda_stream_view s)`
+1. `void* device_memory_resource::allocate_async(std::size_t bytes, cuda_stream_view s)`
    - Returns a pointer to an allocation of at least `bytes` bytes.
 
-2. `void device_memory_resource::deallocate(void* p, std::size_t bytes, cuda_stream_view s)`
-   - Reclaims a previous allocation of size `bytes` pointed to by `p`. 
+2. `void device_memory_resource::deallocate_async(void* p, std::size_t bytes, cuda_stream_view s)`
+   - Reclaims a previous allocation of size `bytes` pointed to by `p`.
    - `p` *must* have been returned by a previous call to `allocate(bytes)`, otherwise behavior is
      undefined
 
 It is up to a derived class to provide implementations of these functions. See
-[available resources](#available-resources) for example `device_memory_resource` derived classes. 
+[available resources](#available-resources) for example `device_memory_resource` derived classes.
 
-Unlike `std::pmr::memory_resource`, `rmm::mr::device_memory_resource` does not allow specifying an 
-alignment argument. All allocations are required to be aligned to at least 256B. Furthermore, 
+Unlike `std::pmr::memory_resource`, `rmm::mr::device_memory_resource` does not allow specifying an
+alignment argument. All allocations are required to be aligned to at least 256B. Furthermore,
 `device_memory_resource` adds an additional `cuda_stream_view` argument to allow specifying the stream
 on which to perform the (de)allocation.
 
@@ -201,26 +201,26 @@ on which to perform the (de)allocation.
 
 `rmm::cuda_stream_view` is a simple non-owning wrapper around a CUDA `cudaStream_t`. This wrapper's
 purpose is to provide strong type safety for stream types. (`cudaStream_t` is an alias for a pointer,
-which can lead to ambiguity in APIs when it is assigned `0`.)  All RMM stream-ordered APIs take a 
+which can lead to ambiguity in APIs when it is assigned `0`.)  All RMM stream-ordered APIs take a
 `rmm::cuda_stream_view` argument.
 
-`rmm::cuda_stream` is a simple owning wrapper around a CUDA `cudaStream_t`. This class provides 
+`rmm::cuda_stream` is a simple owning wrapper around a CUDA `cudaStream_t`. This class provides
 RAII semantics (constructor creates the CUDA stream, destructor destroys it). An `rmm::cuda_stream`
 can never represent the CUDA default stream or per-thread default stream; it only ever represents
 a single non-default stream. `rmm::cuda_stream` cannot be copied, but can be moved.
 
 ## `cuda_stream_pool`
 
-`rmm::cuda_stream_pool` provides fast access to a pool of CUDA streams. This class can be used to 
-create a set of `cuda_stream` objects whose lifetime is equal to the `cuda_stream_pool`. Using the 
+`rmm::cuda_stream_pool` provides fast access to a pool of CUDA streams. This class can be used to
+create a set of `cuda_stream` objects whose lifetime is equal to the `cuda_stream_pool`. Using the
 stream pool can be faster than creating the streams on the fly. The size of the pool is configurable.
-Depending on this size, multiple calls to `cuda_stream_pool::get_stream()` may return instances of 
+Depending on this size, multiple calls to `cuda_stream_pool::get_stream()` may return instances of
 `rmm::cuda_stream_view` that represent identical CUDA streams.
 
 ### Thread Safety
 
 All current device memory resources are thread safe unless documented otherwise. More specifically,
-calls to memory resource `allocate()` and `deallocate()` methods are safe with respect to calls to 
+calls to memory resource `allocate()` and `deallocate()` methods are safe with respect to calls to
 either of these functions from other threads. They are _not_ thread safe with respect to
 construction and destruction of the memory resource object.
 
@@ -234,7 +234,7 @@ with any current RMM device memory resources.
 This allows optimizations such as re-using memory deallocated on the same stream without the
 overhead of synchronization.
 
-A call to `device_memory_resource::allocate(bytes, stream_a)` returns a pointer that is valid to use
+A call to `device_memory_resource::allocate_async(bytes, stream_a)` returns a pointer that is valid to use
 on `stream_a`. Using the memory on a different stream (say `stream_b`) is Undefined Behavior unless
 the two streams are first synchronized, for example by using `cudaStreamSynchronize(stream_a)` or by
 recording a CUDA event on `stream_a` and then calling `cudaStreamWaitEvent(stream_b, event)`.
@@ -246,7 +246,7 @@ used internally by a `device_memory_resource` for managing available memory with
 synchronization, and it may also be synchronized at a later time, for example using a call to
 `cudaStreamSynchronize()`.
 
-For this reason, it is Undefined Behavior to destroy a CUDA stream that is passed to 
+For this reason, it is Undefined Behavior to destroy a CUDA stream that is passed to
 `device_memory_resource::deallocate`. If the stream on which the allocation was last used has been
 destroyed before calling `deallocate` or it is known that it will be destroyed, it is likely better
 to synchronize the stream (before destroying it) and then pass a different stream to `deallocate`
@@ -266,10 +266,10 @@ Allocates and frees device memory using `cudaMalloc` and `cudaFree`.
 
 #### `managed_memory_resource`
 
-Allocates and frees device memory using `cudaMallocManaged` and `cudaFree`. 
+Allocates and frees device memory using `cudaMallocManaged` and `cudaFree`.
 
 Note that `managed_memory_resource` cannot be used with NVIDIA Virtual GPU Software (vGPU, for use
-with virtual machines or hypervisors) because [NVIDIA CUDA Unified Memory is not supported by 
+with virtual machines or hypervisors) because [NVIDIA CUDA Unified Memory is not supported by
 NVIDIA vGPU](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#cuda-open-cl-support-vgpu).
 
 #### `pool_memory_resource`
@@ -283,13 +283,13 @@ cost is constant.
 
 #### `binning_memory_resource`
 
-Configurable to use multiple upstream memory resources for allocations that fall within different 
+Configurable to use multiple upstream memory resources for allocations that fall within different
 bin sizes. Often configured with multiple bins backed by `fixed_size_memory_resource`s and a single
 `pool_memory_resource` for allocations larger than the largest bin size.
 
 ### Default Resources and Per-device Resources
 
-RMM users commonly need to configure a `device_memory_resource` object to use for all allocations 
+RMM users commonly need to configure a `device_memory_resource` object to use for all allocations
 where another resource has not explicitly been provided. A common example is configuring a
 `pool_memory_resource` to use for all allocations to get fast dynamic allocation.
 
@@ -300,7 +300,7 @@ Accessing and modifying the default resource is done through two functions:
 - `device_memory_resource* get_current_device_resource()`
    - Returns a pointer to the default resource for the current CUDA device.
    - The initial default memory resource is an instance of `cuda_memory_resource`.
-   - This function is thread safe with respect to concurrent calls to it and 
+   - This function is thread safe with respect to concurrent calls to it and
      `set_current_device_resource()`.
    - For more explicit control, you can use `get_per_device_resource()`, which takes a device ID.
 
@@ -329,13 +329,13 @@ that was active when the `device_memory_resource` was created. Otherwise behavio
 
 If a `device_memory_resource` is used with a stream associated with a different CUDA device than the
 device for which the memory resource was created, behavior is undefined.
- 
+
 Creating a `device_memory_resource` for each device requires care to set the current device before
 creating each resource, and to maintain the lifetime of the resources as long as they are set as
 per-device resources. Here is an example loop that creates `unique_ptr`s to `pool_memory_resource`
 objects for each device and sets them as the per-device resource for that device.
 
-```c++ 
+```c++
 std::vector<unique_ptr<pool_memory_resource>> per_device_pools;
 for(int i = 0; i < N; ++i) {
     cudaSetDevice(i); // set device i before creating MR
@@ -348,12 +348,12 @@ for(int i = 0; i < N; ++i) {
 
 ### Allocators
 
-C++ interfaces commonly allow customizable memory allocation through an [`Allocator`](https://en.cppreference.com/w/cpp/named_req/Allocator) object. 
+C++ interfaces commonly allow customizable memory allocation through an [`Allocator`](https://en.cppreference.com/w/cpp/named_req/Allocator) object.
 RMM provides several `Allocator` and `Allocator`-like classes.
 
 #### `polymorphic_allocator`
 
-A [stream-ordered](#stream-ordered-memory-allocation) allocator similar to [`std::pmr::polymorphic_allocator`](https://en.cppreference.com/w/cpp/memory/polymorphic_allocator). 
+A [stream-ordered](#stream-ordered-memory-allocation) allocator similar to [`std::pmr::polymorphic_allocator`](https://en.cppreference.com/w/cpp/memory/polymorphic_allocator).
 Unlike the standard C++ `Allocator` interface, the `allocate` and `deallocate` functions take a `cuda_stream_view` indicating the stream on which the (de)allocation occurs.
 
 #### `stream_allocator_adaptor`
@@ -369,17 +369,17 @@ rmm::mr::polymorphic_allocator<int> stream_alloc;
 auto adapted = rmm::mr::make_stream_allocator_adaptor(stream_alloc, stream);
 
 // Allocates 100 bytes using `stream_alloc` on `stream`
-auto p = adapted.allocate(100); 
+auto p = adapted.allocate(100);
 ...
 // Deallocates using `stream_alloc` on `stream`
-adapted.deallocate(p,100); 
+adapted.deallocate(p,100);
 ```
 
 #### `thrust_allocator`
 
 `thrust_allocator` is a device memory allocator that uses the strongly typed `thrust::device_ptr`, making it usable with containers like `thrust::device_vector`.
 
-See [below](#using-rmm-with-thrust) for more information on using RMM with Thrust. 
+See [below](#using-rmm-with-thrust) for more information on using RMM with Thrust.
 
 ## Device Data Structures
 
@@ -392,7 +392,7 @@ An untyped, uninitialized RAII class for stream ordered device memory allocation
 ```c++
 cuda_stream_view s{...};
 // Allocates at least 100 bytes on stream `s` using the *default* resource
-rmm::device_buffer b{100,s}; 
+rmm::device_buffer b{100,s};
 void* p = b.data();                   // Raw, untyped pointer to underlying device memory
 
 kernel<<<..., s.value()>>>(b.data()); // `b` is only safe to use on `s`
@@ -415,11 +415,11 @@ cuda_stream_view s{...};
 // default resource
 rmm::device_uvector<int32_t> v(100, s);
 // Initializes the elements to 0
-thrust::uninitialized_fill(thrust::cuda::par.on(s.value()), v.begin(), v.end(), int32_t{0}); 
+thrust::uninitialized_fill(thrust::cuda::par.on(s.value()), v.begin(), v.end(), int32_t{0});
 
 rmm::mr::device_memory_resource * mr = new my_custom_resource{...};
 // Allocates uninitialized storage for 100 `int32_t` elements on stream `s` using the resource `mr`
-rmm::device_uvector<int32_t> v2{100, s, mr}; 
+rmm::device_uvector<int32_t> v2{100, s, mr};
 ```
 
 ### `device_scalar`
@@ -431,7 +431,7 @@ modifying the value in device memory from the host, or retrieving the value from
 ```c++
 cuda_stream_view s{...};
 // Allocates uninitialized storage for a single `int32_t` in device memory
-rmm::device_scalar<int32_t> a{s}; 
+rmm::device_scalar<int32_t> a{s};
 a.set_value(42, s); // Updates the value in device memory to `42` on stream `s`
 
 kernel<<<...,s.value()>>>(a.data()); // Pass raw pointer to underlying element in device memory
@@ -451,11 +451,11 @@ Similar to `device_memory_resource`, it has two key functions for (de)allocation
      `alignment`
 
 2. `void host_memory_resource::deallocate(void* p, std::size_t bytes, std::size_t alignment)`
-   - Reclaims a previous allocation of size `bytes` pointed to by `p`. 
+   - Reclaims a previous allocation of size `bytes` pointed to by `p`.
 
 
 Unlike `device_memory_resource`, the `host_memory_resource` interface and behavior is identical to
-`std::pmr::memory_resource`. 
+`std::pmr::memory_resource`.
 
 ### Available Resources
 
@@ -504,7 +504,7 @@ RMM includes two forms of logging. Memory event logging and debug logging.
 ### Memory Event Logging and `logging_resource_adaptor`
 
 Memory event logging writes details of every allocation or deallocation to a CSV (comma-separated
-value) file. In C++, Memory Event Logging is enabled by using the `logging_resource_adaptor` as a 
+value) file. In C++, Memory Event Logging is enabled by using the `logging_resource_adaptor` as a
 wrapper around any other `device_memory_resource` object.
 
 Each row in the log represents either an allocation or a deallocation. The columns of the file are
@@ -523,7 +523,7 @@ rmm::mr::cuda_memory_resource upstream;
 rmm::mr::logging_resource_adaptor<rmm::mr::cuda_memory_resource> log_mr{&upstream, filename};
 ```
 
-If a file name is not specified, the environment variable `RMM_LOG_FILE` is queried for the file 
+If a file name is not specified, the environment variable `RMM_LOG_FILE` is queried for the file
 name. If `RMM_LOG_FILE` is not set, then an exception is thrown by the `logging_resource_adaptor`
 constructor.
 
@@ -533,7 +533,7 @@ set to `True`. The log file name can be set using the `log_file_name` parameter.
 
 ### Debug Logging
 
-RMM includes a debug logger which can be enabled to log trace and debug information to a file. This 
+RMM includes a debug logger which can be enabled to log trace and debug information to a file. This
 information can show when errors occur, when additional memory is allocated from upstream resources,
 etc. The default log file is `rmm_log.txt` in the current working directory, but the environment
 variable `RMM_DEBUG_LOG_FILE` can be set to specify the path and file name.
@@ -545,27 +545,27 @@ of more detailed logging. The default is `INFO`. Available levels are `TRACE`, `
 The log relies on the [spdlog](https://github.com/gabime/spdlog.git) library.
 
 Note that to see logging below the `INFO` level, the C++ application must also call
-`rmm::logger().set_level()`, e.g. to enable all levels of logging down to `TRACE`, call 
+`rmm::logger().set_level()`, e.g. to enable all levels of logging down to `TRACE`, call
 `rmm::logger().set_level(spdlog::level::trace)` (and compile with `-DRMM_LOGGING_LEVEL=TRACE`).
 
-Note that debug logging is different from the CSV memory allocation logging provided by 
+Note that debug logging is different from the CSV memory allocation logging provided by
 `rmm::mr::logging_resource_adapter`. The latter is for logging a history of allocation /
 deallocation actions which can be useful for replay with RMM's replay benchmark.
 
 ## RMM and CUDA Memory Bounds Checking
 
 Memory allocations taken from a memory resource that allocates a pool of memory (such as
-`pool_memory_resource` and `arena_memory_resource`) are part of the same low-level CUDA memory 
-allocation. Therefore, out-of-bounds or misaligned accesses to these allocations are not likely to 
-be detected by CUDA tools such as 
+`pool_memory_resource` and `arena_memory_resource`) are part of the same low-level CUDA memory
+allocation. Therefore, out-of-bounds or misaligned accesses to these allocations are not likely to
+be detected by CUDA tools such as
 [CUDA Compute Sanitizer](https://docs.nvidia.com/cuda/compute-sanitizer/index.html) memcheck.
 
-Exceptions to this are `cuda_memory_resource`, which wraps `cudaMalloc`, and 
-`cuda_async_memory_resource`, which uses `cudaMallocAsync` with CUDA's built-in memory pool 
-functionality (CUDA 11.2 or later required). Illegal memory accesses to memory allocated by these 
+Exceptions to this are `cuda_memory_resource`, which wraps `cudaMalloc`, and
+`cuda_async_memory_resource`, which uses `cudaMallocAsync` with CUDA's built-in memory pool
+functionality (CUDA 11.2 or later required). Illegal memory accesses to memory allocated by these
 resources are detectable with Compute Sanitizer Memcheck.
 
-It may be possible in the future to add support for memory bounds checking with other memory 
+It may be possible in the future to add support for memory bounds checking with other memory
 resources using NVTX APIs.
 
 ## Using RMM in Python Code
@@ -624,7 +624,7 @@ array([1., 2., 3.])
 `MemoryResource` objects are used to configure how device memory allocations are made by
 RMM.
 
-By default if a `MemoryResource` is not set explicitly, RMM uses the `CudaMemoryResource`, which 
+By default if a `MemoryResource` is not set explicitly, RMM uses the `CudaMemoryResource`, which
 uses `cudaMalloc` for allocating device memory.
 
 `rmm.reinitialize()` provides an easy way to initialize RMM with specific memory resource options
@@ -664,10 +664,10 @@ of 1 GiB and a maximum size of 4 GiB. The pool uses
 Other MemoryResources include:
 
 * `FixedSizeMemoryResource` for allocating fixed blocks of memory
-* `BinningMemoryResource` for allocating blocks within specified "bin" sizes from different memory 
+* `BinningMemoryResource` for allocating blocks within specified "bin" sizes from different memory
 resources
 
-MemoryResources are highly configurable and can be composed together in different ways. 
+MemoryResources are highly configurable and can be composed together in different ways.
 See `help(rmm.mr)` for more information.
 
 ### Using RMM with CuPy

--- a/benchmarks/random_allocations/random_allocations.cpp
+++ b/benchmarks/random_allocations/random_allocations.cpp
@@ -92,7 +92,7 @@ void random_allocation_free(rmm::mr::device_memory_resource& mr,
     void* ptr = nullptr;
     if (do_alloc) {  // try to allocate
       try {
-        ptr = mr.allocate(size, stream);
+        ptr = mr.allocate_async(size, stream);
       } catch (rmm::bad_alloc const&) {
         do_alloc = false;
 #if VERBOSE
@@ -116,7 +116,7 @@ void random_allocation_free(rmm::mr::device_memory_resource& mr,
         size_t index = index_distribution(generator) % active_allocations;
         active_allocations--;
         allocation to_free = remove_at(allocations, index);
-        mr.deallocate(to_free.p, to_free.size, stream);
+        mr.deallocate_async(to_free.p, to_free.size, stream);
         allocation_size -= to_free.size;
 
 #if VERBOSE

--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -74,7 +74,7 @@ class simulated_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view) override
+  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
   {
     RMM_EXPECTS(begin_ + bytes <= end_, rmm::bad_alloc, "Simulated memory size exceeded");
     auto p = static_cast<void*>(begin_);
@@ -91,7 +91,7 @@ class simulated_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, cuda_stream_view) override {}
+  void do_deallocate(void* p, std::size_t, std::size_t, cuda_stream_view) override {}
 
   /**
    * @brief Get free and available memory for memory resource.

--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -74,7 +74,7 @@ class simulated_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
   {
     RMM_EXPECTS(begin_ + bytes <= end_, rmm::bad_alloc, "Simulated memory size exceeded");
     auto p = static_cast<void*>(begin_);
@@ -91,7 +91,7 @@ class simulated_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_dealloc_async(void* p, std::size_t, std::size_t, cuda_stream_view) override {}
+  void do_deallocate_async(void* p, std::size_t, std::size_t, cuda_stream_view) override {}
 
   /**
    * @brief Get free and available memory for memory resource.

--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -74,7 +74,7 @@ class simulated_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
   {
     RMM_EXPECTS(begin_ + bytes <= end_, rmm::bad_alloc, "Simulated memory size exceeded");
     auto p = static_cast<void*>(begin_);
@@ -91,7 +91,7 @@ class simulated_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, std::size_t, cuda_stream_view) override {}
+  void do_dealloc_async(void* p, std::size_t, std::size_t, cuda_stream_view) override {}
 
   /**
    * @brief Get free and available memory for memory resource.

--- a/include/rmm/cuda_stream.hpp
+++ b/include/rmm/cuda_stream.hpp
@@ -21,6 +21,7 @@
 
 #include <cuda_runtime_api.h>
 
+#include <functional>
 #include <memory>
 
 namespace rmm {

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#ifndef NDEBUG
 #include <rmm/logger.hpp>
+#endif
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -270,7 +270,7 @@ class device_buffer {
     if (new_size <= capacity()) {
       _size = new_size;
     } else {
-      void* const new_data = _mr->allocate(new_size, this->stream());
+      void* const new_data = _mr->allocate_async(new_size, this->stream());
       RMM_CUDA_TRY(
         cudaMemcpyAsync(new_data, data(), size(), cudaMemcpyDefault, this->stream().value()));
       deallocate_async();
@@ -382,7 +382,7 @@ class device_buffer {
   {
     _size     = bytes;
     _capacity = bytes;
-    _data     = (bytes > 0) ? memory_resource()->allocate(bytes, stream()) : nullptr;
+    _data     = (bytes > 0) ? memory_resource()->allocate_async(bytes, stream()) : nullptr;
   }
 
   /**
@@ -396,7 +396,7 @@ class device_buffer {
    */
   void deallocate_async() noexcept
   {
-    if (capacity() > 0) { memory_resource()->deallocate(data(), capacity(), stream()); }
+    if (capacity() > 0) { memory_resource()->deallocate_async(data(), capacity(), stream()); }
     _size     = 0;
     _capacity = 0;
     _data     = nullptr;

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -229,7 +229,7 @@ class aligned_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equivalent
    */
-  [[nodiscard]] bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  [[nodiscard]] bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     if (this == &other)
       return true;

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -127,7 +127,7 @@ class arena_memory_resource final : public device_memory_resource {
    * @param stream The stream to associate this allocation with.
    * @return void* Pointer to the newly allocated memory.
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     if (alignment > 256)
       throw rmm::bad_alloc("Unsupported alignment");
@@ -145,7 +145,7 @@ class arena_memory_resource final : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation.
    */
-  void do_deallocate(void* p, std::size_t bytes, std::size_t, cuda_stream_view stream) override
+  void do_dealloc_async(void* p, std::size_t bytes, std::size_t, cuda_stream_view stream) override
   {
     if (p == nullptr || bytes <= 0) return;
 

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -127,8 +127,10 @@ class arena_memory_resource final : public device_memory_resource {
    * @param stream The stream to associate this allocation with.
    * @return void* Pointer to the newly allocated memory.
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
+  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
+    if (alignment > 256)
+      throw rmm::bad_alloc("Unsupported alignment");
     if (bytes <= 0) return nullptr;
 
     bytes = detail::arena::align_up(bytes);
@@ -143,7 +145,7 @@ class arena_memory_resource final : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation.
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* p, std::size_t bytes, std::size_t, cuda_stream_view stream) override
   {
     if (p == nullptr || bytes <= 0) return;
 

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -127,7 +127,7 @@ class arena_memory_resource final : public device_memory_resource {
    * @param stream The stream to associate this allocation with.
    * @return void* Pointer to the newly allocated memory.
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     if (alignment > 256)
       throw rmm::bad_alloc("Unsupported alignment");
@@ -145,17 +145,17 @@ class arena_memory_resource final : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation.
    */
-  void do_dealloc_async(void* p, std::size_t bytes, std::size_t, cuda_stream_view stream) override
+  void do_deallocate_async(void* p, std::size_t bytes, std::size_t, cuda_stream_view stream) override
   {
     if (p == nullptr || bytes <= 0) return;
 
     bytes = detail::arena::align_up(bytes);
 #ifdef RMM_POOL_TRACK_ALLOCATIONS
-    if (!get_arena(stream).deallocate(p, bytes, stream)) {
+    if (!get_arena(stream).deallocate_async(p, bytes, stream)) {
       deallocate_from_other_arena(p, bytes, stream);
     }
 #else
-    get_arena(stream).deallocate(p, bytes, stream);
+    get_arena(stream).deallocate_async(p, bytes, stream);
 #endif
   }
 

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <shared_mutex>
+#include <thread>
 
 namespace rmm {
 namespace mr {

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -173,10 +173,10 @@ class binning_memory_resource final : public device_memory_resource {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
+  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     if (bytes <= 0) return nullptr;
-    return get_resource(bytes)->allocate(bytes, stream);
+    return get_resource(bytes)->allocate(bytes, alignment, stream);
   }
 
   /**
@@ -189,10 +189,10 @@ class binning_memory_resource final : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     auto res = get_resource(bytes);
-    if (res != nullptr) res->deallocate(p, bytes, stream);
+    if (res != nullptr) res->deallocate(p, bytes, alignment, stream);
   }
 
   /**

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -173,7 +173,7 @@ class binning_memory_resource final : public device_memory_resource {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     if (bytes <= 0) return nullptr;
     return get_resource(bytes)->allocate(bytes, alignment, stream);
@@ -189,7 +189,7 @@ class binning_memory_resource final : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     auto res = get_resource(bytes);
     if (res != nullptr) res->deallocate(p, bytes, alignment, stream);

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -173,10 +173,10 @@ class binning_memory_resource final : public device_memory_resource {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     if (bytes <= 0) return nullptr;
-    return get_resource(bytes)->allocate(bytes, alignment, stream);
+    return get_resource(bytes)->allocate_async(bytes, alignment, stream);
   }
 
   /**
@@ -189,10 +189,10 @@ class binning_memory_resource final : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_deallocate_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     auto res = get_resource(bytes);
-    if (res != nullptr) res->deallocate(p, bytes, alignment, stream);
+    if (res != nullptr) res->deallocate_async(p, bytes, alignment, stream);
   }
 
   /**

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -228,7 +228,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     return dynamic_cast<cuda_async_memory_resource const*>(&other) != nullptr;
   }

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -141,7 +141,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, rmm::cuda_stream_view stream) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, rmm::cuda_stream_view stream) override
   {
     void* p{nullptr};
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
@@ -163,7 +163,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, rmm::cuda_stream_view stream) override
+  void do_deallocate_async(void* p, std::size_t, std::size_t, rmm::cuda_stream_view stream) override
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     if (p != nullptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeAsync(p, stream.value())); }
@@ -182,7 +182,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
   {
     return dynamic_cast<cuda_async_memory_resource const*>(&other) != nullptr;
   }

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -63,7 +63,7 @@ class cuda_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
   {
     if (alignment > 256)
       throw rmm::bad_alloc("Unsupported alignment");
@@ -81,7 +81,7 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_dealloc_async(void* p, std::size_t, std::size_t, cuda_stream_view) override
+  void do_deallocate_async(void* p, std::size_t, std::size_t, cuda_stream_view) override
   {
     RMM_ASSERT_CUDA_SUCCESS(cudaFree(p));
   }

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -63,8 +63,10 @@ class cuda_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view) override
+  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
   {
+    if (alignment > 256)
+      throw rmm::bad_alloc("Unsupported alignment");
     void* p{nullptr};
     RMM_CUDA_TRY(cudaMalloc(&p, bytes), rmm::bad_alloc);
     return p;
@@ -79,7 +81,7 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, cuda_stream_view) override
+  void do_deallocate(void* p, std::size_t, std::size_t, cuda_stream_view) override
   {
     RMM_ASSERT_CUDA_SUCCESS(cudaFree(p));
   }
@@ -96,7 +98,7 @@ class cuda_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
   {
     return dynamic_cast<cuda_memory_resource const*>(&other) != nullptr;
   }

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -63,7 +63,7 @@ class cuda_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
   {
     if (alignment > 256)
       throw rmm::bad_alloc("Unsupported alignment");
@@ -81,7 +81,7 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, std::size_t, cuda_stream_view) override
+  void do_dealloc_async(void* p, std::size_t, std::size_t, cuda_stream_view) override
   {
     RMM_ASSERT_CUDA_SUCCESS(cudaFree(p));
   }

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -98,7 +98,7 @@ class cuda_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     return dynamic_cast<cuda_memory_resource const*>(&other) != nullptr;
   }

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -458,7 +458,7 @@ class arena {
    * @param stream Stream on which to perform deallocation.
    * @return true if the allocation is found, false otherwise.
    */
-  bool deallocate(void* p, std::size_t bytes, cuda_stream_view stream)
+  bool deallocate_async(void* p, std::size_t bytes, cuda_stream_view stream)
   {
     lock_guard lock(mtx_);
 #ifdef RMM_POOL_TRACK_ALLOCATIONS

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -201,8 +201,6 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
    */
   virtual void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    if (alignment > allocation_alignment)
-      throw rmm::bad_alloc("Unsupported alignment");
     RMM_LOG_TRACE("[A][stream {:p}][{}B]", fmt::ptr(stream.value()), bytes);
 
     if (bytes <= 0) return nullptr;

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -199,7 +199,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
    * @param stream The stream to associate this allocation with
    * @return void* Pointer to the newly allocated memory
    */
-  virtual void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  virtual void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     if (alignment > allocation_alignment)
       throw rmm::bad_alloc("Unsupported alignment");
@@ -235,7 +235,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
    *
    * @param p Pointer to be deallocated
    */
-  virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  virtual void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     lock_guard lock(mtx_);
     auto stream_event = get_event(stream);

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -199,7 +199,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
    * @param stream The stream to associate this allocation with
    * @return void* Pointer to the newly allocated memory
    */
-  virtual void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  virtual void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     if (alignment > allocation_alignment)
       throw rmm::bad_alloc("Unsupported alignment");
@@ -235,7 +235,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
    *
    * @param p Pointer to be deallocated
    */
-  virtual void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  virtual void do_deallocate_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     lock_guard lock(mtx_);
     auto stream_event = get_event(stream);

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -44,21 +44,21 @@ namespace mr {
  * allocation. This allows optimizations such as re-using memory deallocated on the same stream
  * without the overhead of stream synchronization.
  *
- * A call to `allocate(bytes, stream_a)` (on any derived class) returns a pointer that is valid to
+ * A call to `allocate_async(bytes, stream_a)` (on any derived class) returns a pointer that is valid to
  * use on `stream_a`. Using the memory on a different stream (say `stream_b`) is Undefined Behavior
  * unless the two streams are first synchronized, for example by using
  * `cudaStreamSynchronize(stream_a)` or by recording a CUDA event on `stream_a` and then
  * calling `cudaStreamWaitEvent(stream_b, event)`.
  *
- * The stream specified to deallocate() should be a stream on which it is valid to use the
+ * The stream specified to deallocate_async() should be a stream on which it is valid to use the
  * deallocated memory immediately for another allocation. Typically this is the stream on which the
- * allocation was *last* used before the call to deallocate(). The passed stream may be used
+ * allocation was *last* used before the call to deallocate_async(). The passed stream may be used
  * internally by a device_memory_resource for managing available memory with minimal
  * synchronization, and it may also be synchronized at a later time, for example using a call to
  * `cudaStreamSynchronize()`.
  *
  * For this reason, it is Undefined Behavior to destroy a CUDA stream that is passed to
- * deallocate(). If the stream on which the allocation was last used has been destroyed before
+ * deallocate_async(). If the stream on which the allocation was last used has been destroyed before
  * calling deallocate() or it is known that it will be destroyed, it is likely better to synchronize
  * the stream (before destroying it) and then pass a different stream to deallocate() (e.g. the
  * default stream).
@@ -81,7 +81,7 @@ namespace mr {
  * }
  * @endcode
  */
-class device_memory_resource : public stream_aware_memory_resource<memory_kind::device> {
+class device_memory_resource : public stream_ordered_memory_resource<memory_kind::device> {
  public:
   virtual ~device_memory_resource() = default;
 

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -17,6 +17,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
+#include <rmm/mr/memory_resource.hpp>
 
 #include <cstddef>
 #include <utility>
@@ -80,67 +81,9 @@ namespace mr {
  * }
  * @endcode
  */
-class device_memory_resource {
+class device_memory_resource : public stream_aware_memory_resource<memory_kind::device> {
  public:
   virtual ~device_memory_resource() = default;
-
-  /**
-   * @brief Allocates memory of size at least \p bytes.
-   *
-   * The returned pointer will have at minimum 256 byte alignment.
-   *
-   * If supported, this operation may optionally be executed on a stream.
-   * Otherwise, the stream is ignored and the null stream is used.
-   *
-   * @throws `rmm::bad_alloc` When the requested `bytes` cannot be allocated on
-   * the specified `stream`.
-   *
-   * @param bytes The size of the allocation
-   * @param stream Stream on which to perform allocation
-   * @return void* Pointer to the newly allocated memory
-   */
-  void* allocate(std::size_t bytes, cuda_stream_view stream = cuda_stream_view{})
-  {
-    return do_allocate(rmm::detail::align_up(bytes, 8), stream);
-  }
-
-  /**
-   * @brief Deallocate memory pointed to by \p p.
-   *
-   * `p` must have been returned by a prior call to `allocate(bytes,stream)` on
-   * a `device_memory_resource` that compares equal to `*this`, and the storage
-   * it points to must not yet have been deallocated, otherwise behavior is
-   * undefined.
-   *
-   * If supported, this operation may optionally be executed on a stream.
-   * Otherwise, the stream is ignored and the null stream is used.
-   *
-   * @throws Nothing.
-   *
-   * @param p Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
-   * @param stream Stream on which to perform deallocation
-   */
-  void deallocate(void* p, std::size_t bytes, cuda_stream_view stream = cuda_stream_view{})
-  {
-    do_deallocate(p, rmm::detail::align_up(bytes, 8), stream);
-  }
-
-  /**
-   * @brief Compare this resource to another.
-   *
-   * Two device_memory_resources compare equal if and only if memory allocated
-   * from one device_memory_resource can be deallocated from the other and vice
-   * versa.
-   *
-   * By default, simply checks if \p *this and \p other refer to the same
-   * object, i.e., does not check if they are two objects of the same class.
-   *
-   * @param other The other resource to compare to
-   * @returns If the two resources are equivalent
-   */
-  bool is_equal(device_memory_resource const& other) const noexcept { return do_is_equal(other); }
 
   /**
    * @brief Query whether the resource supports use of non-null CUDA streams for
@@ -171,52 +114,6 @@ class device_memory_resource {
   }
 
  private:
-  /**
-   * @brief Allocates memory of size at least \p bytes.
-   *
-   * The returned pointer will have at minimum 256 byte alignment.
-   *
-   * If supported, this operation may optionally be executed on a stream.
-   * Otherwise, the stream is ignored and the null stream is used.
-   *
-   * @param bytes The size of the allocation
-   * @param stream Stream on which to perform allocation
-   * @return void* Pointer to the newly allocated memory
-   */
-  virtual void* do_allocate(std::size_t bytes, cuda_stream_view stream) = 0;
-
-  /**
-   * @brief Deallocate memory pointed to by \p p.
-   *
-   * If supported, this operation may optionally be executed on a stream.
-   * Otherwise, the stream is ignored and the null stream is used.
-   *
-   * @param p Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
-   * @param stream Stream on which to perform deallocation
-   */
-  virtual void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) = 0;
-
-  /**
-   * @brief Compare this resource to another.
-   *
-   * Two device_memory_resources compare equal if and only if memory allocated
-   * from one device_memory_resource can be deallocated from the other and vice
-   * versa.
-   *
-   * By default, simply checks if \p *this and \p other refer to the same
-   * object, i.e., does not check if they are two objects of the same class.
-   *
-   * @param other The other resource to compare to
-   * @return true If the two resources are equivalent
-   * @return false If the two resources are not equal
-   */
-  virtual bool do_is_equal(device_memory_resource const& other) const noexcept
-  {
-    return this == &other;
-  }
-
   /**
    * @brief Get free and available memory for memory resource
    *

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -159,7 +159,7 @@ class fixed_size_memory_resource
    */
   free_list blocks_from_upstream(cuda_stream_view stream)
   {
-    void* p = upstream_mr_->allocate(upstream_chunk_size_, stream);
+    void* p = upstream_mr_->allocate_async(upstream_chunk_size_, stream);
     block_type b{p};
     upstream_blocks_.push_back(b);
 

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -123,14 +123,14 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     alignment = std::max(alignment, allocation_alignment_);
     void* p = nullptr;
 
     std::size_t proposed_size = rmm::detail::align_up(bytes, alignment);
     if (proposed_size + allocated_bytes_ <= allocation_limit_) {
-      p = upstream_->allocate(bytes, alignment, stream);
+      p = upstream_->allocate_async(bytes, alignment, stream);
       allocated_bytes_ += proposed_size;
     } else {
       throw rmm::bad_alloc{"Exceeded memory limit"};
@@ -148,11 +148,11 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_deallocate_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     alignment = std::max(alignment, allocation_alignment_);
     std::size_t allocated_size = rmm::detail::align_up(bytes, alignment);
-    upstream_->deallocate(p, bytes, stream);
+    upstream_->deallocate_async(p, bytes, stream);
     allocated_bytes_ -= allocated_size;
   }
 

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -165,7 +165,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     if (this == &other)
       return true;

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -123,7 +123,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     alignment = std::max(alignment, allocation_alignment_);
     void* p = nullptr;
@@ -148,7 +148,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     alignment = std::max(alignment, allocation_alignment_);
     std::size_t allocated_size = rmm::detail::align_up(bytes, alignment);

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -214,9 +214,9 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    auto const p = upstream_->allocate(bytes, alignment, stream);
+    auto const p = upstream_->allocate_async(bytes, alignment, stream);
     logger_->info("allocate,{},{},{},{}", p, bytes, alignment, fmt::ptr(stream.value()));
     return p;
   }
@@ -237,10 +237,10 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_deallocate_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     logger_->info("free,{},{},{},{}", p, bytes, alignment, fmt::ptr(stream.value()));
-    upstream_->deallocate(p, bytes, alignment, stream);
+    upstream_->deallocate_async(p, bytes, alignment, stream);
   }
 
   /**

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -252,7 +252,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     if (this == &other)
       return true;

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -214,7 +214,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     auto const p = upstream_->allocate(bytes, alignment, stream);
     logger_->info("allocate,{},{},{},{}", p, bytes, alignment, fmt::ptr(stream.value()));
@@ -237,7 +237,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     logger_->info("free,{},{},{},{}", p, bytes, alignment, fmt::ptr(stream.value()));
     upstream_->deallocate(p, bytes, alignment, stream);

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -63,7 +63,7 @@ class managed_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
   {
     if (alignment > 256)
       throw rmm::bad_alloc("Unsupported alignment");
@@ -85,7 +85,7 @@ class managed_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, std::size_t, cuda_stream_view) override
+  void do_dealloc_async(void* p, std::size_t, std::size_t, cuda_stream_view) override
   {
     RMM_ASSERT_CUDA_SUCCESS(cudaFree(p));
   }

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -63,7 +63,7 @@ class managed_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view) override
   {
     if (alignment > 256)
       throw rmm::bad_alloc("Unsupported alignment");
@@ -85,7 +85,7 @@ class managed_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_dealloc_async(void* p, std::size_t, std::size_t, cuda_stream_view) override
+  void do_deallocate_async(void* p, std::size_t, std::size_t, cuda_stream_view) override
   {
     RMM_ASSERT_CUDA_SUCCESS(cudaFree(p));
   }

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -102,7 +102,7 @@ class managed_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     return dynamic_cast<managed_memory_resource const*>(&other) != nullptr;
   }

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -148,9 +148,9 @@ class owning_wrapper : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the memory allocated by the wrapped resource
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
+  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    return wrapped().allocate(bytes, stream);
+    return wrapped().allocate(bytes, alignment, stream);
   }
 
   /**
@@ -164,9 +164,9 @@ class owning_wrapper : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to deallocate the memory
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    wrapped().deallocate(p, bytes, stream);
+    wrapped().deallocate(p, bytes, alignment, stream);
   }
 
   /**
@@ -180,7 +180,7 @@ class owning_wrapper : public device_memory_resource {
    * @return true If the two resources are equal
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
   {
     if (this == &other) {
       return true;

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -148,7 +148,7 @@ class owning_wrapper : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the memory allocated by the wrapped resource
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     return wrapped().allocate(bytes, alignment, stream);
   }
@@ -164,7 +164,7 @@ class owning_wrapper : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to deallocate the memory
    */
-  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     wrapped().deallocate(p, bytes, alignment, stream);
   }

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -148,9 +148,9 @@ class owning_wrapper : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the memory allocated by the wrapped resource
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    return wrapped().allocate(bytes, alignment, stream);
+    return wrapped().allocate_async(bytes, alignment, stream);
   }
 
   /**
@@ -164,9 +164,9 @@ class owning_wrapper : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to deallocate the memory
    */
-  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_deallocate_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    wrapped().deallocate(p, bytes, alignment, stream);
+    wrapped().deallocate_async(p, bytes, alignment, stream);
   }
 
   /**

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -180,7 +180,7 @@ class owning_wrapper : public device_memory_resource {
    * @return true If the two resources are equal
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     if (this == &other) {
       return true;

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -91,7 +91,7 @@ class polymorphic_allocator {
    */
   value_type* allocate(std::size_t n, cuda_stream_view stream)
   {
-    return static_cast<value_type*>(resource()->allocate(n * sizeof(T), stream));
+    return static_cast<value_type*>(resource()->allocate_async(n * sizeof(T), stream));
   }
 
   /**
@@ -106,7 +106,7 @@ class polymorphic_allocator {
    */
   void deallocate(value_type* p, std::size_t n, cuda_stream_view stream)
   {
-    resource()->deallocate(p, n * sizeof(T), stream);
+    resource()->deallocate_async(p, n * sizeof(T), stream);
   }
 
   /**

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -275,7 +275,7 @@ class pool_memory_resource final
     if (size == 0) return {};
 
     try {
-      void* p = upstream_mr_->allocate(size, stream);
+      void* p = upstream_mr_->allocate_async(size, stream);
       return thrust::optional<block_type>{
         *upstream_blocks_.emplace(reinterpret_cast<char*>(p), size, true).first};
     } catch (std::exception const& e) {

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -250,7 +250,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     if (this == &other)
       return true;

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -91,10 +91,10 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     lock_t lock(mtx);
-    return upstream_->allocate(bytes, alignment stream);
+    return upstream_->allocate_async(bytes, alignment stream);
   }
 
   /**
@@ -108,10 +108,10 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @param alignment The alignment that was passed to allocate
    * @param stream Stream on which to perform the deallocation
    */
-  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_deallocate_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     lock_t lock(mtx);
-    upstream_->deallocate(p, bytes, alignment, stream);
+    upstream_->deallocate_async(p, bytes, alignment, stream);
   }
 
   /**

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -87,13 +87,14 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * by the upstream resource.
    *
    * @param bytes The size, in bytes, of the allocation
+   * @param alignment The alignment, in bytes, of the allocation. Must be a power of 2.
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
+  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     lock_t lock(mtx);
-    return upstream_->allocate(bytes, stream);
+    return upstream_->allocate(bytes, alignment stream);
   }
 
   /**
@@ -103,13 +104,14 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @throws Nothing.
    *
    * @param p Pointer to be deallocated
-   * @param bytes Size of the allocation
+   * @param bytes The size that was passed to allocate
+   * @param alignment The alignment that was passed to allocate
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     lock_t lock(mtx);
-    upstream_->deallocate(p, bytes, stream);
+    upstream_->deallocate(p, bytes, alignment, stream);
   }
 
   /**
@@ -121,7 +123,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equivalent
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
   {
     if (this == &other)
       return true;

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -91,7 +91,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     lock_t lock(mtx);
     return upstream_->allocate(bytes, alignment stream);
@@ -108,7 +108,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @param alignment The alignment that was passed to allocate
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     lock_t lock(mtx);
     upstream_->deallocate(p, bytes, alignment, stream);

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -123,7 +123,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equivalent
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     if (this == &other)
       return true;

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -96,7 +96,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    */
   pointer allocate(size_type n)
   {
-    return thrust::device_pointer_cast(static_cast<T*>(_mr->allocate(n * sizeof(T), _stream)));
+    return thrust::device_pointer_cast(static_cast<T*>(_mr->allocate_async(n * sizeof(T), _stream)));
   }
 
   /**
@@ -108,7 +108,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    */
   void deallocate(pointer p, size_type n)
   {
-    return _mr->deallocate(thrust::raw_pointer_cast(p), n * sizeof(T), _stream);
+    return _mr->deallocate_async(thrust::raw_pointer_cast(p), n * sizeof(T), _stream);
   }
 
   /**

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -260,7 +260,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
+  bool do_is_equal(memory_resource<mr::memory_kind::device> const& other) const noexcept override
   {
     if (this == &other)
       return true;

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -190,7 +190,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     void* p = upstream_->allocate(bytes, alignment, stream);
 
@@ -214,7 +214,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @param alignment The alignemnt that was passed to allocate
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
     upstream_->deallocate(p, bytes, alignment, stream);
     {

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <mutex>
 #include <rmm/detail/error.hpp>
+#include <rmm/logger.hpp>
 #include <rmm/detail/stack_trace.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <shared_mutex>

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -186,12 +186,13 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * by the upstream resource.
    *
    * @param bytes The size, in bytes, of the allocation
+   * @param alignment The alignment, in bytes, of the allocation
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
+  void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    void* p = upstream_->allocate(bytes, stream);
+    void* p = upstream_->allocate(bytes, alignment, stream);
 
     // track it.
     {
@@ -209,12 +210,13 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @throws Nothing.
    *
    * @param p Pointer to be deallocated
-   * @param bytes Size of the allocation
+   * @param bytes The size that was passed to allcoate
+   * @param alignment The alignemnt that was passed to allocate
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    upstream_->deallocate(p, bytes, stream);
+    upstream_->deallocate(p, bytes, alignment, stream);
     {
       write_lock_t lock(mtx_);
 
@@ -257,7 +259,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  bool do_is_equal(memory_resource<memory_kind::device> const& other) const noexcept override
   {
     if (this == &other)
       return true;

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -190,9 +190,9 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to perform the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void* do_allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    void* p = upstream_->allocate(bytes, alignment, stream);
+    void* p = upstream_->allocate_async(bytes, alignment, stream);
 
     // track it.
     {
@@ -214,9 +214,9 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @param alignment The alignemnt that was passed to allocate
    * @param stream Stream on which to perform the deallocation
    */
-  void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
+  void do_deallocate_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) override
   {
-    upstream_->deallocate(p, bytes, alignment, stream);
+    upstream_->deallocate_async(p, bytes, alignment, stream);
     {
       write_lock_t lock(mtx_);
 

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -46,7 +46,7 @@ namespace mr {
  * derived class implementation is used.
  *
  *---------------------------------------------------------------------------**/
-using host_memory_resource = memory_resource<memory_kind::host, allocation_order::host>;
+using host_memory_resource = memory_resource<memory_kind::host>;
 
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -17,9 +17,11 @@
 
 #include <cstddef>
 #include <utility>
+#include <rmm/mr/memory_resource.hpp>
 
 namespace rmm {
 namespace mr {
+
 /**---------------------------------------------------------------------------*
  * @brief Base class for host memory allocation.
  *
@@ -44,123 +46,7 @@ namespace mr {
  * derived class implementation is used.
  *
  *---------------------------------------------------------------------------**/
-class host_memory_resource {
- public:
-  virtual ~host_memory_resource() = default;
+using host_memory_resource = memory_resource<memory_kind::host, allocation_order::host>;
 
-  /**---------------------------------------------------------------------------*
-   * @brief Allocates memory on the host of size at least `bytes` bytes.
-   *
-   * The returned storage is aligned to the specified `alignment` if supported,
-   * and to `alignof(std::max_align_t)` otherwise.
-   *
-   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be
-   * allocated.
-   *
-   * @param bytes The size of the allocation
-   * @param alignment Alignment of the allocation
-   * @return void* Pointer to the newly allocated memory
-   *---------------------------------------------------------------------------**/
-  void* allocate(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
-  {
-    return do_allocate(bytes, alignment);
-  }
-
-  /**---------------------------------------------------------------------------*
-   * @brief Deallocate memory pointed to by `p`.
-   *
-   * `p` must have been returned by a prior call to `allocate(bytes,alignment)`
-   * on a `host_memory_resource` that compares equal to `*this`, and the storage
-   * it points to must not yet have been deallocated, otherwise behavior is
-   * undefined.
-   *
-   * @throws Nothing.
-   *
-   * @param p Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
-   * @param alignment Alignment of the allocation. This must be equal to the
-   *value of `alignment` that was passed to the `allocate` call that returned
-   *`p`.
-   * @param stream Stream on which to perform deallocation
-   *---------------------------------------------------------------------------**/
-  void deallocate(void* p, std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
-  {
-    do_deallocate(p, bytes, alignment);
-  }
-
-  /**---------------------------------------------------------------------------*
-   * @brief Compare this resource to another.
-   *
-   * Two `host_memory_resource`s compare equal if and only if memory allocated
-   * from one `host_memory_resource` can be deallocated from the other and vice
-   * versa.
-   *
-   * By default, simply checks if \p *this and \p other refer to the same
-   * object, i.e., does not check if they are two objects of the same class.
-   *
-   * @param other The other resource to compare to
-   * @returns If the two resources are equivalent
-   *---------------------------------------------------------------------------**/
-  bool is_equal(host_memory_resource const& other) const noexcept { return do_is_equal(other); }
-
- private:
-  /**---------------------------------------------------------------------------*
-   * @brief Allocates memory on the host of size at least `bytes` bytes.
-   *
-   * The returned storage is aligned to the specified `alignment` if supported,
-   * and to `alignof(std::max_align_t)` otherwise.
-   *
-   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be
-   * allocated.
-   *
-   * @param bytes The size of the allocation
-   * @param alignment Alignment of the allocation
-   * @return void* Pointer to the newly allocated memory
-   *---------------------------------------------------------------------------**/
-  virtual void* do_allocate(std::size_t bytes,
-                            std::size_t alignment = alignof(std::max_align_t)) = 0;
-
-  /**---------------------------------------------------------------------------*
-   * @brief Deallocate memory pointed to by `p`.
-   *
-   * `p` must have been returned by a prior call to `allocate(bytes,alignment)`
-   * on a `host_memory_resource` that compares equal to `*this`, and the storage
-   * it points to must not yet have been deallocated, otherwise behavior is
-   * undefined.
-   *
-   * @throws Nothing.
-   *
-   * @param p Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
-   * @param alignment Alignment of the allocation. This must be equal to the
-   *value of `alignment` that was passed to the `allocate` call that returned
-   *`p`.
-   * @param stream Stream on which to perform deallocation
-   *---------------------------------------------------------------------------**/
-  virtual void do_deallocate(void* p,
-                             std::size_t bytes,
-                             std::size_t alignment = alignof(std::max_align_t)) = 0;
-
-  /**---------------------------------------------------------------------------*
-   * @brief Compare this resource to another.
-   *
-   * Two host_memory_resources compare equal if and only if memory allocated
-   * from one host_memory_resource can be deallocated from the other and vice
-   * versa.
-   *
-   * By default, simply checks if \p *this and \p other refer to the same
-   * object, i.e., does not check if they are two objects of the same class.
-   *
-   * @param other The other resource to compare to
-   * @return true If the two resources are equivalent
-   * @return false If the two resources are not equal
-   *---------------------------------------------------------------------------**/
-  virtual bool do_is_equal(host_memory_resource const& other) const noexcept
-  {
-    return this == &other;
-  }
-};
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -88,7 +88,7 @@ class new_delete_resource final : public host_memory_resource {
     rmm::detail::aligned_deallocate(p, bytes, alignment, [](void* p) { ::operator delete(p); });
   }
 
-  bool do_is_equal(const memory_resource<memory_kind::host> &other) const noexcept override
+  bool do_is_equal(const memory_resource<mr::memory_kind::host> &other) const noexcept override
   {
     return dynamic_cast<const new_delete_resource*>(&other) != nullptr;
   }

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -53,7 +53,7 @@ class new_delete_resource final : public host_memory_resource {
    * @return void* Pointer to the newly allocated memory
    *---------------------------------------------------------------------------**/
   void* do_allocate(std::size_t bytes,
-                    std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
+                    std::size_t alignment = rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
     // If the requested alignment isn't supported, use default
     alignment =
@@ -85,7 +85,7 @@ class new_delete_resource final : public host_memory_resource {
                      std::size_t bytes,
                      std::size_t alignment = rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
-    detail::aligned_deallocate(p, bytes, alignment, [](void* p) { ::operator delete(p); });
+    rmm::detail::aligned_deallocate(p, bytes, alignment, [](void* p) { ::operator delete(p); });
   }
 
   bool do_is_equal(const memory_resource<memory_kind::host> &other) const noexcept override

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -87,6 +87,12 @@ class new_delete_resource final : public host_memory_resource {
   {
     detail::aligned_deallocate(p, bytes, alignment, [](void* p) { ::operator delete(p); });
   }
+
+  bool do_is_equal(const memory_resource<memory_kind::host> &other) const noexcept override
+  {
+    return dynamic_cast<const new_delete_resource*>(&other) != nullptr;
+  }
+
 };
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -57,9 +57,9 @@ class new_delete_resource final : public host_memory_resource {
   {
     // If the requested alignment isn't supported, use default
     alignment =
-      (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
+      (rmm::detail::is_supported_alignment(alignment)) ? alignment : rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
-    return detail::aligned_allocate(
+    return rmm::detail::aligned_allocate(
       bytes, alignment, [](std::size_t size) { return ::operator new(size); });
   }
 
@@ -83,7 +83,7 @@ class new_delete_resource final : public host_memory_resource {
    *---------------------------------------------------------------------------**/
   void do_deallocate(void* p,
                      std::size_t bytes,
-                     std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
+                     std::size_t alignment = rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
     detail::aligned_deallocate(p, bytes, alignment, [](void* p) { ::operator delete(p); });
   }

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -30,7 +30,7 @@ namespace mr {
  *
  * See https://devblogs.nvidia.com/how-optimize-data-transfers-cuda-cc/
  *---------------------------------------------------------------------------**/
-class pinned_memory_resource final : public host_memory_resource {
+class pinned_memory_resource final : public memory_resource<memory_kind::pinned> {
  public:
   pinned_memory_resource()                              = default;
   ~pinned_memory_resource()                             = default;

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -62,7 +62,7 @@ class pinned_memory_resource final : public memory_resource<memory_kind::pinned>
     alignment =
       (rmm::detail::is_supported_alignment(alignment)) ? alignment : rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
-    return detail::aligned_allocate(bytes, alignment, [](std::size_t size) {
+    return rmm::detail::aligned_allocate(bytes, alignment, [](std::size_t size) {
       void* p{nullptr};
       auto status = cudaMallocHost(&p, size);
       if (cudaSuccess != status) { throw std::bad_alloc{}; }
@@ -94,7 +94,7 @@ class pinned_memory_resource final : public memory_resource<memory_kind::pinned>
   {
     (void)alignment;
     if (nullptr == p) { return; }
-    detail::aligned_deallocate(
+    rmm::detail::aligned_deallocate(
       p, bytes, alignment, [](void* p) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeHost(p)); });
   }
 };

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -60,7 +60,7 @@ class pinned_memory_resource final : public host_memory_resource {
 
     // If the requested alignment isn't supported, use default
     alignment =
-      (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
+      (rmm::detail::is_supported_alignment(alignment)) ? alignment : rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
     return detail::aligned_allocate(bytes, alignment, [](std::size_t size) {
       void* p{nullptr};

--- a/include/rmm/mr/memory_resource.hpp
+++ b/include/rmm/mr/memory_resource.hpp
@@ -95,13 +95,13 @@ static constexpr size_t default_alignment = kind == memory_kind::host ? alignof(
  * base class' `allocate` function may log every allocation, no matter what
  * derived class implementation is used.
  */
-template <memory_kind kind, allocation_order order = allocation_order::host>
+template <memory_kind _kind, allocation_order _order = allocation_order::host>
 class memory_resource {
  public:
   virtual ~memory_resource() = default;
 
-  static constexpr mr::memory_kind memory_kind = kind;
-  static constexpr mr::allocation_order allocation_order = order;
+  static constexpr mr::memory_kind kind = _kind;
+  static constexpr mr::allocation_order order = _order;
 
   /**
    * @brief Allocates memory of size at least `bytes` bytes.
@@ -224,10 +224,10 @@ class memory_resource {
 };
 
 template <memory_kind kind, allocation_order order>
-constexpr mr::memory_kind memory_resource<kind, order>::memory_kind;
+constexpr mr::memory_kind memory_resource<kind, order>::kind;
 
 template <memory_kind kind, allocation_order order>
-constexpr mr::allocation_order memory_resource<kind, order>::allocation_order;
+constexpr mr::allocation_order memory_resource<kind, order>::order;
 
 /**
  * @brief Base class for all multi-stream RMM memory resources.
@@ -254,11 +254,11 @@ constexpr mr::allocation_order memory_resource<kind, order>::allocation_order;
  * base class' `allocate` function may log every allocation, no matter what
  * derived class implementation is used.
  */
-template <memory_kind kind>
-class stream_aware_memory_resource : public memory_resource<kind> {
+template <memory_kind _kind>
+class stream_aware_memory_resource : public memory_resource<_kind> {
  public:
-  using memory_resource<kind>::memory_kind;
-  using memory_resource<kind>::allocation_order;
+  using memory_resource<_kind>::kind;
+  using memory_resource<_kind>::order;
 
   /**
    * @brief Allocates memory of size at least \p bytes.

--- a/include/rmm/mr/memory_resource.hpp
+++ b/include/rmm/mr/memory_resource.hpp
@@ -98,6 +98,9 @@ class memory_resource {
  public:
   virtual ~memory_resource() = default;
 
+  static constexpr mr::memory_kind memory_kind = kind;
+  static constexpr mr::allocation_order allocation_order = order;
+
   /**
    * @brief Allocates memory of size at least `bytes` bytes.
    *
@@ -218,6 +221,12 @@ class memory_resource {
   }
 };
 
+template <memory_kind kind, allocation_order order>
+constexpr mr::memory_kind memory_resource<kind, order>::memory_kind;
+
+template <memory_kind kind, allocation_order order>
+constexpr mr::allocation_order memory_resource<kind, order>::allocation_order;
+
 /**
  * @brief Base class for all multi-stream RMM memory resources.
  *
@@ -248,6 +257,9 @@ class stream_aware_memory_resource : public memory_resource<kind> {
  public:
   using memory_resource<kind>::allocate;
   using memory_resource<kind>::deallocate;
+
+  using memory_resource<kind>::memory_kind;
+  using memory_resource<kind>::allocation_order;
 
   /**
    * @brief Allocates memory of size at least \p bytes.

--- a/include/rmm/mr/memory_resource.hpp
+++ b/include/rmm/mr/memory_resource.hpp
@@ -290,7 +290,7 @@ class stream_aware_memory_resource : public memory_resource<kind> {
    */
   void* allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream)
   {
-    return do_allocate(bytes, alignment, stream);
+    return do_alloc_async(bytes, alignment, stream);
   }
 
   /**
@@ -340,7 +340,7 @@ class stream_aware_memory_resource : public memory_resource<kind> {
    */
   void deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream)
   {
-    do_deallocate(p, bytes, alignment, stream);
+    do_dealloc_async(p, bytes, alignment, stream);
   }
 
   /**
@@ -377,7 +377,7 @@ class stream_aware_memory_resource : public memory_resource<kind> {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  virtual void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) = 0;
+  virtual void* do_alloc_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) = 0;
 
   /**
    * @brief Implements host-syncrhonous allocation by using default stream
@@ -385,7 +385,7 @@ class stream_aware_memory_resource : public memory_resource<kind> {
   void* do_allocate(std::size_t bytes, std::size_t alignment) override {
     cuda_stream_view stream = {};
     stream.synchronize();
-    return do_allocate(bytes, alignment, stream);
+    return do_alloc_async(bytes, alignment, stream);
   }
 
   /**
@@ -402,7 +402,7 @@ class stream_aware_memory_resource : public memory_resource<kind> {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) = 0;
+  virtual void do_dealloc_async(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) = 0;
 
   /**
    * @brief Implements host-syncrhonous deallocation by using default stream
@@ -410,7 +410,7 @@ class stream_aware_memory_resource : public memory_resource<kind> {
   void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
     cuda_stream_view stream = {};
     stream.synchronize();
-    return do_deallocate(p, bytes, alignment, stream);
+    return do_dealloc_async(p, bytes, alignment, stream);
   }
 
   /**

--- a/include/rmm/mr/memory_resource.hpp
+++ b/include/rmm/mr/memory_resource.hpp
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/aligned.hpp>
+
+#include <cstddef>
+#include <utility>
+
+namespace rmm {
+
+namespace mr {
+
+/**
+ * @brief Memory kind that a memory resource can allocate
+ */
+enum class memory_kind {
+  /// Ordinary host memory
+  host      = 0,
+
+  /// Page-locked host memory, which can be accessed by device
+  pinned    = 1,
+
+  /// GPU memory
+  device    = 2,
+
+  /// Managed memory, which is automatically migrated between host and device
+  managed   = 3,
+};
+
+enum class allocation_order {
+  /**
+   * @brief Host-ordered allocation
+   *
+   * The memory is usable as soon as allocate function returns.
+   * The memory must no longer be in use when calling deallocate.
+   */
+  host    = 0,
+  /**
+   * @brief Stream-ordered allocation
+   *
+   * The memory can be immediately accessed on a stream associated with the allocation.
+   * Host code must wait until all work that was scheduled on the associated stream prior
+   * to the call to allocate is complete in order to safely access the allocated memory.
+   * Deallocation is scheduled in stream order. Pending work on the associated stream can
+   * still use the memory.
+   * The memory deallocated in stream order can be immediately recycled by allocations
+   * requested for the same stream.
+   */
+  stream  = 1,
+};
+
+
+template <memory_kind kind>
+using default_alignment = std::integral_constant<std::size_t,
+  kind == memory_kind::host ? alignof(std::max_align_t) : 256>;
+
+
+/**
+ * @brief Base class for all host and single-stream RMM memory resources.
+ *
+ * @tparam kind   The kind of memory
+ * @tparam order  Determines the allocation order (host or stream)
+ *
+ * This is based on `std::pmr::memory_resource`:
+ * https://en.cppreference.com/w/cpp/memory/memory_resource
+ *
+ * This class serves as the interface for all memory resources that do not need
+ * to work with multiple CUDA streams.
+ *
+ * There are two private, pure virtual functions that all derived classes must
+ * implement: `do_allocate` and `do_deallocate`. Optionally, derived classes may
+ * also override `is_equal`. By default, `is_equal` simply performs an identity
+ * comparison.
+ *
+ * The public, non-virtual functions `allocate`, `deallocate`, and `is_equal`
+ * simply call the private virtual functions. The reason for this is to allow
+ * implementing shared, default behavior in the base class. For example, the
+ * base class' `allocate` function may log every allocation, no matter what
+ * derived class implementation is used.
+ */
+template <memory_kind kind, allocation_order order = allocation_order::host>
+class memory_resource {
+ public:
+  virtual ~memory_resource() = default;
+
+  /**
+   * @brief Allocates memory of size at least `bytes` bytes.
+   *
+   * The returned storage is aligned to the specified `alignment` if supported,
+   * and to the default alignment for given backend otherwise.
+   *
+   * The memory can be used immediately in any context if host order is used
+   * or on the associated stream if stream order is used.
+   *
+   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be
+   * allocated.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment Alignment of the allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* allocate(std::size_t bytes, std::size_t alignment = default_alignment<kind>::value)
+  {
+    return do_allocate(bytes, alignment);
+  }
+
+  /**
+   * @brief Deallocate memory pointed to by `p`.
+   *
+   * `p` must have been returned by a prior call to `allocate(bytes, alignment)`
+   * on a `memory_resource<kind>` that compares equal to `*this`, and the storage
+   * it points to must not yet have been deallocated, otherwise behavior is
+   * undefined.
+   *
+   * The memory region deallocated by this function.
+   *
+   * @throws Nothing.
+   *
+   * @param p Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the
+   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * @param alignment Alignment of the allocation. This must be equal to the
+   *value of `alignment` that was passed to the `allocate` call that returned
+   *`p`.
+   * @param stream Stream on which to perform deallocation
+   */
+  void deallocate(void* p, std::size_t bytes, std::size_t alignment = default_alignment<kind>::value)
+  {
+    do_deallocate(p, bytes, alignment);
+  }
+
+  /**
+   * @brief Compare this resource to another.
+   *
+   * Two device_memory_resources compare equal if and only if memory allocated
+   * from one device_memory_resource can be deallocated from the other and vice
+   * versa.
+   *
+   * By default, simply checks if \p *this and \p other refer to the same
+   * object, i.e., does not check if they are two objects of the same class.
+   *
+   * @param other The other resource to compare to
+   * @returns If the two resources are equivalent
+   */
+  bool is_equal(memory_resource<kind> const& other) const noexcept { return do_is_equal(other); }
+
+ private:
+  /**---------------------------------------------------------------------------*
+   * @brief Allocates memory on the host of size at least `bytes` bytes.
+   *
+   * The returned storage is aligned to the specified `alignment` if supported,
+   * and to `alignof(std::max_align_t)` otherwise.
+   *
+   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be
+   * allocated.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment Alignment of the allocation
+   * @return void* Pointer to the newly allocated memory
+   *---------------------------------------------------------------------------**/
+  virtual void* do_allocate(std::size_t bytes,
+                            std::size_t alignment = alignof(std::max_align_t)) = 0;
+
+  /**---------------------------------------------------------------------------*
+   * @brief Deallocate memory pointed to by `p`.
+   *
+   * `p` must have been returned by a prior call to `allocate(bytes,alignment)`
+   * on a `host_memory_resource` that compares equal to `*this`, and the storage
+   * it points to must not yet have been deallocated, otherwise behavior is
+   * undefined.
+   *
+   * @throws Nothing.
+   *
+   * @param p Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the
+   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * @param alignment Alignment of the allocation. This must be equal to the
+   *value of `alignment` that was passed to the `allocate` call that returned
+   *`p`.
+   * @param stream Stream on which to perform deallocation
+   *---------------------------------------------------------------------------**/
+  virtual void do_deallocate(void* p,
+                             std::size_t bytes,
+                             std::size_t alignment = alignof(std::max_align_t)) = 0;
+
+  /**---------------------------------------------------------------------------*
+   * @brief Compare this resource to another.
+   *
+   * Two host_memory_resources compare equal if and only if memory allocated
+   * from one host_memory_resource can be deallocated from the other and vice
+   * versa.
+   *
+   * By default, simply checks if \p *this and \p other refer to the same
+   * object, i.e., does not check if they are two objects of the same class.
+   *
+   * @param other The other resource to compare to
+   * @return true If the two resources are equivalent
+   * @return false If the two resources are not equal
+   *---------------------------------------------------------------------------**/
+  virtual bool do_is_equal(memory_resource const& other) const noexcept
+  {
+    return this == &other;
+  }
+};
+
+/**
+ * @brief Base class for all multi-stream RMM memory resources.
+ *
+ * @tparam kind   The kind of memory
+ *
+ * This is based on `std::pmr::memory_resource`:
+ * https://en.cppreference.com/w/cpp/memory/memory_resource
+ *
+ * When C++17 is available for use in RMM, `rmm::host_memory_resource` should
+ * inherit from `std::pmr::memory_resource`.
+ *
+ * This class serves as the interface for all memory resources that do not need
+ * to work with multiple CUDA streams.
+ *
+ * There are two private, pure virtual functions that all derived classes must
+ * implement: `do_allocate` and `do_deallocate`. Optionally, derived classes may
+ * also override `is_equal`. By default, `is_equal` simply performs an identity
+ * comparison.
+ *
+ * The public, non-virtual functions `allocate`, `deallocate`, and `is_equal`
+ * simply call the private virtual functions. The reason for this is to allow
+ * implementing shared, default behavior in the base class. For example, the
+ * base class' `allocate` function may log every allocation, no matter what
+ * derived class implementation is used.
+ */
+template <memory_kind kind>
+class stream_aware_memory_resource : public memory_resource<kind> {
+ public:
+  using memory_resource<kind>::allocate;
+  using memory_resource<kind>::deallocate;
+
+  /**
+   * @brief Allocates memory of size at least \p bytes.
+   *
+   * The returned pointer is aligned at the defautl alignment for the memory kind
+   * allocated by this resource.
+   *
+   * The memory returned must be available for immediate use on given stream.
+   * If an implementation does not support streams, it should return memory which
+   * can be used on any stream.
+   *
+   * @throws `rmm::bad_alloc` When the requested `bytes` cannot be allocated on
+   * the specified `stream`.
+   *
+   * @param bytes The size of the allocation
+   * @param stream Stream on which to perform allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* allocate(std::size_t bytes, cuda_stream_view stream)
+  {
+    return allocate(bytes, default_alignment<kind>::value, stream);
+  }
+
+  /**
+   * @brief Allocates memory of size at least \p bytes.
+   *
+   * If supported, this operation may optionally be executed on a stream.
+   * Otherwise, the stream is ignored and the null stream is used.
+   *
+   * The memory returned must be available for immediate use on given stream.
+   * If an implementation does not support streams, it should return memory which
+   * can be used on any stream.
+   *
+   * @throws `rmm::bad_alloc` When the requested `bytes` cannot be allocated on
+   * the specified `stream`.
+   *
+   * @param bytes The size of the allocation
+   * @param stream Stream on which to perform allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream)
+  {
+    return do_allocate(bytes, alignment, stream);
+  }
+
+  /**
+   * @brief Deallocate memory pointed to by \p p.
+   *
+   * `p` must have been returned by a prior call to `allocate(bytes,stream)` on
+   * a `stream_memory_resource` that compares equal to `*this`, and the storage
+   * it points to must not yet have been deallocated, otherwise behavior is
+   * undefined.
+   *
+   * The memory returned must be available for immediate use on given stream.
+   * If an implementation does not support streams, it should return memory which
+   * can be used on any stream.
+   *
+   * @throws Nothing.
+   *
+   * @param p Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the
+   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * @param stream Stream on which to perform deallocation
+   */
+  void deallocate(void* p, std::size_t bytes, cuda_stream_view stream)
+  {
+    deallocate(p, bytes, default_alignment<kind>::value, stream);
+  }
+
+  /**
+   * @brief Deallocate memory pointed to by \p p.
+   *
+   * `p` must have been returned by a prior call to `allocate(bytes,stream)` on
+   * a `stream_memory_resource` that compares equal to `*this`, and the storage
+   * it points to must not yet have been deallocated, otherwise behavior is
+   * undefined.
+   *
+   * The memory returned must be available for immediate use on given stream.
+   * If an implementation does not support streams, it should return memory which
+   * can be used on any stream.
+   *
+   * @throws Nothing.
+   *
+   * @param p Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the
+   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * @param alignment The alignment of the allocation, as was passed to the
+   * call to `allocate` that returned `p`.
+   * @param stream Stream on which to perform deallocation
+   */
+  void deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream)
+  {
+    do_deallocate(p, bytes, alignment, stream);
+  }
+
+  /**
+   * @brief Query whether the resource supports the get_mem_info API.
+   *
+   * @return bool true if the resource supports get_mem_info, false otherwise.
+   */
+  virtual bool supports_get_mem_info() const noexcept = 0;
+
+  /**
+   * @brief Queries the amount of free and total memory for the resource.
+   *
+   * @param stream the stream whose memory manager we want to retrieve
+   *
+   * @returns a std::pair<size_t,size_t> which contains free memory in bytes
+   * in .first and total amount of memory in .second
+   */
+  std::pair<std::size_t, std::size_t> get_mem_info(cuda_stream_view stream) const
+  {
+    return do_get_mem_info(stream);
+  }
+
+ private:
+  /**
+   * @brief Allocates memory of size at least \p bytes.
+   *
+   * The returned pointer will be aligned at least to the required alignment.
+   *
+   * The memory returned must be available for immediate use on given stream.
+   * If an implementation does not support streams, it should return memory which
+   * can be used on any stream.
+   *
+   * @param bytes The size of the allocation
+   * @param stream Stream on which to perform allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  virtual void* do_allocate(std::size_t bytes, std::size_t alignment, cuda_stream_view stream) = 0;
+
+  /**
+   * @brief Implements host-syncrhonous allocation by using default stream
+   */
+  void* do_allocate(std::size_t bytes, std::size_t alignment) override {
+    cuda_stream_view stream = {};
+    stream.synchronize();
+    return do_allocate(bytes, alignment, stream);
+  }
+
+  /**
+   * @brief Deallocate memory pointed to by \p p.
+   *
+   * The returned pointer will be aligned at least to the required alignment.
+   *
+   * The memory returned must be available for immediate use on given stream.
+   * If an implementation does not support streams, it should return memory which
+   * can be used on any stream.
+   *
+   * @param p Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the
+   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * @param stream Stream on which to perform deallocation
+   */
+  virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment, cuda_stream_view stream) = 0;
+
+  /**
+   * @brief Implements host-syncrhonous deallocation by using default stream
+   */
+  void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override {
+    cuda_stream_view stream = {};
+    stream.synchronize();
+    return do_deallocate(p, bytes, alignment, stream);
+  }
+
+  /**
+   * @brief Get free and available memory for memory resource
+   *
+   * @throws std::runtime_error if we could not get free / total memory
+   *
+   * @param stream the stream being executed on
+   * @return std::pair with available and free memory for resource
+   */
+  virtual std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const = 0;
+};
+}  // namespace mr
+}  // namespace rmm

--- a/include/rmm/mr/memory_resource.hpp
+++ b/include/rmm/mr/memory_resource.hpp
@@ -36,12 +36,14 @@ using stream_view = cuda_stream_view;
  * performance characteristics of accesses.
  *
  */
-enum class memory_kind {
-  device,  ///< Device memory accessible only from device
-  unified, ///< Unified memory accessible from both host and device
-  pinned,  ///< Page-locked system memory accessible from both host and device
-  host     ///< System memory only accessible from host code
-};
+namespace memory_kind {
+
+struct host;    ///< System memory only accessible from host code
+struct pinned;  ///< Page-locked system memory accessible from both host and device
+struct device;  ///< Device memory accessible only from device
+struct managed; ///< Managed memory accessible from both host and device
+
+}  // namespace memory_kind
 
 /**
  * @brief Tag type for the default context of `memory_resource`.
@@ -77,10 +79,10 @@ struct __get_context_impl<any_context> {
  * @tparam _Context The execution context on which the storage may be used
  * without synchronization
  */
-template <memory_kind _Kind, typename _Context = any_context>
+template <typename _Kind, typename _Context = any_context>
 class memory_resource : public detail::__get_context_impl<_Context> {
 public:
-  static constexpr memory_kind kind = _Kind;
+  using memory_kind = _Kind;
   using context = _Context;
 
   static constexpr std::size_t default_alignment = alignof(_CUDA_VSTD::max_align_t);
@@ -243,10 +245,10 @@ private:
  *
  * @tparam _Kind The `memory_kind` of the allocated memory.
  */
-template <memory_kind _Kind>
+template <typename _Kind>
 class stream_ordered_memory_resource : public memory_resource<_Kind /* default context */> {
 public:
-  using memory_resource<_Kind>::kind;
+  using memory_kind = typename memory_resource<_Kind>::memory_kind;
   using memory_resource<_Kind>::default_alignment;
 
   /**

--- a/tests/cuda_stream_tests.cpp
+++ b/tests/cuda_stream_tests.cpp
@@ -21,6 +21,7 @@
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
+#include <functional>
 
 struct CudaStreamTest : public ::testing::Test {
 };

--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -75,8 +75,6 @@ void expect_log_events(std::string const& filename,
                // EXPECT_EQ(expected.thread_id, actual.thread_id);
                // EXPECT_EQ(expected.stream, actual.stream);
                EXPECT_EQ(expected.act, actual.act);
-               // device_memory_resource automatically pads an allocation to a multiple of 8 bytes
-               EXPECT_EQ(rmm::detail::align_up(expected.size, 8), actual.size);
                EXPECT_EQ(expected.pointer, actual.pointer);
                return true;
              });

--- a/tests/mr/device/aligned_mr_tests.cpp
+++ b/tests/mr/device/aligned_mr_tests.cpp
@@ -31,8 +31,8 @@ class mock_resource : public rmm::mr::device_memory_resource {
  public:
   MOCK_METHOD(bool, supports_streams, (), (const, override, noexcept));
   MOCK_METHOD(bool, supports_get_mem_info, (), (const, override, noexcept));
-  MOCK_METHOD(void*, do_allocate, (std::size_t, cuda_stream_view), (override));
-  MOCK_METHOD(void, do_deallocate, (void*, std::size_t, cuda_stream_view), (override));
+  MOCK_METHOD(void*, do_allocate_async, (std::size_t, std::size_t, cuda_stream_view), (override));
+  MOCK_METHOD(void, do_deallocate_async, (void*, std::size_t, std::size_t, cuda_stream_view), (override));
   using size_pair = std::pair<std::size_t, std::size_t>;
   MOCK_METHOD(size_pair, do_get_mem_info, (cuda_stream_view), (const, override));
 };
@@ -87,10 +87,10 @@ TEST(AlignedTest, DefaultAllocationAlignmentPassthrough)
   cuda_stream_view stream;
   void* pointer = reinterpret_cast<void*>(123);
   // device_memory_resource aligns to 8.
-  EXPECT_CALL(mock, do_allocate(8, stream)).WillOnce(Return(pointer));
-  EXPECT_CALL(mock, do_deallocate(pointer, 8, stream)).Times(1);
-  EXPECT_EQ(mr.allocate(5, stream), pointer);
-  mr.deallocate(pointer, 5, stream);
+  EXPECT_CALL(mock, do_allocate_async(8, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
+  EXPECT_CALL(mock, do_deallocate_async(pointer, 8, alignof(std::max_align_t), stream)).Times(1);
+  EXPECT_EQ(mr.allocate_async(5, stream), pointer);
+  mr.deallocate_async(pointer, 5, stream);
 }
 
 TEST(AlignedTest, BelowAlignmentThresholdPassthrough)
@@ -101,16 +101,16 @@ TEST(AlignedTest, BelowAlignmentThresholdPassthrough)
   cuda_stream_view stream;
   void* pointer = reinterpret_cast<void*>(123);
   // device_memory_resource aligns to 8.
-  EXPECT_CALL(mock, do_allocate(8, stream)).WillOnce(Return(pointer));
-  EXPECT_CALL(mock, do_deallocate(pointer, 8, stream)).Times(1);
-  EXPECT_EQ(mr.allocate(3, stream), pointer);
-  mr.deallocate(pointer, 3, stream);
+  EXPECT_CALL(mock, do_allocate_async(8, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
+  EXPECT_CALL(mock, do_deallocate_async(pointer, 8, alignof(std::max_align_t), stream)).Times(1);
+  EXPECT_EQ(mr.allocate_async(3, stream), pointer);
+  mr.deallocate_async(pointer, 3, stream);
 
   void* pointer1 = reinterpret_cast<void*>(456);
-  EXPECT_CALL(mock, do_allocate(65528, stream)).WillOnce(Return(pointer1));
-  EXPECT_CALL(mock, do_deallocate(pointer1, 65528, stream)).Times(1);
-  EXPECT_EQ(mr.allocate(65528, stream), pointer1);
-  mr.deallocate(pointer1, 65528, stream);
+  EXPECT_CALL(mock, do_allocate_async(65528, alignof(std::max_align_t), stream)).WillOnce(Return(pointer1));
+  EXPECT_CALL(mock, do_deallocate_async(pointer1, alignof(std::max_align_t), 65528, stream)).Times(1);
+  EXPECT_EQ(mr.allocate_async(65528, stream), pointer1);
+  mr.deallocate_async(pointer1, 65528, stream);
 }
 
 TEST(AlignedTest, UpstreamAddressAlreadyAligned)
@@ -120,11 +120,11 @@ TEST(AlignedTest, UpstreamAddressAlreadyAligned)
 
   cuda_stream_view stream;
   void* pointer = reinterpret_cast<void*>(4096);
-  EXPECT_CALL(mock, do_allocate(69376, stream)).WillOnce(Return(pointer));
-  EXPECT_CALL(mock, do_deallocate(pointer, 69376, stream)).Times(1);
+  EXPECT_CALL(mock, do_allocate_async(69376, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
+  EXPECT_CALL(mock, do_deallocate_async(pointer, 69376, alignof(std::max_align_t), stream)).Times(1);
 
-  EXPECT_EQ(mr.allocate(65536, stream), pointer);
-  mr.deallocate(pointer, 65536, stream);
+  EXPECT_EQ(mr.allocate_async(65536, stream), pointer);
+  mr.deallocate_async(pointer, 65536, stream);
 }
 
 TEST(AlignedTest, AlignUpstreamAddress)
@@ -134,12 +134,12 @@ TEST(AlignedTest, AlignUpstreamAddress)
 
   cuda_stream_view stream;
   void* pointer = reinterpret_cast<void*>(256);
-  EXPECT_CALL(mock, do_allocate(69376, stream)).WillOnce(Return(pointer));
-  EXPECT_CALL(mock, do_deallocate(pointer, 69376, stream)).Times(1);
+  EXPECT_CALL(mock, do_allocate_async(69376, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
+  EXPECT_CALL(mock, do_deallocate_async(pointer, 69376, alignof(std::max_align_t), stream)).Times(1);
 
   void* expected_pointer = reinterpret_cast<void*>(4096);
-  EXPECT_EQ(mr.allocate(65536, stream), expected_pointer);
-  mr.deallocate(expected_pointer, 65536, stream);
+  EXPECT_EQ(mr.allocate_async(65536, stream), expected_pointer);
+  mr.deallocate_async(expected_pointer, 65536, stream);
 }
 
 TEST(AlignedTest, AlignMultiple)
@@ -151,22 +151,22 @@ TEST(AlignedTest, AlignMultiple)
   void* pointer  = reinterpret_cast<void*>(256);
   void* pointer1 = reinterpret_cast<void*>(131584);
   void* pointer2 = reinterpret_cast<void*>(263168);
-  EXPECT_CALL(mock, do_allocate(69376, stream)).WillOnce(Return(pointer));
-  EXPECT_CALL(mock, do_allocate(77568, stream)).WillOnce(Return(pointer1));
-  EXPECT_CALL(mock, do_allocate(81664, stream)).WillOnce(Return(pointer2));
-  EXPECT_CALL(mock, do_deallocate(pointer, 69376, stream)).Times(1);
-  EXPECT_CALL(mock, do_deallocate(pointer1, 77568, stream)).Times(1);
-  EXPECT_CALL(mock, do_deallocate(pointer2, 81664, stream)).Times(1);
+  EXPECT_CALL(mock, do_allocate_async(69376, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
+  EXPECT_CALL(mock, do_allocate_async(77568, alignof(std::max_align_t), stream)).WillOnce(Return(pointer1));
+  EXPECT_CALL(mock, do_allocate_async(81664, alignof(std::max_align_t), stream)).WillOnce(Return(pointer2));
+  EXPECT_CALL(mock, do_deallocate_async(pointer, 69376, alignof(std::max_align_t), stream)).Times(1);
+  EXPECT_CALL(mock, do_deallocate_async(pointer1, 77568, alignof(std::max_align_t), stream)).Times(1);
+  EXPECT_CALL(mock, do_deallocate_async(pointer2, 81664, alignof(std::max_align_t), stream)).Times(1);
 
   void* expected_pointer  = reinterpret_cast<void*>(4096);
   void* expected_pointer1 = reinterpret_cast<void*>(135168);
   void* expected_pointer2 = reinterpret_cast<void*>(266240);
-  EXPECT_EQ(mr.allocate(65536, stream), expected_pointer);
-  EXPECT_EQ(mr.allocate(73728, stream), expected_pointer1);
-  EXPECT_EQ(mr.allocate(77800, stream), expected_pointer2);
-  mr.deallocate(expected_pointer1, 73728, stream);
-  mr.deallocate(expected_pointer, 65536, stream);
-  mr.deallocate(expected_pointer2, 77800, stream);
+  EXPECT_EQ(mr.allocate_async(65536, stream), expected_pointer);
+  EXPECT_EQ(mr.allocate_async(73728, stream), expected_pointer1);
+  EXPECT_EQ(mr.allocate_async(77800, stream), expected_pointer2);
+  mr.deallocate_async(expected_pointer1, 73728, stream);
+  mr.deallocate_async(expected_pointer, 65536, stream);
+  mr.deallocate_async(expected_pointer2, 77800, stream);
 }
 
 TEST(AlignedTest, AlignRealPointer)

--- a/tests/mr/device/aligned_mr_tests.cpp
+++ b/tests/mr/device/aligned_mr_tests.cpp
@@ -86,9 +86,8 @@ TEST(AlignedTest, DefaultAllocationAlignmentPassthrough)
 
   cuda_stream_view stream;
   void* pointer = reinterpret_cast<void*>(123);
-  // device_memory_resource aligns to 8.
-  EXPECT_CALL(mock, do_allocate_async(8, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
-  EXPECT_CALL(mock, do_deallocate_async(pointer, 8, alignof(std::max_align_t), stream)).Times(1);
+  EXPECT_CALL(mock, do_allocate_async(5, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
+  EXPECT_CALL(mock, do_deallocate_async(pointer, 5, alignof(std::max_align_t), stream)).Times(1);
   EXPECT_EQ(mr.allocate_async(5, stream), pointer);
   mr.deallocate_async(pointer, 5, stream);
 }
@@ -100,15 +99,14 @@ TEST(AlignedTest, BelowAlignmentThresholdPassthrough)
 
   cuda_stream_view stream;
   void* pointer = reinterpret_cast<void*>(123);
-  // device_memory_resource aligns to 8.
-  EXPECT_CALL(mock, do_allocate_async(8, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
-  EXPECT_CALL(mock, do_deallocate_async(pointer, 8, alignof(std::max_align_t), stream)).Times(1);
+  EXPECT_CALL(mock, do_allocate_async(3, alignof(std::max_align_t), stream)).WillOnce(Return(pointer));
+  EXPECT_CALL(mock, do_deallocate_async(pointer, 3, alignof(std::max_align_t), stream)).Times(1);
   EXPECT_EQ(mr.allocate_async(3, stream), pointer);
   mr.deallocate_async(pointer, 3, stream);
 
   void* pointer1 = reinterpret_cast<void*>(456);
   EXPECT_CALL(mock, do_allocate_async(65528, alignof(std::max_align_t), stream)).WillOnce(Return(pointer1));
-  EXPECT_CALL(mock, do_deallocate_async(pointer1, alignof(std::max_align_t), 65528, stream)).Times(1);
+  EXPECT_CALL(mock, do_deallocate_async(pointer1, 65528, alignof(std::max_align_t), stream)).Times(1);
   EXPECT_EQ(mr.allocate_async(65528, stream), pointer1);
   mr.deallocate_async(pointer1, 65528, stream);
 }

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -177,7 +177,7 @@ void allocate_loop(rmm::mr::device_memory_resource* mr,
   for (std::size_t i = 0; i < num_allocations; ++i) {
     size_t size = size_distribution(generator);
     void* ptr{};
-    EXPECT_NO_THROW(ptr = mr->allocate(size, stream));
+    EXPECT_NO_THROW(ptr = mr->allocate_async(size, stream));
     {
       std::lock_guard<std::mutex> lock(mtx);
       allocations.emplace_back(ptr, size);
@@ -199,7 +199,7 @@ void deallocate_loop(rmm::mr::device_memory_resource* mr,
       i++;
       allocation alloc = allocations.front();
       allocations.pop_front();
-      EXPECT_NO_THROW(mr->deallocate(alloc.p, alloc.size, stream));
+      EXPECT_NO_THROW(mr->deallocate_async(alloc.p, alloc.size, stream));
     }
   }
 }

--- a/tests/mr/device/polymorphic_allocator_tests.cpp
+++ b/tests/mr/device/polymorphic_allocator_tests.cpp
@@ -106,9 +106,9 @@ TEST_F(allocator_test, rebind)
 TEST_F(allocator_test, allocate_deallocate)
 {
   rmm::mr::polymorphic_allocator<int> allocator{};
-  auto p = allocator.allocate(1000, stream);
+  auto p = allocator.allocate_async(1000, stream);
   EXPECT_NE(p, nullptr);
-  EXPECT_NO_THROW(allocator.deallocate(p, 1000, stream));
+  EXPECT_NO_THROW(allocator.deallocate_async(p, 1000, stream));
 }
 
 }  // namespace

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -26,6 +26,22 @@
 #include <random>
 
 namespace {
+
+template <rmm::mr::memory_kind kind, rmm::mr::allocation_order order>
+void test_resource_traits(const rmm::mr::memory_resource<kind, order> *) {
+  static_assert(rmm::mr::memory_resource<kind, order>::memory_kind == kind, "Incorrect constant");
+  static_assert(rmm::mr::memory_resource<kind, order>::allocation_order == order, "Incorrect constant");
+}
+
+TEST(MRTest, Constants)
+{
+  rmm::mr::host_memory_resource *mr1 = nullptr;
+  rmm::mr::memory_resource<rmm::mr::memory_kind::pinned, rmm::mr::allocation_order::stream> *mr2 = nullptr;
+  test_resource_traits(mr1);
+  test_resource_traits(mr2);
+}
+
+
 inline bool is_aligned(void* p, std::size_t alignment = alignof(std::max_align_t))
 {
   return (0 == reinterpret_cast<uintptr_t>(p) % alignment);

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -94,7 +94,7 @@ struct allocation {
 
 template <typename MemoryResourceType>
 struct MRTest : public ::testing::Test {
-  std::unique_ptr<rmm::mr::host_memory_resource> mr;
+  std::unique_ptr<rmm::mr::memory_resource<MemoryResourceType::kind>> mr;
 
   MRTest() : mr{new MemoryResourceType} {}
   ~MRTest() = default;

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -29,8 +29,8 @@ namespace {
 
 template <rmm::mr::memory_kind kind, rmm::mr::allocation_order order>
 void test_resource_traits(const rmm::mr::memory_resource<kind, order> *) {
-  static_assert(rmm::mr::memory_resource<kind, order>::memory_kind == kind, "Incorrect constant");
-  static_assert(rmm::mr::memory_resource<kind, order>::allocation_order == order, "Incorrect constant");
+  static_assert(rmm::mr::memory_resource<kind, order>::kind == kind, "Incorrect constant");
+  static_assert(rmm::mr::memory_resource<kind, order>::order == order, "Incorrect constant");
 }
 
 TEST(MRTest, Constants)

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -27,16 +27,16 @@
 
 namespace {
 
-template <rmm::mr::memory_kind kind, rmm::mr::allocation_order order>
-void test_resource_traits(const rmm::mr::memory_resource<kind, order> *) {
-  static_assert(rmm::mr::memory_resource<kind, order>::kind == kind, "Incorrect constant");
-  static_assert(rmm::mr::memory_resource<kind, order>::order == order, "Incorrect constant");
+template <rmm::mr::memory_kind kind, typename Context>
+void test_resource_traits(const rmm::mr::memory_resource<kind, Context> *) {
+  static_assert(rmm::mr::memory_resource<kind, Context>::kind == kind, "Incorrect constant");
+  static_assert(std::is_same<typename rmm::mr::memory_resource<kind, Context>::context, Context>::value, "Incorrect constant");
 }
 
 TEST(MRTest, Constants)
 {
   rmm::mr::host_memory_resource *mr1 = nullptr;
-  rmm::mr::memory_resource<rmm::mr::memory_kind::pinned, rmm::mr::allocation_order::stream> *mr2 = nullptr;
+  rmm::mr::memory_resource<rmm::mr::memory_kind::pinned, void> *mr2 = nullptr;
   test_resource_traits(mr1);
   test_resource_traits(mr2);
 }

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -27,10 +27,10 @@
 
 namespace {
 
-template <rmm::mr::memory_kind kind, typename Context>
-void test_resource_traits(const rmm::mr::memory_resource<kind, Context> *) {
-  static_assert(rmm::mr::memory_resource<kind, Context>::kind == kind, "Incorrect constant");
-  static_assert(std::is_same<typename rmm::mr::memory_resource<kind, Context>::context, Context>::value, "Incorrect constant");
+template <typename Kind, typename Context>
+void test_resource_traits(const rmm::mr::memory_resource<Kind, Context> *) {
+  static_assert(std::is_same<typename rmm::mr::memory_resource<Kind, Context>::memory_kind, Kind>::value, "Incorrect kind");
+  static_assert(std::is_same<typename rmm::mr::memory_resource<Kind, Context>::context, Context>::value, "Incorrect context");
 }
 
 TEST(MRTest, Constants)
@@ -94,7 +94,7 @@ struct allocation {
 
 template <typename MemoryResourceType>
 struct MRTest : public ::testing::Test {
-  std::unique_ptr<rmm::mr::memory_resource<MemoryResourceType::kind>> mr;
+  std::unique_ptr<rmm::mr::memory_resource<typename MemoryResourceType::memory_kind>> mr;
 
   MRTest() : mr{new MemoryResourceType} {}
   ~MRTest() = default;


### PR DESCRIPTION
This is a proposal for the interface rework that would satisfy the requirements outlined in #660

## The changes are:
- add notion of `memory_kind` and `allocation_order`
- add a base class that mimics `pmr::memory_resource`, but is templated with respect to `memory_kind` and `allocation_order`
- add a base class `stream_aware_memory_resource` which covers the functionality previously implemented by `device_memory_resource`, but with configurable `memory_kind`
- make `host_memory_resource` an alias for `memory_resource<memory_kind::host, allocation_order::host>`
- make `device_memory_resource` derive from `stream_aware_resource<memory_kind::device>`
- add synchronous calls to `stream_aware_memory_resource` by inheriting from `memory_resource<kind, allocation_order::host>`
- add default implementation for synchronous allocations
- remove default stream argument
- add `default_alignment<memory_kind>` constant, which resolves to `alignof(max_align_t)` for host and 256B for others

## Behavior changes:
- a call to `stream_aware_memory_resource::allocate` without a stream will cause synchronization (to run on default stream, user needs to explicitly specify the default stream)

## Breaking changes:
- `do_allocate` and `do_deallocate` in `stream_aware_memory_resource` have been renamed to avoid an unfixable warning when compiling with NVCC (see below)
 - `do_alloc_async` / `do_dealloc_async` now accept an alignment

#### NVCC warning problem: 
Overriding a subset of virtual function's overloads causes a warning about hiding a virtual function. It's impossible to disable this warning or to mitigate it in the code, because the functions involved are private and therefore not accessible in the derived class - so we can't add dummy overrides or add using `base::do_allocate`.
