### PR TITLE
device_uvector can be used within thrust::optional

### DIFF
--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -49,6 +49,7 @@ test:
     - test -f $PREFIX/include/rmm/device_buffer.hpp
     - test -f $PREFIX/include/rmm/detail/aligned.hpp
     - test -f $PREFIX/include/rmm/detail/error.hpp
+    - test -f $PREFIX/include/rmm/detail/exec_check_disable.hpp
     - test -f $PREFIX/include/rmm/mr/device/detail/arena.hpp
     - test -f $PREFIX/include/rmm/mr/device/detail/free_list.hpp
     - test -f $PREFIX/include/rmm/mr/device/detail/coalescing_free_list.hpp

--- a/include/rmm/detail/exec_check_disable.hpp
+++ b/include/rmm/detail/exec_check_disable.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+/**
+ * @brief Macro for suppressing __host__ / __device__ function markup
+ * checks that the NVCC compiler does.
+ *
+ * At times it is useful to place rmm host only types inside containers
+ * that work on both host and device. Doing so will generate warnings
+ * of using a host only type inside a host / device type.
+ *
+ * This macro can be used to silence said warnings
+ *
+ */
+
+// #pragma nv_exec_check_disable is only recognized by NVCC so verify
+// that we have both the NVCC compiler and we are compiling a CUDA
+// source
+#if defined(__CUDACC__) && defined(__NVCC__)
+#define RMM_EXEC_CHECK_DISABLE _Pragma("nv_exec_check_disable")
+#else
+#define RMM_EXEC_CHECK_DISABLE
+#endif

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/exec_check_disable.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
@@ -78,8 +79,12 @@ class device_uvector {
   using iterator        = pointer;
   using const_iterator  = const_pointer;
 
-  ~device_uvector()                = default;
+  RMM_EXEC_CHECK_DISABLE
+  ~device_uvector() = default;
+
+  RMM_EXEC_CHECK_DISABLE
   device_uvector(device_uvector&&) = default;
+
   device_uvector& operator=(device_uvector&&) = default;
 
   /**


### PR DESCRIPTION
Fixes https://github.com/rapidsai/cudf/issues/7629

Since thrust::optional is marked with host and device markup,
we need to make sure we don't generate errors when device_uvector
is placed inside of it as it will inherit the device markup.
