### PR TITLE
fix log timestamp format to use a decimal point

### DIFF
--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -181,7 +181,7 @@ class logging_resource_adaptor final : public device_memory_resource {
     if (auto_flush) { logger_->flush_on(spdlog::level::info); }
     logger_->set_pattern("%v");
     logger_->info(header());
-    logger_->set_pattern("%t,%H:%M:%S:%f,%v");
+    logger_->set_pattern("%t,%H:%M:%S.%f,%v");
   }
 
   /**


### PR DESCRIPTION
Fixes #624 by changing the timestamp format from hh:mm:ss:SSSSSS to hh:mm:ss.SSSSSS (dot instead of colon).