### PR TITLE
[HOTFIX] Remove `-g` from cython compile commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ if(BUILD_BENCHMARKS AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   add_subdirectory(benchmarks)
 endif()
 
+include(CPack)
+
 # install export targets
 install(TARGETS rmm EXPORT rmm-exports)
 install(DIRECTORY include/rmm/ DESTINATION include/rmm)

--- a/python/rmm/_lib/cuda_stream.pxd
+++ b/python/rmm/_lib/cuda_stream.pxd
@@ -34,4 +34,4 @@ cdef extern from "rmm/cuda_stream.hpp" namespace "rmm" nogil:
 cdef class CudaStream:
     cdef unique_ptr[cuda_stream] c_obj
     cdef cudaStream_t value(self) nogil except *
-    cpdef bool is_valid(self) nogil except *
+    cdef bool is_valid(self) nogil except *

--- a/python/rmm/_lib/cuda_stream.pyx
+++ b/python/rmm/_lib/cuda_stream.pyx
@@ -30,5 +30,5 @@ cdef class CudaStream:
     cdef cudaStream_t value(self) nogil except *:
         return self.c_obj.get()[0].value()
 
-    cpdef bool is_valid(self) nogil except *:
+    cdef bool is_valid(self) nogil except *:
         return self.c_obj.get()[0].is_valid()

--- a/python/rmm/tests/test_cython.py
+++ b/python/rmm/tests/test_cython.py
@@ -12,36 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-import importlib
-import sys
-
-
-def py_func(func):
-    """
-    Wraps func in a plain Python function.
-    """
-
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        return func(*args, **kwargs)
-
-    return wrapped
-
-
-cython_test_modules = ["rmm._lib.tests.test_device_buffer"]
-
-
-for mod in cython_test_modules:
-    try:
-        # For each callable in `mod` with name `test_*`,
-        # wrap the callable in a plain Python function
-        # and set the result as an attribute of this module.
-        mod = importlib.import_module(mod)
-        for name in dir(mod):
-            item = getattr(mod, name)
-            if callable(item) and name.startswith("test_"):
-                item = py_func(item)
-                setattr(sys.modules[__name__], name, item)
-    except ImportError:
-        pass
+from rmm._lib.tests.test_device_buffer import (  # noqa: F401
+    test_release,
+    test_size_after_release,
+)

--- a/python/rmm/tests/test_cython.py
+++ b/python/rmm/tests/test_cython.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rmm._lib.tests.test_device_buffer import (  # noqa: F401
-    test_release,
-    test_size_after_release,
-)
+import functools
+import importlib
+import sys
+
+
+def py_func(func):
+    """
+    Wraps func in a plain Python function.
+    """
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapped
+
+
+cython_test_modules = ["rmm._lib.tests.test_device_buffer"]
+
+
+for mod in cython_test_modules:
+    try:
+        # For each callable in `mod` with name `test_*`,
+        # wrap the callable in a plain Python function
+        # and set the result as an attribute of this module.
+        mod = importlib.import_module(mod)
+        for name in dir(mod):
+            item = getattr(mod, name)
+            if callable(item) and name.startswith("test_"):
+                item = py_func(item)
+                setattr(sys.modules[__name__], name, item)
+    except ImportError:
+        pass

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,9 +6,21 @@ import os
 import re
 import shutil
 import sysconfig
+
+# Must import in this order:
+#   setuptools -> Cython.Distutils.build_ext -> setuptools.command.build_ext
+# Otherwise, setuptools.command.build_ext ends up inheriting from
+# Cython.Distutils.old_build_ext which we do not want
+import setuptools
+
+try:
+    from Cython.Distutils.build_ext import new_build_ext as _build_ext
+except ImportError:
+    from setuptools.command.build_ext import build_ext as _build_ext
+
 from distutils.sysconfig import get_python_lib
 
-from Cython.Build import cythonize
+import setuptools.command.build_ext
 from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
@@ -100,11 +112,6 @@ for pxd_basename in files_to_preprocess:
     else:
         raise TypeError(f"{CUDA_VERSION} is not supported.")
 
-try:
-    nthreads = int(os.environ.get("PARALLEL_LEVEL", "0") or "0")
-except Exception:
-    nthreads = 0
-
 include_dirs = [
     rmm_include_dir,
     os.path.dirname(sysconfig.get_path("include")),
@@ -117,79 +124,99 @@ library_dirs = [
     cuda_lib_dir,
 ]
 
-# lib:
-extensions = cythonize(
-    [
-        Extension(
-            "*",
-            sources=["rmm/_lib/*.pyx"],
-            include_dirs=include_dirs,
-            library_dirs=library_dirs,
-            runtime_library_dirs=[
-                cuda_lib_dir,
-                os.path.join(os.sys.prefix, "lib"),
-            ],
-            libraries=["cuda", "cudart"],
-            language="c++",
-            extra_compile_args=["-std=c++17"],
-        )
-    ],
-    nthreads=nthreads,
-    compiler_directives=dict(
-        profile=False, language_level=3, embedsignature=True,
+extensions = [
+    # lib:
+    Extension(
+        "*",
+        sources=["rmm/_lib/*.pyx"],
+        include_dirs=include_dirs,
+        library_dirs=library_dirs,
+        runtime_library_dirs=[
+            cuda_lib_dir,
+            os.path.join(os.sys.prefix, "lib"),
+        ],
+        libraries=["cuda", "cudart"],
+        language="c++",
+        extra_compile_args=["-std=c++17"],
     ),
-)
+    # cuda:
+    Extension(
+        "*",
+        sources=["rmm/_cuda/*.pyx"],
+        include_dirs=include_dirs,
+        library_dirs=library_dirs,
+        runtime_library_dirs=[
+            cuda_lib_dir,
+            os.path.join(os.sys.prefix, "lib"),
+        ],
+        libraries=["cuda", "cudart"],
+        language="c++",
+        extra_compile_args=["-std=c++17"],
+    ),
+    # tests:
+    Extension(
+        "*",
+        sources=cython_tests,
+        include_dirs=include_dirs,
+        library_dirs=library_dirs,
+        runtime_library_dirs=[
+            cuda_lib_dir,
+            os.path.join(os.sys.prefix, "lib"),
+        ],
+        libraries=["cuda", "cudart"],
+        language="c++",
+        extra_compile_args=["-std=c++17"],
+    ),
+]
 
 
-# cuda:
-extensions += cythonize(
-    [
-        Extension(
-            "*",
-            sources=["rmm/_cuda/*.pyx"],
-            include_dirs=include_dirs,
-            library_dirs=library_dirs,
-            runtime_library_dirs=[
-                cuda_lib_dir,
-                os.path.join(os.sys.prefix, "lib"),
-            ],
-            libraries=["cuda", "cudart"],
-            language="c++",
-            extra_compile_args=["-std=c++14"],
-        )
-    ],
-    nthreads=nthreads,
-    compiler_directives=dict(
-        profile=False, language_level=3, embedsignature=True,
-    ),
-)
+def remove_flags(compiler, *flags):
+    for flag in flags:
+        try:
+            compiler.compiler_so = list(
+                filter((flag).__ne__, compiler.compiler_so)
+            )
+        except Exception:
+            pass
 
-# tests:
-extensions += cythonize(
-    [
-        Extension(
-            "*",
-            sources=cython_tests,
-            include_dirs=include_dirs,
-            library_dirs=library_dirs,
-            runtime_library_dirs=[
-                cuda_lib_dir,
-                os.path.join(os.sys.prefix, "lib"),
-            ],
-            libraries=["cuda", "cudart"],
-            language="c++",
-            extra_compile_args=["-std=c++14"],
+
+class build_ext_no_debug(_build_ext):
+    def build_extensions(self):
+        # Full optimization
+        self.compiler.compiler_so.append("-O3")
+        # No debug symbols, full optimization, no '-Wstrict-prototypes' warning
+        remove_flags(
+            self.compiler, "-g", "-G", "-O1", "-O2", "-Wstrict-prototypes"
         )
-    ],
-    nthreads=nthreads,
-    compiler_directives=dict(
-        profile=True, language_level=3, embedsignature=True, binding=True
-    ),
-)
+        super().build_extensions()
+
+    def finalize_options(self):
+        if self.distribution.ext_modules:
+            # Delay import this to allow for Cython-less installs
+            from Cython.Build.Dependencies import cythonize
+
+            nthreads = getattr(self, "parallel", None)  # -j option in Py3.5+
+            nthreads = int(nthreads) if nthreads else None
+            self.distribution.ext_modules = cythonize(
+                self.distribution.ext_modules,
+                nthreads=nthreads,
+                force=self.force,
+                gdb_debug=False,
+                compiler_directives=dict(
+                    profile=False, language_level=3, embedsignature=True
+                ),
+            )
+        # Skip calling super() and jump straight to setuptools
+        setuptools.command.build_ext.build_ext.finalize_options(self)
+
+
+cmdclass = dict()
+cmdclass.update(versioneer.get_cmdclass())
+cmdclass["build_ext"] = build_ext_no_debug
 
 setup(
     name="rmm",
-    version="21.08.00",
+    version=versioneer.get_version(),
     description="rmm - RAPIDS Memory Manager",
     url="https://github.com/rapidsai/rmm",
     author="NVIDIA Corporation",
@@ -212,7 +239,7 @@ setup(
         find_packages(include=["rmm._lib", "rmm._lib.includes", "rmm._cuda*"]),
         ["*.hpp", "*.pxd"],
     ),
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass=cmdclass,
     install_requires=install_requires,
     zip_safe=False,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -203,7 +203,10 @@ class build_ext_no_debug(_build_ext):
                 force=self.force,
                 gdb_debug=False,
                 compiler_directives=dict(
-                    profile=False, language_level=3, embedsignature=True
+                    profile=False,
+                    language_level=3,
+                    embedsignature=True,
+                    binding=True,
                 ),
             )
         # Skip calling super() and jump straight to setuptools


### PR DESCRIPTION
Removes `-g` from the compile commands generated by distutils to compile Cython files.

This will make our container images, conda packages, and python wheels smaller.