### PR TITLE
Allow the build directory of rmm to be used for `find_package(rmm)` 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,10 +108,10 @@ install(FILES ${RMM_BINARY_DIR}/include/rmm/version_config.hpp
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rmm)
 
 include(CMakePackageConfigHelpers)
-configure_package_config_file(cmake/rmm-config.cmake.in ${RMM_BINARY_DIR}/rmm-config.cmake
+configure_package_config_file(cmake/rmm-config.cmake.in ${RMM_BINARY_DIR}/cmake/rmm-config.cmake
                               INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
 
-write_basic_package_version_file(${RMM_BINARY_DIR}/rmm-config-version.cmake
+write_basic_package_version_file(${RMM_BINARY_DIR}/cmake/rmm-config-version.cmake
                                  COMPATIBILITY SameMinorVersion)
 
 install(
@@ -120,8 +120,32 @@ install(
   NAMESPACE rmm::
   DESTINATION ${INSTALL_CONFIGDIR})
 
-install(FILES ${RMM_BINARY_DIR}/rmm-config.cmake ${RMM_BINARY_DIR}/rmm-config-version.cmake
-              ${RMM_SOURCE_DIR}/cmake/install/FindThrust.cmake DESTINATION ${INSTALL_CONFIGDIR})
+install(
+  FILES ${RMM_BINARY_DIR}/cmake/rmm-config.cmake ${RMM_BINARY_DIR}/cmake/rmm-config-version.cmake
+        ${RMM_SOURCE_DIR}/cmake/install/FindThrust.cmake DESTINATION ${INSTALL_CONFIGDIR})
+
+# build export targets
+
+set(RMM_BUILD_DIR_EXPORT_SETTINGS
+    "list(PREPEND CMAKE_MODULE_PATH \"${RMM_SOURCE_DIR}/cmake/install/\")")
+
+configure_package_config_file(cmake/rmm-config.cmake.in ${RMM_BINARY_DIR}/rmm-config.cmake
+                              INSTALL_DESTINATION ${RMM_BINARY_DIR})
+
+write_basic_package_version_file(${RMM_BINARY_DIR}/rmm-config-version.cmake
+                                 COMPATIBILITY SameMinorVersion)
+
+export(
+  TARGETS rmm
+  FILE ${RMM_BINARY_DIR}/rmm-targets.cmake
+  NAMESPACE rmm::)
+
+if(SPDLOG_INSTALL)
+  export(
+    APPEND
+    TARGETS spdlog_header_only
+    FILE ${RMM_BINARY_DIR}/rmm-targets.cmake)
+endif()
 
 # make documentation
 

--- a/cmake/install/FindThrust.cmake
+++ b/cmake/install/FindThrust.cmake
@@ -34,11 +34,11 @@ cmake_minimum_required(VERSION 3.17..3.18 FATAL_ERROR)
 find_dependency(CUDAToolkit)
 
 find_path(
-  Thrust_INCLUDE_DIRS
+  Thrust_INCLUDE_DIR
   NAMES thrust/version.h
   HINTS ${CUDAToolkit_INCLUDE_DIRS})
 
-file(READ ${Thrust_INCLUDE_DIRS}/thrust/version.h _version_header)
+file(READ ${Thrust_INCLUDE_DIR}/thrust/version.h _version_header)
 string(REGEX MATCH "#define THRUST_VERSION ([0-9]*)" _match "${_version_header}")
 math(EXPR major "${CMAKE_MATCH_1} / 100000")
 math(EXPR minor "(${CMAKE_MATCH_1} / 100) % 1000")
@@ -47,10 +47,11 @@ set(Thrust_VERSION "${major}.${minor}.${subminor}")
 
 find_package_handle_standard_args(
   Thrust
-  REQUIRED_VARS Thrust_INCLUDE_DIRS
+  REQUIRED_VARS Thrust_INCLUDE_DIR
   VERSION_VAR Thrust_VERSION)
 
 if(Thrust_FOUND)
+  set(Thrust_INCLUDE_DIRS "${Thrust_INCLUDE_DIR}")
   # Create wrapper function to handle situation where we can't use a regular IMPORTED INTERFACE
   # target since that'll use -isystem, leading to the wrong search order with nvcc
   function(thrust_create_target tgt)

--- a/cmake/rmm-config.cmake.in
+++ b/cmake/rmm-config.cmake.in
@@ -2,23 +2,26 @@
 
 cmake_minimum_required(VERSION 3.17)
 
+@RMM_BUILD_DIR_EXPORT_SETTINGS@
+
 # make the bundled find modules in this directory available
-set(_save_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 include(CMakeFindDependencyMacro)
 
+include("${CMAKE_CURRENT_LIST_DIR}/rmm-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/rmm-config-version.cmake")
+
 find_dependency(CUDAToolkit)
 
-find_dependency(spdlog @RMM_MIN_VERSION_spdlog@)
+if(NOT TARGET rmm::spdlog_header_only)
+  find_dependency(spdlog @RMM_MIN_VERSION_spdlog@)
+endif()
 
 find_dependency(Thrust @RMM_MIN_VERSION_Thrust@)
 thrust_create_target(rmm::Thrust FROM_OPTIONS)
 
-set(CMAKE_MODULE_PATH ${_save_CMAKE_MODULE_PATH})
-
-include("${CMAKE_CURRENT_LIST_DIR}/rmm-targets.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/rmm-config-version.cmake")
+list(POP_FRONT CMAKE_MODULE_PATH)
 
 check_required_components(rmm)
 


### PR DESCRIPTION

This folds into the rework for libcudf to support export targets ( https://github.com/rapidsai/cudf/pull/7107 ).

Developers that are iterating on `rmm` and `cudf` should be able `cudf` against a local build of `rmm` without having to re-install `rmm` each time they change a rmm header. This MR supports this use-case by allowing `find_package(rmm)` to work with a `rmm` build directory.

To verify this ( using https://github.com/rapidsai/cudf/pull/7107 ) the following will make sure `cudf` detects your local `rmm` instead of fetching it via `CPM`.

```
cmake -S cudf/cpp -B cudf/cpp/cudf -DCMAKE_PREFIX_PATH=<rmm_build_dir>
```

