### PR TITLE
Add missing include for thrust::cuda::par

### DIFF
--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -24,6 +24,8 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
+#include <thrust/system/cuda/execution_policy.h>
+
 namespace rmm {
 
 /**


### PR DESCRIPTION
Simply adds a missing Thrust header for rmm::exec_policy.hpp