### PR TITLE
Fix PoolMemoryResource Python doc examples [skip-ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ of 1 GiB and a maximum size of 4 GiB. The pool uses
 ```python
 >>> import rmm
 >>> pool = rmm.mr.PoolMemoryResource(
-...     upstream=rmm.mr.CudaMemoryResource(),
+...     rmm.mr.CudaMemoryResource(),
 ...     initial_pool_size=2**30,
 ...     maximum_pool_size=2**32
 ... )

--- a/python/docs/basics.md
+++ b/python/docs/basics.md
@@ -103,7 +103,7 @@ of 1 GiB and a maximum size of 4 GiB. The pool uses
 ```python
 >>> import rmm
 >>> pool = rmm.mr.PoolMemoryResource(
-...     upstream=rmm.mr.CudaMemoryResource(),
+...     rmm.mr.CudaMemoryResource(),
 ...     initial_pool_size=2**30,
 ...     maximum_pool_size=2**32
 ... )
@@ -115,7 +115,7 @@ Similarly, to use a pool of managed memory:
 ```python
 >>> import rmm
 >>> pool = rmm.mr.PoolMemoryResource(
-...     upstream=rmm.mr.ManagedMemoryResource(),
+...     rmm.mr.ManagedMemoryResource(),
 ...     initial_pool_size=2**30,
 ...     maximum_pool_size=2**32
 ... )


### PR DESCRIPTION
Fixes #805. Removes `upstream=` because the API requires at least one positional parameter.
﻿