### PR TITLE
Clarify log file name behaviour in docs

### DIFF
--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -15,7 +15,8 @@ import weakref
 
 from rmm import mr
 from rmm._lib.device_buffer import DeviceBuffer
-from rmm.mr import disable_logging, enable_logging
+from rmm._version import get_versions
+from rmm.mr import disable_logging, enable_logging, get_log_filenames
 from rmm.rmm import (
     RMMError,
     RMMNumbaManager,
@@ -24,7 +25,5 @@ from rmm.rmm import (
     reinitialize,
     rmm_cupy_allocator,
 )
-
-from rmm._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/python/rmm/_lib/device_uvector.pxd
+++ b/python/rmm/_lib/device_uvector.pxd
@@ -1,0 +1,24 @@
+from rmm._lib.device_buffer cimport device_buffer
+from rmm._lib.cuda_stream_view cimport cuda_stream_view
+from rmm._lib.memory_resource cimport device_memory_resource
+
+
+cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
+    cdef cppclass device_uvector[T]:
+        device_uvector(size_t size, cuda_stream_view  stream) except +
+        T* element_ptr(size_t index)
+        void set_element(size_t element_index, const T& v, cuda_stream_view s)
+        void set_element_async(
+            size_t element_index,
+            const T& v,
+            cuda_stream_view s
+        ) except +
+        T front_element(cuda_stream_view s) except +
+        T back_element(cuda_stream_view s) except +
+        void resize(size_t new_size, cuda_stream_view stream) except +
+        void shrink_to_fit(cuda_stream_view stream) except +
+        device_buffer release()
+        size_t capacity()
+        T* data()
+        size_t size()
+        device_memory_resource* memory_resource()

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -683,7 +683,7 @@ def get_log_filenames():
     --------
     >>> import rmm
     >>> rmm.reinitialize(devices=[0, 1], logging=True, log_file_name="rmm.log")
-    >>> rmm.mr.get_log_filenames()
+    >>> rmm.get_log_filenames()
     {0: '/home/ashwin/workspace/rapids/rmm/python/rmm.dev0.log',
      1: '/home/ashwin/workspace/rapids/rmm/python/rmm.dev1.log'}
     """

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -382,7 +382,7 @@ cdef class LoggingResourceAdaptor(UpstreamResourceAdaptor):
         if log_file_name is None:
             log_file_name = os.getenv("RMM_LOG_FILE")
             if not log_file_name:
-                raise TypeError(
+                raise ValueError(
                     "RMM log file must be specified either using "
                     "log_file_name= argument or RMM_LOG_FILE "
                     "environment variable"
@@ -633,7 +633,7 @@ def enable_logging(log_file_name=None):
     ----------
     log_file_name:  str, optional
         Name of the log file. If not specified, the environment variable
-        RMM_LOG_FILE is used. A TypeError is thrown if neither is available.
+        RMM_LOG_FILE is used. A ValueError is thrown if neither is available.
         A separate log file is produced for each device,
         and the suffix `".dev{id}"` is automatically added to the log file
         name.

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -684,8 +684,8 @@ def get_log_filenames():
     >>> import rmm
     >>> rmm.reinitialize(devices=[0, 1], logging=True, log_file_name="rmm.log")
     >>> rmm.get_log_filenames()
-    {0: '/home/ashwin/workspace/rapids/rmm/python/rmm.dev0.log',
-     1: '/home/ashwin/workspace/rapids/rmm/python/rmm.dev1.log'}
+    {0: '/home/user/workspace/rapids/rmm/python/rmm.dev0.log',
+     1: '/home/user/workspace/rapids/rmm/python/rmm.dev1.log'}
     """
     global _per_device_mrs
 

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -680,9 +680,9 @@ def get_log_filenames():
     """
     global _per_device_mrs
 
-    return [
-        each_mr.get_file_name()
+    return {
+        i: each_mr.get_file_name()
         if isinstance(each_mr, LoggingResourceAdaptor)
         else None
-        for each_mr in _per_device_mrs.values()
-    ]
+        for i, each_mr in _per_device_mrs.items()
+    }

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -387,11 +387,12 @@ cdef class LoggingResourceAdaptor(UpstreamResourceAdaptor):
                     "log_file_name= argument or RMM_LOG_FILE "
                     "environment variable"
                 )
+
         # Append the device ID before the file extension
         log_file_name = _append_id(
             log_file_name, getDevice()
         )
-
+        log_file_name = os.path.abspath(log_file_name)
         self._log_file_name = log_file_name
 
         self.c_obj.reset(

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -678,6 +678,14 @@ def get_log_filenames():
     """
     Returns the log filename (or `None` if not writing logs)
     for each device in use.
+
+    Examples
+    --------
+    >>> import rmm
+    >>> rmm.reinitialize(devices=[0, 1], logging=True, log_file_name="rmm.log")
+    >>> rmm.mr.get_log_filenames()
+    {0: '/home/ashwin/workspace/rapids/rmm/python/rmm.dev0.log',
+     1: '/home/ashwin/workspace/rapids/rmm/python/rmm.dev1.log'}
     """
     global _per_device_mrs
 

--- a/python/rmm/mr.py
+++ b/python/rmm/mr.py
@@ -14,6 +14,7 @@ from rmm._lib.memory_resource import (
     enable_logging,
     get_current_device_resource,
     get_current_device_resource_type,
+    get_log_filenames,
     get_per_device_resource,
     get_per_device_resource_type,
     is_initialized,
@@ -40,5 +41,6 @@ __all__ = [
     "get_current_device_resource",
     "get_per_device_resource_type",
     "get_current_device_resource_type",
+    "get_log_filenames",
     "is_initialized",
 ]

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -65,7 +65,7 @@ def reinitialize(
         This has significant performance impact.
     log_file_name : str
         Name of the log file. If not specified, the environment variable
-        RMM_LOG_FILE is used. A TypeError is thrown if neither is available.
+        RMM_LOG_FILE is used. A ValueError is thrown if neither is available.
         A separate log file is produced for each device,
         and the suffix `".dev{id}"` is automatically added to the log file
         name.

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -66,6 +66,9 @@ def reinitialize(
     log_file_name : str
         Name of the log file. If not specified, the environment variable
         RMM_LOG_FILE is used. A TypeError is thrown if neither is available.
+        A separate log file is produced for each device,
+        and the suffix `".dev{id}"` is automatically added to the log file
+        name.
     """
     rmm.mr._initialize(
         pool_allocator=pool_allocator,

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -69,6 +69,17 @@ def reinitialize(
         A separate log file is produced for each device,
         and the suffix `".dev{id}"` is automatically added to the log file
         name.
+
+    Notes
+    -----
+    Note that if you use the environment variable CUDA_VISIBLE_DEVICES
+    with logging enabled, the suffix may not be what you expect. For
+    example, if you set CUDA_VISIBLE_DEVICES=1, the log file produced
+    will still have suffix `0`. Similarly, if you set
+    CUDA_VISIBLE_DEVICES=1,0 and use devices 0 and 1, the log file
+    with suffix `0` will correspond to the GPU with device ID `1`.
+    Use `rmm.get_log_filenames()` to get the log file names
+    corresponding to each device.
     """
     rmm.mr._initialize(
         pool_allocator=pool_allocator,


### PR DESCRIPTION
* Adds docs describing the`.dev{id}` suffix to the log file name 
* Moves the responsibility of suffixing the log file name to the higher level APIs `_initialize` and `enable_logging`
