### PR TITLE
Ship memory_resource_wrappers.hpp as package_data

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -184,7 +184,7 @@ setup(
     packages=find_packages(include=["rmm", "rmm.*"]),
     package_data=dict.fromkeys(
         find_packages(include=["rmm._lib", "rmm._lib.includes", "rmm._cuda*"]),
-        ["*.pxd"],
+        ["*.hpp", "*.pxd"],
     ),
     cmdclass=versioneer.get_cmdclass(),
     install_requires=install_requires,


### PR DESCRIPTION
cuDF builds break after https://github.com/rapidsai/rmm/commit/230369db28e4f9ae47fd4b5f1d9eac54ea136363, because it cimports `device_buffer.pxd`, which in turn includes `memory_resource_wrappers.hpp`. This file isn't curerntly shipped as part of the RMM package. This PR ensures that we do ship it.

However, since PR #662 proposes removing this file entirely, we should _undo_ this change in that PR. This PR is being submitted only to unblock CI in cuDF.