### PR TITLE
Update `rmm` conda recipe pinning of `librmm`

### DIFF
--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set py_version=environ.get('CONDA_PY', 35) %}
@@ -23,7 +23,7 @@ requirements:
     - cmake >=3.14.0
   host:
     - python
-    - librmm {{ version }}
+    - librmm {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
     - setuptools
     - cython >=0.29,<0.30
     - spdlog=1.7.0


### PR DESCRIPTION
Ensure `rmm` conda packages are pinned to use the same build offset for `librmm`. This prevents issues where different versions of `rmm` and `librmm` are solved to currently causing breaks in builds and testing for this library and others. The new pinning will pair the packages together so only a complete pair will solve going forward.