### PR TITLE
REL Fix `21.06` Release Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,23 @@
 
 ## 🐛 Bug Fixes
 
-- FindThust now guads against multiple inclusion by diffeent consumes ([#784](https://github.com/rapidsai/rmm/pull/784)) [@obetmaynad](https://github.com/obetmaynad)
+- FindThrust now guards against multiple inclusion by different consumers ([#784](https://github.com/rapidsai/rmm/pull/784)) [@robertmaynard](https://github.com/robertmaynard)
 
 ## 📖 Documentation
 
-- Document synchonization equiements on device_buffe copy ctos ([#772](https://github.com/rapidsai/rmm/pull/772)) [@haism](https://github.com/haism)
+- Document synchronization requirements on device_buffer copy ctors ([#772](https://github.com/rapidsai/rmm/pull/772)) [@harrism](https://github.com/harrism)
 
-## 🚀 New Featues
+## 🚀 New Features
 
-- add a esouce adapte to align on a specified size ([#768](https://github.com/rapidsai/rmm/pull/768)) [@ongou](https://github.com/ongou)
+- add a resource adapter to align on a specified size ([#768](https://github.com/rapidsai/rmm/pull/768)) [@rongou](https://github.com/rongou)
 
-## 🛠️ Impovements
+## 🛠️ Improvements
 
-- Update envionment vaiable used to detemine `cuda_vesion` ([#785](https://github.com/rapidsai/rmm/pull/785)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update `CHANGELOG.md` links fo calve ([#781](https://github.com/rapidsai/rmm/pull/781)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Mege `banch-0.19` into `banch-21.06` ([#779](https://github.com/rapidsai/rmm/pull/779)) [@ajschmidt8](https://github.com/ajschmidt8)
-- Update docs build scipt ([#776](https://github.com/rapidsai/rmm/pull/776)) [@ajschmidt8](https://github.com/ajschmidt8)
-- upgade spdlog to 1.8.5 ([#658](https://github.com/rapidsai/rmm/pull/658)) [@ongou](https://github.com/ongou)
+- Update environment variable used to determine `cuda_version` ([#785](https://github.com/rapidsai/rmm/pull/785)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update `CHANGELOG.md` links for calver ([#781](https://github.com/rapidsai/rmm/pull/781)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Merge `branch-0.19` into `branch-21.06` ([#779](https://github.com/rapidsai/rmm/pull/779)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update docs build script ([#776](https://github.com/rapidsai/rmm/pull/776)) [@ajschmidt8](https://github.com/ajschmidt8)
+- upgrade spdlog to 1.8.5 ([#658](https://github.com/rapidsai/rmm/pull/658)) [@rongou](https://github.com/rongou)
 
 # RMM 0.19.0 (21 Apr 2021)
 


### PR DESCRIPTION
This PR merges the latest changelog entries from `branch-21.06` into the `main` branch.