### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/conda/environments/rmm_dev_cuda10.1.yml
+++ b/conda/environments/rmm_dev_cuda10.1.yml
@@ -16,5 +16,5 @@ dependencies:
 - cffi>=1.10.0
 - pytest
 - cudatoolkit=10.1
-- spdlog>=1.8.5,<2.0.0a0
+- spdlog>=1.8.5,<1.9
 - cython>=0.29,<0.30

--- a/conda/environments/rmm_dev_cuda10.2.yml
+++ b/conda/environments/rmm_dev_cuda10.2.yml
@@ -16,5 +16,5 @@ dependencies:
 - cffi>=1.10.0
 - pytest
 - cudatoolkit=10.2
-- spdlog>=1.8.5,<2.0.0a0
+- spdlog>=1.8.5,<1.9
 - cython>=0.29,<0.30

--- a/conda/environments/rmm_dev_cuda11.0.yml
+++ b/conda/environments/rmm_dev_cuda11.0.yml
@@ -16,5 +16,5 @@ dependencies:
 - cffi>=1.10.0
 - pytest
 - cudatoolkit=11.0
-- spdlog>=1.8.5,<2.0.0a0
+- spdlog>=1.8.5,<1.9
 - cython>=0.29,<0.30


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.