### PR TITLE
[REVIEW] Pinning spdlog because recent updates are causing compile issues.

### DIFF
--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
-    - spdlog>=1.8.5,<2.0.0a0
+    - spdlog>=1.8.5,<1.9
 
 test:
   commands:


### PR DESCRIPTION
spdlog 1.9 conda package was released yesterday and it's causing compile issues on cuml. We're also pinning it in the integrations repo: https://github.com/rapidsai/integration/pull/318. 