### PR TITLE
[REVIEW] Enforce default visibility for `get_map`.

### DIFF
--- a/include/rmm/detail/export.hpp
+++ b/include/rmm/detail/export.hpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Macros used for defining symbol visibility, only GLIBC is supported
+#if (defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__))
+#define RMM_EXPORT __attribute__ ((visibility ("default")))
+#define RMM_HIDDEN __attribute__ ((visibility ("hidden")))
+#else
+#define RMM_EXPORT
+#define RMM_HIDDEN
+#endif

--- a/include/rmm/detail/export.hpp
+++ b/include/rmm/detail/export.hpp
@@ -18,8 +18,8 @@
 
 // Macros used for defining symbol visibility, only GLIBC is supported
 #if (defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__))
-#define RMM_EXPORT __attribute__ ((visibility ("default")))
-#define RMM_HIDDEN __attribute__ ((visibility ("hidden")))
+#define RMM_EXPORT __attribute__((visibility("default")))
+#define RMM_HIDDEN __attribute__((visibility("hidden")))
 #else
 #define RMM_EXPORT
 #define RMM_HIDDEN

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -17,9 +17,9 @@
 #pragma once
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include <rmm/detail/export.hpp>
 
 #include <map>
 #include <mutex>

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -19,6 +19,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/detail/export.hpp>
 
 #include <map>
 #include <mutex>
@@ -95,7 +96,8 @@ inline std::mutex& map_lock()
   return map_lock;
 }
 
-inline auto& get_map()
+// Must have default visibility, see: https://github.com/rapidsai/rmm/issues/826
+RMM_EXPORT inline auto& get_map()
 {
   static std::map<cuda_device_id::value_type, device_memory_resource*> device_id_to_resource;
   return device_id_to_resource;


### PR DESCRIPTION
Define macros used for specifying symbol visibility and use it on `get_map`.  The macros are only useful for gcc/clang with glibc on Linux.  Sorry I'm not familiar with other platforms.

Close https://github.com/rapidsai/rmm/issues/826 .

> 1. Please ensure that you have written units tests for the changes made and/or features added.

I'm not sure how to test this on CI.