### PR TITLE
tweak the arena mr to reduce fragmentation

### DIFF
--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -75,7 +75,7 @@ struct logger_wrapper {
 struct bytes {
   std::size_t value;
 
-  friend std::ostream& operator<<(std::ostream& os, const bytes& b)
+  friend std::ostream& operator<<(std::ostream& os, bytes const& b)
   {
     std::string const units[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"};
     int i                     = 0;

--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -69,6 +69,25 @@ struct logger_wrapper {
   }
 };
 
+/**
+ * @brief Represent a size in number of bytes.
+ */
+struct bytes {
+  std::size_t value;
+
+  friend std::ostream& operator<<(std::ostream& os, const bytes& b)
+  {
+    std::string const units[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"};
+    int i                     = 0;
+    auto size                 = static_cast<double>(b.value);
+    while (size > 1024) {
+      size /= 1024;
+      i++;
+    }
+    return os << size << ' ' << units[i];
+  }
+};
+
 }  // namespace detail
 
 /**

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -15,16 +15,17 @@
  */
 #pragma once
 
-#include <spdlog/common.h>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/detail/arena.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
-#include <sstream>
 
 #include <cuda_runtime_api.h>
 
+#include <spdlog/common.h>
+
 #include <map>
 #include <shared_mutex>
+#include <sstream>
 
 namespace rmm::mr {
 

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -16,16 +16,17 @@
 #pragma once
 
 #include <rmm/detail/error.hpp>
+#include <rmm/logger.hpp>
 #include <rmm/mr/device/detail/arena.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda_runtime_api.h>
 
 #include <spdlog/common.h>
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include <map>
 #include <shared_mutex>
-#include <sstream>
 
 namespace rmm::mr {
 
@@ -240,23 +241,19 @@ class arena_memory_resource final : public device_memory_resource {
   void dump_memory_log(size_t bytes)
   {
     logger_->info("**************************************************");
-    logger_->info("Ran out of memory trying to allocate {}.", detail::arena::human_size(bytes));
+    logger_->info("Ran out of memory trying to allocate {}.", rmm::detail::bytes{bytes});
     logger_->info("**************************************************");
     logger_->info("Global arena:");
     global_arena_.dump_memory_log(logger_);
     logger_->info("Per-thread arenas:");
     for (auto const& t : thread_arenas_) {
-      std::ostringstream oss;
-      oss << t.first;
-      logger_->info("  Thread {}:", oss.str());
+      logger_->info("  Thread {}:", t.first);
       t.second->dump_memory_log(logger_);
     }
     if (!stream_arenas_.empty()) {
       logger_->info("Per-stream arenas:");
       for (auto const& s : stream_arenas_) {
-        std::ostringstream oss;
-        oss << s.first;
-        logger_->info("  Stream {}:", oss.str());
+        logger_->info("  Stream {}:", static_cast<void*>(s.first));
         s.second.dump_memory_log(logger_);
       }
     }

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -375,7 +375,7 @@ class global_arena final {
   {
     lock_guard lock(mtx_);
 
-    logger->info("  Maximum size: {}", human_size(maximum_size_));
+    logger->info("  Maximum size: {}", bytes{maximum_size_});
     logger->info("  Current size: {}", human_size(current_size_));
 
     logger->info("  # free blocks: {}", free_blocks_.size());

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -364,13 +364,16 @@ class global_arena final {
     logger->info("  Current size: {}", rmm::detail::bytes{current_size_});
 
     logger->info("  # free blocks: {}", free_blocks_.size());
-    std::size_t total_free{};
-    for (auto const& b : free_blocks_) {
-      total_free += b.size();
+    if (!free_blocks_.empty()) {
+      std::size_t total_free{};
+      for (auto const& b : free_blocks_) {
+        total_free += b.size();
+      }
+      logger->info("  Total size of free blocks: {}", rmm::detail::bytes{total_free});
+      auto const m =
+        *std::max_element(free_blocks_.begin(), free_blocks_.end(), block_size_compare);
+      logger->info("  Size of largest free block: {}", rmm::detail::bytes{m.size()});
     }
-    logger->info("  Total size of free blocks: {}", rmm::detail::bytes{total_free});
-    auto const m = *std::max_element(free_blocks_.begin(), free_blocks_.end(), block_size_compare);
-    logger->info("  Size of largest free block: {}", rmm::detail::bytes{m.size()});
 
     logger->info("  # upstream blocks={}", upstream_blocks_.size());
     std::size_t total_upstream{};
@@ -522,13 +525,16 @@ class arena {
   {
     lock_guard lock(mtx_);
     logger->info("    # free blocks: {}", free_blocks_.size());
-    std::size_t total_free{};
-    for (auto const& b : free_blocks_) {
-      total_free += b.size();
+    if (!free_blocks_.empty()) {
+      std::size_t total_free{};
+      for (auto const& b : free_blocks_) {
+        total_free += b.size();
+      }
+      logger->info("    Total size of free blocks: {}", rmm::detail::bytes{total_free});
+      auto const m =
+        *std::max_element(free_blocks_.begin(), free_blocks_.end(), block_size_compare);
+      logger->info("    Size of largest free block: {}", rmm::detail::bytes{m.size()});
     }
-    logger->info("    Total size of free blocks: {}", rmm::detail::bytes{total_free});
-    auto const m = *std::max_element(free_blocks_.begin(), free_blocks_.end(), block_size_compare);
-    logger->info("    Size of largest free block: {}", rmm::detail::bytes{m.size()});
   }
 
  private:

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include <spdlog/common.h>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <sstream>
 
 #include <cuda_runtime_api.h>
 
@@ -29,10 +31,7 @@
 #include <set>
 #include <unordered_map>
 
-namespace rmm {
-namespace mr {
-namespace detail {
-namespace arena {
+namespace rmm::mr::detail::arena {
 
 /// Minimum size of a superblock (256 KiB).
 constexpr std::size_t minimum_superblock_size = 1u << 18u;
@@ -66,16 +65,16 @@ class block {
   block(void* pointer, size_t size) : pointer_(static_cast<char*>(pointer)), size_(size) {}
 
   /// Returns the underlying pointer.
-  void* pointer() const { return pointer_; }
+  [[nodiscard]] void* pointer() const { return pointer_; }
 
   /// Returns the size of the block.
-  size_t size() const { return size_; }
+  [[nodiscard]] size_t size() const { return size_; }
 
   /// Returns true if this block is valid (non-null), false otherwise.
-  bool is_valid() const { return pointer_ != nullptr; }
+  [[nodiscard]] bool is_valid() const { return pointer_ != nullptr; }
 
   /// Returns true if this block is a superblock, false otherwise.
-  bool is_superblock() const { return size_ >= minimum_superblock_size; }
+  [[nodiscard]] bool is_superblock() const { return size_ >= minimum_superblock_size; }
 
   /**
    * @brief Verifies whether this block can be merged to the beginning of block b.
@@ -84,7 +83,10 @@ class block {
    * @return true Returns true if this block's `pointer` + `size` == `b.ptr`, and `not b.is_head`,
                   false otherwise.
    */
-  bool is_contiguous_before(block const& b) const { return pointer_ + size_ == b.pointer_; }
+  [[nodiscard]] bool is_contiguous_before(block const& b) const
+  {
+    return pointer_ + size_ == b.pointer_;
+  }
 
   /**
    * @brief Is this block large enough to fit `sz` bytes?
@@ -92,7 +94,7 @@ class block {
    * @param sz The size in bytes to check for fit.
    * @return true if this block is at least `sz` bytes.
    */
-  bool fits(std::size_t sz) const { return size_ >= sz; }
+  [[nodiscard]] bool fits(std::size_t sz) const { return size_ >= sz; }
 
   /**
    * @brief Split this block into two by the given size.
@@ -100,7 +102,7 @@ class block {
    * @param sz The size in bytes of the first block.
    * @return std::pair<block, block> A pair of blocks split by sz.
    */
-  std::pair<block, block> split(std::size_t sz) const
+  [[nodiscard]] std::pair<block, block> split(std::size_t sz) const
   {
     RMM_LOGGING_ASSERT(size_ >= sz);
     if (size_ > sz) {
@@ -118,7 +120,7 @@ class block {
    * @param b block to merge.
    * @return block The merged block.
    */
-  block merge(block const& b) const
+  [[nodiscard]] block merge(block const& b) const
   {
     RMM_LOGGING_ASSERT(is_contiguous_before(b));
     return {pointer_, size_ + b.size_};
@@ -152,6 +154,26 @@ constexpr std::size_t align_up(std::size_t v) noexcept
 constexpr std::size_t align_down(std::size_t v) noexcept
 {
   return rmm::detail::align_down(v, rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
+}
+
+/**
+ * @brief Return human readable number of bytes.
+ *
+ * @param bytes number of bytes
+ * @return Return human readable number of bytes.
+ */
+inline std::string human_size(std::size_t bytes)
+{
+  const std::string units[] = {"B", "KiB", "MiB", "GiB", "TiB"};
+  int i                     = 0;
+  auto size                 = static_cast<float>(bytes);
+  while (size > 1024) {
+    size /= 1024;
+    i++;
+  }
+  std::ostringstream oss;
+  oss << size << " " << units[i];
+  return oss.str();
 }
 
 /**
@@ -344,6 +366,33 @@ class global_arena final {
     }
   }
 
+  /**
+   * @brief Dump memory to log.
+   *
+   * @param logger the spdlog logger to use
+   */
+  void dump_memory_log(std::shared_ptr<spdlog::logger> const& logger) const
+  {
+    lock_guard lock(mtx_);
+
+    logger->info("  Maximum size: {}", human_size(maximum_size_));
+    logger->info("  Current size: {}", human_size(current_size_));
+
+    logger->info("  # free blocks: {}", free_blocks_.size());
+    std::size_t total_free{};
+    for (auto const& b : free_blocks_) {
+      total_free += b.size();
+    }
+    logger->info("  Total size of free blocks: {}", human_size(total_free));
+
+    logger->info("  # upstream blocks={}", upstream_blocks_.size());
+    std::size_t total_upstream{};
+    for (auto const& b : upstream_blocks_) {
+      total_upstream += b.size();
+    }
+    logger->info("  Total size of upstream blocks: {}", human_size(total_upstream));
+  }
+
  private:
   using lock_guard = std::lock_guard<std::mutex>;
 
@@ -371,14 +420,15 @@ class global_arena final {
    * This simply grows the global arena to the maximum size.
    *
    * @param size The number of bytes required.
-   * @return size The size for the arena to grow.
+   * @return size The size for the arena to grow, or 0 if no more memory.
    */
   constexpr std::size_t size_to_grow(std::size_t size) const
   {
     if (current_size_ + size > maximum_size_) {
-      RMM_FAIL("Maximum pool size exceeded", rmm::bad_alloc);
+      return 0;
+    } else {
+      return maximum_size_ - current_size_;
     }
-    return maximum_size_ - current_size_;
   }
 
   /**
@@ -389,9 +439,13 @@ class global_arena final {
    */
   block expand_arena(std::size_t size)
   {
-    upstream_blocks_.push_back({upstream_mr_->allocate(size), size});
-    current_size_ += size;
-    return upstream_blocks_.back();
+    if (size > 0) {
+      upstream_blocks_.push_back({upstream_mr_->allocate(size), size});
+      current_size_ += size;
+      return upstream_blocks_.back();
+    } else {
+      return {};
+    }
   }
 
   /// The upstream resource to allocate memory from.
@@ -443,9 +497,6 @@ class arena {
   {
     lock_guard lock(mtx_);
     auto const b = get_block(bytes);
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-    allocated_blocks_.emplace(b.pointer(), b);
-#endif
     return b.pointer();
   }
 
@@ -456,44 +507,14 @@ class arena {
    * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
    * that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation.
-   * @return true if the allocation is found, false otherwise.
    */
-  bool deallocate(void* p, std::size_t bytes, cuda_stream_view stream)
+  void deallocate(void* p, std::size_t bytes, cuda_stream_view stream)
   {
     lock_guard lock(mtx_);
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-    auto const b = free_block(p, bytes);
-#else
     block const b{p, bytes};
-#endif
-    if (b.is_valid()) {
-      auto const merged = coalesce_block(free_blocks_, b);
-      shrink_arena(merged, stream);
-    }
-    return b.is_valid();
+    auto const merged = coalesce_block(free_blocks_, b);
+    shrink_arena(merged, stream);
   }
-
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-  /**
-   * @brief Deallocate memory pointed to by `p`, keeping all free superblocks.
-   *
-   * This is done when deallocating from another arena. Since we don't have access to the CUDA
-   * stream associated with this arena, we don't coalesce the freed block and return it directly to
-   * the global arena.
-   *
-   * @param p Pointer to be deallocated.
-   * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
-   * that was passed to the `allocate` call that returned `p`.
-   * @return true if the allocation is found, false otherwise.
-   */
-  bool deallocate(void* p, std::size_t bytes)
-  {
-    lock_guard lock(mtx_);
-    auto const b = free_block(p, bytes);
-    if (b.is_valid()) { global_arena_.deallocate(b); }
-    return b.is_valid();
-  }
-#endif
 
   /**
    * @brief Clean the arena and deallocate free blocks from the global arena.
@@ -505,13 +526,28 @@ class arena {
     lock_guard lock(mtx_);
     global_arena_.deallocate(free_blocks_);
     free_blocks_.clear();
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-    allocated_blocks_.clear();
-#endif
+  }
+
+  /**
+   * Dump memory to log.
+   *
+   * @param logger the spdlog logger to use
+   */
+  void dump_memory_log(std::shared_ptr<spdlog::logger> const& logger) const
+  {
+    lock_guard lock(mtx_);
+    logger->info("    # free blocks: {}", free_blocks_.size());
+    std::size_t total_free{};
+    for (auto const& b : free_blocks_) {
+      total_free += b.size();
+    }
+    logger->info("    Total size of free blocks: {}", human_size(total_free));
   }
 
  private:
   using lock_guard = std::lock_guard<std::mutex>;
+  /// Maximum number of free blocks to keep.
+  static constexpr int max_free_blocks = 16;
 
   /**
    * @brief Get an available memory block of at least `size` bytes.
@@ -529,8 +565,12 @@ class arena {
 
     // No existing larger blocks available, so grow the arena and obtain a superblock.
     auto const superblock = expand_arena(size);
-    coalesce_block(free_blocks_, superblock);
-    return first_fit(free_blocks_, size);
+    if (superblock.is_valid()) {
+      coalesce_block(free_blocks_, superblock);
+      return first_fit(free_blocks_, size);
+    } else {
+      return superblock;
+    }
   }
 
   /**
@@ -544,30 +584,6 @@ class arena {
     return global_arena_.allocate(superblock_size);
   }
 
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-  /**
-   * @brief Finds, frees and returns the block associated with pointer `p`.
-   *
-   * @param p The pointer to the memory to free.
-   * @param size The size of the memory to free. Must be equal to the original allocation size.
-   * @return The (now freed) block associated with `p`. The caller is expected to return the block
-   * to the arena.
-   */
-  block free_block(void* p, std::size_t size) noexcept
-  {
-    auto const i = allocated_blocks_.find(p);
-
-    // The pointer may be allocated in another arena.
-    if (i == allocated_blocks_.end()) { return {}; }
-
-    auto const found = i->second;
-    RMM_LOGGING_ASSERT(found.size() == size);
-    allocated_blocks_.erase(i);
-
-    return found;
-  }
-#endif
-
   /**
    * @brief Shrink this arena by returning free superblocks to upstream.
    *
@@ -576,23 +592,17 @@ class arena {
    */
   void shrink_arena(block const& b, cuda_stream_view stream)
   {
-    // Don't shrink if b is not a superblock.
-    if (!b.is_superblock()) return;
-
-    stream.synchronize_no_throw();
-
-    global_arena_.deallocate(b);
-    free_blocks_.erase(b);
+    if (b.is_superblock() || free_blocks_.size() > max_free_blocks) {
+      stream.synchronize_no_throw();
+      global_arena_.deallocate(b);
+      free_blocks_.erase(b);
+    }
   }
 
   /// The global arena to allocate superblocks from.
   global_arena<Upstream>& global_arena_;
   /// Free blocks.
   std::set<block> free_blocks_;
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-  //// Map of pointer address to allocated blocks.
-  std::unordered_map<void*, block> allocated_blocks_;
-#endif
   /// Mutex for exclusive lock.
   mutable std::mutex mtx_;
 };
@@ -627,7 +637,4 @@ class arena_cleaner {
   std::weak_ptr<arena<Upstream>> arena_;
 };
 
-}  // namespace arena
-}  // namespace detail
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr::detail::arena

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -505,8 +505,6 @@ class arena {
 
   /**
    * @brief Clean the arena and deallocate free blocks from the global arena.
-   *
-   * This is only needed when a per-thread arena is about to die.
    */
   void clean()
   {


### PR DESCRIPTION
We're seeing out-of-memory errors in some cases when there are plenty of free space available, probably due to memory fragmentation. This PR attempts to address the issue:
* Added an option to dump the state when running out of memory. For now just logging the number of free blocks and total size, can be expanded later if needed.
* Limit the number of free blocks in each per-thread arena. This seems to be helpful with the producer-consumer allocation pattern where a large number of small buffers accumulate in an arena.
* Got rid of the allocation tracking code.

With these changes I can run those TPC-DS queries successfully with very high concurrency that previously would run out of memory. Need to do some more benchmarking to verify the behavior.

@abellina 