### PR TITLE
[REVIEW] Execution policy class

### DIFF
--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -36,20 +36,19 @@ using thrust_exec_policy_t =
  * @brief Returns a Thrust CUDA execution policy that uses RMM for temporary memory allocation on
  * the specified stream.
  */
-inline auto create_exec_policy(
-  cuda_stream_view stream             = cuda_stream_default,
-  rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
+inline auto exec_policy(cuda_stream_view stream             = cuda_stream_default,
+                        rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
 {
   return thrust::cuda::par(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value());
 }
 
-class exec_policy : public thrust_exec_policy_t {
- public:
-  exec_policy(cuda_stream_view stream             = cuda_stream_default,
-              rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
-    : thrust_exec_policy_t(create_exec_policy(stream, mr))
-  {
-  }
+struct exec_policy_t {
+  explicit exec_policy_t(cuda_stream_view stream) : stream_(stream) {}
+
+  operator thrust_exec_policy_t() { return exec_policy(stream_); }
+
+ private:
+  cuda_stream_view stream_;
 };
 
 }  // namespace rmm

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -33,22 +33,17 @@ using thrust_exec_policy_t =
                                          thrust::cuda_cub::execute_on_stream_base>;
 
 /**
- * @brief Returns a Thrust CUDA execution policy that uses RMM for temporary memory allocation on
- * the specified stream.
+ * @brief Helper class usable as a Thrust CUDA execution policy
+ * that uses RMM for temporary memory allocation on the specified stream.
  */
-inline auto exec_policy(cuda_stream_view stream             = cuda_stream_default,
-                        rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
-{
-  return thrust::cuda::par(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value());
-}
-
-struct exec_policy_t {
-  explicit exec_policy_t(cuda_stream_view stream) : stream_(stream) {}
-
-  operator thrust_exec_policy_t() { return exec_policy(stream_); }
-
- private:
-  cuda_stream_view stream_;
+class exec_policy : public thrust_exec_policy_t {
+ public:
+  explicit exec_policy(cuda_stream_view stream             = cuda_stream_default,
+                       rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
+    : thrust_exec_policy_t(
+        thrust::cuda::par(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
+  {
+  }
 };
 
 }  // namespace rmm

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -28,14 +28,28 @@
 
 namespace rmm {
 
+using thrust_exec_policy_t =
+  thrust::detail::execute_with_allocator<rmm::mr::thrust_allocator<char>,
+                                         thrust::cuda_cub::execute_on_stream_base>;
+
 /**
  * @brief Returns a Thrust CUDA execution policy that uses RMM for temporary memory allocation on
  * the specified stream.
  */
-inline auto exec_policy(cuda_stream_view stream             = cuda_stream_default,
-                        rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
+inline auto create_exec_policy(
+  cuda_stream_view stream             = cuda_stream_default,
+  rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
 {
   return thrust::cuda::par(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value());
 }
+
+class exec_policy : public thrust_exec_policy_t {
+ public:
+  exec_policy(cuda_stream_view stream             = cuda_stream_default,
+              rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
+    : thrust_exec_policy_t(create_exec_policy(stream, mr))
+  {
+  }
+};
 
 }  // namespace rmm

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -147,7 +147,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   rmm::device_buffer buff(this->size, rmm::cuda_stream_view{}, &this->mr);
 
   // Initialize buffer
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
                    static_cast<char *>(buff.data()),
                    static_cast<char *>(buff.data()) + buff.size(),
                    0);
@@ -161,7 +161,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_TRUE(buff_copy.memory_resource()->is_equal(*rmm::mr::get_current_device_resource()));
   EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{});
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(rmm::cuda_stream_default),
                             static_cast<char *>(buff.data()),
                             static_cast<char *>(buff.data()) + buff.size(),
                             static_cast<char *>(buff_copy.data())));
@@ -172,7 +172,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_TRUE(buff_copy2.memory_resource()->is_equal(*buff.memory_resource()));
   EXPECT_EQ(buff_copy2.stream(), buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(buff_copy.data())));
@@ -186,7 +186,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   auto new_size = this->size - 1;
   buff.resize(new_size, rmm::cuda_stream_default);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char *>(buff.data()),
                    static_cast<signed char *>(buff.data()) + buff.size(),
                    0);
@@ -201,7 +201,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   EXPECT_TRUE(buff_copy.memory_resource()->is_equal(*rmm::mr::get_current_device_resource()));
   EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{});
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(buff_copy.data())));
@@ -211,7 +211,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 {
   rmm::device_buffer buff(this->size, rmm::cuda_stream_default, &this->mr);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char *>(buff.data()),
                    static_cast<signed char *>(buff.data()) + buff.size(),
                    0);
@@ -224,7 +224,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
   EXPECT_TRUE(buff.memory_resource()->is_equal(*buff_copy.memory_resource()));
   EXPECT_NE(buff.stream(), buff_copy.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(buff_copy.stream()),
+  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(buff_copy.stream()),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(buff_copy.data())));
@@ -238,7 +238,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
   auto new_size = this->size - 1;
   buff.resize(new_size, rmm::cuda_stream_default);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char *>(buff.data()),
                    static_cast<signed char *>(buff.data()) + buff.size(),
                    0);
@@ -254,7 +254,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
   EXPECT_TRUE(buff.memory_resource()->is_equal(*buff_copy.memory_resource()));
   EXPECT_NE(buff.stream(), buff_copy.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(buff_copy.stream()),
+  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(buff_copy.stream()),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(buff_copy.data())));
@@ -392,7 +392,7 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 {
   rmm::device_buffer buff(this->size, rmm::cuda_stream_default, &this->mr);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char *>(buff.data()),
                    static_cast<signed char *>(buff.data()) + buff.size(),
                    0);
@@ -415,7 +415,7 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(buff.capacity(), buff.size());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(old_content.data())));

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -147,7 +147,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   rmm::device_buffer buff(this->size, rmm::cuda_stream_view{}, &this->mr);
 
   // Initialize buffer
-  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<char *>(buff.data()),
                    static_cast<char *>(buff.data()) + buff.size(),
                    0);
@@ -161,7 +161,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_TRUE(buff_copy.memory_resource()->is_equal(*rmm::mr::get_current_device_resource()));
   EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{});
 
-  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<char *>(buff.data()),
                             static_cast<char *>(buff.data()) + buff.size(),
                             static_cast<char *>(buff_copy.data())));
@@ -172,7 +172,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_TRUE(buff_copy2.memory_resource()->is_equal(*buff.memory_resource()));
   EXPECT_EQ(buff_copy2.stream(), buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(buff_copy.data())));
@@ -186,7 +186,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   auto new_size = this->size - 1;
   buff.resize(new_size, rmm::cuda_stream_default);
 
-  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char *>(buff.data()),
                    static_cast<signed char *>(buff.data()) + buff.size(),
                    0);
@@ -201,7 +201,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   EXPECT_TRUE(buff_copy.memory_resource()->is_equal(*rmm::mr::get_current_device_resource()));
   EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{});
 
-  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(buff_copy.data())));
@@ -211,7 +211,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 {
   rmm::device_buffer buff(this->size, rmm::cuda_stream_default, &this->mr);
 
-  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char *>(buff.data()),
                    static_cast<signed char *>(buff.data()) + buff.size(),
                    0);
@@ -224,7 +224,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
   EXPECT_TRUE(buff.memory_resource()->is_equal(*buff_copy.memory_resource()));
   EXPECT_NE(buff.stream(), buff_copy.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(buff_copy.stream()),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(buff_copy.stream()),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(buff_copy.data())));
@@ -238,7 +238,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
   auto new_size = this->size - 1;
   buff.resize(new_size, rmm::cuda_stream_default);
 
-  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char *>(buff.data()),
                    static_cast<signed char *>(buff.data()) + buff.size(),
                    0);
@@ -254,7 +254,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
   EXPECT_TRUE(buff.memory_resource()->is_equal(*buff_copy.memory_resource()));
   EXPECT_NE(buff.stream(), buff_copy.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(buff_copy.stream()),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(buff_copy.stream()),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(buff_copy.data())));
@@ -392,7 +392,7 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 {
   rmm::device_buffer buff(this->size, rmm::cuda_stream_default, &this->mr);
 
-  thrust::sequence(rmm::create_exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char *>(buff.data()),
                    static_cast<signed char *>(buff.data()) + buff.size(),
                    0);
@@ -415,7 +415,7 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(buff.capacity(), buff.size());
 
-  EXPECT_TRUE(thrust::equal(rmm::create_exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char *>(buff.data()),
                             static_cast<signed char *>(buff.data()) + buff.size(),
                             static_cast<signed char *>(old_content.data())));


### PR DESCRIPTION
Changes currently planned for the RAFT code include updating the RAFT handle for it to store a singleton of a thrust execution policy. An execution policy class would prove useful to write a clearer code. This PR is a proof of concept for it.

cc @divyegala 