### PR TITLE
find_package(RMM) can now be called multiple times safely

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,9 @@ The goal of the [RMM](https://github.com/rapidsai/rmm) is to provide:
 
 set(code_string
     [=[
-thrust_create_target(rmm::Thrust FROM_OPTIONS)
+if(NOT TARGET rmm::Thrust)
+  thrust_create_target(rmm::Thrust FROM_OPTIONS)
+endif()
 ]=])
 
 rapids_export(


### PR DESCRIPTION
Previously it would try to add the `rmm::Thrust` target multiple times causing errors as a target with that name already existed.

