### PR TITLE
Update to use rapids-cmake 21.10 pre-configured packages

### DIFF
--- a/cmake/thirdparty/get_gtest.cmake
+++ b/cmake/thirdparty/get_gtest.cmake
@@ -13,31 +13,11 @@
 # =============================================================================
 
 # Use CPM to find or clone gtest
-function(find_and_configure_gtest VERSION)
+function(find_and_configure_gtest)
 
-  if(TARGET GTest::gtest)
-    return()
-  endif()
-
-  rapids_cpm_find(
-    GTest ${VERSION}
-    GLOBAL_TARGETS gmock gmock_main gtest gtest_main GTest::gmock GTest::gtest GTest::gtest_main
-    CPM_ARGS
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-${VERSION}
-    GIT_SHALLOW TRUE
-    OPTIONS "INSTALL_GTEST OFF"
-            # googletest >= 1.10.0 provides a cmake config file -- use it if it exists
-            FIND_PACKAGE_ARGUMENTS
-            "CONFIG")
-
-  if(NOT TARGET GTest::gtest)
-    add_library(GTest::gmock ALIAS gmock)
-    add_library(GTest::gmock_main ALIAS gmock_main)
-    add_library(GTest::gtest ALIAS gtest)
-    add_library(GTest::gtest_main ALIAS gtest_main)
-  endif()
+  include(${rapids-cmake-dir}/cpm/gtest.cmake)
+  rapids_cpm_gtest()
 
 endfunction()
 
-find_and_configure_gtest(1.10.0)
+find_and_configure_gtest()

--- a/cmake/thirdparty/get_spdlog.cmake
+++ b/cmake/thirdparty/get_spdlog.cmake
@@ -13,20 +13,11 @@
 # =============================================================================
 
 # Use CPM to find or clone speedlog
-function(find_and_configure_spdlog VERSION)
+function(find_and_configure_spdlog)
 
-  if(TARGET spdlog::spdlog_header_only)
-    return()
-  endif()
+  include(${rapids-cmake-dir}/cpm/spdlog.cmake)
+  rapids_cpm_spdlog()
 
-  rapids_cpm_find(
-    spdlog ${VERSION}
-    CPM_ARGS
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v${VERSION}
-    GIT_SHALLOW TRUE
-    OPTIONS "SPDLOG_INSTALL TRUE")
-  # spdlog
   if(spdlog_ADDED)
     install(TARGETS spdlog_header_only EXPORT rmm-exports)
   else()
@@ -35,4 +26,4 @@ function(find_and_configure_spdlog VERSION)
   endif()
 endfunction()
 
-find_and_configure_spdlog(1.8.5)
+find_and_configure_spdlog()

--- a/cmake/thirdparty/get_thrust.cmake
+++ b/cmake/thirdparty/get_thrust.cmake
@@ -13,20 +13,14 @@
 # =============================================================================
 
 # Use CPM to find or clone thrust
-function(find_and_configure_thrust VERSION)
+function(find_and_configure_thrust)
 
-  rapids_cpm_find(
-    Thrust ${VERSION}
+  include(${rapids-cmake-dir}/cpm/thrust.cmake)
+  rapids_cpm_thrust(
+    NAMESPACE rmm
     BUILD_EXPORT_SET rmm-exports
-    INSTALL_EXPORT_SET rmm-exports
-    CPM_ARGS
-    GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
-    GIT_TAG ${VERSION}
-    GIT_SHALLOW TRUE
-    OPTIONS "THRUST_INSTALL TRUE")
-
-  thrust_create_target(rmm::Thrust FROM_OPTIONS)
+    INSTALL_EXPORT_SET rmm-exports)
 
 endfunction()
 
-find_and_configure_thrust(1.12.0)
+find_and_configure_thrust()


### PR DESCRIPTION
Since rapids-cmake 21.10 offers pre-configured packages we can use those in rmm. 

This removes the need to manually manage the following scripts:

- thrust
- gtest
- spdlog
