### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/python/rmm/_lib/cuda_stream_pool.pxd
+++ b/python/rmm/_lib/cuda_stream_pool.pxd
@@ -16,6 +16,7 @@ cimport cython
 
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
 
+
 cdef extern from "rmm/cuda_stream_pool.hpp" namespace "rmm" nogil:
     cdef cppclass cuda_stream_pool:
         cuda_stream_pool(size_t pool_size)


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.