### PR TITLE
Remove duplicate conda build command

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -66,8 +66,7 @@ if [[ "$BUILD_RMM" == "1" ]]; then
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     gpuci_conda_retry build conda/recipes/rmm --python=$PYTHON
   else
-    gpuci_conda_retry build --dirty --no-remove-work-dir conda/recipes/rmm
-    conda build --dirty --no-remove-work-dir \
+    gpuci_conda_retry build --dirty --no-remove-work-dir \
       -c $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ conda/recipes/rmm
 
   fi


### PR DESCRIPTION
Looks like there was a bad merge and the `conda build` was duplicated. This PR simply corrects the bad merge.