### PR TITLE
Enable tag generation for doxygen [skip-ci]

### DIFF
--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -2081,7 +2081,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = html/rmm.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
This PR configures doxygen to generate a tag file. The tag file will ultimately be used by `cudf` for cross-referencing documentation as described in https://github.com/rapidsai/cudf/issues/5152.