### PR TITLE
Auto-label PRs based on their content [skip-ci] 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,5 +12,8 @@ CMake:
 conda:
   - 'conda/**'
 
+cpp:
+  - 'cpp/**'
+
 gpuCI:
   - 'ci/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,3 +11,6 @@ CMake:
 
 conda:
   - 'conda/**'
+
+gpuCI:
+  - 'ci/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,22 +4,14 @@
 
 Python:
   - 'python/**'
-  - 'notebooks/**'
-  
-librmm:
-  - 'cpp/**'
 
 CMake:
   - '**/CMakeLists.txt'
   - '**/cmake/**'
-  
-Java:
-  - 'java/**'
-  
+
+conda:
+  - 'conda/**'
+
 Ops:
   - '.github/**'
   - 'ci/**'
-  - 'conda/**'
-  - '**/Dockerfile'
-  - '**/.dockerignore'
-  - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,3 @@ CMake:
 
 conda:
   - 'conda/**'
-
-Ops:
-  - '.github/**'
-  - 'ci/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,9 @@ conda:
   - 'conda/**'
 
 cpp:
-  - 'cpp/**'
+  - 'include/**'
+  - 'tests/**'
+  - 'doxygen/**'
 
 gpuCI:
   - 'ci/**'


### PR DESCRIPTION
This PR adds the GitHub action [PR Labeler](https://github.com/actions/labeler) to auto-label PRs based on their content. 

Labeling is managed with a configuration file `.github/labeler.yml` using the following [options](https://github.com/actions/labeler#usage).

**Note: ** This is a duplicate of #681 that we're re-merging since it was merged incorrectly.