### PR TITLE
Upgrade to Thrust 1.12

### DIFF
--- a/cmake/Modules/RMM_thirdparty.cmake
+++ b/cmake/Modules/RMM_thirdparty.cmake
@@ -24,8 +24,8 @@ set(RMM_MIN_VERSION_Thrust 1.9.0)
 CPMFindPackage(
   NAME Thrust
   GITHUB_REPOSITORY NVIDIA/thrust
-  GIT_TAG 1.10.0
-  VERSION 1.10.0
+  GIT_TAG 1.12.0
+  VERSION 1.12.0
   GIT_SHALLOW TRUE
   # If there is no pre-installed thrust we can use, we'll install our fetched copy together with RMM
   OPTIONS "THRUST_INSTALL TRUE")


### PR DESCRIPTION
cudf is on Thrust 1.12, so why not RMM?