### PR TITLE
Update rmm to use the latest version of CPM ( 0.32.0 )

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ export(
   FILE ${RMM_BINARY_DIR}/rmm-targets.cmake
   NAMESPACE rmm::)
 
-if(SPDLOG_INSTALL)
+if(RMM_EXPORT_SPDLOG)
   export(
     APPEND
     TARGETS spdlog_header_only

--- a/cmake/Modules/CPM.cmake
+++ b/cmake/Modules/CPM.cmake
@@ -1,4 +1,4 @@
-set(CPM_DOWNLOAD_VERSION 02d57a16015209c4da38483bef7475a8e78c9da6) # 0.28.4
+set(CPM_DOWNLOAD_VERSION 4fad2eac0a3741df3d9c44b791f9163b74aa7b07) # 0.32.0
 
 if(CPM_SOURCE_CACHE)
   # Expand relative path. This is important if the provided path contains a tilde (~)

--- a/cmake/Modules/RMM_thirdparty.cmake
+++ b/cmake/Modules/RMM_thirdparty.cmake
@@ -10,6 +10,10 @@ CPMFindPackage(
   # If there is no pre-installed spdlog we can use, we'll install our fetched copy together with RMM
   OPTIONS "SPDLOG_INSTALL TRUE")
 
+if(spdlog_ADDED)
+  set(RMM_EXPORT_SPDLOG TRUE)
+endif()
+
 # thrust/cub
 
 set(RMM_MIN_VERSION_Thrust 1.9.0)


### PR DESCRIPTION
The latest version of CPM improves behavior around how options provided to the cpm'ed project behave. This fixes issues
where an option provided to a cpm project would influence the callers or other cpm projects behavior.
