### PR TITLE
Remove CMAKE_CURRENT_BINARY_DIR path in rmm's target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,7 @@ add_library(rmm::rmm ALIAS rmm)
 
 target_include_directories(
   rmm
-  INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-            "$<INSTALL_INTERFACE:include>")
+  INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<INSTALL_INTERFACE:include>")
 
 if(CUDA_STATIC_RUNTIME)
   message(STATUS "RMM: Enabling static linking of cudart")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ add_library(rmm::rmm ALIAS rmm)
 target_include_directories(
   rmm
   INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-            "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>" "$<INSTALL_INTERFACE:include>")
+            "$<INSTALL_INTERFACE:include>")
 
 if(CUDA_STATIC_RUNTIME)
   message(STATUS "RMM: Enabling static linking of cudart")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,8 @@ find_package(CUDAToolkit REQUIRED)
 add_library(rmm INTERFACE)
 add_library(rmm::rmm ALIAS rmm)
 
-target_include_directories(
-  rmm
-  INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<INSTALL_INTERFACE:include>")
+target_include_directories(rmm INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                         "$<INSTALL_INTERFACE:include>")
 
 if(CUDA_STATIC_RUNTIME)
   message(STATUS "RMM: Enabling static linking of cudart")


### PR DESCRIPTION
This PR removes the `CMAKE_CURRENT_BINARY_DIR` path in rmm's `target_include_directories`.

Best I can tell, the build generates a `version_config.hpp` file and places it there for installation later. It doesn't seem to be included by any actual RMM library headers.

This breaks `ccache` in a few different ways:

* Building against different RMM build dirs:
  1. Build cuDF against RMM at `rmm/build-dir-1` (note `-I rmm/build-dir-1/include` in cuDF compile commands).
  2. Rebuild cuDF against RMM at `rmm/build-dir-2`  (note `-I rmm/build-dir-2/include` in cuDF compile commands).
  3. `ccache` rebuilds all cuDF source files even though none of the RMM headers actually changed.
 * Build RMM as a dependency of cuDF retrieved via CPM (with `CPM_SOURCE_CACHE`):
   1. Project A calls `CPMFindPackage(cudf ...)`, cuDF and RMM are downloaded and placed in `CPM_SOURCE_CACHE`.
   2. Project B calls `CPMFindPackage(cudf ...)`, which uses cuDF and RMM source cached in `CPM_SOURCE_CACHE`.
   3. The ccache for cuDF source files cannot be shared between Project A and Project B, because the compile command for each cuDF object includes `-I ProjectA/build/_deps/rmm-build/include` and `-I ProjectB/build/_deps/rmm-build/include`, respectively.
