### PR TITLE
set CMAKE_CUDA_ARCHITECTURES to OFF instead of undefined

### DIFF
--- a/cmake/Modules/EvalGPUArchs.cmake
+++ b/cmake/Modules/EvalGPUArchs.cmake
@@ -11,7 +11,7 @@
 # the License.
 
 # Unset this first in case it's set to <empty_string>
-unset(CMAKE_CUDA_ARCHITECTURES CACHE)
+set(CMAKE_CUDA_ARCHITECTURES OFF)
 
 # Enable CUDA so we can invoke nvcc
 enable_language(CUDA)


### PR DESCRIPTION
Follow up to https://github.com/rapidsai/rmm/pull/727 after discussing with @robertmaynard it was decided that setting `CMAKE_CUDA_ARCHITECTURES` to `OFF` instead of undefined is better.