### PR TITLE
Disable construction of cuda_stream_view from literal zero or nullptr

### DIFF
--- a/benchmarks/synchronization/synchronization.cpp
+++ b/benchmarks/synchronization/synchronization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
 
 cuda_event_timer::cuda_event_timer(benchmark::State& state,
                                    bool flush_l2_cache,
-                                   cudaStream_t stream)
+                                   rmm::cuda_stream_view stream)
   : stream(stream), p_state(&state)
 {
   // flush all of L2$
@@ -44,18 +44,19 @@ cuda_event_timer::cuda_event_timer(benchmark::State& state,
     if (l2_cache_bytes > 0) {
       const int memset_value = 0;
       rmm::device_buffer l2_cache_buffer(l2_cache_bytes, stream);
-      RMM_CUDA_TRY(cudaMemsetAsync(l2_cache_buffer.data(), memset_value, l2_cache_bytes, stream));
+      RMM_CUDA_TRY(
+        cudaMemsetAsync(l2_cache_buffer.data(), memset_value, l2_cache_bytes, stream.value()));
     }
   }
 
   RMM_CUDA_TRY(cudaEventCreate(&start));
   RMM_CUDA_TRY(cudaEventCreate(&stop));
-  RMM_CUDA_TRY(cudaEventRecord(start, stream));
+  RMM_CUDA_TRY(cudaEventRecord(start, stream.value()));
 }
 
 cuda_event_timer::~cuda_event_timer()
 {
-  RMM_CUDA_ASSERT_OK(cudaEventRecord(stop, stream));
+  RMM_CUDA_ASSERT_OK(cudaEventRecord(stop, stream.value()));
   RMM_CUDA_ASSERT_OK(cudaEventSynchronize(stop));
 
   float milliseconds = 0.0f;

--- a/benchmarks/synchronization/synchronization.hpp
+++ b/benchmarks/synchronization/synchronization.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,8 @@
 
 #pragma once
 
+#include <rmm/cuda_stream_view.hpp>
+
 // Google Benchmark library
 #include <benchmark/benchmark.h>
 #include <cuda_runtime_api.h>
@@ -70,11 +72,13 @@ class cuda_event_timer {
    *
    * @param[in,out] state  This is the benchmark::State whose timer we are going
    * to update.
-   * @param[in] flush_l2_cache_ whether or not to flush the L2 cache before
+   * @param[in] flush_l2_cache whether or not to flush the L2 cache before
    *                            every iteration.
-   * @param[in] stream_ The CUDA stream we are measuring time on.
+   * @param[in] stream The CUDA stream we are measuring time on.
    */
-  cuda_event_timer(benchmark::State& state, bool flush_l2_cache, cudaStream_t stream_ = 0);
+  cuda_event_timer(benchmark::State& state,
+                   bool flush_l2_cache,
+                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
 
   // The user will HAVE to provide a benchmark::State object to set
   // the timer so we disable the default c'tor.
@@ -88,6 +92,6 @@ class cuda_event_timer {
  private:
   cudaEvent_t start;
   cudaEvent_t stop;
-  cudaStream_t stream;
+  rmm::cuda_stream_view stream;
   benchmark::State* p_state;
 };

--- a/include/rmm/cuda_stream_view.hpp
+++ b/include/rmm/cuda_stream_view.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +40,9 @@ class cuda_stream_view {
   constexpr cuda_stream_view& operator=(cuda_stream_view&&) = default;
   ~cuda_stream_view()                                       = default;
 
-  // TODO disable construction from 0 after cuDF and others adopt cuda_stream_view
-  // cuda_stream_view(int)            = delete; //< Prevent cast from 0
-  // cuda_stream_view(std::nullptr_t) = delete; //< Prevent cast from nullptr
-  // TODO also disable implicit conversion from cudaStream_t
+  // Disable construction from literal 0
+  constexpr cuda_stream_view(int)            = delete;  //< Prevent cast from 0
+  constexpr cuda_stream_view(std::nullptr_t) = delete;  //< Prevent cast from nullptr
 
   /**
    * @brief Implicit conversion from cudaStream_t.

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ class fixed_size_memory_resource
       upstream_chunk_size_{block_size * blocks_to_preallocate}
   {
     // allocate initial blocks and insert into free list
-    this->insert_blocks(std::move(blocks_from_upstream(cudaStreamLegacy)), cudaStreamLegacy);
+    this->insert_blocks(std::move(blocks_from_upstream(cuda_stream_legacy)), cuda_stream_legacy);
   }
 
   /**

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ class pool_memory_resource final
       if (not initial_size.has_value()) {
         std::size_t free{}, total{};
         std::tie(free, total) = (get_upstream()->supports_get_mem_info())
-                                  ? get_upstream()->get_mem_info(cudaStreamLegacy)
+                                  ? get_upstream()->get_mem_info(cuda_stream_legacy)
                                   : detail::available_device_memory();
         return rmm::detail::align_up(std::min(free, total / 2), allocation_alignment);
       } else {
@@ -222,8 +222,8 @@ class pool_memory_resource final
                 "Initial pool size exceeds the maximum pool size!");
 
     if (try_size > 0) {
-      auto const b = try_to_expand(try_size, try_size, cudaStreamLegacy);
-      this->insert_block(b, cudaStreamLegacy);
+      auto const b = try_to_expand(try_size, try_size, cuda_stream_legacy);
+      this->insert_block(b, cuda_stream_legacy);
     }
   }
 

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ using exec_policy_t = std::unique_ptr<par_t, deleter_t>;
  */
 inline exec_policy_t exec_policy(cudaStream_t stream = 0)
 {
-  auto *alloc  = new rmm::mr::thrust_allocator<char>(stream);
+  auto *alloc  = new rmm::mr::thrust_allocator<char>(cuda_stream_view{stream});
   auto deleter = [alloc](par_t *pointer) {
     delete alloc;
     delete pointer;

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ TEST(PoolTest, DeletedStream)
   cudaStream_t stream;  // we don't use rmm::cuda_stream here to make destruction more explicit
   const int size = 10000;
   EXPECT_EQ(cudaSuccess, cudaStreamCreate(&stream));
-  EXPECT_NO_THROW(rmm::device_buffer buff(size, stream, &mr));
+  EXPECT_NO_THROW(rmm::device_buffer buff(size, cuda_stream_view{stream}, &mr));
   EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream));
   EXPECT_NO_THROW(mr.allocate(size));
 }


### PR DESCRIPTION
This deletes the `rmm::cuda_stream_view` constructors from `int` and `nullptr_t` to disable construction from literal zero or `nullptr`. This makes stream parameters harder to misuse and more strongly types stream parameters in RAPIDS APIs.

This is a breaking change that will more than likely require corresponding changes in dependent RAPIDS libraries.