### PR TITLE
FindThrust now guards against multiple inclusion by different consumers

### DIFF
--- a/cmake/install/FindThrust.cmake
+++ b/cmake/install/FindThrust.cmake
@@ -60,7 +60,7 @@ if(Thrust_FOUND)
         add_library(thrust_internal INTERFACE)
         set_target_properties(thrust_internal PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
                                                          "${Thrust_INCLUDE_DIRS}")
-        endif()
+      endif()
       add_library(${tgt} ALIAS thrust_internal)
     endif()
   endfunction()

--- a/cmake/install/FindThrust.cmake
+++ b/cmake/install/FindThrust.cmake
@@ -56,9 +56,11 @@ if(Thrust_FOUND)
   # target since that'll use -isystem, leading to the wrong search order with nvcc
   function(thrust_create_target tgt)
     if(NOT TARGET ${tgt})
-      add_library(thrust_internal INTERFACE)
-      set_target_properties(thrust_internal PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                                       "${Thrust_INCLUDE_DIRS}")
+      if(NOT TARGET thrust_internal)
+        add_library(thrust_internal INTERFACE)
+        set_target_properties(thrust_internal PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                         "${Thrust_INCLUDE_DIRS}")
+        endif()
       add_library(${tgt} ALIAS thrust_internal)
     endif()
   endfunction()


### PR DESCRIPTION
When multiple projects included via CPM depend on RMM we need
to make sure that we only try to add target `thrust_internal`.
