### PR TITLE
Update docs build script [skip ci]

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -15,7 +15,6 @@ export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
 export HOME=$WORKSPACE
 export PROJECT_WORKSPACE=/rapids/rmm
 export LIBCUDF_KERNEL_CACHE_PATH="$HOME/.jitify-cache"
-export NIGHTLY_VERSION=$(echo $BRANCH_VERSION | awk -F. '{print $2}')
 export PROJECTS=(librmm rmm)
 
 gpuci_logger "Check environment"


### PR DESCRIPTION
This PR removes a variable that is no longer necessary for docs builds after the calver transition.
