### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,22 +4,18 @@
 
 Python:
   - 'python/**'
-  - 'notebooks/**'
-  
-librmm:
-  - 'cpp/**'
 
 CMake:
   - '**/CMakeLists.txt'
   - '**/cmake/**'
-  
-Java:
-  - 'java/**'
-  
-Ops:
-  - '.github/**'
-  - 'ci/**'
+
+conda:
   - 'conda/**'
-  - '**/Dockerfile'
-  - '**/.dockerignore'
-  - 'docker/**'
+
+cpp:
+  - 'include/**'
+  - 'tests/**'
+  - 'doxygen/**'
+
+gpuCI:
+  - 'ci/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,6 @@
-# RMM 0.18.0 (Date TBD)
+# 0.18.0
 
-## New Features
-
-- PR #636 Add a `Stream` class to manage CUDA streams in Python
-
-## Improvements
-
-- PR #647 Simplify `rmm::exec_policy` and refactor Thrust support
-
-## Bug Fixes
-
+Please see https://github.com/rapidsai/rmm/releases/tag/branch-0.18-latest for the latest changes to this development branch.
 
 # RMM 0.17.0 (10 Dec 2020)
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.