### PR TITLE
CMake spdlog target, check for existing

### DIFF
--- a/cmake/Modules/RMM_thirdparty.cmake
+++ b/cmake/Modules/RMM_thirdparty.cmake
@@ -2,16 +2,18 @@
 
 set(RMM_MIN_VERSION_spdlog 1.7.0)
 
-CPMFindPackage(
-  NAME spdlog
-  GITHUB_REPOSITORY gabime/spdlog
-  VERSION ${RMM_MIN_VERSION_spdlog}
-  GIT_SHALLOW TRUE
-  # If there is no pre-installed spdlog we can use, we'll install our fetched copy together with RMM
-  OPTIONS "SPDLOG_INSTALL TRUE")
+if (NOT TARGET sldlog)
+  CPMFindPackage(
+    NAME spdlog
+    GITHUB_REPOSITORY gabime/spdlog
+    VERSION ${RMM_MIN_VERSION_spdlog}
+    GIT_SHALLOW TRUE
+    # If there is no pre-installed spdlog we can use, we'll install our fetched copy together with RMM
+    OPTIONS "SPDLOG_INSTALL TRUE")
 
-if(spdlog_ADDED)
-  set(RMM_EXPORT_SPDLOG TRUE)
+  if(spdlog_ADDED)
+    set(RMM_EXPORT_SPDLOG TRUE)
+  endif()
 endif()
 
 # thrust/cub

--- a/cmake/Modules/RMM_thirdparty.cmake
+++ b/cmake/Modules/RMM_thirdparty.cmake
@@ -2,13 +2,14 @@
 
 set(RMM_MIN_VERSION_spdlog 1.7.0)
 
-if (NOT TARGET spdlog)
+if(NOT TARGET spdlog)
   CPMFindPackage(
     NAME spdlog
     GITHUB_REPOSITORY gabime/spdlog
     VERSION ${RMM_MIN_VERSION_spdlog}
     GIT_SHALLOW TRUE
-    # If there is no pre-installed spdlog we can use, we'll install our fetched copy together with RMM
+    # If there is no pre-installed spdlog we can use, we'll install our fetched copy together with
+    # RMM
     OPTIONS "SPDLOG_INSTALL TRUE")
 
   if(spdlog_ADDED)

--- a/cmake/Modules/RMM_thirdparty.cmake
+++ b/cmake/Modules/RMM_thirdparty.cmake
@@ -2,7 +2,7 @@
 
 set(RMM_MIN_VERSION_spdlog 1.7.0)
 
-if (NOT TARGET sldlog)
+if (NOT TARGET spdlog)
   CPMFindPackage(
     NAME spdlog
     GITHUB_REPOSITORY gabime/spdlog


### PR DESCRIPTION
Currently if including RMM in a thirdparty application that might already be using spdlog the build will fail. This PR prevents attempting to include the spdlog target again if it already exists.