### PR TITLE
Update `CHANGELOG.md` links for calver [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# RMM 0.20.0 (Date TBD)
+# RMM 21.06.00 (Date TBD)
 
-Please see https://github.com/rapidsai/rmm/releases/tag/v0.20.0a for the latest changes to this development branch.
+Please see https://github.com/rapidsai/rmm/releases/tag/v21.06.00a for the latest changes to this development branch.
 
 # RMM 0.19.0 (21 Apr 2021)
 


### PR DESCRIPTION
This PR updates the `0.20` references in `CHANGELOG.md` to be `21.06`.
