### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/conda/environments/rmm_dev_cuda10.1.yml
+++ b/conda/environments/rmm_dev_cuda10.1.yml
@@ -10,7 +10,7 @@ dependencies:
 - flake8=3.8.3
 - black=19.10
 - isort=5.0.7
-- python>=3.6,<3.8
+- python>=3.7,<3.9
 - numba>=0.49
 - numpy
 - cffi>=1.10.0

--- a/conda/environments/rmm_dev_cuda10.2.yml
+++ b/conda/environments/rmm_dev_cuda10.2.yml
@@ -10,7 +10,7 @@ dependencies:
 - flake8=3.8.3
 - black=19.10
 - isort=5.0.7
-- python>=3.6,<3.8
+- python>=3.7,<3.9
 - numba>=0.49
 - numpy
 - cffi>=1.10.0

--- a/conda/environments/rmm_dev_cuda11.0.yml
+++ b/conda/environments/rmm_dev_cuda11.0.yml
@@ -10,7 +10,7 @@ dependencies:
 - flake8=3.8.3
 - black=19.10
 - isort=5.0.7
-- python>=3.6,<3.8
+- python>=3.7,<3.9
 - numba>=0.49
 - numpy
 - cffi>=1.10.0

--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+
+clang==8.0.1
+flake8==3.8.3
+black==19.10b0
+isort==5.0.7
+cmake-format==0.6.11
+numpy
+numba>=0.49
+pytest
+pytest-xdist
+cython>=0.29,<0.30
+wheel
+setuptools

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,3 +1,13 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+
+[build-system]
+
+requires = [
+    "wheel",
+    "setuptools",
+    "Cython>=0.29,<0.30",
+]
+
 [tool.black]
 line-length = 79
 target-version = ["py36"]

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,8 +1,9 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
 
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the
 # resulting files.
+
 
 [versioneer]
 VCS = git
@@ -48,3 +49,11 @@ skip=
     build
     dist
     __init__.py
+
+
+[options]
+packages = find:
+install_requires =
+    numpy
+    numba>=0.49
+python_requires = >=3.7,<3.9

--- a/python/setup.py
+++ b/python/setup.py
@@ -201,11 +201,12 @@ setup(
         "Topic :: Scientific/Engineering",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     # Include the separately-compiled shared library
-    setup_requires=["cython"],
+    setup_requires=["Cython>=0.29,<0.30"],
+    extras_requires={"test": ["pytest", "pytest-xdist"]},
     ext_modules=extensions,
     packages=find_packages(include=["rmm", "rmm.*"]),
     package_data=dict.fromkeys(


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.