### PR TITLE
Fix auto-detecting GPU architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,9 @@ message(STATUS "RMM: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'")
 
 if(BUILD_TESTS OR BUILD_BENCHMARKS)
   # Auto-detect available GPU compute architectures
-  enable_language(CUDA)
   include(${RMM_SOURCE_DIR}/cmake/Modules/SetGPUArchs.cmake)
+  # Enable the CUDA language after setting CMAKE_CUDA_ARCHITECTURES
+  enable_language(CUDA)
   message(STATUS "RMM: Building benchmarks with GPU Architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 endif()
 

--- a/cmake/Modules/EvalGPUArchs.cmake
+++ b/cmake/Modules/EvalGPUArchs.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -9,6 +9,12 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
+
+# Unset this first in case it's set to <empty_string>
+unset(CMAKE_CUDA_ARCHITECTURES CACHE)
+
+# Enable CUDA so we can invoke nvcc
+enable_language(CUDA)
 
 # Function uses the CUDA runtime API to query the compute capability of the device, so if a user
 # doesn't pass any architecture options to CMake we only build the current architecture

--- a/cmake/Modules/SetGPUArchs.cmake
+++ b/cmake/Modules/SetGPUArchs.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Fixes regression from https://github.com/rapidsai/rmm/pull/726 in auto-detecting GPU architectures when `-DCMAKE_CUDA_ARCHITECTURES=` is passed on the CLI.

Now that the cached `CMAKE_CUDA_ARCHITECTURES` isn't unset before calling `enable_language(CUDA)`, this call throws an error and configuration fails. This change ensures we call `enable_language(CUDA)` after any potential rewrites of `CMAKE_CUDA_ARCHITECTURES`.
