### PR TITLE
Bump isort, enable Cython package resorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,13 @@
 repos:
-    - repo: https://github.com/timothycrosley/isort
-      rev: 5.0.7
+    - repo: https://github.com/pycqa/isort
+      rev: 5.6.4
       hooks:
           - id: isort
+            args: ["--settings-path=python/setup.cfg"]
+            files: python/.*
+            exclude: __init__.py$
+            types: [text]
+            types_or: [python, cython]
     - repo: https://github.com/ambv/black
       rev: 19.10b0
       hooks:

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -15,7 +15,7 @@ LANG=C.UTF-8
 conda activate rapids
 
 # Run isort and get results/return code
-ISORT=`isort --check-only python`
+ISORT=`isort --check-only python --settings-path=python/setup.cfg `
 ISORT_RETVAL=$?
 
 # Run black and get results/return code

--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -15,7 +15,7 @@ LANG=C.UTF-8
 conda activate rapids
 
 # Run isort and get results/return code
-ISORT=`isort --recursive --check-only python`
+ISORT=`isort --check-only python`
 ISORT_RETVAL=$?
 
 # Run black and get results/return code


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

With rapidsai/integration#286, the version of isort running on gpuCI will be bumped to 5.6.4, allowing us to enforce the sorting of packages in Cython (pyx, pxd) files. This PR intends to:

- Enable these checks in the gpuCI style script
- Enable Cython package resorting in the pre-commit hook
- Resort all the Cython files in this repo so they pass the newly enabled checks