### PR TITLE
[FIX] Pin spdlog in dev conda envs

### DIFF
--- a/conda/environments/rmm_dev_cuda10.1.yml
+++ b/conda/environments/rmm_dev_cuda10.1.yml
@@ -16,5 +16,5 @@ dependencies:
 - cffi>=1.10.0
 - pytest
 - cudatoolkit=10.1
-- spdlog>=1.8.5,<2.0.0a0
+- spdlog>=1.8.5,<1.9
 - cython>=0.29,<0.30

--- a/conda/environments/rmm_dev_cuda10.2.yml
+++ b/conda/environments/rmm_dev_cuda10.2.yml
@@ -16,5 +16,5 @@ dependencies:
 - cffi>=1.10.0
 - pytest
 - cudatoolkit=10.2
-- spdlog>=1.8.5,<2.0.0a0
+- spdlog>=1.8.5,<1.9
 - cython>=0.29,<0.30

--- a/conda/environments/rmm_dev_cuda11.0.yml
+++ b/conda/environments/rmm_dev_cuda11.0.yml
@@ -16,5 +16,5 @@ dependencies:
 - cffi>=1.10.0
 - pytest
 - cudatoolkit=11.0
-- spdlog>=1.8.5,<2.0.0a0
+- spdlog>=1.8.5,<1.9
 - cython>=0.29,<0.30


### PR DESCRIPTION
Follow up to https://github.com/rapidsai/rmm/pull/831, this pins spdlog in the dev conda envs too.
