### PR TITLE
Fix building on cuda 11.4

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -75,19 +75,22 @@ files_to_preprocess = ["gpu.pxd"]
 cuda_version_to_pxi_dir = {
     "10.1": "10.1",
     "10.2": "10.2",
-    "11.0": "11.x",
-    "11.1": "11.x",
-    "11.2": "11.x",
-    "11.3": "11.x",
+    "11": "11.x",
 }
 
 for pxd_basename in files_to_preprocess:
     pxi_basename = os.path.splitext(pxd_basename)[0] + ".pxi"
-    if CUDA_VERSION in cuda_version_to_pxi_dir:
+    pxi_dir = cuda_version_to_pxi_dir.get(CUDA_VERSION)
+    if not pxi_dir:
+        # didn't get an exact match on major.minor version - see if
+        # we have a match on just the major version
+        pxi_dir = cuda_version_to_pxi_dir.get(CUDA_VERSION.split(".")[0])
+
+    if pxi_dir:
         pxi_pathname = os.path.join(
             cwd,
             "rmm/_cuda",
-            cuda_version_to_pxi_dir[CUDA_VERSION],
+            pxi_dir,
             pxi_basename,
         )
         pxd_pathname = os.path.join(cwd, "rmm/_cuda", pxd_basename)

--- a/python/setup.py
+++ b/python/setup.py
@@ -87,12 +87,7 @@ for pxd_basename in files_to_preprocess:
         pxi_dir = cuda_version_to_pxi_dir.get(CUDA_VERSION.split(".")[0])
 
     if pxi_dir:
-        pxi_pathname = os.path.join(
-            cwd,
-            "rmm/_cuda",
-            pxi_dir,
-            pxi_basename,
-        )
+        pxi_pathname = os.path.join(cwd, "rmm/_cuda", pxi_dir, pxi_basename,)
         pxd_pathname = os.path.join(cwd, "rmm/_cuda", pxd_basename)
         try:
             if filecmp.cmp(pxi_pathname, pxd_pathname):


### PR DESCRIPTION
Fix building on cuda 11.4 by allowing looking up the pxi directory just on
cuda major versions, rather than whitelisting for each specific minor
version of cuda 11.
