### PR TITLE
CMAKE_CUDA_ARCHITECTURES doesn't change when build-system invokes cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,9 @@ cmake_minimum_required(VERSION 3.18...3.18 FATAL_ERROR)
 
 # This needs to be run before enabling the CUDA language due to the default initialization behavior
 # of `CMAKE_CUDA_ARCHITECTURES`, https://gitlab.kitware.com/cmake/cmake/-/issues/21302
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES OR CMAKE_CUDA_ARCHITECTURES STREQUAL "ALL")
   set(RMM_BUILD_FOR_ALL_ARCHS TRUE)
 elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "")
-  unset(CMAKE_CUDA_ARCHITECTURES CACHE)
   set(RMM_BUILD_FOR_DETECTED_ARCHS TRUE)
 endif()
 


### PR DESCRIPTION
Consider the following:
```
cmake -DCMAKE_CUDA_ARCHITECTURES="" . #build for detected
touch <rmm_dir>/CMakeLists.txt
ninja #should be build for detected

cmake -DCMAKE_CUDA_ARCHITECTURES= . #build for all
touch <rmm_dir>/CMakeLists.txt
ninja #should be build for all

cmake -DCMAKE_CUDA_ARCHITECTURES="" . #build for detected
touch <rmm_dir>/CMakeLists.txt
ninja #should be build for detected
```

Before these changes the invocations of `ninja` would always
go back to building for all when ever `ninja` was invoked. The issue
is that once a CMake cache variable exists it can't be removed
via `-DCMAKE_CUDA_ARCHITECTURES=` and therefore becomes sticky.

To resolve the issue you can now pass `-DCMAKE_CUDA_ARCHITECTURES=ALL`
to consistently get all archs, and now the build-system should not
change what CUDA archs you are building for.

