### PR TITLE
[REVIEW] Build RMM tests/benchmarks with -Wall flag

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -58,11 +58,9 @@ function(ConfigureBench BENCH_NAME BENCH_SRC)
     target_compile_definitions(${BENCH_NAME} PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
   endif(PER_THREAD_DEFAULT_STREAM)
 
-  target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Werror
-                                              -Wno-error=deprecated-declarations>)
+  target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror -Wno-error=deprecated-declarations>)
   if(DISABLE_DEPRECATION_WARNING)
-    target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler
-                                                -Wno-deprecated-declarations>)
+    target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)
     target_compile_options(${BENCH_NAME}
                            PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
   endif(DISABLE_DEPRECATION_WARNING)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -58,9 +58,11 @@ function(ConfigureBench BENCH_NAME BENCH_SRC)
     target_compile_definitions(${BENCH_NAME} PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
   endif(PER_THREAD_DEFAULT_STREAM)
 
-  target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror -Wno-error=deprecated-declarations>)
+  target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
+                                              -Wno-error=deprecated-declarations>)
   if(DISABLE_DEPRECATION_WARNING)
-    target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)
+    target_compile_options(
+      ${BENCH_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)
     target_compile_options(${BENCH_NAME}
                            PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
   endif(DISABLE_DEPRECATION_WARNING)

--- a/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
+++ b/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
@@ -29,7 +29,7 @@ static void BM_StreamPoolGetStream(benchmark::State& state)
 
   for (auto _ : state) {
     auto s = stream_pool.get_stream();
-    auto e = cudaStreamQuery(s.value());
+    cudaStreamQuery(s.value());
   }
 
   state.SetItemsProcessed(state.iterations());
@@ -40,7 +40,7 @@ static void BM_CudaStreamClass(benchmark::State& state)
 {
   for (auto _ : state) {
     auto s = rmm::cuda_stream{};
-    auto e = cudaStreamQuery(s.view().value());
+    cudaStreamQuery(s.view().value());
   }
 
   state.SetItemsProcessed(state.iterations());

--- a/benchmarks/random_allocations/random_allocations.cpp
+++ b/benchmarks/random_allocations/random_allocations.cpp
@@ -73,13 +73,12 @@ void random_allocation_free(rmm::mr::device_memory_resource& mr,
   std::uniform_int_distribution<int> index_distribution(0, num_allocations - 1);
 
   int active_allocations{0};
-  int allocation_count{0};
+  std::size_t allocation_count{0};
 
   allocation_vector allocations{};
   size_t allocation_size{0};
-  size_t total_allocated{0};
 
-  for (int i = 0; i < num_allocations * 2; ++i) {
+  for (std::size_t i = 0; i < num_allocations * 2; ++i) {
     bool do_alloc = true;
     size_t size   = static_cast<size_t>(size_distribution(generator));
 

--- a/benchmarks/synchronization/synchronization.cpp
+++ b/benchmarks/synchronization/synchronization.cpp
@@ -18,16 +18,20 @@
 
 #include <rmm/device_buffer.hpp>
 
+#ifdef NDEBUG
+#define RMM_CUDA_ASSERT_OK(expr) expr
+#else
 #define RMM_CUDA_ASSERT_OK(expr)       \
   do {                                 \
     cudaError_t const status = (expr); \
     assert(cudaSuccess == status);     \
   } while (0);
+#endif
 
 cuda_event_timer::cuda_event_timer(benchmark::State& state,
                                    bool flush_l2_cache,
                                    cudaStream_t stream)
-  : p_state(&state), stream(stream)
+  : stream(stream), p_state(&state)
 {
   // flush all of L2$
   if (flush_l2_cache) {

--- a/benchmarks/utilities/log_parser.hpp
+++ b/benchmarks/utilities/log_parser.hpp
@@ -51,7 +51,7 @@ struct event {
   event(action a, std::size_t s, uintptr_t p) : act{a}, size{s}, pointer{p} {}
 
   event(std::size_t tid, action a, std::size_t sz, uintptr_t p, uintptr_t s, std::size_t i)
-    : thread_id{tid}, act{a}, size{sz}, pointer{p}, stream{s}, index{i}
+    : act{a}, size{sz}, pointer{p}, thread_id{tid}, stream{s}, index{i}
   {
   }
 

--- a/include/rmm/detail/stack_trace.hpp
+++ b/include/rmm/detail/stack_trace.hpp
@@ -64,7 +64,7 @@ class stack_trace {
       os << "But no stack trace could be found!" << std::endl;
     } else {
       ///@todo: support for demangling of C++ symbol names
-      for (int i = 0; i < st.stack_ptrs.size(); ++i) {
+      for (std::size_t i = 0; i < st.stack_ptrs.size(); ++i) {
         os << "#" << i << " in " << strings.get()[i] << std::endl;
       }
     }

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -47,10 +47,10 @@ class limiting_resource_adaptor final : public device_memory_resource {
   limiting_resource_adaptor(Upstream* upstream,
                             std::size_t allocation_limit,
                             std::size_t allocation_alignment = 256)
-    : upstream_{upstream},
-      allocation_limit_{allocation_limit},
+    : allocation_limit_{allocation_limit},
+      allocated_bytes_(0),
       allocation_alignment_(allocation_alignment),
-      allocated_bytes_(0)
+      upstream_{upstream}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
   }

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -73,10 +73,10 @@ class logging_resource_adaptor final : public device_memory_resource {
   logging_resource_adaptor(Upstream* upstream,
                            std::string const& filename = get_default_filename(),
                            bool auto_flush             = false)
-    : upstream_{upstream},
-      logger_{std::make_shared<spdlog::logger>(
+    : logger_{std::make_shared<spdlog::logger>(
         "RMM",
-        std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename, true /*truncate file*/))}
+        std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename, true /*truncate file*/))},
+      upstream_{upstream}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
 
@@ -98,9 +98,9 @@ class logging_resource_adaptor final : public device_memory_resource {
    * performance.
    */
   logging_resource_adaptor(Upstream* upstream, std::ostream& stream, bool auto_flush = false)
-    : upstream_{upstream},
-      logger_{std::make_shared<spdlog::logger>(
-        "RMM", std::make_shared<spdlog::sinks::ostream_sink_mt>(stream))}
+    : logger_{std::make_shared<spdlog::logger>(
+        "RMM", std::make_shared<spdlog::sinks::ostream_sink_mt>(stream))},
+      upstream_{upstream}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
 

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -75,7 +75,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @param capture_stacks If true, capture stacks for allocation calls
    */
   tracking_resource_adaptor(Upstream* upstream, bool capture_stacks = false)
-    : upstream_{upstream}, capture_stacks_{capture_stacks}, allocated_bytes_{0}
+    : capture_stacks_{capture_stacks}, allocated_bytes_{0}, upstream_{upstream}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,12 +60,11 @@ function(ConfigureTestInternal TEST_NAME TEST_SRC)
                CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
   target_compile_definitions(${TEST_NAME}
                              PUBLIC "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM_LOGGING_LEVEL}")
-  target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Werror
+  target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
                                              -Wno-error=deprecated-declarations>)
 
   if(DISABLE_DEPRECATION_WARNING)
-    target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler
-                                               -Wno-deprecated-declarations>)
+    target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)
     target_compile_options(${TEST_NAME}
                            PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
   endif(DISABLE_DEPRECATION_WARNING)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,7 +64,8 @@ function(ConfigureTestInternal TEST_NAME TEST_SRC)
                                              -Wno-error=deprecated-declarations>)
 
   if(DISABLE_DEPRECATION_WARNING)
-    target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)
+    target_compile_options(
+      ${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)
     target_compile_options(${TEST_NAME}
                            PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
   endif(DISABLE_DEPRECATION_WARNING)

--- a/tests/mr/device/limiting_mr_tests.cpp
+++ b/tests/mr/device/limiting_mr_tests.cpp
@@ -54,6 +54,7 @@ TEST(LimitingTest, UnderLimitDueToFrees)
   EXPECT_NO_THROW(mr.allocate(6_MiB));
   EXPECT_EQ(mr.get_allocated_bytes(), 10_MiB);
   EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 0);
+  mr.deallocate(p2, 4_MiB);
 }
 
 TEST(LimitingTest, OverLimit)
@@ -68,6 +69,8 @@ TEST(LimitingTest, OverLimit)
   EXPECT_THROW(mr.allocate(3_MiB), rmm::bad_alloc);
   EXPECT_EQ(mr.get_allocated_bytes(), 8_MiB);
   EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 2_MiB);
+  mr.deallocate(p1, 4_MiB);
+  mr.deallocate(p2, 4_MiB);
 }
 
 }  // namespace

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -49,7 +49,7 @@ void spawn_n(std::size_t num_threads, Task task, Arguments&&... args)
 {
   std::vector<std::thread> threads;
   threads.reserve(num_threads);
-  for (int i = 0; i < num_threads; ++i)
+  for (std::size_t i = 0; i < num_threads; ++i)
     threads.emplace_back(std::thread(task, std::forward<Arguments>(args)...));
 
   for (auto& t : threads)
@@ -75,7 +75,7 @@ TEST(DefaultTest, CurrentDeviceResourceIsCUDA_mt)
 TEST(DefaultTest, GetCurrentDeviceResource_mt)
 {
   spawn([]() {
-    rmm::mr::device_memory_resource* mr;
+    rmm::mr::device_memory_resource* mr{nullptr};
     EXPECT_NO_THROW(mr = rmm::mr::get_current_device_resource());
     EXPECT_NE(nullptr, mr);
     EXPECT_TRUE(mr->is_equal(rmm::mr::cuda_memory_resource{}));

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -146,11 +146,10 @@ inline void test_random_allocations(rmm::mr::device_memory_resource* mr,
       EXPECT_TRUE(is_pointer_aligned(a.p));
     });
 
-  std::for_each(
-    allocations.begin(), allocations.end(), [generator, distribution, stream, mr](allocation& a) {
-      EXPECT_NO_THROW(mr->deallocate(a.p, a.size, stream));
-      if (not stream.is_default()) stream.synchronize();
-    });
+  std::for_each(allocations.begin(), allocations.end(), [stream, mr](allocation& a) {
+    EXPECT_NO_THROW(mr->deallocate(a.p, a.size, stream));
+    if (not stream.is_default()) stream.synchronize();
+  });
 }
 
 inline void test_mixed_random_allocation_free(rmm::mr::device_memory_resource* mr,
@@ -166,12 +165,12 @@ inline void test_mixed_random_allocation_free(rmm::mr::device_memory_resource* m
   std::uniform_int_distribution<int> op_distribution(0, 99);
   std::uniform_int_distribution<int> index_distribution(0, num_allocations - 1);
 
-  int active_allocations{0};
-  int allocation_count{0};
+  std::size_t active_allocations{0};
+  std::size_t allocation_count{0};
 
   std::vector<allocation> allocations;
 
-  for (int i = 0; i < num_allocations * 2; ++i) {
+  for (std::size_t i = 0; i < num_allocations * 2; ++i) {
     bool do_alloc = true;
     if (active_allocations > 0) {
       int chance = op_distribution(generator);

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -99,7 +99,7 @@ TEST_P(mr_test, GetMemInfo)
     std::pair<std::size_t, std::size_t> mem_info;
     EXPECT_NO_THROW(mem_info = this->mr->get_mem_info(rmm::cuda_stream_view{}));
     std::size_t allocation_size = 16 * 256;
-    void* ptr;
+    void* ptr{nullptr};
     EXPECT_NO_THROW(ptr = this->mr->allocate(allocation_size));
     EXPECT_NO_THROW(mem_info = this->mr->get_mem_info(rmm::cuda_stream_view{}));
     EXPECT_TRUE(mem_info.first >= allocation_size);


### PR DESCRIPTION
Discovered RMM's not building with `-Wall`, so `-Wall -Werror` is surfacing RMM warnings in downstream projects.

<details><summary>Click to see build errors</summary><pre>[1/97] Building CXX object tests/CMakeFiles/LOGGER_PTDS_TEST.dir/logger_tests.cpp.o
FAILED: tests/CMakeFiles/LOGGER_PTDS_TEST.dir/logger_tests.cpp.o 
/usr/local/bin/g++-7 -DCUDA_API_PER_THREAD_DEFAULT_STREAM -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/LOGGER_PTDS_TEST.dir/logger_tests.cpp.o -MF tests/CMakeFiles/LOGGER_PTDS_TEST.dir/logger_tests.cpp.o.d -o tests/CMakeFiles/LOGGER_PTDS_TEST.dir/logger_tests.cpp.o -c ../../../../tests/logger_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/logger_tests.cpp:17:0</b></font>:
<font color="#FFFFFF"><b>../../../../benchmarks/utilities/log_parser.hpp:</b></font> In constructor &apos;<font color="#FFFFFF"><b>rmm::detail::event::event(std::size_t, rmm::detail::action, std::size_t, uintptr_t, uintptr_t, std::size_t)</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../benchmarks/utilities/log_parser.hpp:69:15:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::detail::event::thread_id</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::size_t <font color="#FF8787"><b>thread_id</b></font>;  ///&lt; ID of the thread that initiated the event
               <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../benchmarks/utilities/log_parser.hpp:65:14:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>rmm::detail::action rmm::detail::event::act</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   action act{<font color="#FF8787"><b>}</b></font>;           ///&lt; Indicates if the event is an allocation or a free
              <font color="#FF8787"><b>^</b></font>
<font color="#FFFFFF"><b>../../../../benchmarks/utilities/log_parser.hpp:53:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>event</b></font>(std::size_t tid, action a, std::size_t sz, uintptr_t p, uintptr_t s, std::size_t i)
   <font color="#FF8787"><b>^~~~~</b></font>
In file included from <font color="#FFFFFF"><b>../../../../tests/logger_tests.cpp:19:0</b></font>:
../../../../include/rmm/mr/device/logging_resource_adaptor.hpp: In instantiation of &apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;Upstream&gt;::logging_resource_adaptor(Upstream*, const string&amp;, bool) [with Upstream = rmm::mr::cuda_memory_resource; std::__cxx11::string = std::__cxx11::basic_string&lt;char&gt;]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/logger_tests.cpp:89:94:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:273:13:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::upstream_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   Upstream* <font color="#FF8787"><b>upstream_</b></font>;  ///&lt; The upstream resource used for satisfying
             <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:271:35:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::shared_ptr&lt;spdlog::logger&gt; rmm::mr::logging_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::logger_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::shared_ptr&lt;spdlog::logger&gt; <font color="#FF8787"><b>logger_</b></font>;  ///&lt; spdlog logger object
                                   <font color="#FF8787"><b>^~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:73:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>logging_resource_adaptor</b></font>(Upstream* upstream,
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~</b></font>
../../../../include/rmm/mr/device/logging_resource_adaptor.hpp: In instantiation of &apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;Upstream&gt;::logging_resource_adaptor(Upstream*, std::ostream&amp;, bool) [with Upstream = rmm::mr::cuda_memory_resource; std::ostream = std::basic_ostream&lt;char&gt;]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:308:73:</b></font>   required from &apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;Upstream&gt; rmm::mr::make_logging_adaptor(Upstream*, std::ostream&amp;, bool) [with Upstream = rmm::mr::cuda_memory_resource; std::ostream = std::basic_ostream&lt;char&gt;]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/logger_tests.cpp:173:67:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:273:13:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::upstream_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   Upstream* <font color="#FF8787"><b>upstream_</b></font>;  ///&lt; The upstream resource used for satisfying
             <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:271:35:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::shared_ptr&lt;spdlog::logger&gt; rmm::mr::logging_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::logger_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::shared_ptr&lt;spdlog::logger&gt; <font color="#FF8787"><b>logger_</b></font>;  ///&lt; spdlog logger object
                                   <font color="#FF8787"><b>^~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:100:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>logging_resource_adaptor</b></font>(Upstream* upstream, std::ostream&amp; stream, bool auto_flush = false)
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~</b></font>
cc1plus: all warnings being treated as errors
[8/97] Building CXX object tests/CMakeFiles/POOL_MR_PTDS_TEST.dir/mr/device/pool_mr_tests.cpp.o
FAILED: tests/CMakeFiles/POOL_MR_PTDS_TEST.dir/mr/device/pool_mr_tests.cpp.o 
/usr/local/bin/g++-7 -DCUDA_API_PER_THREAD_DEFAULT_STREAM -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/POOL_MR_PTDS_TEST.dir/mr/device/pool_mr_tests.cpp.o -MF tests/CMakeFiles/POOL_MR_PTDS_TEST.dir/mr/device/pool_mr_tests.cpp.o.d -o tests/CMakeFiles/POOL_MR_PTDS_TEST.dir/mr/device/pool_mr_tests.cpp.o -c ../../../../tests/mr/device/pool_mr_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/mr/device/pool_mr_tests.cpp:24:0</b></font>:
../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp: In instantiation of &apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;Upstream&gt;::limiting_resource_adaptor(Upstream*, std::size_t, std::size_t) [with Upstream = rmm::mr::cuda_memory_resource; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/pool_mr_tests.cpp:80:34:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:200:13:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::upstream_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   Upstream* <font color="#FF8787"><b>upstream_</b></font>;  ///&lt; The upstream resource used for satisfying
             <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:192:15:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::size_t rmm::mr::limiting_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::allocation_limit_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::size_t <font color="#FF8787"><b>allocation_limit_</b></font>;
               <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:47:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>limiting_resource_adaptor</b></font>(Upstream* upstream,
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:198:15:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::allocation_alignment_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::size_t <font color="#FF8787"><b>allocation_alignment_</b></font>;
               <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:195:28:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::atomic&lt;long unsigned int&gt; rmm::mr::limiting_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::allocated_bytes_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::atomic&lt;std::size_t&gt; <font color="#FF8787"><b>allocated_bytes_</b></font>;
                            <font color="#FF8787"><b>^~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:47:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>limiting_resource_adaptor</b></font>(Upstream* upstream,
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
cc1plus: all warnings being treated as errors
[9/97] Building CXX object tests/CMakeFiles/LIMITING_PTDS_TEST.dir/mr/device/limiting_mr_tests.cpp.o
FAILED: tests/CMakeFiles/LIMITING_PTDS_TEST.dir/mr/device/limiting_mr_tests.cpp.o 
/usr/local/bin/g++-7 -DCUDA_API_PER_THREAD_DEFAULT_STREAM -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/LIMITING_PTDS_TEST.dir/mr/device/limiting_mr_tests.cpp.o -MF tests/CMakeFiles/LIMITING_PTDS_TEST.dir/mr/device/limiting_mr_tests.cpp.o.d -o tests/CMakeFiles/LIMITING_PTDS_TEST.dir/mr/device/limiting_mr_tests.cpp.o -c ../../../../tests/mr/device/limiting_mr_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/mr/device/limiting_mr_tests.cpp:22:0</b></font>:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:</b></font> In function &apos;<font color="#FFFFFF"><b>void rmm::test::test_mixed_random_allocation_free(rmm::mr::device_memory_resource*, std::size_t, rmm::cuda_stream_view)</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:174:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
   for (int i = 0; <font color="#FF8787"><b>i &lt; num_allocations * 2</b></font>; ++i) {
                   <font color="#FF8787"><b>~~^~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:178:75:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
       do_alloc   = (chance &lt; allocation_probability) &amp;&amp; (<font color="#FF8787"><b>allocation_count &lt; num_allocations</b></font>);
                                                          <font color="#FF8787"><b>~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/limiting_mr_tests.cpp:</b></font> In member function &apos;<font color="#FFFFFF"><b>virtual void rmm::test::{anonymous}::LimitingTest_UnderLimitDueToFrees_Test::TestBody()</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/limiting_mr_tests.cpp:46:8:</b></font> <font color="#FF8787"><b>error: </b></font>unused variable &apos;<font color="#FFFFFF"><b>p2</b></font>&apos; [<font color="#FF8787"><b>-Werror=unused-variable</b></font>]
   auto <font color="#FF8787"><b>p2</b></font> = mr.allocate(4_MiB);
        <font color="#FF8787"><b>^~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/limiting_mr_tests.cpp:</b></font> In member function &apos;<font color="#FFFFFF"><b>virtual void rmm::test::{anonymous}::LimitingTest_OverLimit_Test::TestBody()</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/limiting_mr_tests.cpp:62:8:</b></font> <font color="#FF8787"><b>error: </b></font>unused variable &apos;<font color="#FFFFFF"><b>p1</b></font>&apos; [<font color="#FF8787"><b>-Werror=unused-variable</b></font>]
   auto <font color="#FF8787"><b>p1</b></font> = mr.allocate(4_MiB);
        <font color="#FF8787"><b>^~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/limiting_mr_tests.cpp:65:8:</b></font> <font color="#FF8787"><b>error: </b></font>unused variable &apos;<font color="#FFFFFF"><b>p2</b></font>&apos; [<font color="#FF8787"><b>-Werror=unused-variable</b></font>]
   auto <font color="#FF8787"><b>p2</b></font> = mr.allocate(4_MiB);
        <font color="#FF8787"><b>^~</b></font>
In file included from <font color="#FFFFFF"><b>../../../../tests/mr/device/limiting_mr_tests.cpp:19:0</b></font>:
../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp: In instantiation of &apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;Upstream&gt;::limiting_resource_adaptor(Upstream*, std::size_t, std::size_t) [with Upstream = rmm::mr::device_memory_resource; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/limiting_mr_tests.cpp:30:69:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:200:13:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;rmm::mr::device_memory_resource&gt;::upstream_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   Upstream* <font color="#FF8787"><b>upstream_</b></font>;  ///&lt; The upstream resource used for satisfying
             <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:192:15:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::size_t rmm::mr::limiting_resource_adaptor&lt;rmm::mr::device_memory_resource&gt;::allocation_limit_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::size_t <font color="#FF8787"><b>allocation_limit_</b></font>;
               <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:47:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>limiting_resource_adaptor</b></font>(Upstream* upstream,
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:198:15:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;rmm::mr::device_memory_resource&gt;::allocation_alignment_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::size_t <font color="#FF8787"><b>allocation_alignment_</b></font>;
               <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:195:28:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::atomic&lt;long unsigned int&gt; rmm::mr::limiting_resource_adaptor&lt;rmm::mr::device_memory_resource&gt;::allocated_bytes_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::atomic&lt;std::size_t&gt; <font color="#FF8787"><b>allocated_bytes_</b></font>;
                            <font color="#FF8787"><b>^~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:47:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>limiting_resource_adaptor</b></font>(Upstream* upstream,
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
cc1plus: all warnings being treated as errors
[10/97] Building CXX object tests/CMakeFiles/LOGGER_TEST.dir/logger_tests.cpp.o
FAILED: tests/CMakeFiles/LOGGER_TEST.dir/logger_tests.cpp.o 
/usr/local/bin/g++-7 -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/LOGGER_TEST.dir/logger_tests.cpp.o -MF tests/CMakeFiles/LOGGER_TEST.dir/logger_tests.cpp.o.d -o tests/CMakeFiles/LOGGER_TEST.dir/logger_tests.cpp.o -c ../../../../tests/logger_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/logger_tests.cpp:17:0</b></font>:
<font color="#FFFFFF"><b>../../../../benchmarks/utilities/log_parser.hpp:</b></font> In constructor &apos;<font color="#FFFFFF"><b>rmm::detail::event::event(std::size_t, rmm::detail::action, std::size_t, uintptr_t, uintptr_t, std::size_t)</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../benchmarks/utilities/log_parser.hpp:69:15:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::detail::event::thread_id</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::size_t <font color="#FF8787"><b>thread_id</b></font>;  ///&lt; ID of the thread that initiated the event
               <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../benchmarks/utilities/log_parser.hpp:65:14:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>rmm::detail::action rmm::detail::event::act</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   action act{<font color="#FF8787"><b>}</b></font>;           ///&lt; Indicates if the event is an allocation or a free
              <font color="#FF8787"><b>^</b></font>
<font color="#FFFFFF"><b>../../../../benchmarks/utilities/log_parser.hpp:53:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>event</b></font>(std::size_t tid, action a, std::size_t sz, uintptr_t p, uintptr_t s, std::size_t i)
   <font color="#FF8787"><b>^~~~~</b></font>
In file included from <font color="#FFFFFF"><b>../../../../tests/logger_tests.cpp:19:0</b></font>:
../../../../include/rmm/mr/device/logging_resource_adaptor.hpp: In instantiation of &apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;Upstream&gt;::logging_resource_adaptor(Upstream*, const string&amp;, bool) [with Upstream = rmm::mr::cuda_memory_resource; std::__cxx11::string = std::__cxx11::basic_string&lt;char&gt;]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/logger_tests.cpp:89:94:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:273:13:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::upstream_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   Upstream* <font color="#FF8787"><b>upstream_</b></font>;  ///&lt; The upstream resource used for satisfying
             <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:271:35:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::shared_ptr&lt;spdlog::logger&gt; rmm::mr::logging_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::logger_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::shared_ptr&lt;spdlog::logger&gt; <font color="#FF8787"><b>logger_</b></font>;  ///&lt; spdlog logger object
                                   <font color="#FF8787"><b>^~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:73:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>logging_resource_adaptor</b></font>(Upstream* upstream,
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~</b></font>
../../../../include/rmm/mr/device/logging_resource_adaptor.hpp: In instantiation of &apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;Upstream&gt;::logging_resource_adaptor(Upstream*, std::ostream&amp;, bool) [with Upstream = rmm::mr::cuda_memory_resource; std::ostream = std::basic_ostream&lt;char&gt;]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:308:73:</b></font>   required from &apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;Upstream&gt; rmm::mr::make_logging_adaptor(Upstream*, std::ostream&amp;, bool) [with Upstream = rmm::mr::cuda_memory_resource; std::ostream = std::basic_ostream&lt;char&gt;]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/logger_tests.cpp:173:67:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:273:13:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::logging_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::upstream_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   Upstream* <font color="#FF8787"><b>upstream_</b></font>;  ///&lt; The upstream resource used for satisfying
             <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:271:35:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::shared_ptr&lt;spdlog::logger&gt; rmm::mr::logging_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::logger_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::shared_ptr&lt;spdlog::logger&gt; <font color="#FF8787"><b>logger_</b></font>;  ///&lt; spdlog logger object
                                   <font color="#FF8787"><b>^~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/logging_resource_adaptor.hpp:100:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>logging_resource_adaptor</b></font>(Upstream* upstream, std::ostream&amp; stream, bool auto_flush = false)
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~</b></font>
cc1plus: all warnings being treated as errors
[11/97] Building CXX object tests/CMakeFiles/POOL_MR_TEST.dir/mr/device/pool_mr_tests.cpp.o
FAILED: tests/CMakeFiles/POOL_MR_TEST.dir/mr/device/pool_mr_tests.cpp.o 
/usr/local/bin/g++-7 -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/POOL_MR_TEST.dir/mr/device/pool_mr_tests.cpp.o -MF tests/CMakeFiles/POOL_MR_TEST.dir/mr/device/pool_mr_tests.cpp.o.d -o tests/CMakeFiles/POOL_MR_TEST.dir/mr/device/pool_mr_tests.cpp.o -c ../../../../tests/mr/device/pool_mr_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/mr/device/pool_mr_tests.cpp:24:0</b></font>:
../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp: In instantiation of &apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;Upstream&gt;::limiting_resource_adaptor(Upstream*, std::size_t, std::size_t) [with Upstream = rmm::mr::cuda_memory_resource; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/pool_mr_tests.cpp:80:34:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:200:13:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::upstream_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   Upstream* <font color="#FF8787"><b>upstream_</b></font>;  ///&lt; The upstream resource used for satisfying
             <font color="#FF8787"><b>^~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:192:15:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::size_t rmm::mr::limiting_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::allocation_limit_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::size_t <font color="#FF8787"><b>allocation_limit_</b></font>;
               <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:47:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>limiting_resource_adaptor</b></font>(Upstream* upstream,
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:198:15:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>rmm::mr::limiting_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::allocation_alignment_</b></font>&apos; will be initialized after [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::size_t <font color="#FF8787"><b>allocation_alignment_</b></font>;
               <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:195:28:</b></font> <font color="#FF8787"><b>error: </b></font>  &apos;<font color="#FFFFFF"><b>std::atomic&lt;long unsigned int&gt; rmm::mr::limiting_resource_adaptor&lt;rmm::mr::cuda_memory_resource&gt;::allocated_bytes_</b></font>&apos; [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   std::atomic&lt;std::size_t&gt; <font color="#FF8787"><b>allocated_bytes_</b></font>;
                            <font color="#FF8787"><b>^~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/limiting_resource_adaptor.hpp:47:3:</b></font> <font color="#FF8787"><b>error: </b></font>  when initialized here [<font color="#FF8787"><b>-Werror=reorder</b></font>]
   <font color="#FF8787"><b>limiting_resource_adaptor</b></font>(Upstream* upstream,
   <font color="#FF8787"><b>^~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
cc1plus: all warnings being treated as errors
[13/97] Building CXX object tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_tests.cpp.o
FAILED: tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_tests.cpp.o 
/usr/local/bin/g++-7 -DCUDA_API_PER_THREAD_DEFAULT_STREAM -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_tests.cpp.o -MF tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_tests.cpp.o.d -o tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_tests.cpp.o -c ../../../../tests/mr/device/mr_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/mr/device/mr_tests.cpp:18:0</b></font>:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:</b></font> In function &apos;<font color="#FFFFFF"><b>void rmm::test::test_mixed_random_allocation_free(rmm::mr::device_memory_resource*, std::size_t, rmm::cuda_stream_view)</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:174:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
   for (int i = 0; <font color="#FF8787"><b>i &lt; num_allocations * 2</b></font>; ++i) {
                   <font color="#FF8787"><b>~~^~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:178:75:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
       do_alloc   = (chance &lt; allocation_probability) &amp;&amp; (<font color="#FF8787"><b>allocation_count &lt; num_allocations</b></font>);
                                                          <font color="#FF8787"><b>~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~</b></font>
In file included from <font color="#FFFFFF"><b>../../../../include/rmm/mr/device/cuda_memory_resource.hpp:18:0</b></font>,
                 from <font color="#FFFFFF"><b>../../../../include/rmm/mr/device/per_device_resource.hpp:19</b></font>,
                 from <font color="#FFFFFF"><b>../../../../tests/mr/device/mr_tests.cpp:17</b></font>:
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/device_memory_resource.hpp:</b></font> In member function &apos;<font color="#FFFFFF"><b>virtual void rmm::test::{anonymous}::mr_test_GetMemInfo_Test::TestBody()</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/device_memory_resource.hpp:127:18:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>ptr</b></font>&apos; may be used uninitialized in this function [<font color="#FF8787"><b>-Werror=maybe-uninitialized</b></font>]
     <font color="#FF8787"><b>do_deallocate(p, rmm::detail::align_up(bytes, 8), stream)</b></font>;
     <font color="#FF8787"><b>~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_tests.cpp:102:11:</b></font> <font color="#4CCCE6"><b>note: </b></font>&apos;<font color="#FFFFFF"><b>ptr</b></font>&apos; was declared here
     void* <font color="#4CCCE6"><b>ptr</b></font>;
           <font color="#4CCCE6"><b>^~~</b></font>
cc1plus: all warnings being treated as errors
[15/97] Building CXX object tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_tests.cpp.o
FAILED: tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_tests.cpp.o 
/usr/local/bin/g++-7 -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_tests.cpp.o -MF tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_tests.cpp.o.d -o tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_tests.cpp.o -c ../../../../tests/mr/device/mr_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/mr/device/mr_tests.cpp:18:0</b></font>:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:</b></font> In function &apos;<font color="#FFFFFF"><b>void rmm::test::test_mixed_random_allocation_free(rmm::mr::device_memory_resource*, std::size_t, rmm::cuda_stream_view)</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:174:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
   for (int i = 0; <font color="#FF8787"><b>i &lt; num_allocations * 2</b></font>; ++i) {
                   <font color="#FF8787"><b>~~^~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:178:75:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
       do_alloc   = (chance &lt; allocation_probability) &amp;&amp; (<font color="#FF8787"><b>allocation_count &lt; num_allocations</b></font>);
                                                          <font color="#FF8787"><b>~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~</b></font>
In file included from <font color="#FFFFFF"><b>../../../../include/rmm/mr/device/cuda_memory_resource.hpp:18:0</b></font>,
                 from <font color="#FFFFFF"><b>../../../../include/rmm/mr/device/per_device_resource.hpp:19</b></font>,
                 from <font color="#FFFFFF"><b>../../../../tests/mr/device/mr_tests.cpp:17</b></font>:
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/device_memory_resource.hpp:</b></font> In member function &apos;<font color="#FFFFFF"><b>virtual void rmm::test::{anonymous}::mr_test_GetMemInfo_Test::TestBody()</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../include/rmm/mr/device/device_memory_resource.hpp:127:18:</b></font> <font color="#FF8787"><b>error: </b></font>&apos;<font color="#FFFFFF"><b>ptr</b></font>&apos; may be used uninitialized in this function [<font color="#FF8787"><b>-Werror=maybe-uninitialized</b></font>]
     <font color="#FF8787"><b>do_deallocate(p, rmm::detail::align_up(bytes, 8), stream)</b></font>;
     <font color="#FF8787"><b>~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_tests.cpp:102:11:</b></font> <font color="#4CCCE6"><b>note: </b></font>&apos;<font color="#FFFFFF"><b>ptr</b></font>&apos; was declared here
     void* <font color="#4CCCE6"><b>ptr</b></font>;
           <font color="#4CCCE6"><b>^~~</b></font>
cc1plus: all warnings being treated as errors
[17/97] Building CXX object tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o
FAILED: tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o 
/usr/local/bin/g++-7 -DCUDA_API_PER_THREAD_DEFAULT_STREAM -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o -MF tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o.d -o tests/CMakeFiles/DEVICE_MR_PTDS_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o -c ../../../../tests/mr/device/mr_multithreaded_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:17:0</b></font>:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:</b></font> In function &apos;<font color="#FFFFFF"><b>void rmm::test::test_mixed_random_allocation_free(rmm::mr::device_memory_resource*, std::size_t, rmm::cuda_stream_view)</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:174:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
   for (int i = 0; <font color="#FF8787"><b>i &lt; num_allocations * 2</b></font>; ++i) {
                   <font color="#FF8787"><b>~~^~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:178:75:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
       do_alloc   = (chance &lt; allocation_probability) &amp;&amp; (<font color="#FF8787"><b>allocation_count &lt; num_allocations</b></font>);
                                                          <font color="#FF8787"><b>~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~</b></font>
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = void (*)(); Arguments = {}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = void (*)(); Arguments = {}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:65:88:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
   for (int i = 0; <font color="#FF8787"><b>i &lt; num_threads</b></font>; ++i)
                   <font color="#FF8787"><b>~~^~~~~~~~~~~~~</b></font>
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::DefaultTest_CurrentDeviceResourceIsCUDA_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::DefaultTest_CurrentDeviceResourceIsCUDA_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:72:4:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::DefaultTest_GetCurrentDeviceResource_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::DefaultTest_GetCurrentDeviceResource_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:82:4:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::mr_test_mt_SetCurrentDeviceResource_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::mr_test_mt_SetCurrentDeviceResource_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:96:4:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, rmm::cuda_stream_view}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, rmm::cuda_stream_view}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:138:74:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, long unsigned int, long unsigned int, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, int, long int, rmm::cuda_stream_view}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, long unsigned int, long unsigned int, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, int, long int, rmm::cuda_stream_view}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:148:85:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, long unsigned int, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, long int, rmm::cuda_stream_view}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, long unsigned int, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, long int, rmm::cuda_stream_view}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:158:90:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
cc1plus: all warnings being treated as errors
[18/97] Building CXX object tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o
FAILED: tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o 
/usr/local/bin/g++-7 -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -I../../../../ -I../../../../include -I_deps/thrust-src -I_deps/thrust-src/dependencies/cub -isystem _deps/gtest-src/googlemock/include -isystem _deps/gtest-src/googlemock -isystem _deps/gtest-src/include -isystem _deps/gtest-src -isystem _deps/gtest-src/googletest/include -isystem _deps/gtest-src/googletest -isystem /usr/local/cuda-10.2/include -isystem /home/ptaylor/dev/rapids/compose/etc/conda/cuda_10.2/envs/rapids/include -fdiagnostics-color=always -Wno-deprecated-declarations -O3 -DNDEBUG -fPIE -Wall -Werror -Wno-error=deprecated-declarations -Wno-deprecated-declarations -pthread -MD -MT tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o -MF tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o.d -o tests/CMakeFiles/DEVICE_MR_TEST.dir/mr/device/mr_multithreaded_tests.cpp.o -c ../../../../tests/mr/device/mr_multithreaded_tests.cpp
In file included from <font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:17:0</b></font>:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:</b></font> In function &apos;<font color="#FFFFFF"><b>void rmm::test::test_mixed_random_allocation_free(rmm::mr::device_memory_resource*, std::size_t, rmm::cuda_stream_view)</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:174:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
   for (int i = 0; <font color="#FF8787"><b>i &lt; num_allocations * 2</b></font>; ++i) {
                   <font color="#FF8787"><b>~~^~~~~~~~~~~~~~~~~~~~~</b></font>
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_test.hpp:178:75:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
       do_alloc   = (chance &lt; allocation_probability) &amp;&amp; (<font color="#FF8787"><b>allocation_count &lt; num_allocations</b></font>);
                                                          <font color="#FF8787"><b>~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~</b></font>
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = void (*)(); Arguments = {}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = void (*)(); Arguments = {}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:65:88:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
   for (int i = 0; <font color="#FF8787"><b>i &lt; num_threads</b></font>; ++i)
                   <font color="#FF8787"><b>~~^~~~~~~~~~~~~</b></font>
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::DefaultTest_CurrentDeviceResourceIsCUDA_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::DefaultTest_CurrentDeviceResourceIsCUDA_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:72:4:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::DefaultTest_GetCurrentDeviceResource_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::DefaultTest_GetCurrentDeviceResource_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:82:4:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::mr_test_mt_SetCurrentDeviceResource_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = rmm::test::{anonymous}::mr_test_mt_SetCurrentDeviceResource_mt_Test::TestBody()::&lt;lambda()&gt;; Arguments = {}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:96:4:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, rmm::cuda_stream_view}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, rmm::cuda_stream_view}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:138:74:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, long unsigned int, long unsigned int, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, int, long int, rmm::cuda_stream_view}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, long unsigned int, long unsigned int, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, int, long int, rmm::cuda_stream_view}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:148:85:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
../../../../tests/mr/device/mr_multithreaded_tests.cpp: In instantiation of &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn_n(std::size_t, Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, long unsigned int, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, long int, rmm::cuda_stream_view}; std::size_t = long unsigned int]</b></font>&apos;:
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:62:10:</b></font>   required from &apos;<font color="#FFFFFF"><b>void rmm::test::{anonymous}::spawn(Task, Arguments&amp;&amp; ...) [with Task = void (*)(rmm::mr::device_memory_resource*, long unsigned int, rmm::cuda_stream_view); Arguments = {rmm::mr::device_memory_resource*, long int, rmm::cuda_stream_view}]</b></font>&apos;
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:158:90:</b></font>   required from here
<font color="#FFFFFF"><b>../../../../tests/mr/device/mr_multithreaded_tests.cpp:52:21:</b></font> <font color="#FF8787"><b>error: </b></font>comparison between signed and unsigned integer expressions [<font color="#FF8787"><b>-Werror=sign-compare</b></font>]
cc1plus: all warnings being treated as errors
[20/97] Building CUDA object tests/CMakeFiles/THRUST_ALLOCATOR_TEST.dir/mr/device/thrust_allocator_tests.cu.o
ninja: build stopped: subcommand failed.
</pre></details>