### PR TITLE
Fix `test_cython.py`

### DIFF
--- a/python/rmm/_lib/cuda_stream.pxd
+++ b/python/rmm/_lib/cuda_stream.pxd
@@ -34,4 +34,4 @@ cdef extern from "rmm/cuda_stream.hpp" namespace "rmm" nogil:
 cdef class CudaStream:
     cdef unique_ptr[cuda_stream] c_obj
     cdef cudaStream_t value(self) nogil except *
-    cpdef bool is_valid(self) nogil except *
+    cdef bool is_valid(self) nogil except *

--- a/python/rmm/_lib/cuda_stream.pyx
+++ b/python/rmm/_lib/cuda_stream.pyx
@@ -30,5 +30,5 @@ cdef class CudaStream:
     cdef cudaStream_t value(self) nogil except *:
         return self.c_obj.get()[0].value()
 
-    cpdef bool is_valid(self) nogil except *:
+    cdef bool is_valid(self) nogil except *:
         return self.c_obj.get()[0].is_valid()

--- a/python/setup.py
+++ b/python/setup.py
@@ -203,7 +203,10 @@ class build_ext_no_debug(_build_ext):
                 force=self.force,
                 gdb_debug=False,
                 compiler_directives=dict(
-                    profile=False, language_level=3, embedsignature=True
+                    profile=False,
+                    language_level=3,
+                    embedsignature=True,
+                    binding=True,
                 ),
             )
         # Skip calling super() and jump straight to setuptools


### PR DESCRIPTION
This PR fixes the `test_cython.py` file so that the cython tests are picked up when running `pytest`.

cc: @shwina @trxcllnt