### PR TITLE
Update cuda_async_memory_resource to use explicit pool 

### DIFF
--- a/include/rmm/cuda_device.hpp
+++ b/include/rmm/cuda_device.hpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace rmm {
+
+/**
+ * @brief Strong type for a CUDA device identifier.
+ *
+ */
+struct cuda_device_id {
+  using value_type = int;
+
+  /**
+   * @brief Construct a `cuda_device_id` from the specified integer value
+   *
+   * @param id The device's integer identifier
+   */
+  explicit constexpr cuda_device_id(value_type id) noexcept : id_{id} {}
+
+  /// Returns the wrapped integer value
+  constexpr value_type value() const noexcept { return id_; }
+
+ private:
+  value_type id_;
+};
+
+namespace detail {
+/**
+ * @brief Returns a `cuda_device_id` for the current device
+ *
+ * The current device is the device on which the calling thread executes device code.
+ *
+ * @return `cuda_device_id` for the current device
+ */
+inline cuda_device_id current_device()
+{
+  int dev_id;
+  RMM_CUDA_TRY(cudaGetDevice(&dev_id));
+  return cuda_device_id{dev_id};
+}
+}  // namespace detail
+}  // namespace rmm

--- a/include/rmm/detail/cuda_util.hpp
+++ b/include/rmm/detail/cuda_util.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <rmm/detail/error.hpp>
+
+namespace rmm {
+namespace detail {
+
+/// Gets the available and total device memory in bytes for the current device
+inline std::pair<std::size_t, std::size_t> available_device_memory()
+{
+  std::size_t free{}, total{};
+  RMM_CUDA_TRY(cudaMemGetInfo(&free, &total));
+  return {free, total};
+}
+
+}  // namespace detail
+}  // namespace rmm

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -48,10 +48,10 @@ class cuda_async_memory_resource final : public device_memory_resource {
    *
    * @throws rmm::runtime_error if the CUDA version does not support `cudaMallocAsync`
    *
-   * @param initial_pool_size Optional initial size of the pool. If no value is provided, initial
-   * pool size is 0.
-   * @param release_threshold Optional release threshold of the pool. If no value is provided, the
-   * release threshold is set to the total amount of memory on the current device.
+   * @param initial_pool_size Optional initial size in bytes of the pool. If no value is provided,
+   * initial pool size is 0.
+   * @param release_threshold Optional release threshold size in bytes of the pool. If no value is
+   * provided, the release threshold is set to the total amount of memory on the current device.
    */
   cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size = {},
                              thrust::optional<std::size_t> release_threshold = {})

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -93,11 +93,13 @@ class cuda_async_memory_resource final : public device_memory_resource {
 #endif
   }
 
+#ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   /**
    * @brief Returns the underlying native handle to the CUDA pool
    *
    */
   cudaMemPool_t pool_handle() const noexcept { return cuda_pool_handle_; }
+#endif
 
   ~cuda_async_memory_resource()                                 = default;
   cuda_async_memory_resource(cuda_async_memory_resource const&) = default;
@@ -121,7 +123,9 @@ class cuda_async_memory_resource final : public device_memory_resource {
   bool supports_get_mem_info() const noexcept override { return false; }
 
  private:
+#ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   cudaMemPool_t cuda_pool_handle_;
+#endif
 
   /**
    * @brief Allocates memory of size at least `bytes` using cudaMalloc.

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -74,6 +74,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
     RMM_CUDA_TRY(cudaMemPoolCreate(&cuda_pool_handle_, &pool_props));
 
     auto const [free, total] = rmm::detail::available_device_memory();
+    (void)free;
 
     // Need an l-value to take address to pass to cudaMemPoolSetAttribute
     uint64_t threshold = release_threshold.value_or(total);

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -16,11 +16,11 @@
 #pragma once
 
 #include <limits>
-#include <rmm/detail/error.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/cuda_util.hpp>
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda_runtime_api.h>
 
@@ -60,16 +60,17 @@ class cuda_async_memory_resource final : public device_memory_resource {
     // Check if cudaMallocAsync Memory pool supported
     auto const device = rmm::detail::current_device();
     int cuda_pool_supported{};
-    auto e = cudaDeviceGetAttribute(&cuda_pool_supported, cudaDevAttrMemoryPoolsSupported, device.value());
+    auto e =
+      cudaDeviceGetAttribute(&cuda_pool_supported, cudaDevAttrMemoryPoolsSupported, device.value());
     RMM_EXPECTS(e == cudaSuccess && cuda_pool_supported,
                 "cudaMallocAsync not supported with this CUDA driver/runtime version");
 
     // Construct explicit pool
     cudaMemPoolProps pool_props{};
-    pool_props.allocType        = cudaMemAllocationTypePinned;
-    pool_props.handleTypes      = cudaMemHandleTypePosixFileDescriptor;
-    pool_props.location.type    = cudaMemLocationTypeDevice;
-    pool_props.location.id      = device.value();
+    pool_props.allocType     = cudaMemAllocationTypePinned;
+    pool_props.handleTypes   = cudaMemHandleTypePosixFileDescriptor;
+    pool_props.location.type = cudaMemLocationTypeDevice;
+    pool_props.location.id   = device.value();
     cudaMemPoolCreate(&cuda_pool_handle_, &pool_props);
 
     auto const [free, total] = rmm::detail::available_device_memory();
@@ -80,9 +81,9 @@ class cuda_async_memory_resource final : public device_memory_resource {
 
     // Allocate and immediately deallocate the initial_pool_size to prime the pool with the
     // specified size
-    if(initial_pool_size){
-        auto p = do_allocate(*initial_pool_size, cuda_stream_default);
-        do_deallocate(p, *initial_pool_size, cuda_stream_default);
+    if (initial_pool_size) {
+      auto p = do_allocate(*initial_pool_size, cuda_stream_default);
+      do_deallocate(p, *initial_pool_size, cuda_stream_default);
     }
 
 #else

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -15,11 +15,16 @@
  */
 #pragma once
 
+#include <limits>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include "rmm/cuda_stream_view.hpp"
+#include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/cuda_util.hpp>
 
 #include <cuda_runtime_api.h>
+
+#include <optional>
 
 #if CUDART_VERSION >= 11020  // 11.2 introduced cudaMallocAsync
 #define RMM_CUDA_MALLOC_ASYNC_SUPPORT
@@ -35,25 +40,62 @@ namespace mr {
 class cuda_async_memory_resource final : public device_memory_resource {
  public:
   /**
-   * @brief Default constructor
+   * @brief Constructs a cuda_async_memory_resource with the optionally specified initial pool size
+   * and release threshold.
+   *
+   * If the pool size grows beyond the release threshold, unused memory held by the pool will be
+   * released at the next synchronization event.
    *
    * @throws rmm::runtime_error if the CUDA version does not support `cudaMallocAsync`
+   *
+   * @param initial_pool_size Optional initial size of the pool. If no value is provided, initial
+   * pool size is 0.
+   * @param release_threshold Optional release threshold of the pool. If no value is provided, the
+   * release threshold is set to the total amount of memory on the current device.
    */
-  cuda_async_memory_resource()
+  cuda_async_memory_resource(std::optional<std::size_t> initial_pool_size = {},
+                             std::optional<std::size_t> release_threshold = {})
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     // Check if cudaMallocAsync Memory pool supported
-    int device{0};
-    RMM_CUDA_TRY(cudaGetDevice(&device));
-    int v{0};
-    auto e = cudaDeviceGetAttribute(&v, cudaDevAttrMemoryPoolsSupported, device);
-    RMM_EXPECTS(e == cudaSuccess && v == 1,
+    auto const device = rmm::detail::current_device();
+    int cuda_pool_supported{};
+    auto e = cudaDeviceGetAttribute(&cuda_pool_supported, cudaDevAttrMemoryPoolsSupported, device.value());
+    RMM_EXPECTS(e == cudaSuccess && cuda_pool_supported,
                 "cudaMallocAsync not supported with this CUDA driver/runtime version");
+
+    // Construct explicit pool
+    cudaMemPoolProps pool_props{};
+    pool_props.allocType        = cudaMemAllocationTypePinned;
+    pool_props.handleTypes      = cudaMemHandleTypePosixFileDescriptor;
+    pool_props.location.type    = cudaMemLocationTypeDevice;
+    pool_props.location.id      = device.value();
+    cudaMemPoolCreate(&cuda_pool_handle_, &pool_props);
+
+    auto const [free, total] = rmm::detail::available_device_memory();
+
+    // Need an l-value to take address to pass to cudaMemPoolSetAttribute
+    uint64_t threshold = release_threshold.value_or(total);
+    cudaMemPoolSetAttribute(cuda_pool_handle_, cudaMemPoolAttrReleaseThreshold, &threshold);
+
+    // Allocate and immediately deallocate the initial_pool_size to prime the pool with the
+    // specified size
+    if(initial_pool_size){
+        auto p = do_allocate(*initial_pool_size, cuda_stream_default);
+        do_deallocate(p, *initial_pool_size, cuda_stream_default);
+    }
+
 #else
     RMM_FAIL(
       "cudaMallocAsync not supported by the version of the CUDA Toolkit used for this build");
 #endif
   }
+
+  /**
+   * @brief Returns the underlying native handle to the CUDA pool
+   *
+   */
+  cudaMemPool_t pool_handle() const noexcept { return cuda_pool_handle_; }
 
   ~cuda_async_memory_resource()                                 = default;
   cuda_async_memory_resource(cuda_async_memory_resource const&) = default;
@@ -77,6 +119,8 @@ class cuda_async_memory_resource final : public device_memory_resource {
   bool supports_get_mem_info() const noexcept override { return false; }
 
  private:
+  cudaMemPool_t cuda_pool_handle_;
+
   /**
    * @brief Allocates memory of size at least `bytes` using cudaMalloc.
    *
@@ -91,7 +135,10 @@ class cuda_async_memory_resource final : public device_memory_resource {
   {
     void* p{nullptr};
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
-    if (bytes > 0) { RMM_CUDA_TRY(cudaMallocAsync(&p, bytes, stream.value()), rmm::bad_alloc); }
+    if (bytes > 0) {
+      RMM_CUDA_TRY(cudaMallocFromPoolAsync(&p, bytes, pool_handle(), stream.value()),
+                   rmm::bad_alloc);
+    }
 #else
     (void)bytes;
     (void)stream;

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -77,7 +77,8 @@ class cuda_async_memory_resource final : public device_memory_resource {
 
     // Need an l-value to take address to pass to cudaMemPoolSetAttribute
     uint64_t threshold = release_threshold.value_or(total);
-    RMM_CUDA_TRY(cudaMemPoolSetAttribute(cuda_pool_handle_, cudaMemPoolAttrReleaseThreshold, &threshold));
+    RMM_CUDA_TRY(
+      cudaMemPoolSetAttribute(cuda_pool_handle_, cudaMemPoolAttrReleaseThreshold, &threshold));
 
     // Allocate and immediately deallocate the initial_pool_size to prime the pool with the
     // specified size

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -24,7 +24,7 @@
 
 #include <cuda_runtime_api.h>
 
-#include <optional>
+#include <thrust/optional.h>
 
 #if CUDART_VERSION >= 11020  // 11.2 introduced cudaMallocAsync
 #define RMM_CUDA_MALLOC_ASYNC_SUPPORT
@@ -53,8 +53,8 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @param release_threshold Optional release threshold of the pool. If no value is provided, the
    * release threshold is set to the total amount of memory on the current device.
    */
-  cuda_async_memory_resource(std::optional<std::size_t> initial_pool_size = {},
-                             std::optional<std::size_t> release_threshold = {})
+  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size = {},
+                             thrust::optional<std::size_t> release_threshold = {})
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     // Check if cudaMallocAsync Memory pool supported

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -71,13 +71,13 @@ class cuda_async_memory_resource final : public device_memory_resource {
     pool_props.handleTypes   = cudaMemHandleTypePosixFileDescriptor;
     pool_props.location.type = cudaMemLocationTypeDevice;
     pool_props.location.id   = device.value();
-    cudaMemPoolCreate(&cuda_pool_handle_, &pool_props);
+    RMM_CUDA_TRY(cudaMemPoolCreate(&cuda_pool_handle_, &pool_props));
 
     auto const [free, total] = rmm::detail::available_device_memory();
 
     // Need an l-value to take address to pass to cudaMemPoolSetAttribute
     uint64_t threshold = release_threshold.value_or(total);
-    cudaMemPoolSetAttribute(cuda_pool_handle_, cudaMemPoolAttrReleaseThreshold, &threshold);
+    RMM_CUDA_TRY(cudaMemPoolSetAttribute(cuda_pool_handle_, cudaMemPoolAttrReleaseThreshold, &threshold));
 
     // Allocate and immediately deallocate the initial_pool_size to prime the pool with the
     // specified size

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -16,9 +16,9 @@
 
 #pragma once
 
+#include <rmm/cuda_device.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/cuda_device.hpp>
 
 #include <map>
 #include <mutex>
@@ -71,7 +71,6 @@
  */
 
 namespace rmm {
-
 
 namespace mr {
 

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -18,6 +18,7 @@
 
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/cuda_device.hpp>
 
 #include <map>
 #include <mutex>
@@ -71,26 +72,6 @@
 
 namespace rmm {
 
-/**
- * @brief Strong type for a CUDA device identifier.
- *
- */
-struct cuda_device_id {
-  using value_type = int;
-
-  /**
-   * @brief Construct a `cuda_device_id` from the specified integer value
-   *
-   * @param id The device's integer identifier
-   */
-  explicit constexpr cuda_device_id(value_type id) noexcept : id_{id} {}
-
-  /// Returns the wrapped integer value
-  constexpr value_type value() const noexcept { return id_; }
-
- private:
-  value_type id_;
-};
 
 namespace mr {
 
@@ -121,19 +102,6 @@ inline auto& get_map()
   return device_id_to_resource;
 }
 
-/**
- * @brief Returns a `cuda_device_id` for the current device
- *
- * The current device is the device on which the calling thread executes device code.
- *
- * @return `cuda_device_id` for the current device
- */
-inline cuda_device_id current_device()
-{
-  int dev_id;
-  RMM_CUDA_TRY(cudaGetDevice(&dev_id));
-  return cuda_device_id{dev_id};
-}
 }  // namespace detail
 
 /**
@@ -228,7 +196,7 @@ inline device_memory_resource* set_per_device_resource(cuda_device_id id,
  */
 inline device_memory_resource* get_current_device_resource()
 {
-  return get_per_device_resource(detail::current_device());
+  return get_per_device_resource(rmm::detail::current_device());
 }
 
 /**
@@ -257,7 +225,7 @@ inline device_memory_resource* get_current_device_resource()
  */
 inline device_memory_resource* set_current_device_resource(device_memory_resource* new_mr)
 {
-  return set_per_device_resource(detail::current_device(), new_mr);
+  return set_per_device_resource(rmm::detail::current_device(), new_mr);
 }
 }  // namespace mr
 }  // namespace rmm

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -22,6 +22,7 @@
 #include <rmm/mr/device/detail/coalescing_free_list.hpp>
 #include <rmm/mr/device/detail/stream_ordered_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/detail/cuda_util.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
@@ -42,15 +43,6 @@
 
 namespace rmm {
 namespace mr {
-namespace detail {
-/// Gets the available and total device memory in bytes for the current device
-inline std::pair<std::size_t, std::size_t> available_device_memory()
-{
-  std::size_t free{}, total{};
-  RMM_CUDA_TRY(cudaMemGetInfo(&free, &total));
-  return {free, total};
-}
-}  // namespace detail
 
 /**
  * @brief A coalescing best-fit suballocator which uses a pool of memory allocated from
@@ -208,7 +200,7 @@ class pool_memory_resource final
         std::size_t free{}, total{};
         std::tie(free, total) = (get_upstream()->supports_get_mem_info())
                                   ? get_upstream()->get_mem_info(cudaStreamLegacy)
-                                  : detail::available_device_memory();
+                                  : rmm::detail::available_device_memory();
         return rmm::detail::align_up(std::min(free, total / 2), allocation_alignment);
       } else {
         return initial_size.value();

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -17,12 +17,12 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
+#include <rmm/detail/cuda_util.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/device/detail/coalescing_free_list.hpp>
 #include <rmm/mr/device/detail/stream_ordered_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/detail/cuda_util.hpp>
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -55,17 +55,12 @@ class new_delete_resource final : public host_memory_resource {
   void *do_allocate(std::size_t bytes,
                     std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
-#if __cplusplus >= 201703L
-    return ::operator new(bytes, std::align_val_t(alignment));
-#else
-
     // If the requested alignment isn't supported, use default
     alignment =
       (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
     return detail::aligned_allocate(
       bytes, alignment, [](std::size_t size) { return ::operator new(size); });
-#endif
   }
 
   /**---------------------------------------------------------------------------*
@@ -90,11 +85,7 @@ class new_delete_resource final : public host_memory_resource {
                      std::size_t bytes,
                      std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
-#if __cplusplus >= 201703L
-    ::operator delete(p, bytes, std::align_val_t(alignment));
-#else
     detail::aligned_deallocate(p, bytes, alignment, [](void *p) { ::operator delete(p); });
-#endif
   }
 };
 }  // namespace mr

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -35,6 +35,26 @@ TEST(PoolTest, ThrowIfNotSupported)
 #endif
 }
 
+#if defined(RMM_CUDA_MALLOC_ASYNC_SUPPORT)
+TEST(PoolTest, ExplicitInitialPoolSize){
+    cuda_async_mr mr{100};
+    void* p;
+    EXPECT_NO_THROW(p = mr.allocate(100));
+    EXPECT_NO_THROW(mr.deallocate(p,100));
+    RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
+TEST(PoolTest, ExplicitReleaseThreshold){
+    cuda_async_mr mr{100, 1000};
+    void* p;
+    EXPECT_NO_THROW(p = mr.allocate(100));
+    EXPECT_NO_THROW(mr.deallocate(p,100));
+    RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
+
+#endif
+
 }  // namespace
 }  // namespace test
 }  // namespace rmm

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -36,22 +36,23 @@ TEST(PoolTest, ThrowIfNotSupported)
 }
 
 #if defined(RMM_CUDA_MALLOC_ASYNC_SUPPORT)
-TEST(PoolTest, ExplicitInitialPoolSize){
-    cuda_async_mr mr{100};
-    void* p;
-    EXPECT_NO_THROW(p = mr.allocate(100));
-    EXPECT_NO_THROW(mr.deallocate(p,100));
-    RMM_CUDA_TRY(cudaDeviceSynchronize());
+TEST(PoolTest, ExplicitInitialPoolSize)
+{
+  cuda_async_mr mr{100};
+  void* p;
+  EXPECT_NO_THROW(p = mr.allocate(100));
+  EXPECT_NO_THROW(mr.deallocate(p, 100));
+  RMM_CUDA_TRY(cudaDeviceSynchronize());
 }
 
-TEST(PoolTest, ExplicitReleaseThreshold){
-    cuda_async_mr mr{100, 1000};
-    void* p;
-    EXPECT_NO_THROW(p = mr.allocate(100));
-    EXPECT_NO_THROW(mr.deallocate(p,100));
-    RMM_CUDA_TRY(cudaDeviceSynchronize());
+TEST(PoolTest, ExplicitReleaseThreshold)
+{
+  cuda_async_mr mr{100, 1000};
+  void* p;
+  EXPECT_NO_THROW(p = mr.allocate(100));
+  EXPECT_NO_THROW(mr.deallocate(p, 100));
+  RMM_CUDA_TRY(cudaDeviceSynchronize());
 }
-
 
 #endif
 

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <rmm/detail/aligned.hpp>
+#include <rmm/detail/cuda_util.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
@@ -22,7 +23,6 @@
 #include <rmm/mr/device/limiting_resource_adaptor.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
-#include <rmm/detail/cuda_util.hpp>
 
 #include <gtest/gtest.h>
 

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -53,6 +53,7 @@ TEST(PoolTest, AllocateNinetyPercent)
 {
   auto allocate_ninety = []() {
     auto const [free, total] = rmm::detail::available_device_memory();
+    (void)total;
     auto const ninety_percent_pool =
       rmm::detail::align_up(static_cast<std::size_t>(free * 0.9), pool_mr::allocation_alignment);
     pool_mr mr{rmm::mr::get_current_device_resource(), ninety_percent_pool};
@@ -64,6 +65,7 @@ TEST(PoolTest, TwoLargeBuffers)
 {
   auto two_large = []() {
     auto const [free, total] = rmm::detail::available_device_memory();
+    (void)total;
     pool_mr mr{rmm::mr::get_current_device_resource()};
     auto p1 = mr.allocate(free / 4);
     auto p2 = mr.allocate(free / 4);

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -22,6 +22,7 @@
 #include <rmm/mr/device/limiting_resource_adaptor.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
+#include <rmm/detail/cuda_util.hpp>
 
 #include <gtest/gtest.h>
 
@@ -51,8 +52,7 @@ TEST(PoolTest, ThrowMaxLessThanInitial)
 TEST(PoolTest, AllocateNinetyPercent)
 {
   auto allocate_ninety = []() {
-    std::size_t free{}, total{};
-    std::tie(free, total) = rmm::mr::detail::available_device_memory();
+    auto const [free, total] = rmm::detail::available_device_memory();
     auto const ninety_percent_pool =
       rmm::detail::align_up(static_cast<std::size_t>(free * 0.9), pool_mr::allocation_alignment);
     pool_mr mr{rmm::mr::get_current_device_resource(), ninety_percent_pool};
@@ -63,8 +63,7 @@ TEST(PoolTest, AllocateNinetyPercent)
 TEST(PoolTest, TwoLargeBuffers)
 {
   auto two_large = []() {
-    std::size_t free{}, total{};
-    std::tie(free, total) = rmm::mr::detail::available_device_memory();
+    auto const [free, total] = rmm::detail::available_device_memory();
     pool_mr mr{rmm::mr::get_current_device_resource()};
     auto p1 = mr.allocate(free / 4);
     auto p2 = mr.allocate(free / 4);


### PR DESCRIPTION
Added constructor parameters to `cuda_async_memory_resource` to allow specifying an initial pool size and release threshold.

Updated implementation to explicitly construct a `cudaMemPool_t` to allow setting it's threshold. Updated allocation to be done from the explicit pool object without setting it as the new default. 

Moved around some utilities to make them available to `cuda_async_memory_resource`. 

Also, I had to fix an issue in `new_delete_resource` as compiling with C++17 enabled a new code path that used the aligned versions of `new/delete` that throw on an unsupported alignment. Not sure how that passed CI, but I just removed those for now and always use the existing logic. 

