### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
-# RMM 21.06.00 (Date TBD)
+# RMM 21.06.00 (9 Jun 2021)
 
-Please see https://github.com/rapidsai/rmm/releases/tag/v21.06.00a for the latest changes to this development branch.
+## 🐛 Bug Fixes
+
+- FindThust now guads against multiple inclusion by diffeent consumes ([#784](https://github.com/rapidsai/rmm/pull/784)) [@obetmaynad](https://github.com/obetmaynad)
+
+## 📖 Documentation
+
+- Document synchonization equiements on device_buffe copy ctos ([#772](https://github.com/rapidsai/rmm/pull/772)) [@haism](https://github.com/haism)
+
+## 🚀 New Featues
+
+- add a esouce adapte to align on a specified size ([#768](https://github.com/rapidsai/rmm/pull/768)) [@ongou](https://github.com/ongou)
+
+## 🛠️ Impovements
+
+- Update envionment vaiable used to detemine `cuda_vesion` ([#785](https://github.com/rapidsai/rmm/pull/785)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update `CHANGELOG.md` links fo calve ([#781](https://github.com/rapidsai/rmm/pull/781)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Mege `banch-0.19` into `banch-21.06` ([#779](https://github.com/rapidsai/rmm/pull/779)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update docs build scipt ([#776](https://github.com/rapidsai/rmm/pull/776)) [@ajschmidt8](https://github.com/ajschmidt8)
+- upgade spdlog to 1.8.5 ([#658](https://github.com/rapidsai/rmm/pull/658)) [@ongou](https://github.com/ongou)
 
 # RMM 0.19.0 (21 Apr 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,23 @@
 
 ## 🐛 Bug Fixes
 
-- FindThust now guads against multiple inclusion by diffeent consumes ([#784](https://github.com/rapidsai/rmm/pull/784)) [@obetmaynad](https://github.com/obetmaynad)
+- FindThrust now guards against multiple inclusion by different consumers ([#784](https://github.com/rapidsai/rmm/pull/784)) [@robertmaynard](https://github.com/robertmaynard)
 
 ## 📖 Documentation
 
-- Document synchonization equiements on device_buffe copy ctos ([#772](https://github.com/rapidsai/rmm/pull/772)) [@haism](https://github.com/haism)
+- Document synchronization requirements on device_buffer copy ctors ([#772](https://github.com/rapidsai/rmm/pull/772)) [@harrism](https://github.com/harrism)
 
-## 🚀 New Featues
+## 🚀 New Features
 
-- add a esouce adapte to align on a specified size ([#768](https://github.com/rapidsai/rmm/pull/768)) [@ongou](https://github.com/ongou)
+- add a resource adapter to align on a specified size ([#768](https://github.com/rapidsai/rmm/pull/768)) [@rongou](https://github.com/rongou)
 
-## 🛠️ Impovements
+## 🛠️ Improvements
 
-- Update envionment vaiable used to detemine `cuda_vesion` ([#785](https://github.com/rapidsai/rmm/pull/785)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update `CHANGELOG.md` links fo calve ([#781](https://github.com/rapidsai/rmm/pull/781)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Mege `banch-0.19` into `banch-21.06` ([#779](https://github.com/rapidsai/rmm/pull/779)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update docs build scipt ([#776](https://github.com/rapidsai/rmm/pull/776)) [@ajschmidt8](https://github.com/ajschmidt8)
-- upgade spdlog to 1.8.5 ([#658](https://github.com/rapidsai/rmm/pull/658)) [@ongou](https://github.com/ongou)
+- Update environment variable used to determine `cuda_version` ([#785](https://github.com/rapidsai/rmm/pull/785)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update `CHANGELOG.md` links for calver ([#781](https://github.com/rapidsai/rmm/pull/781)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Merge `branch-0.19` into `branch-21.06` ([#779](https://github.com/rapidsai/rmm/pull/779)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update docs build script ([#776](https://github.com/rapidsai/rmm/pull/776)) [@ajschmidt8](https://github.com/ajschmidt8)
+- upgrade spdlog to 1.8.5 ([#658](https://github.com/rapidsai/rmm/pull/658)) [@rongou](https://github.com/rongou)
 
 # RMM 0.19.0 (21 Apr 2021)
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -11,7 +11,7 @@
 NEXT_FULL_TAG=$1
 
 # Get current version
-CURRENT_TAG=$(git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v')
+CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
 CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
 CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
 CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.