### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - cmake >=3.14.0
   host:
     - python
-    - librmm {{ version }}=*_{{ GIT_DESCRIBE_NUMBER }}
+    - librmm {{ version }}
     - setuptools
     - cython >=0.29,<0.30
     - spdlog=1.7.0


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.