### PR TITLE
Deprecate old rmm::exec_policy

### DIFF
--- a/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/benchmarks/device_uvector/device_uvector_bench.cu
@@ -17,8 +17,8 @@
 #include <benchmark/benchmark.h>
 
 #include <cuda_runtime_api.h>
-#include <rmm/thrust_rmm_allocator.h>
 #include <rmm/device_uvector.hpp>
+#include <rmm/device_vector.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -37,7 +37,8 @@ using exec_policy_t = std::unique_ptr<par_t, deleter_t>;
  * @Returns A Thrust execution policy that will use RMM for temporary memory
  * allocation.
  */
-inline exec_policy_t exec_policy(cudaStream_t stream = 0)
+[[deprecated("Use new exec_policy in rmm/exec_policy.hpp")]] inline exec_policy_t exec_policy(
+  cudaStream_t stream = 0)
 {
   auto *alloc  = new rmm::mr::thrust_allocator<char>(cuda_stream_view{stream});
   auto deleter = [alloc](par_t *pointer) {

--- a/tests/mr/device/thrust_allocator_tests.cu
+++ b/tests/mr/device/thrust_allocator_tests.cu
@@ -15,7 +15,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/device_vector.hpp>
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 #include "mr_test.hpp"
 


### PR DESCRIPTION
There are two versions of `rmm::exec_policy`. This PR deprecates the old one in `thrust_rmm_allocator.h` in favor of the new one in `exec_policy.hpp`.