### PR TITLE
Add .clang-tidy and fix clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks:          'clang-diagnostic-*,
                   readability-*,
                   llvm-*,
                   -modernize-use-trailing-return-type,
+                  -readability-named-parameter,
                   -cppcoreguidelines-macro-usage'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
@@ -54,8 +55,8 @@ CheckOptions:
     value:           'mr|os'
   - key:             readability-identifier-length.IgnoredVariableNames
     value:           'mr|_'
-  - key:             readability-function-cognitive-complexity.IgnoreMacros
-    value:           '1'
+  #- key:             readability-function-cognitive-complexity.IgnoreMacros
+  #  value:           '1'
   - key:             bugprone-easily-swappable-parameters.IgnoredParameterNames
     value:           'alignment'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,4 +56,6 @@ CheckOptions:
     value:           'mr|_'
   - key:             readability-function-cognitive-complexity.IgnoreMacros
     value:           '1'
+  - key:             bugprone-easily-swappable-parameters.IgnoredParameterNames
+    value:           'alignment'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,9 +7,10 @@ Checks:          'clang-diagnostic-*,
                   performance-*,
                   readability-*,
                   llvm-*,
+                  -cppcoreguidelines-macro-usage,
+                  -llvm-header-guard,
                   -modernize-use-trailing-return-type,
-                  -readability-named-parameter,
-                  -cppcoreguidelines-macro-usage'
+                  -readability-named-parameter'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
@@ -59,4 +60,8 @@ CheckOptions:
   #  value:           '1'
   - key:             bugprone-easily-swappable-parameters.IgnoredParameterNames
     value:           'alignment'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnorePowersOf2IntegerValues
+    value:           '1'
+  - key:             readability-magic-numbers.IgnorePowersOf2IntegerValues
+    value:           '1'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,4 +54,6 @@ CheckOptions:
     value:           'mr|os'
   - key:             readability-identifier-length.IgnoredVariableNames
     value:           'mr|_'
+  - key:             readability-function-cognitive-complexity.IgnoreMacros
+    value:           '1'
 ...

--- a/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
+++ b/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include <benchmark/benchmark.h>
-
 #include <rmm/cuda_stream_pool.hpp>
 #include <rmm/detail/error.hpp>
 
 #include <cuda_runtime_api.h>
+
+#include <benchmark/benchmark.h>
 
 #include <stdexcept>
 
@@ -27,23 +27,23 @@ static void BM_StreamPoolGetStream(benchmark::State& state)
 {
   rmm::cuda_stream_pool stream_pool{};
 
-  for (auto _ : state) {
-    auto s = stream_pool.get_stream();
-    cudaStreamQuery(s.value());
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
+    auto stream = stream_pool.get_stream();
+    cudaStreamQuery(stream.value());
   }
 
-  state.SetItemsProcessed(state.iterations());
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
 }
 BENCHMARK(BM_StreamPoolGetStream)->Unit(benchmark::kMicrosecond);
 
 static void BM_CudaStreamClass(benchmark::State& state)
 {
-  for (auto _ : state) {
-    auto s = rmm::cuda_stream{};
-    cudaStreamQuery(s.view().value());
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
+    auto stream = rmm::cuda_stream{};
+    cudaStreamQuery(stream.view().value());
   }
 
-  state.SetItemsProcessed(state.iterations());
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
 }
 BENCHMARK(BM_CudaStreamClass)->Unit(benchmark::kMicrosecond);
 

--- a/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/benchmarks/device_uvector/device_uvector_bench.cu
@@ -40,13 +40,9 @@ static void BM_UvectorSizeConstruction(benchmark::State& state)
   rmm::mr::set_current_device_resource(nullptr);
 }
 
-const auto range_multiplier{10};
-const auto range_start{10'000};
-const auto range_end{1'000'000'000};
-
 BENCHMARK(BM_UvectorSizeConstruction)
-  ->RangeMultiplier(range_multiplier)
-  ->Range(range_start, range_end)
+  ->RangeMultiplier(10)           // NOLINT
+  ->Range(10'000, 1'000'000'000)  // NOLINT
   ->Unit(benchmark::kMicrosecond);
 
 static void BM_ThrustVectorSizeConstruction(benchmark::State& state)
@@ -66,8 +62,8 @@ static void BM_ThrustVectorSizeConstruction(benchmark::State& state)
 }
 
 BENCHMARK(BM_ThrustVectorSizeConstruction)
-  ->RangeMultiplier(range_multiplier)
-  ->Range(range_start, range_end)
+  ->RangeMultiplier(10)           // NOLINT
+  ->Range(10'000, 1'000'000'000)  // NOLINT
   ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/benchmarks/device_uvector/device_uvector_bench.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-#include <benchmark/benchmark.h>
-
-#include <cuda_runtime_api.h>
 #include <rmm/device_uvector.hpp>
 #include <rmm/device_vector.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
+
+#include <benchmark/benchmark.h>
+
+#include <cuda_runtime_api.h>
 
 static void BM_UvectorSizeConstruction(benchmark::State& state)
 {
@@ -29,18 +30,23 @@ static void BM_UvectorSizeConstruction(benchmark::State& state)
   rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource> mr{&cuda_mr};
   rmm::mr::set_current_device_resource(&mr);
 
-  for (auto _ : state) {
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_uvector<int32_t> vec(state.range(0), rmm::cuda_stream_view{});
     cudaDeviceSynchronize();
   }
 
-  state.SetItemsProcessed(state.iterations());
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
 
   rmm::mr::set_current_device_resource(nullptr);
 }
+
+const auto range_multiplier{10};
+const auto range_start{10'000};
+const auto range_end{1'000'000'000};
+
 BENCHMARK(BM_UvectorSizeConstruction)
-  ->RangeMultiplier(10)
-  ->Range(10'000, 1'000'000'000)
+  ->RangeMultiplier(range_multiplier)
+  ->Range(range_start, range_end)
   ->Unit(benchmark::kMicrosecond);
 
 static void BM_ThrustVectorSizeConstruction(benchmark::State& state)
@@ -49,19 +55,19 @@ static void BM_ThrustVectorSizeConstruction(benchmark::State& state)
   rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource> mr{&cuda_mr};
   rmm::mr::set_current_device_resource(&mr);
 
-  for (auto _ : state) {
+  for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_vector<int32_t> vec(state.range(0));
     cudaDeviceSynchronize();
   }
 
-  state.SetItemsProcessed(state.iterations());
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
 
   rmm::mr::set_current_device_resource(nullptr);
 }
 
 BENCHMARK(BM_ThrustVectorSizeConstruction)
-  ->RangeMultiplier(10)
-  ->Range(10'000, 1'000'000'000)
+  ->RangeMultiplier(range_multiplier)
+  ->Range(range_start, range_end)
   ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
+++ b/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
@@ -117,9 +117,9 @@ inline auto make_binning()
   return mr;
 }
 
-static void benchmark_range(benchmark::internal::Benchmark* b)
+static void benchmark_range(benchmark::internal::Benchmark* bench)
 {
-  b  //
+  bench  //
     ->RangeMultiplier(2)
     ->Ranges({{1, 4}, {4, 4}, {false, true}})
     ->Unit(benchmark::kMicrosecond);
@@ -177,6 +177,7 @@ void declare_benchmark(std::string const& name)
   std::cout << "Error: invalid memory_resource name: " << name << std::endl;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void run_profile(std::string const& resource_name, int kernel_count, int stream_count, bool prewarm)
 {
   auto mr_factory  = get_mr_factory(resource_name);

--- a/benchmarks/random_allocations/random_allocations.cpp
+++ b/benchmarks/random_allocations/random_allocations.cpp
@@ -197,7 +197,7 @@ static void BM_RandomAllocations(benchmark::State& state, MRFactoryFunc const& f
   std::size_t max_size        = state.range(1);
 
   try {
-    for (auto _ : state) {
+    for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
       uniform_random_allocations(*mr, num_allocations, max_size, max_usage);
     }
   } catch (std::exception const& e) {
@@ -321,7 +321,11 @@ int main(int argc, char** argv)
     std::cout << "Profiling " << resource << " with " << num_allocations << " allocations of max "
               << max_size << "B\n";
 
-    profile_random_allocations(funcs.at(resource), num_allocations, max_size);
+    try {
+      profile_random_allocations(funcs.at(resource), num_allocations, max_size);
+    } catch (std::exception const& e) {
+      std::cout << "Exception caught: " << e.what() << std::endl;
+    }
 
     std::cout << "Finished\n";
   } else {

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -220,7 +220,7 @@ struct replay_benchmark {
           set_allocation(event.pointer, allocation{ptr, event.size});
         } else {
           auto alloc = remove_allocation(event.pointer);
-          mr_->deallocate(alloc.p, event.size);
+          mr_->deallocate(alloc.ptr, event.size);
         }
 
         event_index++;

--- a/benchmarks/replay/replay.cpp
+++ b/benchmarks/replay/replay.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <atomic>
 #include <benchmarks/utilities/cxxopts.hpp>
 #include <benchmarks/utilities/log_parser.hpp>
 #include <benchmarks/utilities/simulated_memory_resource.hpp>
@@ -37,6 +36,7 @@
 
 #include <spdlog/common.h>
 
+#include <atomic>
 #include <chrono>
 #include <iterator>
 #include <memory>
@@ -45,7 +45,7 @@
 #include <thread>
 
 /// MR factory functions
-std::shared_ptr<rmm::mr::device_memory_resource> make_cuda(std::size_t = 0)
+std::shared_ptr<rmm::mr::device_memory_resource> make_cuda(std::size_t /*unused*/ = 0)
 {
   return std::make_shared<rmm::mr::cuda_memory_resource>();
 }
@@ -75,7 +75,9 @@ inline auto make_binning(std::size_t simulated_size)
 {
   auto pool = make_pool(simulated_size);
   auto mr   = rmm::mr::make_owning_wrapper<rmm::mr::binning_memory_resource>(pool);
-  for (std::size_t i = 18; i <= 22; i++) {
+  const auto min_size_exp{18};
+  const auto max_size_exp{22};
+  for (std::size_t i = min_size_exp; i <= max_size_exp; i++) {
     mr->wrapped().add_bin(1 << i);
   }
   return mr;
@@ -89,8 +91,8 @@ using MRFactoryFunc = std::function<std::shared_ptr<rmm::mr::device_memory_resou
  */
 struct allocation {
   allocation() = default;
-  allocation(void* p_, std::size_t size_) : p{p_}, size{size_} {}
-  void* p{};
+  void* ptr{};
+  allocation(void* ptr, std::size_t size) : ptr{ptr}, size{size} {}
   std::size_t size{};
 };
 
@@ -127,10 +129,8 @@ struct replay_benchmark {
                    std::vector<std::vector<rmm::detail::event>> const& events)
     : factory_{std::move(factory)},
       simulated_size_{simulated_size},
-      mr_{},
       events_{events},
-      allocation_map{events.size()},
-      event_index{0}
+      allocation_map{events.size()}
   {
   }
 
@@ -144,12 +144,14 @@ struct replay_benchmark {
       simulated_size_{other.simulated_size_},
       mr_{std::move(other.mr_)},
       events_{other.events_},
-      allocation_map{events_.size()},
-      event_index{0}
+      allocation_map{std::move(other.allocation_map)}
   {
   }
 
+  ~replay_benchmark()                       = default;
   replay_benchmark(replay_benchmark const&) = delete;
+  replay_benchmark& operator=(replay_benchmark const&) = delete;
+  replay_benchmark& operator=(replay_benchmark&& other) noexcept = delete;
 
   /// Add an allocation to the map (NOT thread safe)
   void set_allocation(uintptr_t ptr, allocation alloc) { allocation_map.insert({ptr, alloc}); }
@@ -159,9 +161,9 @@ struct replay_benchmark {
   {
     auto iter = allocation_map.find(ptr);
     if (iter != allocation_map.end()) {
-      allocation a = iter->second;
+      allocation alloc = iter->second;
       allocation_map.erase(iter);
-      return a;
+      return alloc;
     }
     return allocation{};
   }
@@ -187,11 +189,12 @@ struct replay_benchmark {
         auto alloc = ptr_alloc.second;
         num_leaked++;
         total_leaked += alloc.size;
-        mr_->deallocate(alloc.p, alloc.size);
+        mr_->deallocate(alloc.ptr, alloc.size);
       }
-      if (num_leaked > 0)
+      if (num_leaked > 0) {
         std::cout << "LOG shows leak of " << num_leaked << " allocations of " << total_leaked
                   << " total bytes\n";
+      }
       allocation_map.clear();
       mr_.reset();
     }
@@ -204,20 +207,20 @@ struct replay_benchmark {
 
     auto const& my_events = events_.at(state.thread_index);
 
-    for (auto _ : state) {
-      std::for_each(my_events.begin(), my_events.end(), [&state, this](auto e) {
+    for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
+      std::for_each(my_events.begin(), my_events.end(), [this](auto event) {
         // ensure correct ordering between threads
         std::unique_lock<std::mutex> lock{event_mutex};
-        if (event_index != e.index) {
-          cv.wait(lock, [&]() { return event_index == e.index; });
+        if (event_index != event.index) {
+          cv.wait(lock, [&]() { return event_index == event.index; });
         }
 
-        if (rmm::detail::action::ALLOCATE == e.act) {
-          auto p = mr_->allocate(e.size);
-          set_allocation(e.pointer, allocation{p, e.size});
+        if (rmm::detail::action::ALLOCATE == event.act) {
+          auto ptr = mr_->allocate(event.size);
+          set_allocation(event.pointer, allocation{ptr, event.size});
         } else {
-          auto a = remove_allocation(e.pointer);
-          mr_->deallocate(a.p, e.size);
+          auto alloc = remove_allocation(event.pointer);
+          mr_->deallocate(alloc.p, event.size);
         }
 
         event_index++;
@@ -242,11 +245,11 @@ std::vector<std::vector<rmm::detail::event>> parse_per_thread_events(std::string
 
   RMM_EXPECTS(std::all_of(all_events.begin(),
                           all_events.end(),
-                          [](auto const& e) {
-                            cudaStream_t cs;
-                            memcpy(&cs, &e.stream, sizeof(cudaStream_t));
-                            auto s = rmm::cuda_stream_view{cs};
-                            return s.is_default() or s.is_per_thread_default();
+                          [](auto const& event) {
+                            cudaStream_t custream;
+                            memcpy(&custream, &event.stream, sizeof(cudaStream_t));
+                            auto stream = rmm::cuda_stream_view{custream};
+                            return stream.is_default() or stream.is_per_thread_default();
                           }),
               "Non-default streams not currently supported.");
 
@@ -294,28 +297,29 @@ void declare_benchmark(std::string const& name,
                        std::vector<std::vector<rmm::detail::event>> const& per_thread_events,
                        std::size_t num_threads)
 {
-  if (name == "cuda")
+  if (name == "cuda") {
     benchmark::RegisterBenchmark("CUDA Resource",
                                  replay_benchmark(&make_cuda, simulated_size, per_thread_events))
       ->Unit(benchmark::kMillisecond)
-      ->Threads(num_threads);
-  else if (name == "binning")
+      ->Threads(static_cast<int>(num_threads));
+  } else if (name == "binning") {
     benchmark::RegisterBenchmark("Binning Resource",
                                  replay_benchmark(&make_binning, simulated_size, per_thread_events))
       ->Unit(benchmark::kMillisecond)
-      ->Threads(num_threads);
-  else if (name == "pool")
+      ->Threads(static_cast<int>(num_threads));
+  } else if (name == "pool") {
     benchmark::RegisterBenchmark("Pool Resource",
                                  replay_benchmark(&make_pool, simulated_size, per_thread_events))
       ->Unit(benchmark::kMillisecond)
-      ->Threads(num_threads);
-  else if (name == "arena")
+      ->Threads(static_cast<int>(num_threads));
+  } else if (name == "arena") {
     benchmark::RegisterBenchmark("Arena Resource",
                                  replay_benchmark(&make_arena, simulated_size, per_thread_events))
       ->Unit(benchmark::kMillisecond)
-      ->Threads(num_threads);
-  else
+      ->Threads(static_cast<int>(num_threads));
+  } else {
     std::cout << "Error: invalid memory_resource name: " << name << "\n";
+  }
 }
 
 // Usage: REPLAY_BENCHMARK -f "path/to/log/file"
@@ -355,14 +359,22 @@ int main(int argc, char** argv)
 
   auto filename = args["file"].as<std::string>();
 
-  auto per_thread_events = parse_per_thread_events(filename);
+  auto per_thread_events = [filename]() {
+    try {
+      auto events = parse_per_thread_events(filename);
+      return events;
+    } catch (std::exception const& e) {
+      std::cout << "Failed to parse events: " << e.what() << std::endl;
+      return std::vector<std::vector<rmm::detail::event>>{};
+    }
+  }();
 
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
   std::cout << "Using CUDA per-thread default stream.\n";
 #endif
 
   auto const simulated_size =
-    static_cast<std::size_t>(args["size"].as<float>() * static_cast<float>(1u << 30u));
+    static_cast<std::size_t>(args["size"].as<float>() * static_cast<float>(1U << 30U));
   if (simulated_size != 0 && args["resource"].as<std::string>() != "cuda") {
     std::cout << "Simulating GPU with memory size of " << simulated_size << " bytes.\n";
   }
@@ -375,11 +387,11 @@ int main(int argc, char** argv)
                  [](std::size_t accum, auto const& events) { return accum + events.size(); })
             << std::endl;
 
-  for (std::size_t t = 0; t < per_thread_events.size(); ++t) {
-    std::cout << "Thread " << t << ": " << per_thread_events[t].size() << " events\n";
+  for (std::size_t thread = 0; thread < per_thread_events.size(); ++thread) {
+    std::cout << "Thread " << thread << ": " << per_thread_events[thread].size() << " events\n";
     if (args["verbose"].as<bool>()) {
-      for (auto const& e : per_thread_events[t]) {
-        std::cout << e << std::endl;
+      for (auto const& event : per_thread_events[thread]) {
+        std::cout << event << std::endl;
       }
     }
   }
@@ -396,8 +408,8 @@ int main(int argc, char** argv)
     std::array<std::string, 4> mrs{"pool", "arena", "binning", "cuda"};
     std::for_each(std::cbegin(mrs),
                   std::cend(mrs),
-                  [&simulated_size, &per_thread_events, &num_threads](auto const& s) {
-                    declare_benchmark(s, simulated_size, per_thread_events, num_threads);
+                  [&simulated_size, &per_thread_events, &num_threads](auto const& mr) {
+                    declare_benchmark(mr, simulated_size, per_thread_events, num_threads);
                   });
   }
 

--- a/benchmarks/synchronization/synchronization.cpp
+++ b/benchmarks/synchronization/synchronization.cpp
@@ -59,9 +59,10 @@ cuda_event_timer::~cuda_event_timer()
   RMM_CUDA_ASSERT_OK(cudaEventRecord(stop, stream.value()));
   RMM_CUDA_ASSERT_OK(cudaEventSynchronize(stop));
 
-  float milliseconds = 0.0f;
+  float milliseconds = 0.0F;
   RMM_CUDA_ASSERT_OK(cudaEventElapsedTime(&milliseconds, start, stop));
-  p_state->SetIterationTime(milliseconds / (1000.0f));
+  const auto to_milliseconds{1.0F / 1000};
+  p_state->SetIterationTime(milliseconds * to_milliseconds);
   RMM_CUDA_ASSERT_OK(cudaEventDestroy(start));
   RMM_CUDA_ASSERT_OK(cudaEventDestroy(stop));
 }

--- a/benchmarks/synchronization/synchronization.hpp
+++ b/benchmarks/synchronization/synchronization.hpp
@@ -89,9 +89,15 @@ class cuda_event_timer {
   // will be set to the value given by `cudaEventElapsedTime`.
   ~cuda_event_timer();
 
+  // disable copy and move
+  cuda_event_timer(cuda_event_timer const&) = delete;
+  cuda_event_timer& operator=(cuda_event_timer const&) = delete;
+  cuda_event_timer(cuda_event_timer&&)                 = delete;
+  cuda_event_timer& operator=(cuda_event_timer&&) = delete;
+
  private:
-  cudaEvent_t start;
-  cudaEvent_t stop;
-  rmm::cuda_stream_view stream;
-  benchmark::State* p_state;
+  cudaEvent_t start{};
+  cudaEvent_t stop{};
+  rmm::cuda_stream_view stream{};
+  benchmark::State* p_state{};
 };

--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -77,7 +77,7 @@ class simulated_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view /*stream*/) override
+  void* do_allocate(std::size_t bytes, cuda_stream_view) override
   {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     RMM_EXPECTS(begin_ + bytes <= end_, rmm::bad_alloc, "Simulated memory size exceeded");
@@ -95,7 +95,7 @@ class simulated_memory_resource final : public device_memory_resource {
    *
    * @param ptr Pointer to be deallocated
    */
-  void do_deallocate(void* ptr, std::size_t /*bytes*/, cuda_stream_view /*stream*/) override {}
+  void do_deallocate(void* ptr, std::size_t, cuda_stream_view) override {}
 
   /**
    * @brief Get free and available memory for memory resource.

--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,7 @@
 
 #include <cuda_runtime_api.h>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 
 /**
  * @brief A device memory resource that simulates a fix-sized GPU.
@@ -39,14 +38,18 @@ class simulated_memory_resource final : public device_memory_resource {
    * @param memory_size_bytes The size of the memory to simulate.
    */
   explicit simulated_memory_resource(std::size_t memory_size_bytes)
-    : begin_{reinterpret_cast<char*>(0x100)},
-      end_{reinterpret_cast<char*>(begin_ + memory_size_bytes)}
+    : begin_{reinterpret_cast<char*>(0x100)},                    // NOLINT
+      end_{reinterpret_cast<char*>(begin_ + memory_size_bytes)}  // NOLINT
   {
   }
+
+  ~simulated_memory_resource() override = default;
 
   // Disable copy (and move) semantics.
   simulated_memory_resource(simulated_memory_resource const&) = delete;
   simulated_memory_resource& operator=(simulated_memory_resource const&) = delete;
+  simulated_memory_resource(simulated_memory_resource&&)                 = delete;
+  simulated_memory_resource& operator=(simulated_memory_resource&&) = delete;
 
   /**
    * @brief Query whether the resource supports use of non-null CUDA streams for
@@ -54,14 +57,14 @@ class simulated_memory_resource final : public device_memory_resource {
    *
    * @returns bool false
    */
-  bool supports_streams() const noexcept override { return false; }
+  [[nodiscard]] bool supports_streams() const noexcept override { return false; }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return false
    */
-  bool supports_get_mem_info() const noexcept override { return false; }
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 
  private:
   /**
@@ -74,24 +77,25 @@ class simulated_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view) override
+  void* do_allocate(std::size_t bytes, cuda_stream_view /*stream*/) override
   {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     RMM_EXPECTS(begin_ + bytes <= end_, rmm::bad_alloc, "Simulated memory size exceeded");
-    auto p = static_cast<void*>(begin_);
-    begin_ += bytes;
-    return p;
+    auto* ptr = static_cast<void*>(begin_);
+    begin_ += bytes;  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return ptr;
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by `p`.
    *
    * @note This call is ignored.
    *
    * @throws Nothing.
    *
-   * @param p Pointer to be deallocated
+   * @param ptr Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, cuda_stream_view) override {}
+  void do_deallocate(void* ptr, std::size_t /*bytes*/, cuda_stream_view /*stream*/) override {}
 
   /**
    * @brief Get free and available memory for memory resource.
@@ -99,14 +103,13 @@ class simulated_memory_resource final : public device_memory_resource {
    * @param stream to execute on.
    * @return std::pair containing free_size and total_size of memory.
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
   {
     return std::make_pair(0, 0);
   }
 
- private:
-  char* begin_;
-  char* end_;
+  char* begin_{};
+  char* end_{};
 };
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/cmake/thirdparty/get_gtest.cmake
+++ b/cmake/thirdparty/get_gtest.cmake
@@ -12,7 +12,6 @@
 # the License.
 # =============================================================================
 
-
 function(find_and_configure_gtest)
   include(${rapids-cmake-dir}/cpm/gtest.cmake)
   rapids_cpm_gtest()

--- a/cmake/thirdparty/get_gtest.cmake
+++ b/cmake/thirdparty/get_gtest.cmake
@@ -23,8 +23,8 @@ function(find_and_configure_gtest VERSION)
     GTest ${VERSION}
     GLOBAL_TARGETS gmock gmock_main gtest gtest_main GTest::gmock GTest::gtest GTest::gtest_main
     CPM_ARGS
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-${VERSION}
+    GIT_REPOSITORY https://github.com/harrism/googletest.git
+    GIT_TAG fix-clang-tidy-nolint
     GIT_SHALLOW TRUE
     OPTIONS "INSTALL_GTEST OFF"
             # googletest >= 1.10.0 provides a cmake config file -- use it if it exists
@@ -40,4 +40,4 @@ function(find_and_configure_gtest VERSION)
 
 endfunction()
 
-find_and_configure_gtest(1.10.0)
+find_and_configure_gtest(1.11.0)

--- a/cmake/thirdparty/get_gtest.cmake
+++ b/cmake/thirdparty/get_gtest.cmake
@@ -12,6 +12,7 @@
 # the License.
 # =============================================================================
 
+# Use CPM to find or clone gtest
 function(find_and_configure_gtest)
   include(${rapids-cmake-dir}/cpm/gtest.cmake)
   rapids_cpm_gtest()

--- a/include/rmm/cuda_device.hpp
+++ b/include/rmm/cuda_device.hpp
@@ -33,10 +33,10 @@ struct cuda_device_id {
    *
    * @param id The device's integer identifier
    */
-  explicit constexpr cuda_device_id(value_type id) noexcept : id_{id} {}
+  explicit constexpr cuda_device_id(value_type dev_id) noexcept : id_{dev_id} {}
 
   /// Returns the wrapped integer value
-  constexpr value_type value() const noexcept { return id_; }
+  [[nodiscard]] constexpr value_type value() const noexcept { return id_; }
 
  private:
   value_type id_;
@@ -52,7 +52,7 @@ namespace detail {
  */
 inline cuda_device_id current_device()
 {
-  int dev_id;
+  int dev_id{};
   RMM_CUDA_TRY(cudaGetDevice(&dev_id));
   return cuda_device_id{dev_id};
 }

--- a/include/rmm/cuda_stream.hpp
+++ b/include/rmm/cuda_stream.hpp
@@ -57,13 +57,13 @@ class cuda_stream {
    */
   cuda_stream()
     : stream_{[]() {
-                auto* s = new cudaStream_t;
-                RMM_CUDA_TRY(cudaStreamCreate(s));
-                return s;
+                auto* stream = new cudaStream_t;  // NOLINT(cppcoreguidelines-owning-memory)
+                RMM_CUDA_TRY(cudaStreamCreate(stream));
+                return stream;
               }(),
               [](cudaStream_t* stream) {
                 RMM_ASSERT_CUDA_SUCCESS(cudaStreamDestroy(*stream));
-                delete stream;
+                delete stream;  // NOLINT(cppcoreguidelines-owning-memory)
               }}
   {
   }

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -24,7 +24,8 @@
 
 namespace rmm::detail {
 
-enum alignment_type : std::size_t {};
+// enum alignment_type : std::size_t {};
+using alignment_type = std::size_t;
 
 /**
  * @brief Default alignment used for host memory allocated by RMM.

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -24,17 +24,19 @@
 
 namespace rmm::detail {
 
+enum alignment_type : std::size_t {};
+
 /**
  * @brief Default alignment used for host memory allocated by RMM.
  *
  */
-static constexpr std::size_t RMM_DEFAULT_HOST_ALIGNMENT{alignof(std::max_align_t)};
+static constexpr alignment_type RMM_DEFAULT_HOST_ALIGNMENT{alignof(std::max_align_t)};
 
 /**
  * @brief Default alignment used for CUDA memory allocation.
  *
  */
-static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
+static constexpr alignment_type CUDA_ALLOCATION_ALIGNMENT{256};
 
 /**
  * @brief Returns whether or not `n` is a power of 2.
@@ -46,7 +48,7 @@ constexpr bool is_pow2(std::size_t value) { return (0 == (value & (value - 1)));
  * @brief Returns whether or not `alignment` is a valid memory alignment.
  *
  */
-constexpr bool is_supported_alignment(std::size_t alignment) { return is_pow2(alignment); }
+constexpr bool is_supported_alignment(alignment_type alignment) { return is_pow2(alignment); }
 
 /**
  * @brief Align up to nearest multiple of specified power of 2
@@ -56,10 +58,10 @@ constexpr bool is_supported_alignment(std::size_t alignment) { return is_pow2(al
  *
  * @return Return the aligned value, as one would expect
  */
-constexpr std::size_t align_up(std::size_t value, std::size_t align_bytes) noexcept
+constexpr std::size_t align_up(std::size_t value, alignment_type alignment) noexcept
 {
-  assert(is_supported_alignment(align_bytes));
-  return (value + (align_bytes - 1)) & ~(align_bytes - 1);
+  assert(is_supported_alignment(alignment));
+  return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
 /**
@@ -70,10 +72,10 @@ constexpr std::size_t align_up(std::size_t value, std::size_t align_bytes) noexc
  *
  * @return Return the aligned value, as one would expect
  */
-constexpr std::size_t align_down(std::size_t value, std::size_t align_bytes) noexcept
+constexpr std::size_t align_down(std::size_t value, alignment_type alignment) noexcept
 {
-  assert(is_supported_alignment(align_bytes));
-  return value & ~(align_bytes - 1);
+  assert(is_supported_alignment(alignment));
+  return value & ~(alignment - 1);
 }
 
 /**
@@ -84,13 +86,13 @@ constexpr std::size_t align_down(std::size_t value, std::size_t align_bytes) noe
  *
  * @return true if aligned
  */
-constexpr bool is_aligned(std::size_t value, std::size_t align_bytes) noexcept
+constexpr bool is_aligned(std::size_t value, alignment_type alignment) noexcept
 {
-  assert(is_supported_alignment(align_bytes));
-  return value == align_down(value, align_bytes);
+  assert(is_supported_alignment(alignment));
+  return value == align_down(value, alignment);
 }
 
-inline bool is_pointer_aligned(void* ptr, std::size_t alignment = CUDA_ALLOCATION_ALIGNMENT)
+inline bool is_pointer_aligned(void* ptr, alignment_type alignment = CUDA_ALLOCATION_ALIGNMENT)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   return rmm::detail::is_aligned(reinterpret_cast<ptrdiff_t>(ptr), alignment);
@@ -124,7 +126,7 @@ inline bool is_pointer_aligned(void* ptr, std::size_t alignment = CUDA_ALLOCATIO
  * `alignment`.
  */
 template <typename Alloc>
-void* aligned_allocate(std::size_t bytes, std::size_t alignment, Alloc alloc)
+void* aligned_allocate(std::size_t bytes, alignment_type alignment, Alloc alloc)
 {
   assert(is_pow2(alignment));
 
@@ -168,7 +170,7 @@ void* aligned_allocate(std::size_t bytes, std::size_t alignment, Alloc alloc)
  */
 template <typename Dealloc>
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void aligned_deallocate(void* ptr, std::size_t bytes, std::size_t alignment, Dealloc dealloc)
+void aligned_deallocate(void* ptr, std::size_t bytes, alignment_type alignment, Dealloc dealloc)
 {
   (void)alignment;
 

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -24,20 +24,17 @@
 
 namespace rmm::detail {
 
-// enum alignment_type : std::size_t {};
-using alignment_type = std::size_t;
-
 /**
  * @brief Default alignment used for host memory allocated by RMM.
  *
  */
-static constexpr alignment_type RMM_DEFAULT_HOST_ALIGNMENT{alignof(std::max_align_t)};
+static constexpr std::size_t RMM_DEFAULT_HOST_ALIGNMENT{alignof(std::max_align_t)};
 
 /**
  * @brief Default alignment used for CUDA memory allocation.
  *
  */
-static constexpr alignment_type CUDA_ALLOCATION_ALIGNMENT{256};
+static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
 
 /**
  * @brief Returns whether or not `n` is a power of 2.
@@ -49,7 +46,7 @@ constexpr bool is_pow2(std::size_t value) { return (0 == (value & (value - 1)));
  * @brief Returns whether or not `alignment` is a valid memory alignment.
  *
  */
-constexpr bool is_supported_alignment(alignment_type alignment) { return is_pow2(alignment); }
+constexpr bool is_supported_alignment(std::size_t alignment) { return is_pow2(alignment); }
 
 /**
  * @brief Align up to nearest multiple of specified power of 2
@@ -59,7 +56,7 @@ constexpr bool is_supported_alignment(alignment_type alignment) { return is_pow2
  *
  * @return Return the aligned value, as one would expect
  */
-constexpr std::size_t align_up(std::size_t value, alignment_type alignment) noexcept
+constexpr std::size_t align_up(std::size_t value, std::size_t alignment) noexcept
 {
   assert(is_supported_alignment(alignment));
   return (value + (alignment - 1)) & ~(alignment - 1);
@@ -73,7 +70,7 @@ constexpr std::size_t align_up(std::size_t value, alignment_type alignment) noex
  *
  * @return Return the aligned value, as one would expect
  */
-constexpr std::size_t align_down(std::size_t value, alignment_type alignment) noexcept
+constexpr std::size_t align_down(std::size_t value, std::size_t alignment) noexcept
 {
   assert(is_supported_alignment(alignment));
   return value & ~(alignment - 1);
@@ -87,13 +84,13 @@ constexpr std::size_t align_down(std::size_t value, alignment_type alignment) no
  *
  * @return true if aligned
  */
-constexpr bool is_aligned(std::size_t value, alignment_type alignment) noexcept
+constexpr bool is_aligned(std::size_t value, std::size_t alignment) noexcept
 {
   assert(is_supported_alignment(alignment));
   return value == align_down(value, alignment);
 }
 
-inline bool is_pointer_aligned(void* ptr, alignment_type alignment = CUDA_ALLOCATION_ALIGNMENT)
+inline bool is_pointer_aligned(void* ptr, std::size_t alignment = CUDA_ALLOCATION_ALIGNMENT)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   return rmm::detail::is_aligned(reinterpret_cast<ptrdiff_t>(ptr), alignment);
@@ -127,7 +124,7 @@ inline bool is_pointer_aligned(void* ptr, alignment_type alignment = CUDA_ALLOCA
  * `alignment`.
  */
 template <typename Alloc>
-void* aligned_allocate(std::size_t bytes, alignment_type alignment, Alloc alloc)
+void* aligned_allocate(std::size_t bytes, std::size_t alignment, Alloc alloc)
 {
   assert(is_pow2(alignment));
 
@@ -171,7 +168,7 @@ void* aligned_allocate(std::size_t bytes, alignment_type alignment, Alloc alloc)
  */
 template <typename Dealloc>
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void aligned_deallocate(void* ptr, std::size_t bytes, alignment_type alignment, Dealloc dealloc)
+void aligned_deallocate(void* ptr, std::size_t bytes, std::size_t alignment, Dealloc dealloc)
 {
   (void)alignment;
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -100,10 +100,11 @@ class out_of_range : public std::out_of_range {
   GET_RMM_EXPECTS_MACRO(__VA_ARGS__, RMM_EXPECTS_3, RMM_EXPECTS_2) \
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
-#define RMM_EXPECTS_3(_condition, _exception_type, _reason)              \
-  (!!(_condition)) ? static_cast<void>(0) : throw _exception_type        \
-  {                                                                      \
-    "RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason \
+#define RMM_EXPECTS_3(_condition, _exception_type, _reason)                       \
+  (!!(_condition)) ? static_cast<void>(0)                                         \
+                   : throw _exception_type /*NOLINT(bugprone-macro-parentheses)*/ \
+  {                                                                               \
+    "RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason          \
   }
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, rmm::logic_error, _reason)
 
@@ -123,7 +124,8 @@ class out_of_range : public std::out_of_range {
   GET_RMM_FAIL_MACRO(__VA_ARGS__, RMM_FAIL_2, RMM_FAIL_1) \
   (__VA_ARGS__)
 #define GET_RMM_FAIL_MACRO(_1, _2, NAME, ...) NAME
-#define RMM_FAIL_2(_what, _exception_type) \
+#define RMM_FAIL_2(_what, _exception_type)       \
+  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/ \
   throw _exception_type{"RMM failure at:" __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what};
 #define RMM_FAIL_1(_what) RMM_FAIL_2(_what, rmm::logic_error)
 
@@ -157,6 +159,7 @@ class out_of_range : public std::out_of_range {
     cudaError_t const error = (_call);                                                       \
     if (cudaSuccess != error) {                                                              \
       cudaGetLastError();                                                                    \
+      /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                         \
       throw _exception_type{std::string{"CUDA error at: "} + __FILE__ + ":" +                \
                             RMM_STRINGIFY(__LINE__) + ": " + cudaGetErrorName(error) + " " + \
                             cudaGetErrorString(error)};                                      \

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -101,7 +101,7 @@ class out_of_range : public std::out_of_range {
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
 #define RMM_EXPECTS_3(_condition, _exception_type, _reason)              \
-  (!!(_condition)) ? static_cast<void>(0) : throw(_exception_type)       \
+  (!!(_condition)) ? static_cast<void>(0) : throw _exception_type        \
   {                                                                      \
     "RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason \
   }
@@ -124,7 +124,7 @@ class out_of_range : public std::out_of_range {
   (__VA_ARGS__)
 #define GET_RMM_FAIL_MACRO(_1, _2, NAME, ...) NAME
 #define RMM_FAIL_2(_what, _exception_type) \
-  throw(_exception_type){"RMM failure at:" __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what};
+  throw _exception_type{"RMM failure at:" __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what};
 #define RMM_FAIL_1(_what) RMM_FAIL_2(_what, rmm::logic_error)
 
 /**
@@ -152,15 +152,15 @@ class out_of_range : public std::out_of_range {
   GET_RMM_CUDA_TRY_MACRO(__VA_ARGS__, RMM_CUDA_TRY_2, RMM_CUDA_TRY_1) \
   (__VA_ARGS__)
 #define GET_RMM_CUDA_TRY_MACRO(_1, _2, NAME, ...) NAME
-#define RMM_CUDA_TRY_2(_call, _exception_type)                                                \
-  do {                                                                                        \
-    cudaError_t const error = (_call);                                                        \
-    if (cudaSuccess != error) {                                                               \
-      cudaGetLastError();                                                                     \
-      throw(_exception_type){std::string{"CUDA error at: "} + __FILE__ + ":" +                \
-                             RMM_STRINGIFY(__LINE__) + ": " + cudaGetErrorName(error) + " " + \
-                             cudaGetErrorString(error)};                                      \
-    }                                                                                         \
+#define RMM_CUDA_TRY_2(_call, _exception_type)                                               \
+  do {                                                                                       \
+    cudaError_t const error = (_call);                                                       \
+    if (cudaSuccess != error) {                                                              \
+      cudaGetLastError();                                                                    \
+      throw _exception_type{std::string{"CUDA error at: "} + __FILE__ + ":" +                \
+                            RMM_STRINGIFY(__LINE__) + ": " + cudaGetErrorName(error) + " " + \
+                            cudaGetErrorString(error)};                                      \
+    }                                                                                        \
   } while (0)
 #define RMM_CUDA_TRY_1(_call) RMM_CUDA_TRY_2(_call, rmm::cuda_error)
 

--- a/include/rmm/detail/stack_trace.hpp
+++ b/include/rmm/detail/stack_trace.hpp
@@ -53,7 +53,7 @@ class stack_trace {
     const int MaxStackDepth = 64;
     std::array<void*, MaxStackDepth> stack{};
     auto const depth = backtrace(stack.begin(), MaxStackDepth);
-    stack_ptrs.insert(stack_ptrs.end(), stack.begin(), &stack.at(depth));
+    stack_ptrs.insert(stack_ptrs.end(), stack.begin(), stack.begin() + depth);
 #endif  // RMM_ENABLE_STACK_TRACES
   }
 

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -88,10 +88,7 @@ class device_buffer {
   // `__host__ __device__` specifiers to the defaulted constructor when it is called within the
   // context of both host and device functions. Specifically, the `cudf::type_dispatcher` is a host-
   // device function. This causes warnings/errors because this ctor invokes host-only functions.
-  device_buffer()
-    : _data{nullptr}, _size{}, _capacity{}, _stream{}, _mr{rmm::mr::get_current_device_resource()}
-  {
-  }
+  device_buffer() : _mr{rmm::mr::get_current_device_resource()} {}
 
   /**
    * @brief Constructs a new device buffer of `size` uninitialized bytes
@@ -310,7 +307,7 @@ class device_buffer {
   /**
    * @brief Returns raw pointer to underlying device memory allocation
    */
-  void const* data() const noexcept { return _data; }
+  [[nodiscard]] void const* data() const noexcept { return _data; }
 
   /**
    * @brief Returns raw pointer to underlying device memory allocation
@@ -321,7 +318,7 @@ class device_buffer {
    * @brief Returns size in bytes that was requested for the device memory
    * allocation
    */
-  std::size_t size() const noexcept { return _size; }
+  [[nodiscard]] std::size_t size() const noexcept { return _size; }
 
   /**
    * @brief Returns whether the size in bytes of the `device_buffer` is zero.
@@ -330,19 +327,19 @@ class device_buffer {
    * if `capacity() > 0`.
    *
    */
-  bool is_empty() const noexcept { return 0 == size(); }
+  [[nodiscard]] bool is_empty() const noexcept { return 0 == size(); }
 
   /**
    * @brief Returns actual size in bytes of device memory allocation.
    *
    * The invariant `size() <= capacity()` holds.
    */
-  std::size_t capacity() const noexcept { return _capacity; }
+  [[nodiscard]] std::size_t capacity() const noexcept { return _capacity; }
 
   /**
    * @brief Returns stream most recently specified for allocation/deallocation
    */
-  cuda_stream_view stream() const noexcept { return _stream; }
+  [[nodiscard]] cuda_stream_view stream() const noexcept { return _stream; }
 
   /**
    * @brief Sets the stream to be used for deallocation
@@ -360,7 +357,7 @@ class device_buffer {
    * @brief Returns pointer to the memory resource used to allocate and
    * deallocate the device memory
    */
-  mr::device_memory_resource* memory_resource() const noexcept { return _mr; }
+  [[nodiscard]] mr::device_memory_resource* memory_resource() const noexcept { return _mr; }
 
  private:
   void* _data{nullptr};        ///< Pointer to device memory allocation

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -186,9 +186,9 @@ class device_scalar {
    * @param v The host value which will be copied to device
    * @param stream CUDA stream on which to perform the copy
    */
-  void set_value_async(value_type const& v, cuda_stream_view s)
+  void set_value_async(value_type const& value, cuda_stream_view stream)
   {
-    _storage.set_element_async(0, v, s);
+    _storage.set_element_async(0, value, stream);
   }
 
   // Disallow passing literals to set_value to avoid race conditions where the memory holding the
@@ -209,9 +209,9 @@ class device_scalar {
    *
    * @param stream CUDA stream on which to perform the copy
    */
-  void set_value_to_zero_async(cuda_stream_view s)
+  void set_value_to_zero_async(cuda_stream_view stream)
   {
-    _storage.set_element_to_zero_async(value_type{0}, s);
+    _storage.set_element_to_zero_async(value_type{0}, stream);
   }
 
   /**

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -147,7 +147,10 @@ class device_scalar {
    * @return T The value of the scalar.
    * @param stream CUDA stream on which to perform the copy and synchronize.
    */
-  value_type value(cuda_stream_view stream) const { return _storage.front_element(stream); }
+  [[nodiscard]] value_type value(cuda_stream_view stream) const
+  {
+    return _storage.front_element(stream);
+  }
 
   /**
    * @brief Sets the value of the `device_scalar` to the value of `v`.
@@ -222,7 +225,7 @@ class device_scalar {
    * streams (e.g. using `cudaStreamWaitEvent()` or `cudaStreamSynchronize()`), otherwise there may
    * be a race condition.
    */
-  pointer data() noexcept { return static_cast<pointer>(_storage.data()); }
+  [[nodiscard]] pointer data() noexcept { return static_cast<pointer>(_storage.data()); }
 
   /**
    * @brief Returns const pointer to object in device memory.
@@ -232,7 +235,10 @@ class device_scalar {
    * streams (e.g. using `cudaStreamWaitEvent()` or `cudaStreamSynchronize()`), otherwise there may
    * be a race condition.
    */
-  const_pointer data() const noexcept { return static_cast<const_pointer>(_storage.data()); }
+  [[nodiscard]] const_pointer data() const noexcept
+  {
+    return static_cast<const_pointer>(_storage.data());
+  }
 
  private:
   rmm::device_uvector<T> _storage;

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -47,9 +47,9 @@ class device_scalar {
   ~device_scalar() = default;
 
   RMM_EXEC_CHECK_DISABLE
-  device_scalar(device_scalar&&) = default;
+  device_scalar(device_scalar&&) noexcept = default;
 
-  device_scalar& operator=(device_scalar&&) = default;
+  device_scalar& operator=(device_scalar&&) noexcept = default;
 
   /**
    * @brief Copy ctor is deleted as it doesn't allow a stream argument

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -147,7 +147,7 @@ class device_uvector {
    * @param element_index Index of the specified element.
    * @return T* Pointer to the desired element
    */
-  pointer element_ptr(std::size_t element_index) noexcept
+  [[nodiscard]] pointer element_ptr(std::size_t element_index) noexcept
   {
     assert(element_index < size());
     return data() + element_index;
@@ -161,7 +161,7 @@ class device_uvector {
    * @param element_index Index of the specified element.
    * @return T* Pointer to the desired element
    */
-  const_pointer element_ptr(std::size_t element_index) const noexcept
+  [[nodiscard]] const_pointer element_ptr(std::size_t element_index) const noexcept
   {
     assert(element_index < size());
     return data() + element_index;
@@ -323,7 +323,10 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the first element
    */
-  value_type front_element(cuda_stream_view stream) const { return element(0, stream); }
+  [[nodiscard]] value_type front_element(cuda_stream_view stream) const
+  {
+    return element(0, stream);
+  }
 
   /**
    * @brief Returns the last element.
@@ -336,7 +339,10 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the last element
    */
-  value_type back_element(cuda_stream_view stream) const { return element(size() - 1, stream); }
+  [[nodiscard]] value_type back_element(cuda_stream_view stream) const
+  {
+    return element(size() - 1, stream);
+  }
 
   /**
    * @brief Resizes the vector to contain `new_size` elements.
@@ -373,7 +379,7 @@ class device_uvector {
    *
    * @return The `device_buffer` used to store the vector elements
    */
-  device_buffer release() noexcept { return std::move(_storage); }
+  [[nodiscard]] device_buffer release() noexcept { return std::move(_storage); }
 
   /**
    * @brief Returns the number of elements that can be held in currently allocated storage.
@@ -394,7 +400,7 @@ class device_uvector {
    *
    * @return Raw pointer to element storage in device memory.
    */
-  pointer data() noexcept { return static_cast<pointer>(_storage.data()); }
+  [[nodiscard]] pointer data() noexcept { return static_cast<pointer>(_storage.data()); }
 
   /**
    * @brief Returns const pointer to underlying device storage.
@@ -404,7 +410,10 @@ class device_uvector {
    *
    * @return const_pointer Raw const pointer to element storage in device memory.
    */
-  const_pointer data() const noexcept { return static_cast<const_pointer>(_storage.data()); }
+  [[nodiscard]] const_pointer data() const noexcept
+  {
+    return static_cast<const_pointer>(_storage.data());
+  }
 
   /**
    * @brief Returns an iterator to the first element.
@@ -413,7 +422,7 @@ class device_uvector {
    *
    * @return Iterator to the first element.
    */
-  iterator begin() noexcept { return data(); }
+  [[nodiscard]] iterator begin() noexcept { return data(); }
 
   /**
    * @brief Returns a const_iterator to the first element.
@@ -422,7 +431,7 @@ class device_uvector {
    *
    * @return Immutable iterator to the first element.
    */
-  const_iterator cbegin() const noexcept { return data(); }
+  [[nodiscard]] const_iterator cbegin() const noexcept { return data(); }
 
   /**
    * @brief Returns a const_iterator to the first element.
@@ -431,7 +440,7 @@ class device_uvector {
    *
    * @return Immutable iterator to the first element.
    */
-  const_iterator begin() const noexcept { return cbegin(); }
+  [[nodiscard]] const_iterator begin() const noexcept { return cbegin(); }
 
   /**
    * @brief Returns an iterator to the element following the last element of the vector.
@@ -441,7 +450,7 @@ class device_uvector {
    *
    * @return Iterator to one past the last element.
    */
-  iterator end() noexcept { return data() + size(); }
+  [[nodiscard]] iterator end() noexcept { return data() + size(); }
 
   /**
    * @brief Returns a const_iterator to the element following the last element of the vector.
@@ -451,7 +460,7 @@ class device_uvector {
    *
    * @return Immutable iterator to one past the last element.
    */
-  const_iterator cend() const noexcept { return data() + size(); }
+  [[nodiscard]] const_iterator cend() const noexcept { return data() + size(); }
 
   /**
    * @brief Returns an iterator to the element following the last element of the vector.
@@ -461,7 +470,7 @@ class device_uvector {
    *
    * @return Immutable iterator to one past the last element.
    */
-  const_iterator end() const noexcept { return cend(); }
+  [[nodiscard]] const_iterator end() const noexcept { return cend(); }
 
   /**
    * @brief Returns the number of elements in the vector.

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -301,7 +301,7 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the specified element
    */
-  value_type element(std::size_t element_index, cuda_stream_view stream) const
+  [[nodiscard]] value_type element(std::size_t element_index, cuda_stream_view stream) const
   {
     RMM_EXPECTS(
       element_index < size(), rmm::out_of_range, "Attempt to access out of bounds element.");

--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -75,16 +75,17 @@ struct logger_wrapper {
 struct bytes {
   std::size_t value;
 
-  friend std::ostream& operator<<(std::ostream& os, bytes const& b)
+  friend std::ostream& operator<<(std::ostream& os, bytes const& value)
   {
-    std::string const units[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"};
-    int i                     = 0;
-    auto size                 = static_cast<double>(b.value);
+    static std::array<std::string, 9> const units{
+      "B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"};
+    int index = 0;
+    auto size = static_cast<double>(value.value);
     while (size > 1024) {
       size /= 1024;
-      i++;
+      index++;
     }
-    return os << size << ' ' << units[i];
+    return os << size << ' ' << units.at(index);
   }
 };
 

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -61,8 +61,8 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   explicit aligned_resource_adaptor(
     Upstream* upstream,
-    std::size_t allocation_alignment = rmm::detail::CUDA_ALLOCATION_ALIGNMENT,
-    std::size_t alignment_threshold  = default_alignment_threshold)
+    rmm::detail::alignment_type allocation_alignment = rmm::detail::CUDA_ALLOCATION_ALIGNMENT,
+    std::size_t alignment_threshold                  = default_alignment_threshold)
     : upstream_{upstream},
       allocation_alignment_{allocation_alignment},
       alignment_threshold_{alignment_threshold}
@@ -124,18 +124,20 @@ class aligned_resource_adaptor final : public device_memory_resource {
     if (allocation_alignment_ == rmm::detail::CUDA_ALLOCATION_ALIGNMENT ||
         bytes < alignment_threshold_) {
       return upstream_->allocate(bytes, stream);
-    } else {
-      auto const size            = upstream_allocation_size(bytes);
-      void* pointer              = upstream_->allocate(size, stream);
-      auto const address         = reinterpret_cast<std::size_t>(pointer);
-      auto const aligned_address = rmm::detail::align_up(address, allocation_alignment_);
-      void* aligned_pointer      = reinterpret_cast<void*>(aligned_address);
-      if (pointer != aligned_pointer) {
-        lock_guard lock(mtx_);
-        pointers_.emplace(aligned_pointer, pointer);
-      }
-      return aligned_pointer;
     }
+    auto const size = upstream_allocation_size(bytes);
+    void* pointer   = upstream_->allocate(size, stream);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto const address = reinterpret_cast<std::size_t>(pointer);
+    auto const aligned_address =
+      rmm::detail::align_up(address, rmm::detail::alignment_type{allocation_alignment_});
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
+    void* aligned_pointer = reinterpret_cast<void*>(aligned_address);
+    if (pointer != aligned_pointer) {
+      lock_guard lock(mtx_);
+      pointers_.emplace(aligned_pointer, pointer);
+    }
+    return aligned_pointer;
   }
 
   /**
@@ -147,21 +149,21 @@ class aligned_resource_adaptor final : public device_memory_resource {
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override
   {
     if (allocation_alignment_ == rmm::detail::CUDA_ALLOCATION_ALIGNMENT ||
         bytes < alignment_threshold_) {
-      upstream_->deallocate(p, bytes, stream);
+      upstream_->deallocate(ptr, bytes, stream);
     } else {
       {
         lock_guard lock(mtx_);
-        auto const i = pointers_.find(p);
-        if (i != pointers_.end()) {
-          p = i->second;
-          pointers_.erase(i);
+        auto const iter = pointers_.find(ptr);
+        if (iter != pointers_.end()) {
+          ptr = iter->second;
+          pointers_.erase(iter);
         }
       }
-      upstream_->deallocate(p, upstream_allocation_size(bytes), stream);
+      upstream_->deallocate(ptr, upstream_allocation_size(bytes), stream);
     }
   }
 
@@ -176,14 +178,11 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
-    if (this == &other)
-      return true;
-    else {
-      auto cast = dynamic_cast<aligned_resource_adaptor<Upstream> const*>(&other);
-      return cast != nullptr && upstream_->is_equal(*cast->get_upstream()) &&
-             allocation_alignment_ == cast->allocation_alignment_ &&
-             alignment_threshold_ == cast->alignment_threshold_;
-    }
+    if (this == &other) { return true; }
+    auto cast = dynamic_cast<aligned_resource_adaptor<Upstream> const*>(&other);
+    return cast != nullptr && upstream_->is_equal(*cast->get_upstream()) &&
+           allocation_alignment_ == cast->allocation_alignment_ &&
+           alignment_threshold_ == cast->alignment_threshold_;
   }
 
   /**
@@ -211,7 +210,8 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   std::size_t upstream_allocation_size(std::size_t bytes) const
   {
-    auto const aligned_size = rmm::detail::align_up(bytes, allocation_alignment_);
+    auto const aligned_size =
+      rmm::detail::align_up(bytes, rmm::detail::alignment_type{allocation_alignment_});
     return aligned_size + allocation_alignment_ - rmm::detail::CUDA_ALLOCATION_ALIGNMENT;
   }
 

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -55,20 +55,17 @@ class aligned_resource_adaptor final : public device_memory_resource {
    * @throws `rmm::logic_error` if `allocation_alignment` is not a power of 2
    *
    * @param upstream The resource used for allocating/deallocating device memory.
-   * @param allocation_alignment The size used for allocation alignment.
+   * @param alignment The size used for allocation alignment.
    * @param alignment_threshold Only allocations with a size larger than or equal to this threshold
    * are aligned.
    */
-  explicit aligned_resource_adaptor(
-    Upstream* upstream,
-    rmm::detail::alignment_type allocation_alignment = rmm::detail::CUDA_ALLOCATION_ALIGNMENT,
-    std::size_t alignment_threshold                  = default_alignment_threshold)
-    : upstream_{upstream},
-      allocation_alignment_{allocation_alignment},
-      alignment_threshold_{alignment_threshold}
+  explicit aligned_resource_adaptor(Upstream* upstream,
+                                    std::size_t alignment = rmm::detail::CUDA_ALLOCATION_ALIGNMENT,
+                                    std::size_t alignment_threshold = default_alignment_threshold)
+    : upstream_{upstream}, alignment_{alignment}, alignment_threshold_{alignment_threshold}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
-    RMM_EXPECTS(rmm::detail::is_supported_alignment(allocation_alignment),
+    RMM_EXPECTS(rmm::detail::is_supported_alignment(alignment),
                 "Allocation alignment is not a power of 2.");
   }
 
@@ -121,16 +118,14 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
-    if (allocation_alignment_ == rmm::detail::CUDA_ALLOCATION_ALIGNMENT ||
-        bytes < alignment_threshold_) {
+    if (alignment_ == rmm::detail::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
       return upstream_->allocate(bytes, stream);
     }
     auto const size = upstream_allocation_size(bytes);
     void* pointer   = upstream_->allocate(size, stream);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    auto const address = reinterpret_cast<std::size_t>(pointer);
-    auto const aligned_address =
-      rmm::detail::align_up(address, rmm::detail::alignment_type{allocation_alignment_});
+    auto const address         = reinterpret_cast<std::size_t>(pointer);
+    auto const aligned_address = rmm::detail::align_up(address, alignment_);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
     void* aligned_pointer = reinterpret_cast<void*>(aligned_address);
     if (pointer != aligned_pointer) {
@@ -151,8 +146,7 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override
   {
-    if (allocation_alignment_ == rmm::detail::CUDA_ALLOCATION_ALIGNMENT ||
-        bytes < alignment_threshold_) {
+    if (alignment_ == rmm::detail::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
       upstream_->deallocate(ptr, bytes, stream);
     } else {
       {
@@ -181,8 +175,7 @@ class aligned_resource_adaptor final : public device_memory_resource {
     if (this == &other) { return true; }
     auto cast = dynamic_cast<aligned_resource_adaptor<Upstream> const*>(&other);
     return cast != nullptr && upstream_->is_equal(*cast->get_upstream()) &&
-           allocation_alignment_ == cast->allocation_alignment_ &&
-           alignment_threshold_ == cast->alignment_threshold_;
+           alignment_ == cast->alignment_ && alignment_threshold_ == cast->alignment_threshold_;
   }
 
   /**
@@ -210,14 +203,13 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   std::size_t upstream_allocation_size(std::size_t bytes) const
   {
-    auto const aligned_size =
-      rmm::detail::align_up(bytes, rmm::detail::alignment_type{allocation_alignment_});
-    return aligned_size + allocation_alignment_ - rmm::detail::CUDA_ALLOCATION_ALIGNMENT;
+    auto const aligned_size = rmm::detail::align_up(bytes, alignment_);
+    return aligned_size + alignment_ - rmm::detail::CUDA_ALLOCATION_ALIGNMENT;
   }
 
   Upstream* upstream_;  ///< The upstream resource used for satisfying allocation requests
   std::unordered_map<void*, void*> pointers_;  ///< Map of aligned pointers to upstream pointers.
-  std::size_t allocation_alignment_;           ///< The size used for allocation alignment
+  std::size_t alignment_;                      ///< The size used for allocation alignment
   std::size_t alignment_threshold_;  ///< The size above which allocations should be aligned
   mutable std::mutex mtx_;           ///< Mutex for exclusive lock.
 };

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -25,8 +25,7 @@
 #include <map>
 #include <shared_mutex>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 
 /**
  * @brief A suballocator that emphasizes fragmentation avoidance and scalable concurrency support.
@@ -92,9 +91,12 @@ class arena_memory_resource final : public device_memory_resource {
   {
   }
 
+  ~arena_memory_resource() override = default;
   // Disable copy (and move) semantics.
   arena_memory_resource(arena_memory_resource const&) = delete;
   arena_memory_resource& operator=(arena_memory_resource const&) = delete;
+  arena_memory_resource(arena_memory_resource&&)                 = delete;
+  arena_memory_resource& operator=(arena_memory_resource&&) = delete;
 
   /**
    * @brief Queries whether the resource supports use of non-null CUDA streams for
@@ -130,44 +132,44 @@ class arena_memory_resource final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
-    if (bytes <= 0) return nullptr;
+    if (bytes <= 0) { return nullptr; }
 
     bytes = detail::arena::align_up(bytes);
     return get_arena(stream).allocate(bytes);
   }
 
   /**
-   * @brief Deallocate memory pointed to by `p`.
+   * @brief Deallocate memory pointed to by `ptr`.
    *
-   * @param p Pointer to be deallocated.
+   * @param ptr Pointer to be deallocated.
    * @param bytes The size in bytes of the allocation. This must be equal to the
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation.
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override
   {
-    if (p == nullptr || bytes <= 0) return;
+    if (ptr == nullptr || bytes <= 0) { return; }
 
     bytes = detail::arena::align_up(bytes);
 #ifdef RMM_POOL_TRACK_ALLOCATIONS
-    if (!get_arena(stream).deallocate(p, bytes, stream)) {
-      deallocate_from_other_arena(p, bytes, stream);
+    if (!get_arena(stream).deallocate(ptr, bytes, stream)) {
+      deallocate_from_other_arena(ptr, bytes, stream);
     }
 #else
-    get_arena(stream).deallocate(p, bytes, stream);
+    get_arena(stream).deallocate(ptr, bytes, stream);
 #endif
   }
 
 #ifdef RMM_POOL_TRACK_ALLOCATIONS
   /**
-   * @brief Deallocate memory pointed to by `p` that was allocated in a different arena.
+   * @brief Deallocate memory pointed to by `ptr` that was allocated in a different arena.
    *
-   * @param p Pointer to be deallocated.
+   * @param ptr Pointer to be deallocated.
    * @param bytes The size in bytes of the allocation. This must be equal to the
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation.
    */
-  void deallocate_from_other_arena(void* p, std::size_t bytes, cuda_stream_view stream)
+  void deallocate_from_other_arena(void* ptr, std::size_t bytes, cuda_stream_view stream)
   {
     stream.synchronize_no_throw();
 
@@ -178,19 +180,19 @@ class arena_memory_resource final : public device_memory_resource {
       for (auto& kv : thread_arenas_) {
         // If the arena does not belong to the current thread, try to deallocate from it, and return
         // if successful.
-        if (kv.first != id && kv.second->deallocate(p, bytes)) return;
+        if (kv.first != id && kv.second->deallocate(ptr, bytes)) return;
       }
     } else {
       for (auto& kv : stream_arenas_) {
         // If the arena does not belong to the current stream, try to deallocate from it, and return
         // if successful.
-        if (stream != kv.first && kv.second.deallocate(p, bytes)) return;
+        if (stream != kv.first && kv.second.deallocate(ptr, bytes)) return;
       }
     }
 
     // The thread that originally allocated the block has terminated, deallocate directly in the
     // global arena.
-    global_arena_.deallocate({p, bytes});
+    global_arena_.deallocate({ptr, bytes});
   }
 #endif
 
@@ -202,11 +204,8 @@ class arena_memory_resource final : public device_memory_resource {
    */
   arena& get_arena(cuda_stream_view stream)
   {
-    if (use_per_thread_arena(stream)) {
-      return get_thread_arena();
-    } else {
-      return get_stream_arena(stream);
-    }
+    if (use_per_thread_arena(stream)) { return get_thread_arena(); }
+    return get_stream_arena(stream);
   }
 
   /**
@@ -216,18 +215,18 @@ class arena_memory_resource final : public device_memory_resource {
    */
   arena& get_thread_arena()
   {
-    auto const id = std::this_thread::get_id();
+    auto const thread_id = std::this_thread::get_id();
     {
       read_lock lock(mtx_);
-      auto const it = thread_arenas_.find(id);
-      if (it != thread_arenas_.end()) { return *it->second; }
+      auto const iter = thread_arenas_.find(thread_id);
+      if (iter != thread_arenas_.end()) { return *iter->second; }
     }
     {
       write_lock lock(mtx_);
-      auto a = std::make_shared<arena>(global_arena_);
-      thread_arenas_.emplace(id, a);
-      thread_local detail::arena::arena_cleaner<Upstream> cleaner{a};
-      return *a;
+      auto thread_arena = std::make_shared<arena>(global_arena_);
+      thread_arenas_.emplace(thread_id, thread_arena);
+      thread_local detail::arena::arena_cleaner<Upstream> cleaner{thread_arena};
+      return *thread_arena;
     }
   }
 
@@ -241,8 +240,8 @@ class arena_memory_resource final : public device_memory_resource {
     RMM_LOGGING_ASSERT(!use_per_thread_arena(stream));
     {
       read_lock lock(mtx_);
-      auto const it = stream_arenas_.find(stream.value());
-      if (it != stream_arenas_.end()) { return it->second; }
+      auto const iter = stream_arenas_.find(stream.value());
+      if (iter != stream_arenas_.end()) { return iter->second; }
     }
     {
       write_lock lock(mtx_);
@@ -285,5 +284,4 @@ class arena_memory_resource final : public device_memory_resource {
   mutable std::shared_timed_mutex mtx_;
 };
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -69,7 +69,7 @@ class binning_memory_resource final : public device_memory_resource {
    * @param max_size_exponent The maximum base-2 exponent bin size.
    */
   binning_memory_resource(Upstream* upstream_resource,
-                          int8_t min_size_exponent,
+                          int8_t min_size_exponent,  // NOLINT(bugprone-easily-swappable-parameters)
                           int8_t max_size_exponent)
     : upstream_mr_{[upstream_resource]() {
         RMM_EXPECTS(nullptr != upstream_resource, "Unexpected null upstream pointer.");
@@ -113,7 +113,7 @@ class binning_memory_resource final : public device_memory_resource {
    *
    * @return UpstreamResource* the upstream memory resource.
    */
-  Upstream* get_upstream() const noexcept { return upstream_mr_; }
+  [[nodiscard]] Upstream* get_upstream() const noexcept { return upstream_mr_; }
 
   /**
    * @brief Add a bin allocator to this resource

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,7 @@
 #include <memory>
 #include <vector>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 
 /**
  * @brief Allocates memory from upstream resources associated with bin sizes.
@@ -77,15 +76,16 @@ class binning_memory_resource final : public device_memory_resource {
         return upstream_resource;
       }()}
   {
-    for (auto i = min_size_exponent; i <= max_size_exponent; i++)
+    for (auto i = min_size_exponent; i <= max_size_exponent; i++) {
       add_bin(1 << i);
+    }
   }
 
   /**
    * @brief Destroy the binning_memory_resource and free all memory allocated from the upstream
    * resource.
    */
-  ~binning_memory_resource() = default;
+  ~binning_memory_resource() override = default;
 
   binning_memory_resource()                               = delete;
   binning_memory_resource(binning_memory_resource const&) = delete;
@@ -99,14 +99,14 @@ class binning_memory_resource final : public device_memory_resource {
    *
    * @returns true
    */
-  bool supports_streams() const noexcept override { return true; }
+  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override { return false; }
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 
   /**
    * @brief Get the upstream memory_resource object.
@@ -136,15 +136,13 @@ class binning_memory_resource final : public device_memory_resource {
     allocation_size =
       rmm::detail::align_up(allocation_size, rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
 
-    if (nullptr != bin_resource)
+    if (nullptr != bin_resource) {
       resource_bins_.insert({allocation_size, bin_resource});
-    else {
-      // If the bin already exists, do nothing.
-      if (resource_bins_.count(allocation_size) == 0) {
-        owned_bin_resources_.push_back(
-          std::make_unique<fixed_size_memory_resource<Upstream>>(upstream_mr_, allocation_size));
-        resource_bins_.insert({allocation_size, owned_bin_resources_.back().get()});
-      }
+    } else if (resource_bins_.count(allocation_size) == 0) {  // do nothing if bin already exists
+
+      owned_bin_resources_.push_back(
+        std::make_unique<fixed_size_memory_resource<Upstream>>(upstream_mr_, allocation_size));
+      resource_bins_.insert({allocation_size, owned_bin_resources_.back().get()});
     }
   }
 
@@ -175,7 +173,7 @@ class binning_memory_resource final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
-    if (bytes <= 0) return nullptr;
+    if (bytes <= 0) { return nullptr; }
     return get_resource(bytes)->allocate(bytes, stream);
   }
 
@@ -189,10 +187,10 @@ class binning_memory_resource final : public device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override
   {
     auto res = get_resource(bytes);
-    if (res != nullptr) res->deallocate(p, bytes, stream);
+    if (res != nullptr) { res->deallocate(ptr, bytes, stream); }
   }
 
   /**
@@ -203,7 +201,8 @@ class binning_memory_resource final : public device_memory_resource {
    * @param stream the stream being executed on
    * @return std::pair with available and free memory for resource
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
   {
     return std::make_pair(0, 0);
   }
@@ -215,5 +214,4 @@ class binning_memory_resource final : public device_memory_resource {
   std::map<std::size_t, device_memory_resource*> resource_bins_;
 };
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -165,7 +165,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* ptr, std::size_t /*bytes*/, rmm::cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t, rmm::cuda_stream_view stream) override
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     if (ptr != nullptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeAsync(ptr, stream.value())); }
@@ -197,7 +197,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @return std::pair contaiing free_size and total_size of memory
    */
   [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    rmm::cuda_stream_view /*stream*/) const override
+    rmm::cuda_stream_view) const override
   {
     return std::make_pair(0, 0);
   }

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -40,7 +40,6 @@ namespace rmm::mr {
  */
 class cuda_async_memory_resource final : public device_memory_resource {
  public:
-  enum release_threshold_size_type : std::size_t {};
   /**
    * @brief Constructs a cuda_async_memory_resource with the optionally specified initial pool size
    * and release threshold.
@@ -55,8 +54,9 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @param release_threshold Optional release threshold size in bytes of the pool. If no value is
    * provided, the release threshold is set to the total amount of memory on the current device.
    */
-  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size                 = {},
-                             thrust::optional<release_threshold_size_type> release_threshold = {})
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size = {},
+                             thrust::optional<std::size_t> release_threshold = {})
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     // Check if cudaMallocAsync Memory pool supported
@@ -78,7 +78,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
     auto const [free, total] = rmm::detail::available_device_memory();
 
     // Need an l-value to take address to pass to cudaMemPoolSetAttribute
-    uint64_t threshold = release_threshold.value_or(release_threshold_size_type{total});
+    uint64_t threshold = release_threshold.value_or(total);
     RMM_CUDA_TRY(
       cudaMemPoolSetAttribute(cuda_pool_handle_, cudaMemPoolAttrReleaseThreshold, &threshold));
 

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -32,8 +32,7 @@
 #define RMM_CUDA_MALLOC_ASYNC_SUPPORT
 #endif
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 
 /**
  * @brief `device_memory_resource` derived class that uses `cudaMallocAsync`/`cudaFreeAsync` for
@@ -41,6 +40,7 @@ namespace mr {
  */
 class cuda_async_memory_resource final : public device_memory_resource {
  public:
+  enum release_threshold_size_type : std::size_t {};
   /**
    * @brief Constructs a cuda_async_memory_resource with the optionally specified initial pool size
    * and release threshold.
@@ -55,16 +55,16 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @param release_threshold Optional release threshold size in bytes of the pool. If no value is
    * provided, the release threshold is set to the total amount of memory on the current device.
    */
-  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size = {},
-                             thrust::optional<std::size_t> release_threshold = {})
+  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size                 = {},
+                             thrust::optional<release_threshold_size_type> release_threshold = {})
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     // Check if cudaMallocAsync Memory pool supported
     auto const device = rmm::detail::current_device();
     int cuda_pool_supported{};
-    auto e =
+    auto result =
       cudaDeviceGetAttribute(&cuda_pool_supported, cudaDevAttrMemoryPoolsSupported, device.value());
-    RMM_EXPECTS(e == cudaSuccess && cuda_pool_supported,
+    RMM_EXPECTS(result == cudaSuccess && cuda_pool_supported,
                 "cudaMallocAsync not supported with this CUDA driver/runtime version");
 
     // Construct explicit pool
@@ -78,15 +78,15 @@ class cuda_async_memory_resource final : public device_memory_resource {
     auto const [free, total] = rmm::detail::available_device_memory();
 
     // Need an l-value to take address to pass to cudaMemPoolSetAttribute
-    uint64_t threshold = release_threshold.value_or(total);
+    uint64_t threshold = release_threshold.value_or(release_threshold_size_type{total});
     RMM_CUDA_TRY(
       cudaMemPoolSetAttribute(cuda_pool_handle_, cudaMemPoolAttrReleaseThreshold, &threshold));
 
     // Allocate and immediately deallocate the initial_pool_size to prime the pool with the
     // specified size
-    auto const pool_size = initial_pool_size.value_or(free * 0.5);
-    auto p               = do_allocate(pool_size, cuda_stream_default);
-    do_deallocate(p, pool_size, cuda_stream_default);
+    auto const pool_size = initial_pool_size.value_or(free / 2);
+    auto* ptr            = do_allocate(pool_size, cuda_stream_default);
+    do_deallocate(ptr, pool_size, cuda_stream_default);
 
 #else
     RMM_FAIL(
@@ -99,10 +99,10 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @brief Returns the underlying native handle to the CUDA pool
    *
    */
-  cudaMemPool_t pool_handle() const noexcept { return cuda_pool_handle_; }
+  [[nodiscard]] cudaMemPool_t pool_handle() const noexcept { return cuda_pool_handle_; }
 #endif
 
-  ~cuda_async_memory_resource()
+  ~cuda_async_memory_resource() override
   {
 #if defined(RMM_CUDA_MALLOC_ASYNC_SUPPORT)
     RMM_ASSERT_CUDA_SUCCESS(cudaMemPoolDestroy(pool_handle()));
@@ -119,18 +119,18 @@ class cuda_async_memory_resource final : public device_memory_resource {
    *
    * @returns bool true
    */
-  bool supports_streams() const noexcept override { return true; }
+  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return true
    */
-  bool supports_get_mem_info() const noexcept override { return false; }
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 
  private:
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
-  cudaMemPool_t cuda_pool_handle_;
+  cudaMemPool_t cuda_pool_handle_{};
 #endif
 
   /**
@@ -145,17 +145,17 @@ class cuda_async_memory_resource final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, rmm::cuda_stream_view stream) override
   {
-    void* p{nullptr};
+    void* ptr{nullptr};
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     if (bytes > 0) {
-      RMM_CUDA_TRY(cudaMallocFromPoolAsync(&p, bytes, pool_handle(), stream.value()),
+      RMM_CUDA_TRY(cudaMallocFromPoolAsync(&ptr, bytes, pool_handle(), stream.value()),
                    rmm::bad_alloc);
     }
 #else
     (void)bytes;
     (void)stream;
 #endif
-    return p;
+    return ptr;
   }
 
   /**
@@ -165,12 +165,12 @@ class cuda_async_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, rmm::cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t /*bytes*/, rmm::cuda_stream_view stream) override
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
-    if (p != nullptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeAsync(p, stream.value())); }
+    if (ptr != nullptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeAsync(ptr, stream.value())); }
 #else
-    (void)p;
+    (void)ptr;
     (void)stream;
 #endif
   }
@@ -184,7 +184,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
     return dynamic_cast<cuda_async_memory_resource const*>(&other) != nullptr;
   }
@@ -196,11 +196,11 @@ class cuda_async_memory_resource final : public device_memory_resource {
    *
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(rmm::cuda_stream_view) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    rmm::cuda_stream_view /*stream*/) const override
   {
     return std::make_pair(0, 0);
   }
 };
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -64,7 +64,7 @@ class cuda_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view /*stream*/) override
+  void* do_allocate(std::size_t bytes, cuda_stream_view) override
   {
     void* ptr{nullptr};
     RMM_CUDA_TRY(cudaMalloc(&ptr, bytes), rmm::bad_alloc);
@@ -80,7 +80,7 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * @param p Pointer to be deallocated
    */
-  void do_deallocate(void* ptr, std::size_t /*bytes*/, cuda_stream_view /*stream*/) override
+  void do_deallocate(void* ptr, std::size_t, cuda_stream_view) override
   {
     RMM_ASSERT_CUDA_SUCCESS(cudaFree(ptr));
   }
@@ -109,8 +109,7 @@ class cuda_memory_resource final : public device_memory_resource {
    *
    * @return std::pair contaiing free_size and total_size of memory
    */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view /*stream*/) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view) const override
   {
     std::size_t free_size{};
     std::size_t total_size{};

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -84,6 +84,7 @@ class block {
    */
   [[nodiscard]] bool is_contiguous_before(block const& blk) const
   {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     return pointer_ + size_ == blk.pointer_;
   }
 
@@ -104,6 +105,7 @@ class block {
   [[nodiscard]] std::pair<block, block> split(std::size_t size) const
   {
     RMM_LOGGING_ASSERT(size_ >= size);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     if (size_ > size) { return {{pointer_, size}, {pointer_ + size, size_ - size}}; }
     return {*this, {}};
   }

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -19,24 +19,26 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/logger.hpp>
 
 #include <cuda_runtime_api.h>
+
+#include <spdlog/common.h>
+#include <spdlog/fmt/bundled/ostream.h>
 
 #include <algorithm>
 #include <cstddef>
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <set>
 #include <unordered_map>
 
-namespace rmm {
-namespace mr {
-namespace detail {
-namespace arena {
+namespace rmm::mr::detail::arena {
 
 /// Minimum size of a superblock (256 KiB).
-constexpr std::size_t minimum_superblock_size = 1u << 18u;
+constexpr std::size_t minimum_superblock_size = 1U << 18U;
 
 /**
  * @brief Represents a chunk of memory that can be allocated and deallocated.
@@ -67,16 +69,16 @@ class block {
   block(void* pointer, std::size_t size) : pointer_(static_cast<char*>(pointer)), size_(size) {}
 
   /// Returns the underlying pointer.
-  void* pointer() const { return pointer_; }
+  [[nodiscard]] void* pointer() const { return pointer_; }
 
   /// Returns the size of the block.
-  std::size_t size() const { return size_; }
+  [[nodiscard]] std::size_t size() const { return size_; }
 
   /// Returns true if this block is valid (non-null), false otherwise.
-  bool is_valid() const { return pointer_ != nullptr; }
+  [[nodiscard]] bool is_valid() const { return pointer_ != nullptr; }
 
   /// Returns true if this block is a superblock, false otherwise.
-  bool is_superblock() const { return size_ >= minimum_superblock_size; }
+  [[nodiscard]] bool is_superblock() const { return size_ >= minimum_superblock_size; }
 
   /**
    * @brief Verifies whether this block can be merged to the beginning of block b.
@@ -85,30 +87,32 @@ class block {
    * @return true Returns true if this block's `pointer` + `size` == `b.ptr`, and `not b.is_head`,
                   false otherwise.
    */
-  bool is_contiguous_before(block const& b) const { return pointer_ + size_ == b.pointer_; }
+  [[nodiscard]] bool is_contiguous_before(block const& blk) const
+  {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return pointer_ + size_ == blk.pointer_;
+  }
 
   /**
    * @brief Is this block large enough to fit `sz` bytes?
    *
-   * @param sz The size in bytes to check for fit.
+   * @param size The size in bytes to check for fit.
    * @return true if this block is at least `sz` bytes.
    */
-  bool fits(std::size_t sz) const { return size_ >= sz; }
+  [[nodiscard]] bool fits(std::size_t size) const { return size_ >= size; }
 
   /**
    * @brief Split this block into two by the given size.
    *
-   * @param sz The size in bytes of the first block.
+   * @param size The size in bytes of the first block.
    * @return std::pair<block, block> A pair of blocks split by sz.
    */
-  std::pair<block, block> split(std::size_t sz) const
+  [[nodiscard]] std::pair<block, block> split(std::size_t size) const
   {
     RMM_LOGGING_ASSERT(size_ >= sz);
-    if (size_ > sz) {
-      return {{pointer_, sz}, {pointer_ + sz, size_ - sz}};
-    } else {
-      return {*this, {}};
-    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    if (size_ > size) { return {{pointer_, size}, {pointer_ + size, size_ - size}}; }
+    return {*this, {}};
   }
 
   /**
@@ -119,19 +123,21 @@ class block {
    * @param b block to merge.
    * @return block The merged block.
    */
-  block merge(block const& b) const
+  [[nodiscard]] block merge(block const& blk) const
   {
     RMM_LOGGING_ASSERT(is_contiguous_before(b));
-    return {pointer_, size_ + b.size_};
+    return {pointer_, size_ + blk.size_};
   }
 
   /// Used by std::set to compare blocks.
-  bool operator<(block const& b) const { return pointer_ < b.pointer_; }
+  bool operator<(block const& blk) const { return pointer_ < blk.pointer_; }
 
  private:
   char* pointer_{};     ///< Raw memory pointer.
   std::size_t size_{};  ///< Size in bytes.
 };
+
+inline bool block_size_compare(block lhs, block rhs) { return lhs.size() < rhs.size(); }
 
 /**
  * @brief Align up to the allocation alignment.
@@ -139,9 +145,9 @@ class block {
  * @param[in] v value to align
  * @return Return the aligned value
  */
-constexpr std::size_t align_up(std::size_t v) noexcept
+constexpr std::size_t align_up(std::size_t value) noexcept
 {
-  return rmm::detail::align_up(v, rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
+  return rmm::detail::align_up(value, rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 /**
@@ -150,9 +156,9 @@ constexpr std::size_t align_up(std::size_t v) noexcept
  * @param[in] v value to align
  * @return Return the aligned value
  */
-constexpr std::size_t align_down(std::size_t v) noexcept
+constexpr std::size_t align_down(std::size_t value) noexcept
 {
-  return rmm::detail::align_down(v, rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
+  return rmm::detail::align_down(value, rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 /**
@@ -172,24 +178,20 @@ constexpr std::size_t align_down(std::size_t v) noexcept
 inline block first_fit(std::set<block>& free_blocks, std::size_t size)
 {
   auto const iter = std::find_if(
-    free_blocks.cbegin(), free_blocks.cend(), [size](auto const& b) { return b.fits(size); });
+    free_blocks.cbegin(), free_blocks.cend(), [size](auto const& blk) { return blk.fits(size); });
 
-  if (iter == free_blocks.cend()) {
-    return {};
-  } else {
-    // Remove the block from the free_list.
-    auto const b = *iter;
-    auto const i = free_blocks.erase(iter);
+  if (iter == free_blocks.cend()) { return {}; }
+  // Remove the block from the free_list.
+  auto const blk  = *iter;
+  auto const next = free_blocks.erase(iter);
 
-    if (b.size() > size) {
-      // Split the block and put the remainder back.
-      auto const split = b.split(size);
-      free_blocks.insert(i, split.second);
-      return split.first;
-    } else {
-      return b;
-    }
+  if (blk.size() > size) {
+    // Split the block and put the remainder back.
+    auto const split = blk.split(size);
+    free_blocks.insert(next, split.second);
+    return split.first;
   }
+  return blk;
 }
 
 /**
@@ -199,37 +201,45 @@ inline block first_fit(std::set<block>& free_blocks, std::size_t size)
  * @param b The block to coalesce.
  * @return block The coalesced block.
  */
-inline block coalesce_block(std::set<block>& free_blocks, block const& b)
+inline block coalesce_block(std::set<block>& free_blocks, block const& blk)
 {
-  if (!b.is_valid()) return b;
+  if (!blk.is_valid()) { return blk; }
 
   // Find the right place (in ascending address order) to insert the block.
-  auto const next     = free_blocks.lower_bound(b);
+  auto const next     = free_blocks.lower_bound(blk);
   auto const previous = next == free_blocks.cbegin() ? next : std::prev(next);
 
   // Coalesce with neighboring blocks.
-  bool const merge_prev = previous->is_contiguous_before(b);
-  bool const merge_next = next != free_blocks.cend() && b.is_contiguous_before(*next);
+  bool const merge_prev = previous->is_contiguous_before(blk);
+  bool const merge_next = next != free_blocks.cend() && blk.is_contiguous_before(*next);
 
   block merged{};
   if (merge_prev && merge_next) {
-    merged = previous->merge(b).merge(*next);
+    merged = previous->merge(blk).merge(*next);
     free_blocks.erase(previous);
-    auto const i = free_blocks.erase(next);
-    free_blocks.insert(i, merged);
+    auto const iter = free_blocks.erase(next);
+    free_blocks.insert(iter, merged);
   } else if (merge_prev) {
-    merged       = previous->merge(b);
-    auto const i = free_blocks.erase(previous);
-    free_blocks.insert(i, merged);
+    merged          = previous->merge(blk);
+    auto const iter = free_blocks.erase(previous);
+    free_blocks.insert(iter, merged);
   } else if (merge_next) {
-    merged       = b.merge(*next);
-    auto const i = free_blocks.erase(next);
-    free_blocks.insert(i, merged);
+    merged          = blk.merge(*next);
+    auto const iter = free_blocks.erase(next);
+    free_blocks.insert(iter, merged);
   } else {
-    free_blocks.emplace(b);
-    merged = b;
+    free_blocks.emplace(blk);
+    merged = blk;
   }
   return merged;
+}
+
+template <typename T>
+inline auto total_block_size(T const& blocks)
+{
+  return std::accumulate(blocks.cbegin(), blocks.cend(), std::size_t{}, [](auto lhs, auto rhs) {
+    return lhs + rhs.size();
+  });
 }
 
 /**
@@ -248,7 +258,7 @@ class global_arena final {
   /// The default maximum size for the global arena.
   static constexpr std::size_t default_maximum_size = std::numeric_limits<std::size_t>::max();
   /// Reserved memory that should not be allocated (64 MiB).
-  static constexpr std::size_t reserved_size = 1u << 26u;
+  static constexpr std::size_t reserved_size = 1U << 26U;
 
   /**
    * @brief Construct a global arena.
@@ -275,7 +285,8 @@ class global_arena final {
                 "Error, Maximum arena size required to be a multiple of 256 bytes");
 
     if (initial_size == default_initial_size || maximum_size == default_maximum_size) {
-      std::size_t free{}, total{};
+      std::size_t free{};
+      std::size_t total{};
       RMM_CUDA_TRY(cudaMemGetInfo(&free, &total));
       if (initial_size == default_initial_size) {
         initial_size = align_up(std::min(free, total / 2));
@@ -290,8 +301,10 @@ class global_arena final {
   }
 
   // Disable copy (and move) semantics.
-  global_arena(const global_arena&) = delete;
-  global_arena& operator=(const global_arena&) = delete;
+  global_arena(global_arena const&) = delete;
+  global_arena& operator=(global_arena const&) = delete;
+  global_arena(global_arena&&) noexcept        = delete;
+  global_arena& operator=(global_arena&&) noexcept = delete;
 
   /**
    * @brief Destroy the global arena and deallocate all memory it allocated using the upstream
@@ -300,8 +313,8 @@ class global_arena final {
   ~global_arena()
   {
     lock_guard lock(mtx_);
-    for (auto const& b : upstream_blocks_) {
-      upstream_mr_->deallocate(b.pointer(), b.size());
+    for (auto const& blk : upstream_blocks_) {
+      upstream_mr_->deallocate(blk.pointer(), blk.size());
     }
   }
 
@@ -320,16 +333,14 @@ class global_arena final {
   }
 
   /**
-   * @brief Deallocate memory pointed to by `p`.
+   * @brief Deallocate memory pointed to by `blk`.
    *
-   * @param p Pointer to be deallocated.
-   * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
-   * that was passed to the `allocate` call that returned `p`.
+   * @param blk Block to be deallocated.
    */
-  void deallocate(block const& b)
+  void deallocate(block const& blk)
   {
     lock_guard lock(mtx_);
-    coalesce_block(free_blocks_, b);
+    coalesce_block(free_blocks_, blk);
   }
 
   /**
@@ -340,9 +351,35 @@ class global_arena final {
   void deallocate(std::set<block> const& free_blocks)
   {
     lock_guard lock(mtx_);
-    for (auto const& b : free_blocks) {
-      coalesce_block(free_blocks_, b);
+    for (auto const& blk : free_blocks) {
+      coalesce_block(free_blocks_, blk);
     }
+  }
+
+  /**
+   * @brief Dump memory to log.
+   *
+   * @param logger the spdlog logger to use
+   */
+  void dump_memory_log(std::shared_ptr<spdlog::logger> const& logger) const
+  {
+    lock_guard lock(mtx_);
+
+    logger->info("  Maximum size: {}", rmm::detail::bytes{maximum_size_});
+    logger->info("  Current size: {}", rmm::detail::bytes{current_size_});
+
+    logger->info("  # free blocks: {}", free_blocks_.size());
+    if (!free_blocks_.empty()) {
+      logger->info("  Total size of free blocks: {}",
+                   rmm::detail::bytes{total_block_size(free_blocks_)});
+      auto const largest_free =
+        *std::max_element(free_blocks_.begin(), free_blocks_.end(), block_size_compare);
+      logger->info("  Size of largest free block: {}", rmm::detail::bytes{largest_free.size()});
+    }
+
+    logger->info("  # upstream blocks={}", upstream_blocks_.size());
+    logger->info("  Total size of upstream blocks: {}",
+                 rmm::detail::bytes{total_block_size(upstream_blocks_)});
   }
 
  private:
@@ -357,8 +394,8 @@ class global_arena final {
   block get_block(std::size_t size)
   {
     // Find the first-fit free block.
-    auto const b = first_fit(free_blocks_, size);
-    if (b.is_valid()) return b;
+    auto const blk = first_fit(free_blocks_, size);
+    if (blk.is_valid()) { return blk; }
 
     // No existing larger blocks available, so grow the arena.
     auto const upstream_block = expand_arena(size_to_grow(size));
@@ -372,13 +409,11 @@ class global_arena final {
    * This simply grows the global arena to the maximum size.
    *
    * @param size The number of bytes required.
-   * @return size The size for the arena to grow.
+   * @return size The size for the arena to grow, or 0 if no more memory.
    */
   constexpr std::size_t size_to_grow(std::size_t size) const
   {
-    if (current_size_ + size > maximum_size_) {
-      RMM_FAIL("Maximum pool size exceeded", rmm::bad_alloc);
-    }
+    if (current_size_ + size > maximum_size_) { return 0; }
     return maximum_size_ - current_size_;
   }
 
@@ -390,9 +425,12 @@ class global_arena final {
    */
   block expand_arena(std::size_t size)
   {
-    upstream_blocks_.push_back({upstream_mr_->allocate(size), size});
-    current_size_ += size;
-    return upstream_blocks_.back();
+    if (size > 0) {
+      upstream_blocks_.push_back({upstream_mr_->allocate(size), size});
+      current_size_ += size;
+      return upstream_blocks_.back();
+    }
+    return {};
   }
 
   /// The upstream resource to allocate memory from.
@@ -428,9 +466,13 @@ class arena {
    */
   explicit arena(global_arena<Upstream>& global_arena) : global_arena_{global_arena} {}
 
+  ~arena() = default;
+
   // Disable copy (and move) semantics.
-  arena(const arena&) = delete;
-  arena& operator=(const arena&) = delete;
+  arena(arena const&) = delete;
+  arena& operator=(arena const&) = delete;
+  arena(arena&&) noexcept        = delete;
+  arena& operator=(arena&&) noexcept = delete;
 
   /**
    * @brief Allocates memory of size at least `bytes`.
@@ -443,101 +485,86 @@ class arena {
   void* allocate(std::size_t bytes)
   {
     lock_guard lock(mtx_);
-    auto const b = get_block(bytes);
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-    allocated_blocks_.emplace(b.pointer(), b);
-#endif
-    return b.pointer();
+    auto const blk = get_block(bytes);
+    return blk.pointer();
   }
 
   /**
-   * @brief Deallocate memory pointed to by `p`, and possibly return superblocks to upstream.
+   * @brief Deallocate memory pointed to by `ptr`, and possibly return superblocks to upstream.
    *
-   * @param p Pointer to be deallocated.
+   * @param ptr Pointer to be deallocated.
    * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
    * that was passed to the `allocate` call that returned `p`.
    * @param stream Stream on which to perform deallocation.
-   * @return true if the allocation is found, false otherwise.
    */
-  bool deallocate(void* p, std::size_t bytes, cuda_stream_view stream)
+  void deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream)
   {
     lock_guard lock(mtx_);
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-    auto const b = free_block(p, bytes);
-#else
-    block const b{p, bytes};
-#endif
-    if (b.is_valid()) {
-      auto const merged = coalesce_block(free_blocks_, b);
-      shrink_arena(merged, stream);
-    }
-    return b.is_valid();
+    block const blk{ptr, bytes};
+    auto const merged = coalesce_block(free_blocks_, blk);
+    shrink_arena(merged, stream);
   }
-
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-  /**
-   * @brief Deallocate memory pointed to by `p`, keeping all free superblocks.
-   *
-   * This is done when deallocating from another arena. Since we don't have access to the CUDA
-   * stream associated with this arena, we don't coalesce the freed block and return it directly to
-   * the global arena.
-   *
-   * @param p Pointer to be deallocated.
-   * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
-   * that was passed to the `allocate` call that returned `p`.
-   * @return true if the allocation is found, false otherwise.
-   */
-  bool deallocate(void* p, std::size_t bytes)
-  {
-    lock_guard lock(mtx_);
-    auto const b = free_block(p, bytes);
-    if (b.is_valid()) { global_arena_.deallocate(b); }
-    return b.is_valid();
-  }
-#endif
 
   /**
    * @brief Clean the arena and deallocate free blocks from the global arena.
-   *
-   * This is only needed when a per-thread arena is about to die.
    */
   void clean()
   {
     lock_guard lock(mtx_);
     global_arena_.deallocate(free_blocks_);
     free_blocks_.clear();
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-    allocated_blocks_.clear();
-#endif
+  }
+
+  /**
+   * Dump memory to log.
+   *
+   * @param logger the spdlog logger to use
+   */
+  void dump_memory_log(std::shared_ptr<spdlog::logger> const& logger) const
+  {
+    lock_guard lock(mtx_);
+    logger->info("    # free blocks: {}", free_blocks_.size());
+    if (!free_blocks_.empty()) {
+      logger->info("    Total size of free blocks: {}",
+                   rmm::detail::bytes{total_block_size(free_blocks_)});
+      auto const largest_free =
+        *std::max_element(free_blocks_.begin(), free_blocks_.end(), block_size_compare);
+      logger->info("    Size of largest free block: {}", rmm::detail::bytes{largest_free.size()});
+    }
   }
 
  private:
   using lock_guard = std::lock_guard<std::mutex>;
+  /// Maximum number of free blocks to keep.
+  static constexpr int max_free_blocks = 16;
 
   /**
    * @brief Get an available memory block of at least `size` bytes.
    *
    * @param size The number of bytes to allocate.
-   * @return block A block of memory of at least `size` bytes.
+   * @return A block of memory of at least `size` bytes.
    */
   block get_block(std::size_t size)
   {
     if (size < minimum_superblock_size) {
       // Find the first-fit free block.
-      auto const b = first_fit(free_blocks_, size);
-      if (b.is_valid()) { return b; }
+      auto const blk = first_fit(free_blocks_, size);
+      if (blk.is_valid()) { return blk; }
     }
 
     // No existing larger blocks available, so grow the arena and obtain a superblock.
     auto const superblock = expand_arena(size);
-    coalesce_block(free_blocks_, superblock);
-    return first_fit(free_blocks_, size);
+    if (superblock.is_valid()) {
+      coalesce_block(free_blocks_, superblock);
+      return first_fit(free_blocks_, size);
+    }
+    return superblock;
   }
 
   /**
    * @brief Allocate space from upstream to supply the arena and return a superblock.
    *
-   * @return block A superblock.
+   * @return A superblock.
    */
   block expand_arena(std::size_t size)
   {
@@ -545,55 +572,25 @@ class arena {
     return global_arena_.allocate(superblock_size);
   }
 
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-  /**
-   * @brief Finds, frees and returns the block associated with pointer `p`.
-   *
-   * @param p The pointer to the memory to free.
-   * @param size The size of the memory to free. Must be equal to the original allocation size.
-   * @return The (now freed) block associated with `p`. The caller is expected to return the block
-   * to the arena.
-   */
-  block free_block(void* p, std::size_t size) noexcept
-  {
-    auto const i = allocated_blocks_.find(p);
-
-    // The pointer may be allocated in another arena.
-    if (i == allocated_blocks_.end()) { return {}; }
-
-    auto const found = i->second;
-    RMM_LOGGING_ASSERT(found.size() == size);
-    allocated_blocks_.erase(i);
-
-    return found;
-  }
-#endif
-
   /**
    * @brief Shrink this arena by returning free superblocks to upstream.
    *
-   * @param b The block that can be used to shrink the arena.
+   * @param blk The block that can be used to shrink the arena.
    * @param stream Stream on which to perform shrinking.
    */
-  void shrink_arena(block const& b, cuda_stream_view stream)
+  void shrink_arena(block const& blk, cuda_stream_view stream)
   {
-    // Don't shrink if b is not a superblock.
-    if (!b.is_superblock()) return;
-
-    stream.synchronize_no_throw();
-
-    global_arena_.deallocate(b);
-    free_blocks_.erase(b);
+    if (blk.is_superblock() || free_blocks_.size() > max_free_blocks) {
+      stream.synchronize_no_throw();
+      global_arena_.deallocate(blk);
+      free_blocks_.erase(blk);
+    }
   }
 
   /// The global arena to allocate superblocks from.
   global_arena<Upstream>& global_arena_;
   /// Free blocks.
   std::set<block> free_blocks_;
-#ifdef RMM_POOL_TRACK_ALLOCATIONS
-  //// Map of pointer address to allocated blocks.
-  std::unordered_map<void*, block> allocated_blocks_;
-#endif
   /// Mutex for exclusive lock.
   mutable std::mutex mtx_;
 };
@@ -609,11 +606,13 @@ class arena {
 template <typename Upstream>
 class arena_cleaner {
  public:
-  explicit arena_cleaner(std::shared_ptr<arena<Upstream>> const& a) : arena_(a) {}
+  explicit arena_cleaner(std::shared_ptr<arena<Upstream>> const& arena) : arena_(arena) {}
 
   // Disable copy (and move) semantics.
-  arena_cleaner(const arena_cleaner&) = delete;
-  arena_cleaner& operator=(const arena_cleaner&) = delete;
+  arena_cleaner(arena_cleaner const&) = delete;
+  arena_cleaner& operator=(arena_cleaner const&) = delete;
+  arena_cleaner(arena_cleaner&&) noexcept        = delete;
+  arena_cleaner& operator=(arena_cleaner&&) = delete;
 
   ~arena_cleaner()
   {
@@ -628,7 +627,4 @@ class arena_cleaner {
   std::weak_ptr<arena<Upstream>> arena_;
 };
 
-}  // namespace arena
-}  // namespace detail
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr::detail::arena

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -98,12 +98,12 @@ class block {
   /**
    * @brief Split this block into two by the given size.
    *
-   * @param sz The size in bytes of the first block.
-   * @return std::pair<block, block> A pair of blocks split by sz.
+   * @param size The size in bytes of the first block.
+   * @return std::pair<block, block> A pair of blocks split by size.
    */
   [[nodiscard]] std::pair<block, block> split(std::size_t size) const
   {
-    RMM_LOGGING_ASSERT(size_ >= sz);
+    RMM_LOGGING_ASSERT(size_ >= size);
     if (size_ > size) { return {{pointer_, size}, {pointer_ + size, size_ - size}}; }
     return {*this, {}};
   }
@@ -113,12 +113,12 @@ class block {
    *
    * `this->is_contiguous_before(b)` must be true.
    *
-   * @param b block to merge.
+   * @param blk block to merge.
    * @return block The merged block.
    */
   [[nodiscard]] block merge(block const& blk) const
   {
-    RMM_LOGGING_ASSERT(is_contiguous_before(b));
+    RMM_LOGGING_ASSERT(is_contiguous_before(blk));
     return {pointer_, size_ + blk.size_};
   }
 

--- a/include/rmm/mr/device/detail/coalescing_free_list.hpp
+++ b/include/rmm/mr/device/detail/coalescing_free_list.hpp
@@ -25,9 +25,7 @@
 #include <iostream>
 #include <list>
 
-namespace rmm {
-namespace mr {
-namespace detail {
+namespace rmm::mr::detail {
 
 /**
  * @brief A simple block structure specifying the size and location of a block
@@ -46,14 +44,14 @@ struct block : public block_base {
    *
    * @return the pointer to the memory represented by this block.
    */
-  inline char* pointer() const { return static_cast<char*>(ptr); }
+  [[nodiscard]] inline char* pointer() const { return static_cast<char*>(ptr); }
 
   /**
    * @brief Returns the size of the memory represented by this block.
    *
    * @return the size in bytes of the memory represented by this block.
    */
-  inline std::size_t size() const { return size_bytes; }
+  [[nodiscard]] inline std::size_t size() const { return size_bytes; }
 
   /**
    * @brief Returns whether this block is the start of an allocation from an upstream allocator.
@@ -62,7 +60,7 @@ struct block : public block_base {
    *
    * @return true if this block is the start of an allocation from an upstream allocator.
    */
-  inline bool is_head() const { return head; }
+  [[nodiscard]] inline bool is_head() const { return head; }
 
   /**
    * @brief Comparison operator to enable comparing blocks and storing in ordered containers.
@@ -84,10 +82,10 @@ struct block : public block_base {
    * @param b block to merge
    * @return block The merged block
    */
-  inline block merge(block const& b) const noexcept
+  [[nodiscard]] inline block merge(block const& blk) const noexcept
   {
     assert(is_contiguous_before(b));
-    return block(pointer(), size() + b.size(), is_head());
+    return {pointer(), size() + blk.size(), is_head()};
   }
 
   /**
@@ -97,9 +95,10 @@ struct block : public block_base {
    * @return true Returns true if this blocks's `ptr` + `size` == `b.ptr`, and `not b.is_head`,
                   false otherwise.
    */
-  inline bool is_contiguous_before(block const& b) const noexcept
+  [[nodiscard]] inline bool is_contiguous_before(block const& blk) const noexcept
   {
-    return (pointer() + size() == b.ptr) and not(b.is_head());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return (pointer() + size() == blk.ptr) and not(blk.is_head());
   }
 
   /**
@@ -108,7 +107,7 @@ struct block : public block_base {
    * @param sz The size in bytes to check for fit.
    * @return true if this block is at least `sz` bytes
    */
-  inline bool fits(std::size_t sz) const noexcept { return size() >= sz; }
+  [[nodiscard]] inline bool fits(std::size_t bytes) const noexcept { return size() >= bytes; }
 
   /**
    * @brief Is this block a better fit for `sz` bytes than block `b`?
@@ -118,9 +117,9 @@ struct block : public block_base {
    * @return true If this block is a tighter fit for `sz` bytes than block `b`.
    * @return false If this block does not fit `sz` bytes or `b` is a tighter fit.
    */
-  inline bool is_better_fit(std::size_t sz, block const& b) const noexcept
+  [[nodiscard]] inline bool is_better_fit(std::size_t bytes, block const& blk) const noexcept
   {
-    return fits(sz) && (size() < b.size() || b.size() < sz);
+    return fits(bytes) && (size() < blk.size() || blk.size() < bytes);
   }
 
   /**
@@ -128,7 +127,7 @@ struct block : public block_base {
    */
   inline void print() const
   {
-    std::cout << reinterpret_cast<void*>(pointer()) << " " << size() << " B\n";
+    std::cout << fmt::format("{} {} B", fmt::ptr(pointer()), size()) << std::endl;
   }
 
  private:
@@ -137,9 +136,9 @@ struct block : public block_base {
 };
 
 /// Print block on an ostream
-inline std::ostream& operator<<(std::ostream& out, const block& b)
+inline std::ostream& operator<<(std::ostream& out, const block& blk)
 {
-  out << b.pointer() << " " << b.size() << " B\n";
+  out << fmt::format("{} {} B\n", fmt::ptr(blk.pointer()), blk.size());
   return out;
 }
 
@@ -166,8 +165,8 @@ struct compare_blocks {
  * @tparam list_type the type of the internal list data structure.
  */
 struct coalescing_free_list : free_list<block> {
-  coalescing_free_list()  = default;
-  ~coalescing_free_list() = default;
+  coalescing_free_list()           = default;
+  ~coalescing_free_list() override = default;
 
   coalescing_free_list(coalescing_free_list const&) = delete;
   coalescing_free_list& operator=(coalescing_free_list const&) = delete;
@@ -180,31 +179,32 @@ struct coalescing_free_list : free_list<block> {
    *
    * @param b The block to insert.
    */
-  void insert(block_type const& b)
+  void insert(block_type const& block)
   {
     if (is_empty()) {
-      free_list::insert(cend(), b);
+      free_list::insert(cend(), block);
       return;
     }
 
     // Find the right place (in ascending ptr order) to insert the block
     // Can't use binary_search because it's a linked list and will be quadratic
-    auto const next     = std::find_if(begin(), end(), [b](block_type const& i) { return b < i; });
+    auto const next =
+      std::find_if(begin(), end(), [block](block_type const& blk) { return block < blk; });
     auto const previous = (next == cbegin()) ? next : std::prev(next);
 
     // Coalesce with neighboring blocks or insert the new block if it can't be coalesced
-    bool const merge_prev = previous->is_contiguous_before(b);
-    bool const merge_next = (next != cend()) && b.is_contiguous_before(*next);
+    bool const merge_prev = previous->is_contiguous_before(block);
+    bool const merge_next = (next != cend()) && block.is_contiguous_before(*next);
 
     if (merge_prev && merge_next) {
-      *previous = previous->merge(b).merge(*next);
+      *previous = previous->merge(block).merge(*next);
       erase(next);
     } else if (merge_prev) {
-      *previous = previous->merge(b);
+      *previous = previous->merge(block);
     } else if (merge_next) {
-      *next = b.merge(*next);
+      *next = block.merge(*next);
     } else {
-      free_list::insert(next, b);  // cannot be coalesced, just insert
+      free_list::insert(next, block);  // cannot be coalesced, just insert
     }
   }
 
@@ -220,7 +220,7 @@ struct coalescing_free_list : free_list<block> {
   {
     std::for_each(std::make_move_iterator(other.begin()),
                   std::make_move_iterator(other.end()),
-                  [this](block_type&& b) { this->insert(std::move(b)); });
+                  [this](block_type&& block) { this->insert(block); });
   }
 
   /**
@@ -259,6 +259,4 @@ struct coalescing_free_list : free_list<block> {
   }
 };  // coalescing_free_list
 
-}  // namespace detail
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr::detail

--- a/include/rmm/mr/device/detail/coalescing_free_list.hpp
+++ b/include/rmm/mr/device/detail/coalescing_free_list.hpp
@@ -79,8 +79,8 @@ struct block : public block_base {
    * `this` must immediately precede `b` and both `this` and `b` must be from the same upstream
    * allocation. That is, `this->is_contiguous_before(b)`. Otherwise behavior is undefined.
    *
-   * @param b block to merge
-   * @return block The merged block
+   * @param blk block to merge
+   * @return The merged block
    */
   [[nodiscard]] inline block merge(block const& blk) const noexcept
   {
@@ -91,9 +91,9 @@ struct block : public block_base {
   /**
    * @brief Verifies whether this block can be merged to the beginning of block b.
    *
-   * @param b The block to check for contiguity.
-   * @return true Returns true if this blocks's `ptr` + `size` == `b.ptr`, and `not b.is_head`,
-                  false otherwise.
+   * @param blk The block to check for contiguity.
+   * @return Returns true if this blocks's `ptr` + `size` == `b.ptr`, and `not b.is_head`,
+             false otherwise.
    */
   [[nodiscard]] inline bool is_contiguous_before(block const& blk) const noexcept
   {
@@ -104,18 +104,18 @@ struct block : public block_base {
   /**
    * @brief Is this block large enough to fit `sz` bytes?
    *
-   * @param sz The size in bytes to check for fit.
-   * @return true if this block is at least `sz` bytes
+   * @param bytes The size in bytes to check for fit.
+   * @return true if this block is at least `bytes` bytes
    */
   [[nodiscard]] inline bool fits(std::size_t bytes) const noexcept { return size() >= bytes; }
 
   /**
    * @brief Is this block a better fit for `sz` bytes than block `b`?
    *
-   * @param sz The size in bytes to check for best fit.
-   * @param b The other block to check for fit.
-   * @return true If this block is a tighter fit for `sz` bytes than block `b`.
-   * @return false If this block does not fit `sz` bytes or `b` is a tighter fit.
+   * @param bytes The size in bytes to check for best fit.
+   * @param blk The other block to check for fit.
+   * @return true If this block is a tighter fit for `bytes` bytes than block `blk`.
+   * @return false If this block does not fit `bytes` bytes or `blk` is a tighter fit.
    */
   [[nodiscard]] inline bool is_better_fit(std::size_t bytes, block const& blk) const noexcept
   {
@@ -209,12 +209,11 @@ struct coalescing_free_list : free_list<block> {
   }
 
   /**
-   * @brief Moves blocks from range `[first, last)` into the free_list in their correct order,
+   * @brief Moves blocks from free_list `other` into this free_list in their correct order,
    *        coalescing them with their preceding and following blocks if they are contiguous.
    *
    * @tparam InputIt iterator type
-   * @param first The beginning of the range of blocks to insert
-   * @param last The end of the range of blocks to insert.
+   * @param other free_list of blocks to insert
    */
   void insert(free_list&& other)
   {
@@ -229,7 +228,7 @@ struct coalescing_free_list : free_list<block> {
    * This is a "best fit" search.
    *
    * @param size The size in bytes of the desired block.
-   * @return block A block large enough to store `size` bytes.
+   * @return A block large enough to store `size` bytes.
    */
   block_type get_block(std::size_t size)
   {

--- a/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+++ b/include/rmm/mr/device/detail/fixed_size_free_list.hpp
@@ -49,15 +49,14 @@ struct fixed_size_free_list : free_list<block_base> {
    * @brief Inserts a block into the `free_list` in the correct order, coalescing it with the
    *        preceding and following blocks if either is contiguous.
    *
-   * @param b The block to insert.
+   * @param block The block to insert.
    */
   void insert(block_type const& block) { push_back(block); }
 
   /**
-   * @brief Splices blocks from range `[first, last)` onto the free_list.
+   * @brief Inserts blocks from another free list into this free_list.
    *
-   * @param first The beginning of the range of blocks to insert
-   * @param last The end of the range of blocks to insert.
+   * @param other The free_list to insert into this free_list.
    */
   void insert(free_list&& other) { splice(cend(), std::move(other)); }
 
@@ -65,7 +64,7 @@ struct fixed_size_free_list : free_list<block_base> {
    * @brief Returns the first block in the free list.
    *
    * @param size The size in bytes of the desired block (unused).
-   * @return block A block large enough to store `size` bytes.
+   * @return A block large enough to store `size` bytes.
    */
   block_type get_block(std::size_t size)
   {

--- a/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+++ b/include/rmm/mr/device/detail/fixed_size_free_list.hpp
@@ -21,13 +21,11 @@
 #include <cstddef>
 #include <iostream>
 
-namespace rmm {
-namespace mr {
-namespace detail {
+namespace rmm::mr::detail {
 
 struct fixed_size_free_list : free_list<block_base> {
-  fixed_size_free_list()  = default;
-  ~fixed_size_free_list() = default;
+  fixed_size_free_list()           = default;
+  ~fixed_size_free_list() override = default;
 
   fixed_size_free_list(fixed_size_free_list const&) = delete;
   fixed_size_free_list& operator=(fixed_size_free_list const&) = delete;
@@ -44,7 +42,7 @@ struct fixed_size_free_list : free_list<block_base> {
   template <class InputIt>
   fixed_size_free_list(InputIt first, InputIt last)
   {
-    std::for_each(first, last, [this](block_type const& b) { insert(b); });
+    std::for_each(first, last, [this](block_type const& block) { insert(block); });
   }
 
   /**
@@ -53,7 +51,7 @@ struct fixed_size_free_list : free_list<block_base> {
    *
    * @param b The block to insert.
    */
-  void insert(block_type const& b) { push_back(b); }
+  void insert(block_type const& block) { push_back(block); }
 
   /**
    * @brief Splices blocks from range `[first, last)` onto the free_list.
@@ -71,16 +69,11 @@ struct fixed_size_free_list : free_list<block_base> {
    */
   block_type get_block(std::size_t size)
   {
-    if (is_empty())
-      return block_type{};
-    else {
-      block_type b = *begin();
-      pop_front();
-      return b;
-    }
+    if (is_empty()) { return block_type{}; }
+    block_type block = *begin();
+    pop_front();
+    return block;
   }
 };
 
-}  // namespace detail
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr::detail

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -20,25 +20,23 @@
 #include <iostream>
 #include <list>
 
-namespace rmm {
-namespace mr {
-namespace detail {
+namespace rmm::mr::detail {
 
 struct block_base {
   void* ptr{};  ///< Raw memory pointer
 
   /// Returns the raw pointer for this block
-  inline void* pointer() const { return ptr; }
+  [[nodiscard]] inline void* pointer() const { return ptr; }
   /// Returns true if this block is valid (non-null), false otherwise
-  inline bool is_valid() const { return pointer() != nullptr; }
+  [[nodiscard]] inline bool is_valid() const { return pointer() != nullptr; }
   /// Prints the block to stdout
   inline void print() const { std::cout << pointer(); }
 };
 
 /// Print block_base on an ostream
-inline std::ostream& operator<<(std::ostream& out, const block_base& b)
+inline std::ostream& operator<<(std::ostream& out, const block_base& block)
 {
-  out << b.pointer();
+  out << block.pointer();
   return out;
 }
 
@@ -93,7 +91,7 @@ class free_list {
    * @return true If there are blocks in the free_list.
    * @return false If there are no blocks in the free_list.
    */
-  bool is_empty() const noexcept { return blocks.empty(); }
+  [[nodiscard]] bool is_empty() const noexcept { return blocks.empty(); }
 
   /**
    * @brief Removes the block indicated by `iter` from the free list.
@@ -114,8 +112,8 @@ class free_list {
   void print() const
   {
     std::cout << size() << std::endl;
-    for (auto const& b : blocks) {
-      std::cout << b << std::endl;
+    for (auto const& block : blocks) {
+      std::cout << block << std::endl;
     }
   }
 
@@ -126,7 +124,7 @@ class free_list {
    * @param pos iterator before which the block will be inserted. pos may be the end() iterator.
    * @param b The block to insert.
    */
-  void insert(const_iterator pos, block_type const& b) { blocks.insert(pos, b); }
+  void insert(const_iterator pos, block_type const& block) { blocks.insert(pos, block); }
 
   /**
    * @brief Inserts a list of blocks in the free list before the specified position
@@ -144,14 +142,14 @@ class free_list {
    *
    * @param b The block to append.
    */
-  void push_back(const block_type& b) { blocks.push_back(b); }
+  void push_back(const block_type& block) { blocks.push_back(block); }
 
   /**
    * @brief Appends the given block to the end of the free list. `b` is moved to the new element.
    *
    * @param b The block to append.
    */
-  void push_back(block_type&& b) { blocks.push_back(std::move(b)); }
+  void push_back(block_type&& block) { blocks.push_back(std::move(block)); }
 
   /**
    * @brief Removes the first element of the free list. If there are no elements in the free list,
@@ -165,6 +163,4 @@ class free_list {
   list_type blocks;  // The internal container of blocks
 };
 
-}  // namespace detail
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr::detail

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -70,20 +70,26 @@ class free_list {
   using iterator       = typename list_type::iterator;
   using const_iterator = typename list_type::const_iterator;
 
-  iterator begin() noexcept { return blocks.begin(); }                /// beginning of the free list
-  const_iterator begin() const noexcept { return blocks.begin(); }    /// beginning of the free list
-  const_iterator cbegin() const noexcept { return blocks.cbegin(); }  /// beginning of the free list
+  /// beginning of the free list
+  [[nodiscard]] iterator begin() noexcept { return blocks.begin(); }
+  /// beginning of the free list
+  [[nodiscard]] const_iterator begin() const noexcept { return blocks.begin(); }
+  /// beginning of the free list
+  [[nodiscard]] const_iterator cbegin() const noexcept { return blocks.cbegin(); }
 
-  iterator end() noexcept { return blocks.end(); }                /// end of the free list
-  const_iterator end() const noexcept { return blocks.end(); }    /// end of the free list
-  const_iterator cend() const noexcept { return blocks.cend(); }  /// end of the free list
+  /// end of the free list
+  [[nodiscard]] iterator end() noexcept { return blocks.end(); }
+  /// beginning of the free list
+  [[nodiscard]] const_iterator end() const noexcept { return blocks.end(); }
+  /// beginning of the free list
+  [[nodiscard]] const_iterator cend() const noexcept { return blocks.cend(); }
 
   /**
    * @brief The size of the free list in blocks.
    *
    * @return size_type The number of blocks in the free list.
    */
-  size_type size() const noexcept { return blocks.size(); }
+  [[nodiscard]] size_type size() const noexcept { return blocks.size(); }
 
   /**
    * @brief checks whether the free_list is empty.

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -25,6 +25,9 @@ namespace rmm::mr::detail {
 struct block_base {
   void* ptr{};  ///< Raw memory pointer
 
+  block_base() = default;
+  block_base(void* ptr) : ptr{ptr} {};
+
   /// Returns the raw pointer for this block
   [[nodiscard]] inline void* pointer() const { return ptr; }
   /// Returns true if this block is valid (non-null), false otherwise

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -122,7 +122,7 @@ class free_list {
    * @brief Insert a block in the free list before the specified position
    *
    * @param pos iterator before which the block will be inserted. pos may be the end() iterator.
-   * @param b The block to insert.
+   * @param block The block to insert.
    */
   void insert(const_iterator pos, block_type const& block) { blocks.insert(pos, block); }
 
@@ -130,7 +130,7 @@ class free_list {
    * @brief Inserts a list of blocks in the free list before the specified position
    *
    * @param pos iterator before which the block will be inserted. pos may be the end() iterator.
-   * @param b The block to insert.
+   * @param other The free list to insert.
    */
   void splice(const_iterator pos, free_list&& other)
   {
@@ -140,14 +140,14 @@ class free_list {
   /**
    * @brief Appends the given block to the end of the free list.
    *
-   * @param b The block to append.
+   * @param block The block to append.
    */
   void push_back(const block_type& block) { blocks.push_back(block); }
 
   /**
    * @brief Appends the given block to the end of the free list. `b` is moved to the new element.
    *
-   * @param b The block to append.
+   * @param block The block to append.
    */
   void push_back(block_type&& block) { blocks.push_back(std::move(block)); }
 

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -85,8 +85,8 @@ class device_memory_resource {
   virtual ~device_memory_resource()                     = default;
   device_memory_resource(device_memory_resource const&) = default;
   device_memory_resource& operator=(device_memory_resource const&) = default;
-  device_memory_resource(device_memory_resource&&)                 = default;
-  device_memory_resource& operator=(device_memory_resource&&) = default;
+  device_memory_resource(device_memory_resource&&) noexcept        = default;
+  device_memory_resource& operator=(device_memory_resource&&) noexcept = default;
 
   /**
    * @brief Allocates memory of size at least \p bytes.

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -179,7 +179,7 @@ class device_memory_resource {
 
  private:
   // All allocations are padded to a multiple of allocation_size_alignment bytes.
-  static constexpr auto allocation_size_alignment = rmm::detail::alignment_type{8};
+  static constexpr auto allocation_size_alignment = std::size_t{8};
 
   /**
    * @brief Allocates memory of size at least \p bytes.

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -81,6 +81,7 @@ namespace rmm::mr {
  */
 class device_memory_resource {
  public:
+  device_memory_resource()                              = default;
   virtual ~device_memory_resource()                     = default;
   device_memory_resource(device_memory_resource const&) = default;
   device_memory_resource& operator=(device_memory_resource const&) = default;

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -33,9 +33,7 @@
 #include <utility>
 #include <vector>
 
-namespace rmm {
-
-namespace mr {
+namespace rmm::mr {
 
 /**
  * @brief A `device_memory_resource` which allocates memory blocks of a single fixed size.
@@ -97,14 +95,14 @@ class fixed_size_memory_resource
    *
    * @returns true
    */
-  bool supports_streams() const noexcept override { return true; }
+  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override { return false; }
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 
   /**
    * @brief Get the upstream memory_resource object.
@@ -118,7 +116,7 @@ class fixed_size_memory_resource
    *
    * @return std::size_t size in bytes of allocated blocks.
    */
-  std::size_t get_block_size() const noexcept { return block_size_; }
+  [[nodiscard]] std::size_t get_block_size() const noexcept { return block_size_; }
 
  protected:
   using free_list  = detail::fixed_size_free_list;
@@ -133,7 +131,7 @@ class fixed_size_memory_resource
    * @return std::size_t The (fixed) maximum size of a single allocation supported by this memory
    * resource
    */
-  std::size_t get_maximum_allocation_size() const { return get_block_size(); }
+  [[nodiscard]] std::size_t get_maximum_allocation_size() const { return get_block_size(); }
 
   /**
    * @brief Allocate a block from upstream to supply the suballocation pool.
@@ -160,49 +158,53 @@ class fixed_size_memory_resource
    */
   free_list blocks_from_upstream(cuda_stream_view stream)
   {
-    void* p = upstream_mr_->allocate(upstream_chunk_size_, stream);
-    block_type b{p};
-    upstream_blocks_.push_back(b);
+    void* ptr = upstream_mr_->allocate(upstream_chunk_size_, stream);
+    block_type block{ptr};
+    upstream_blocks_.push_back(block);
 
     auto num_blocks = upstream_chunk_size_ / block_size_;
 
-    auto g     = [p, this](int i) { return block_type{static_cast<char*>(p) + i * block_size_}; };
-    auto first = thrust::make_transform_iterator(thrust::make_counting_iterator(std::size_t{0}), g);
+    auto block_gen = [ptr, this](int index) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      return block_type{static_cast<char*>(ptr) + index * block_size_};
+    };
+    auto first =
+      thrust::make_transform_iterator(thrust::make_counting_iterator(std::size_t{0}), block_gen);
     return free_list(first, first + num_blocks);
   }
 
   /**
-   * @brief Splits block `b` if necessary to return a pointer to memory of `size` bytes.
+   * @brief Splits block if necessary to return a pointer to memory of `size` bytes.
    *
    * If the block is split, the remainder is returned to the pool.
    *
-   * @param b The block to allocate from.
+   * @param block The block to allocate from.
    * @param size The size in bytes of the requested allocation.
    * @param stream_event The stream and associated event on which the allocation will be used.
    * @return A pair comprising the allocated pointer and any unallocated remainder of the input
    * block.
    */
-  split_block allocate_from_block(block_type const& b, std::size_t size)
+  split_block allocate_from_block(block_type const& block, std::size_t size)
   {
-    return {b, block_type{nullptr}};
+    return {block, block_type{nullptr}};
   }
 
   /**
-   * @brief Finds, frees and returns the block associated with pointer `p`.
+   * @brief Finds, frees and returns the block associated with pointer.
    *
-   * @param p The pointer to the memory to free.
+   * @param ptr The pointer to the memory to free.
    * @param size The size of the memory to free. Must be equal to the original allocation size.
    * @param stream The stream-event pair for the stream on which the memory was last used.
    * @return The (now freed) block associated with `p`. The caller is expected to return the block
    * to the pool.
    */
-  block_type free_block(void* p, std::size_t size) noexcept
+  block_type free_block(void* ptr, std::size_t size) noexcept
   {
     // Deallocating a fixed-size block just inserts it in the free list, which is
     // handled by the parent class
     RMM_LOGGING_ASSERT(rmm::detail::align_up(size, rmm::detail::CUDA_ALLOCATION_ALIGNMENT) <=
                        block_size_);
-    return block_type{p};
+    return block_type{ptr};
   }
 
   /**
@@ -213,7 +215,8 @@ class fixed_size_memory_resource
    * @param stream the stream being executed on
    * @return std::pair with available and free memory for resource
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
   {
     return std::make_pair(0, 0);
   }
@@ -226,8 +229,9 @@ class fixed_size_memory_resource
   {
     lock_guard lock(this->get_mutex());
 
-    for (auto b : upstream_blocks_)
-      upstream_mr_->deallocate(b.pointer(), upstream_chunk_size_);
+    for (auto block : upstream_blocks_) {
+      upstream_mr_->deallocate(block.pointer(), upstream_chunk_size_);
+    }
     upstream_blocks_.clear();
   }
 
@@ -235,15 +239,14 @@ class fixed_size_memory_resource
   {
     lock_guard lock(this->get_mutex());
 
-    std::size_t free, total;
-    std::tie(free, total) = upstream_mr_->get_mem_info(0);
+    auto const [free, total] = upstream_mr_->get_mem_info(0);
     std::cout << "GPU free memory: " << free << " total: " << total << "\n";
 
     std::cout << "upstream_blocks: " << upstream_blocks_.size() << "\n";
     std::size_t upstream_total{0};
 
-    for (auto h : upstream_blocks_) {
-      h.print();
+    for (auto blocks : upstream_blocks_) {
+      blocks.print();
       upstream_total += upstream_chunk_size_;
     }
     std::cout << "total upstream: " << upstream_total << " B\n";
@@ -265,6 +268,7 @@ class fixed_size_memory_resource
                              : std::make_pair(block_size_, blocks.size() * block_size_);
   }
 
+ private:
   Upstream* upstream_mr_;  // The resource from which to allocate new blocks
 
   std::size_t const block_size_;           // size of blocks this MR allocates
@@ -274,5 +278,4 @@ class fixed_size_memory_resource
   std::vector<block_type> upstream_blocks_;
 };
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -81,7 +81,7 @@ class fixed_size_memory_resource
    * @brief Destroy the `fixed_size_memory_resource` and free all memory allocated from upstream.
    *
    */
-  ~fixed_size_memory_resource() { release(); }
+  ~fixed_size_memory_resource() override { release(); }
 
   fixed_size_memory_resource()                                  = delete;
   fixed_size_memory_resource(fixed_size_memory_resource const&) = delete;

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -21,8 +21,7 @@
 
 #include <cstddef>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 /**
  * @brief Resource that uses `Upstream` to allocate memory and limits the total
  * allocations possible.
@@ -47,24 +46,23 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @param upstream The resource used for allocating/deallocating device memory
    * @param allocation_limit Maximum memory allowed for this allocator.
    */
-  limiting_resource_adaptor(
-    Upstream* upstream,
-    std::size_t allocation_limit,
-    std::size_t allocation_alignment = rmm::detail::CUDA_ALLOCATION_ALIGNMENT)
+  limiting_resource_adaptor(Upstream* upstream,
+                            std::size_t allocation_limit,
+                            std::size_t alignment = rmm::detail::CUDA_ALLOCATION_ALIGNMENT)
     : allocation_limit_{allocation_limit},
       allocated_bytes_(0),
-      allocation_alignment_(allocation_alignment),
+      alignment_(alignment),
       upstream_{upstream}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
   }
 
   limiting_resource_adaptor()                                 = delete;
-  ~limiting_resource_adaptor()                                = default;
+  ~limiting_resource_adaptor() override                       = default;
   limiting_resource_adaptor(limiting_resource_adaptor const&) = delete;
-  limiting_resource_adaptor(limiting_resource_adaptor&&)      = default;
   limiting_resource_adaptor& operator=(limiting_resource_adaptor const&) = delete;
-  limiting_resource_adaptor& operator=(limiting_resource_adaptor&&) = default;
+  limiting_resource_adaptor(limiting_resource_adaptor&&) noexcept        = default;
+  limiting_resource_adaptor& operator=(limiting_resource_adaptor&&) noexcept = default;
 
   /**
    * @brief Return pointer to the upstream resource.
@@ -79,14 +77,17 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @return true The upstream resource supports streams
    * @return false The upstream resource does not support streams.
    */
-  bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
+  [[nodiscard]] bool supports_streams() const noexcept override
+  {
+    return upstream_->supports_streams();
+  }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return bool true if the upstream resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override
   {
     return upstream_->supports_get_mem_info();
   }
@@ -100,7 +101,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @return std::size_t number of bytes that have been allocated through this
    * allocator.
    */
-  std::size_t get_allocated_bytes() const { return allocated_bytes_; }
+  [[nodiscard]] std::size_t get_allocated_bytes() const { return allocated_bytes_; }
 
   /**
    * @brief Query the maximum number of bytes that this allocator is allowed
@@ -109,7 +110,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    *
    * @return std::size_t max number of bytes allowed for this allocator
    */
-  std::size_t get_allocation_limit() const { return allocation_limit_; }
+  [[nodiscard]] std::size_t get_allocation_limit() const { return allocation_limit_; }
 
  private:
   /**
@@ -127,32 +128,30 @@ class limiting_resource_adaptor final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
-    void* p = nullptr;
+    std::size_t proposed_size = rmm::detail::align_up(bytes, alignment_);
+    RMM_EXPECTS(proposed_size + allocated_bytes_ <= allocation_limit_,
+                rmm::bad_alloc,
+                "Exceeded memory limit");
 
-    std::size_t proposed_size = rmm::detail::align_up(bytes, allocation_alignment_);
-    if (proposed_size + allocated_bytes_ <= allocation_limit_) {
-      p = upstream_->allocate(bytes, stream);
-      allocated_bytes_ += proposed_size;
-    } else {
-      throw rmm::bad_alloc{"Exceeded memory limit"};
-    }
+    auto* const ptr = upstream_->allocate(bytes, stream);
+    allocated_bytes_ += proposed_size;
 
-    return p;
+    return ptr;
   }
 
   /**
-   * @brief Free allocation of size `bytes` pointed to by `p`
+   * @brief Free allocation of size `bytes` pointed to by `ptr`
    *
    * @throws Nothing.
    *
-   * @param p Pointer to be deallocated
+   * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override
   {
-    std::size_t allocated_size = rmm::detail::align_up(bytes, allocation_alignment_);
-    upstream_->deallocate(p, bytes, stream);
+    std::size_t allocated_size = rmm::detail::align_up(bytes, alignment_);
+    upstream_->deallocate(ptr, bytes, stream);
     allocated_bytes_ -= allocated_size;
   }
 
@@ -165,18 +164,12 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
-    if (this == &other)
-      return true;
-    else {
-      limiting_resource_adaptor<Upstream> const* cast =
-        dynamic_cast<limiting_resource_adaptor<Upstream> const*>(&other);
-      if (cast != nullptr)
-        return upstream_->is_equal(*cast->get_upstream());
-      else
-        return upstream_->is_equal(other);
-    }
+    if (this == &other) { return true; }
+    auto const* cast = dynamic_cast<limiting_resource_adaptor<Upstream> const*>(&other);
+    if (cast != nullptr) { return upstream_->is_equal(*cast->get_upstream()); }
+    return upstream_->is_equal(other);
   }
 
   /**
@@ -187,7 +180,8 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
   {
     return {allocation_limit_ - allocated_bytes_, allocation_limit_};
   }
@@ -199,7 +193,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
   std::atomic<std::size_t> allocated_bytes_;
 
   // todo: should be some way to ask the upstream...
-  std::size_t allocation_alignment_;
+  std::size_t alignment_;
 
   Upstream* upstream_;  ///< The upstream resource used for satisfying
                         ///< allocation requests
@@ -220,5 +214,4 @@ limiting_resource_adaptor<Upstream> make_limiting_adaptor(Upstream* upstream,
   return limiting_resource_adaptor<Upstream>{upstream, allocation_limit};
 }
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -69,7 +69,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    *
    * @return Upstream* Pointer to the upstream resource.
    */
-  Upstream* get_upstream() const noexcept { return upstream_; }
+  [[nodiscard]] Upstream* get_upstream() const noexcept { return upstream_; }
 
   /**
    * @brief Checks whether the upstream resource supports streams.

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -28,8 +28,7 @@
 #include <memory>
 #include <sstream>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 /**
  * @brief Resource that uses `Upstream` to allocate memory and logs information
  * about the requested allocation/deallocations.
@@ -113,11 +112,11 @@ class logging_resource_adaptor final : public device_memory_resource {
   }
 
   logging_resource_adaptor()                                = delete;
-  ~logging_resource_adaptor()                               = default;
+  ~logging_resource_adaptor() override                      = default;
   logging_resource_adaptor(logging_resource_adaptor const&) = delete;
-  logging_resource_adaptor(logging_resource_adaptor&&)      = default;
   logging_resource_adaptor& operator=(logging_resource_adaptor const&) = delete;
-  logging_resource_adaptor& operator=(logging_resource_adaptor&&) = default;
+  logging_resource_adaptor(logging_resource_adaptor&&) noexcept        = default;
+  logging_resource_adaptor& operator=(logging_resource_adaptor&&) noexcept = default;
 
   /**
    * @brief Return pointer to the upstream resource.
@@ -132,14 +131,17 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @return true The upstream resource supports streams
    * @return false The upstream resource does not support streams.
    */
-  bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
+  [[nodiscard]] bool supports_streams() const noexcept override
+  {
+    return upstream_->supports_streams();
+  }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return bool true if the upstream resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override
   {
     return upstream_->supports_get_mem_info();
   }
@@ -154,7 +156,10 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * @return CSV formatted header string of column names
    */
-  std::string header() const { return std::string{"Thread,Time,Action,Pointer,Size,Stream"}; }
+  [[nodiscard]] std::string header() const
+  {
+    return std::string{"Thread,Time,Action,Pointer,Size,Stream"};
+  }
 
  private:
   // make_logging_adaptor needs access to private get_default_filename
@@ -172,7 +177,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    */
   static std::string get_default_filename()
   {
-    auto filename = std::getenv("RMM_LOG_FILE");
+    auto* filename = std::getenv("RMM_LOG_FILE");
     RMM_EXPECTS(filename != nullptr,
                 "RMM logging requested without an explicit file name, but RMM_LOG_FILE is unset");
     return std::string{filename};
@@ -210,13 +215,13 @@ class logging_resource_adaptor final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
-    auto const p = upstream_->allocate(bytes, stream);
-    logger_->info("allocate,{},{},{}", p, bytes, fmt::ptr(stream.value()));
-    return p;
+    auto const ptr = upstream_->allocate(bytes, stream);
+    logger_->info("allocate,{},{},{}", ptr, bytes, fmt::ptr(stream.value()));
+    return ptr;
   }
 
   /**
-   * @brief Free allocation of size `bytes` pointed to by `p` and log the
+   * @brief Free allocation of size `bytes` pointed to by `ptr` and log the
    * deallocation.
    *
    * Every invocation of `logging_resource_adaptor::do_deallocate` will write
@@ -227,14 +232,14 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * @throws Nothing.
    *
-   * @param p Pointer to be deallocated
+   * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override
   {
-    logger_->info("free,{},{},{}", p, bytes, fmt::ptr(stream.value()));
-    upstream_->deallocate(p, bytes, stream);
+    logger_->info("free,{},{},{}", ptr, bytes, fmt::ptr(stream.value()));
+    upstream_->deallocate(ptr, bytes, stream);
   }
 
   /**
@@ -246,18 +251,12 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
-    if (this == &other)
-      return true;
-    else {
-      logging_resource_adaptor<Upstream> const* cast =
-        dynamic_cast<logging_resource_adaptor<Upstream> const*>(&other);
-      if (cast != nullptr)
-        return upstream_->is_equal(*cast->get_upstream());
-      else
-        return upstream_->is_equal(other);
-    }
+    if (this == &other) { return true; }
+    auto const* cast = dynamic_cast<logging_resource_adaptor<Upstream> const*>(&other);
+    if (cast != nullptr) { return upstream_->is_equal(*cast->get_upstream()); }
+    return upstream_->is_equal(other);
   }
 
   /**
@@ -268,7 +267,8 @@ class logging_resource_adaptor final : public device_memory_resource {
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
   {
     return upstream_->get_mem_info(stream);
   }
@@ -313,5 +313,4 @@ logging_resource_adaptor<Upstream> make_logging_adaptor(Upstream* upstream,
   return logging_resource_adaptor<Upstream>{upstream, stream, auto_flush};
 }
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -123,7 +123,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * @return Upstream* Pointer to the upstream resource.
    */
-  Upstream* get_upstream() const noexcept { return upstream_; }
+  [[nodiscard]] Upstream* get_upstream() const noexcept { return upstream_; }
 
   /**
    * @brief Checks whether the upstream resource supports streams.
@@ -162,12 +162,6 @@ class logging_resource_adaptor final : public device_memory_resource {
   }
 
  private:
-  // make_logging_adaptor needs access to private get_default_filename
-  template <typename T>
-  friend logging_resource_adaptor<T> make_logging_adaptor(T* upstream,
-                                                          std::string const& filename,
-                                                          bool auto_flush);
-
   /**
    * @brief Return the value of the environment variable RMM_LOG_FILE.
    *
@@ -272,6 +266,13 @@ class logging_resource_adaptor final : public device_memory_resource {
   {
     return upstream_->get_mem_info(stream);
   }
+
+  // make_logging_adaptor needs access to private get_default_filename
+  template <typename T>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend logging_resource_adaptor<T> make_logging_adaptor(T* upstream,
+                                                          std::string const& filename,
+                                                          bool auto_flush);
 
   std::shared_ptr<spdlog::logger> logger_;  ///< spdlog logger object
 

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -22,8 +22,7 @@
 
 #include <cstddef>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 /**
  * @brief `device_memory_resource` derived class that uses
  * cudaMallocManaged/Free for allocation/deallocation.
@@ -31,7 +30,7 @@ namespace mr {
 class managed_memory_resource final : public device_memory_resource {
  public:
   managed_memory_resource()                               = default;
-  ~managed_memory_resource()                              = default;
+  ~managed_memory_resource() override                     = default;
   managed_memory_resource(managed_memory_resource const&) = default;
   managed_memory_resource(managed_memory_resource&&)      = default;
   managed_memory_resource& operator=(managed_memory_resource const&) = default;
@@ -43,18 +42,18 @@ class managed_memory_resource final : public device_memory_resource {
    *
    * @returns false
    */
-  bool supports_streams() const noexcept override { return false; }
+  [[nodiscard]] bool supports_streams() const noexcept override { return false; }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override { return true; }
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return true; }
 
  private:
   /**
-   * @brief Allocates memory of size at least \p bytes using cudaMallocManaged.
+   * @brief Allocates memory of size at least `bytes` using cudaMallocManaged.
    *
    * The returned pointer has at least 256B alignment.
    *
@@ -65,29 +64,29 @@ class managed_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view) override
+  void* do_allocate(std::size_t bytes, cuda_stream_view /*stream*/) override
   {
     // FIXME: Unlike cudaMalloc, cudaMallocManaged will throw an error for 0
     // size allocations.
     if (bytes == 0) { return nullptr; }
 
-    void* p{nullptr};
-    RMM_CUDA_TRY(cudaMallocManaged(&p, bytes), rmm::bad_alloc);
-    return p;
+    void* ptr{nullptr};
+    RMM_CUDA_TRY(cudaMallocManaged(&ptr, bytes), rmm::bad_alloc);
+    return ptr;
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by `ptr`.
    *
    * @note Stream argument is ignored.
    *
    * @throws Nothing.
    *
-   * @param p Pointer to be deallocated
+   * @param ptr Pointer to be deallocated
    */
-  void do_deallocate(void* p, std::size_t, cuda_stream_view) override
+  void do_deallocate(void* ptr, std::size_t /*bytes*/, cuda_stream_view /*stream*/) override
   {
-    RMM_ASSERT_CUDA_SUCCESS(cudaFree(p));
+    RMM_ASSERT_CUDA_SUCCESS(cudaFree(ptr));
   }
 
   /**
@@ -102,7 +101,7 @@ class managed_memory_resource final : public device_memory_resource {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
     return dynamic_cast<managed_memory_resource const*>(&other) != nullptr;
   }
@@ -115,7 +114,8 @@ class managed_memory_resource final : public device_memory_resource {
    * @param stream to execute on
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
   {
     std::size_t free_size{};
     std::size_t total_size{};
@@ -124,5 +124,4 @@ class managed_memory_resource final : public device_memory_resource {
   }
 };
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -64,7 +64,7 @@ class managed_memory_resource final : public device_memory_resource {
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, cuda_stream_view /*stream*/) override
+  void* do_allocate(std::size_t bytes, cuda_stream_view) override
   {
     // FIXME: Unlike cudaMalloc, cudaMallocManaged will throw an error for 0
     // size allocations.
@@ -84,7 +84,7 @@ class managed_memory_resource final : public device_memory_resource {
    *
    * @param ptr Pointer to be deallocated
    */
-  void do_deallocate(void* ptr, std::size_t /*bytes*/, cuda_stream_view /*stream*/) override
+  void do_deallocate(void* ptr, std::size_t, cuda_stream_view) override
   {
     RMM_ASSERT_CUDA_SUCCESS(cudaFree(ptr));
   }

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -22,21 +22,23 @@
 #include <memory>
 #include <utility>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 namespace detail {
 /// Converts a tuple into a parameter pack
 template <typename Resource, typename UpstreamTuple, std::size_t... Indices, typename... Args>
-auto make_resource_impl(UpstreamTuple const& t, std::index_sequence<Indices...>, Args&&... args)
+auto make_resource_impl(UpstreamTuple const& upstreams,
+                        std::index_sequence<Indices...> /*indices*/,
+                        Args&&... args)
 {
-  return std::make_unique<Resource>(std::get<Indices>(t).get()..., std::forward<Args>(args)...);
+  return std::make_unique<Resource>(std::get<Indices>(upstreams).get()...,
+                                    std::forward<Args>(args)...);
 }
 
 template <typename Resource, typename... Upstreams, typename... Args>
-auto make_resource(std::tuple<std::shared_ptr<Upstreams>...> const& t, Args&&... args)
+auto make_resource(std::tuple<std::shared_ptr<Upstreams>...> const& upstreams, Args&&... args)
 {
   return make_resource_impl<Resource>(
-    t, std::index_sequence_for<Upstreams...>{}, std::forward<Args>(args)...);
+    upstreams, std::index_sequence_for<Upstreams...>{}, std::forward<Args>(args)...);
 }
 }  // namespace detail
 
@@ -128,14 +130,20 @@ class owning_wrapper : public device_memory_resource {
   /**
    * @copydoc rmm::mr::device_memory_resource::supports_streams()
    */
-  bool supports_streams() const noexcept override { return wrapped().supports_streams(); }
+  [[nodiscard]] bool supports_streams() const noexcept override
+  {
+    return wrapped().supports_streams();
+  }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return true if the upstream resource supports get_mem_info, false otherwise.
    */
-  bool supports_get_mem_info() const noexcept override { return wrapped().supports_get_mem_info(); }
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override
+  {
+    return wrapped().supports_get_mem_info();
+  }
 
  private:
   /**
@@ -156,17 +164,17 @@ class owning_wrapper : public device_memory_resource {
   /**
    * @brief Returns an allocation to the wrapped resource.
    *
-   * `p` must have been returned from a prior call to `do_allocate(bytes)`.
+   * `ptr` must have been returned from a prior call to `do_allocate(bytes)`.
    *
    * @throws Nothing.
    *
-   * @param p Pointer to the allocation to free.
+   * @param ptr Pointer to the allocation to free.
    * @param bytes Size of the allocation
    * @param stream Stream on which to deallocate the memory
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override
   {
-    wrapped().deallocate(p, bytes, stream);
+    wrapped().deallocate(ptr, bytes, stream);
   }
 
   /**
@@ -180,18 +188,12 @@ class owning_wrapper : public device_memory_resource {
    * @return true If the two resources are equal
    * @return false If the two resources are not equal
    */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
+  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
-    if (this == &other) {
-      return true;
-    } else {
-      auto casted = dynamic_cast<owning_wrapper<Resource, Upstreams...> const*>(&other);
-      if (nullptr != casted) {
-        return wrapped().is_equal(casted->wrapped());
-      } else {
-        return wrapped().is_equal(other);
-      }
-    }
+    if (this == &other) { return true; }
+    auto casted = dynamic_cast<owning_wrapper<Resource, Upstreams...> const*>(&other);
+    if (nullptr != casted) { return wrapped().is_equal(casted->wrapped()); }
+    return wrapped().is_equal(other);
   }
 
   /**
@@ -202,7 +204,8 @@ class owning_wrapper : public device_memory_resource {
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
   {
     return wrapped().get_mem_info(stream);
   }
@@ -272,5 +275,4 @@ auto make_owning_wrapper(std::shared_ptr<Upstream> upstream, Args&&... args)
                                        std::forward<Args>(args)...);
 }
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -119,13 +119,13 @@ class owning_wrapper : public device_memory_resource {
    * @brief Returns a constant reference to the wrapped resource.
    *
    */
-  Resource const& wrapped() const noexcept { return *wrapped_; }
+  [[nodiscard]] Resource const& wrapped() const noexcept { return *wrapped_; }
 
   /**
    * @brief Returns reference to the wrapped resource.
    *
    */
-  Resource& wrapped() noexcept { return *wrapped_; }
+  [[nodiscard]] Resource& wrapped() noexcept { return *wrapped_; }
 
   /**
    * @copydoc rmm::mr::device_memory_resource::supports_streams()

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -27,7 +27,7 @@ namespace detail {
 /// Converts a tuple into a parameter pack
 template <typename Resource, typename UpstreamTuple, std::size_t... Indices, typename... Args>
 auto make_resource_impl(UpstreamTuple const& upstreams,
-                        std::index_sequence<Indices...> /*indices*/,
+                        std::index_sequence<Indices...>,
                         Args&&... args)
 {
   return std::make_unique<Resource>(std::get<Indices>(upstreams).get()...,

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -221,7 +221,7 @@ class stream_allocator_adaptor {
    * @brief Returns the underlying stream-ordered allocator
    *
    */
-  Allocator underlying_allocator() const noexcept { return alloc_; }
+  [[nodiscard]] Allocator underlying_allocator() const noexcept { return alloc_; }
 
  private:
   Allocator alloc_;          ///< Underlying allocator used for (de)allocation

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -99,7 +99,7 @@ class pool_memory_resource final
    * @brief Destroy the `pool_memory_resource` and deallocate all memory it allocated using
    * the upstream resource.
    */
-  ~pool_memory_resource() { release(); }
+  ~pool_memory_resource() override { release(); }
 
   pool_memory_resource()                            = delete;
   pool_memory_resource(pool_memory_resource const&) = delete;
@@ -195,6 +195,7 @@ class pool_memory_resource final
    * @param initial_size The optional initial size for the pool
    * @param maximum_size The optional maximum size for the pool
    */
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   void initialize_pool(thrust::optional<std::size_t> initial_size,
                        thrust::optional<std::size_t> maximum_size)
   {

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -41,8 +41,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 
 /**
  * @brief A coalescing best-fit suballocator which uses a pool of memory allocated from
@@ -114,14 +113,14 @@ class pool_memory_resource final
    *
    * @returns bool true.
    */
-  bool supports_streams() const noexcept override { return true; }
+  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
    * @return bool false
    */
-  bool supports_get_mem_info() const noexcept override { return false; }
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 
   /**
    * @brief Get the upstream memory_resource object.
@@ -145,7 +144,7 @@ class pool_memory_resource final
    *
    * @return std::size_t The maximum size of a single allocation supported by this memory resource
    */
-  std::size_t get_maximum_allocation_size() const
+  [[nodiscard]] std::size_t get_maximum_allocation_size() const
   {
     return std::numeric_limits<std::size_t>::max();
   }
@@ -168,12 +167,14 @@ class pool_memory_resource final
   block_type try_to_expand(std::size_t try_size, std::size_t min_size, cuda_stream_view stream)
   {
     while (try_size >= min_size) {
-      auto b = block_from_upstream(try_size, stream);
-      if (b.has_value()) {
-        current_pool_size_ += b.value().size();
-        return b.value();
+      auto block = block_from_upstream(try_size, stream);
+      if (block.has_value()) {
+        current_pool_size_ += block.value().size();
+        return block.value();
       }
-      if (try_size == min_size) break;  // only try `size` once
+      if (try_size == min_size) {
+        break;  // only try `size` once
+      }
       try_size = std::max(min_size, try_size / 2);
     }
     RMM_LOG_ERROR("[A][Stream {}][Upstream {}B][FAILURE maximum pool size exceeded]",
@@ -199,15 +200,13 @@ class pool_memory_resource final
   {
     auto const try_size = [&]() {
       if (not initial_size.has_value()) {
-        std::size_t free{}, total{};
-        std::tie(free, total) = (get_upstream()->supports_get_mem_info())
-                                  ? get_upstream()->get_mem_info(cuda_stream_legacy)
-                                  : rmm::detail::available_device_memory();
+        auto const [free, total] = (get_upstream()->supports_get_mem_info())
+                                     ? get_upstream()->get_mem_info(cuda_stream_legacy)
+                                     : rmm::detail::available_device_memory();
         return rmm::detail::align_up(std::min(free, total / 2),
                                      rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
-      } else {
-        return initial_size.value();
       }
+      return initial_size.value();
     }();
 
     current_pool_size_ = 0;  // try_to_expand will set this if it succeeds
@@ -217,8 +216,8 @@ class pool_memory_resource final
                 "Initial pool size exceeds the maximum pool size!");
 
     if (try_size > 0) {
-      auto const b = try_to_expand(try_size, try_size, cuda_stream_legacy);
-      this->insert_block(b, cuda_stream_legacy);
+      auto const block = try_to_expand(try_size, try_size, cuda_stream_legacy);
+      this->insert_block(block, cuda_stream_legacy);
     }
   }
 
@@ -252,7 +251,7 @@ class pool_memory_resource final
    * @param size The size of the minimum allocation immediately needed
    * @return std::size_t The computed size to grow the pool.
    */
-  std::size_t size_to_grow(std::size_t size) const
+  [[nodiscard]] std::size_t size_to_grow(std::size_t size) const
   {
     if (maximum_pool_size_.has_value()) {
       auto const unaligned_remaining = maximum_pool_size_.value() - pool_size();
@@ -260,8 +259,8 @@ class pool_memory_resource final
         rmm::detail::align_up(unaligned_remaining, rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
       auto const aligned_size = rmm::detail::align_up(size, rmm::detail::CUDA_ALLOCATION_ALIGNMENT);
       return (aligned_size <= remaining) ? std::max(aligned_size, remaining / 2) : 0;
-    } else
-      return std::max(size, pool_size());
+    }
+    return std::max(size, pool_size());
   };
 
   /**
@@ -275,64 +274,66 @@ class pool_memory_resource final
   {
     RMM_LOG_DEBUG("[A][Stream {}][Upstream {}B]", fmt::ptr(stream.value()), size);
 
-    if (size == 0) return {};
+    if (size == 0) { return {}; }
 
     try {
-      void* p = upstream_mr_->allocate(size, stream);
+      void* ptr = upstream_mr_->allocate(size, stream);
       return thrust::optional<block_type>{
-        *upstream_blocks_.emplace(reinterpret_cast<char*>(p), size, true).first};
+        *upstream_blocks_.emplace(static_cast<char*>(ptr), size, true).first};
     } catch (std::exception const& e) {
       return thrust::nullopt;
     }
   }
 
   /**
-   * @brief Splits block `b` if necessary to return a pointer to memory of `size` bytes.
+   * @brief Splits `block` if necessary to return a pointer to memory of `size` bytes.
    *
    * If the block is split, the remainder is returned to the pool.
    *
-   * @param b The block to allocate from.
+   * @param block The block to allocate from.
    * @param size The size in bytes of the requested allocation.
    * @param stream_event The stream and associated event on which the allocation will be used.
    * @return A pair comprising the allocated pointer and any unallocated remainder of the input
    * block.
    */
-  split_block allocate_from_block(block_type const& b, std::size_t size)
+  split_block allocate_from_block(block_type const& block, std::size_t size)
   {
-    block_type const alloc{b.pointer(), size, b.is_head()};
+    block_type const alloc{block.pointer(), size, block.is_head()};
 #ifdef RMM_POOL_TRACK_ALLOCATIONS
     allocated_blocks_.insert(alloc);
 #endif
 
-    auto rest =
-      (b.size() > size) ? block_type{b.pointer() + size, b.size() - size, false} : block_type{};
+    auto rest = (block.size() > size)
+                  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                  ? block_type{block.pointer() + size, block.size() - size, false}
+                  : block_type{};
     return {alloc, rest};
   }
 
   /**
-   * @brief Finds, frees and returns the block associated with pointer `p`.
+   * @brief Finds, frees and returns the block associated with pointer `ptr`.
    *
-   * @param p The pointer to the memory to free.
+   * @param ptr The pointer to the memory to free.
    * @param size The size of the memory to free. Must be equal to the original allocation size.
    * @param stream The stream-event pair for the stream on which the memory was last used.
    * @return The (now freed) block associated with `p`. The caller is expected to return the block
    * to the pool.
    */
-  block_type free_block(void* p, std::size_t size) noexcept
+  block_type free_block(void* ptr, std::size_t size) noexcept
   {
 #ifdef RMM_POOL_TRACK_ALLOCATIONS
-    if (p == nullptr) return block_type{};
-    auto const i = allocated_blocks_.find(static_cast<char*>(p));
-    RMM_LOGGING_ASSERT(i != allocated_blocks_.end());
+    if (ptr == nullptr) return block_type{};
+    auto const iter = allocated_blocks_.find(static_cast<char*>(ptr));
+    RMM_LOGGING_ASSERT(iter != allocated_blocks_.end());
 
-    auto block = *i;
+    auto block = *iter;
     RMM_LOGGING_ASSERT(block.size() == rmm::detail::align_up(size, allocation_alignment));
-    allocated_blocks_.erase(i);
+    allocated_blocks_.erase(iter);
 
     return block;
 #else
-    auto const i = upstream_blocks_.find(static_cast<char*>(p));
-    return block_type{static_cast<char*>(p), size, (i != upstream_blocks_.end())};
+    auto const iter = upstream_blocks_.find(static_cast<char*>(ptr));
+    return block_type{static_cast<char*>(ptr), size, (iter != upstream_blocks_.end())};
 #endif
   }
 
@@ -343,7 +344,7 @@ class pool_memory_resource final
    *
    * @return std::size_t The total size of the currently allocated pool.
    */
-  std::size_t pool_size() const noexcept { return current_pool_size_; }
+  [[nodiscard]] std::size_t pool_size() const noexcept { return current_pool_size_; }
 
   /**
    * @brief Free all memory allocated from the upstream memory_resource.
@@ -353,8 +354,9 @@ class pool_memory_resource final
   {
     lock_guard lock(this->get_mutex());
 
-    for (auto b : upstream_blocks_)
-      upstream_mr_->deallocate(b.pointer(), b.size());
+    for (auto block : upstream_blocks_) {
+      upstream_mr_->deallocate(block.pointer(), block.size());
+    }
     upstream_blocks_.clear();
 #ifdef RMM_POOL_TRACK_ALLOCATIONS
     allocated_blocks_.clear();
@@ -373,23 +375,22 @@ class pool_memory_resource final
   {
     lock_guard lock(this->get_mutex());
 
-    std::size_t free, total;
-    std::tie(free, total) = upstream_mr_->get_mem_info(0);
+    auto const [free, total] = upstream_mr_->get_mem_info(0);
     std::cout << "GPU free memory: " << free << " total: " << total << "\n";
 
     std::cout << "upstream_blocks: " << upstream_blocks_.size() << "\n";
     std::size_t upstream_total{0};
 
-    for (auto h : upstream_blocks_) {
-      h.print();
-      upstream_total += h.size();
+    for (auto blocks : upstream_blocks_) {
+      blocks.print();
+      upstream_total += blocks.size();
     }
     std::cout << "total upstream: " << upstream_total << " B\n";
 
 #ifdef RMM_POOL_TRACK_ALLOCATIONS
     std::cout << "allocated_blocks: " << allocated_blocks_.size() << "\n";
-    for (auto b : allocated_blocks_)
-      b.print();
+    for (auto block : allocated_blocks_)
+      block.print();
 #endif
 
     this->print_free_blocks();
@@ -407,9 +408,9 @@ class pool_memory_resource final
   {
     std::size_t largest{};
     std::size_t total{};
-    std::for_each(blocks.cbegin(), blocks.cend(), [&largest, &total](auto const& b) {
-      total += b.size();
-      largest = std::max(largest, b.size());
+    std::for_each(blocks.cbegin(), blocks.cend(), [&largest, &total](auto const& block) {
+      total += block.size();
+      largest = std::max(largest, block.size());
     });
     return {largest, total};
   }
@@ -422,14 +423,14 @@ class pool_memory_resource final
    * @param stream to execute on
    * @return std::pair contaiing free_size and total_size of memory
    */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
   {
-    std::size_t free_size{};
-    std::size_t total_size{};
     // TODO implement this
-    return std::make_pair(free_size, total_size);
+    return {0, 0};
   }
 
+ private:
   Upstream* upstream_mr_;  // The "heap" to allocate the pool from
   std::size_t current_pool_size_{};
   thrust::optional<std::size_t> maximum_pool_size_{};
@@ -442,5 +443,4 @@ class pool_memory_resource final
   std::set<block_type, rmm::mr::detail::compare_blocks<block_type>> upstream_blocks_;
 };  // namespace mr
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -21,8 +21,7 @@
 #include <mutex>
 #include <shared_mutex>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 /**
  * @brief Resource that uses `Upstream` to allocate memory and tracks statistics
  * on memory allocations.
@@ -52,17 +51,17 @@ class statistics_resource_adaptor final : public device_memory_resource {
     int64_t peak{0};   // Max value of `value`
     int64_t total{0};  // Sum of all added values
 
-    counter& operator+=(int64_t x)
+    counter& operator+=(int64_t val)
     {
-      value += x;
-      total += x;
+      value += val;
+      total += val;
       peak = std::max(value, peak);
       return *this;
     }
 
-    counter& operator-=(int64_t x)
+    counter& operator-=(int64_t val)
     {
-      value -= x;
+      value -= val;
       return *this;
     }
   };
@@ -81,11 +80,11 @@ class statistics_resource_adaptor final : public device_memory_resource {
   }
 
   statistics_resource_adaptor()                                   = delete;
-  virtual ~statistics_resource_adaptor()                          = default;
+  ~statistics_resource_adaptor() override                         = default;
   statistics_resource_adaptor(statistics_resource_adaptor const&) = delete;
-  statistics_resource_adaptor(statistics_resource_adaptor&&)      = default;
   statistics_resource_adaptor& operator=(statistics_resource_adaptor const&) = delete;
-  statistics_resource_adaptor& operator=(statistics_resource_adaptor&&) = default;
+  statistics_resource_adaptor(statistics_resource_adaptor&&) noexcept        = default;
+  statistics_resource_adaptor& operator=(statistics_resource_adaptor&&) noexcept = default;
 
   /**
    * @brief Return pointer to the upstream resource.
@@ -156,7 +155,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
-    void* p = upstream_->allocate(bytes, stream);
+    void* ptr = upstream_->allocate(bytes, stream);
 
     // increment the stats
     {
@@ -167,21 +166,21 @@ class statistics_resource_adaptor final : public device_memory_resource {
       allocations_ += 1;
     }
 
-    return p;
+    return ptr;
   }
 
   /**
-   * @brief Free allocation of size `bytes` pointed to by `p`
+   * @brief Free allocation of size `bytes` pointed to by `ptr`
    *
    * @throws Nothing.
    *
-   * @param p Pointer to be deallocated
+   * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
    */
-  void do_deallocate(void* p, std::size_t bytes, cuda_stream_view stream) override
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override
   {
-    upstream_->deallocate(p, bytes, stream);
+    upstream_->deallocate(ptr, bytes, stream);
 
     {
       write_lock_t lock(mtx_);
@@ -203,13 +202,10 @@ class statistics_resource_adaptor final : public device_memory_resource {
    */
   bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
-    if (this == &other)
-      return true;
-    else {
-      auto cast = dynamic_cast<statistics_resource_adaptor<Upstream> const*>(&other);
-      return cast != nullptr ? upstream_->is_equal(*cast->get_upstream())
-                             : upstream_->is_equal(other);
-    }
+    if (this == &other) { return true; }
+    auto cast = dynamic_cast<statistics_resource_adaptor<Upstream> const*>(&other);
+    return cast != nullptr ? upstream_->is_equal(*cast->get_upstream())
+                           : upstream_->is_equal(other);
   }
 
   /**
@@ -244,5 +240,4 @@ statistics_resource_adaptor<Upstream> make_statistics_adaptor(Upstream* upstream
   return statistics_resource_adaptor<Upstream>{upstream};
 }
 
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -22,8 +22,7 @@
 #include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/device_malloc_allocator.h>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 /**
  * @brief An `allocator` compatible with Thrust containers and algorithms using
  * a `device_memory_resource` for memory (de)allocation.
@@ -91,39 +90,38 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   /**
    * @brief Allocate objects of type `T`
    *
-   * @param n  The number of elements of type `T` to allocate
+   * @param num  The number of elements of type `T` to allocate
    * @return pointer Pointer to the newly allocated storage
    */
-  pointer allocate(size_type n)
+  pointer allocate(size_type num)
   {
-    return thrust::device_pointer_cast(static_cast<T*>(_mr->allocate(n * sizeof(T), _stream)));
+    return thrust::device_pointer_cast(static_cast<T*>(_mr->allocate(num * sizeof(T), _stream)));
   }
 
   /**
    * @brief Deallocates objects of type `T`
    *
-   * @param p Pointer returned by a previous call to `allocate`
-   * @param n number of elements, *must* be equal to the argument passed to the
+   * @param ptr Pointer returned by a previous call to `allocate`
+   * @param num number of elements, *must* be equal to the argument passed to the
    * prior `allocate` call that produced `p`
    */
-  void deallocate(pointer p, size_type n)
+  void deallocate(pointer ptr, size_type num)
   {
-    return _mr->deallocate(thrust::raw_pointer_cast(p), n * sizeof(T), _stream);
+    return _mr->deallocate(thrust::raw_pointer_cast(ptr), num * sizeof(T), _stream);
   }
 
   /**
    * @brief Returns the device memory resource used by this allocator.
    */
-  device_memory_resource* resource() const noexcept { return _mr; }
+  [[nodiscard]] device_memory_resource* resource() const noexcept { return _mr; }
 
   /**
    * @brief Returns the stream used by this allocator.
    */
-  cuda_stream_view stream() const noexcept { return _stream; }
+  [[nodiscard]] cuda_stream_view stream() const noexcept { return _stream; }
 
  private:
   cuda_stream_view _stream{};
   device_memory_resource* _mr{rmm::mr::get_current_device_resource()};
 };
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 #include <cstddef>
 #include <utility>
 
-namespace rmm {
-namespace mr {
-/**---------------------------------------------------------------------------*
+namespace rmm::mr {
+
+/**
  * @brief Base class for host memory allocation.
  *
  * This is based on `std::pmr::memory_resource`:
@@ -43,124 +43,121 @@ namespace mr {
  * base class' `allocate` function may log every allocation, no matter what
  * derived class implementation is used.
  *
- *---------------------------------------------------------------------------**/
+ */
 class host_memory_resource {
  public:
-  virtual ~host_memory_resource() = default;
+  host_memory_resource()                            = default;
+  virtual ~host_memory_resource()                   = default;
+  host_memory_resource(host_memory_resource const&) = default;
+  host_memory_resource& operator=(host_memory_resource const&) = default;
+  host_memory_resource(host_memory_resource&&) noexcept        = default;
+  host_memory_resource& operator=(host_memory_resource&&) noexcept = default;
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Allocates memory on the host of size at least `bytes` bytes.
    *
-   * The returned storage is aligned to the specified `alignment` if supported,
-   * and to `alignof(std::max_align_t)` otherwise.
+   * The returned storage is aligned to the specified `alignment` if supported, and to
+   * `alignof(std::max_align_t)` otherwise.
    *
-   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be
-   * allocated.
+   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be allocated.
    *
    * @param bytes The size of the allocation
    * @param alignment Alignment of the allocation
    * @return void* Pointer to the newly allocated memory
-   *---------------------------------------------------------------------------**/
+   */
   void* allocate(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
   {
     return do_allocate(bytes, alignment);
   }
 
-  /**---------------------------------------------------------------------------*
-   * @brief Deallocate memory pointed to by `p`.
+  /**
+   * @brief Deallocate memory pointed to by `ptr`.
    *
-   * `p` must have been returned by a prior call to `allocate(bytes,alignment)`
-   * on a `host_memory_resource` that compares equal to `*this`, and the storage
-   * it points to must not yet have been deallocated, otherwise behavior is
-   * undefined.
+   * `ptr` must have been returned by a prior call to `allocate(bytes,alignment)` on a
+   * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
+   * yet have been deallocated, otherwise behavior is undefined.
    *
    * @throws Nothing.
    *
-   * @param p Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
-   * @param alignment Alignment of the allocation. This must be equal to the
-   *value of `alignment` that was passed to the `allocate` call that returned
-   *`p`.
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
+   *              that was passed to the `allocate` call that returned `ptr`.
+   * @param alignment Alignment of the allocation. This must be equal to the value of `alignment`
+   *                  that was passed to the `allocate` call that returned `ptr`.
    * @param stream Stream on which to perform deallocation
-   *---------------------------------------------------------------------------**/
-  void deallocate(void* p, std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
+   */
+  void deallocate(void* ptr, std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
   {
-    do_deallocate(p, bytes, alignment);
+    do_deallocate(ptr, bytes, alignment);
   }
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Compare this resource to another.
    *
-   * Two `host_memory_resource`s compare equal if and only if memory allocated
-   * from one `host_memory_resource` can be deallocated from the other and vice
-   * versa.
+   * Two `host_memory_resource`s compare equal if and only if memory allocated from one
+   * `host_memory_resource` can be deallocated from the other and vice versa.
    *
-   * By default, simply checks if \p *this and \p other refer to the same
-   * object, i.e., does not check if they are two objects of the same class.
+   * By default, simply checks if \p *this and \p other refer to the same object, i.e., does not
+   * check if they are two objects of the same class.
    *
    * @param other The other resource to compare to
-   * @returns If the two resources are equivalent
-   *---------------------------------------------------------------------------**/
-  bool is_equal(host_memory_resource const& other) const noexcept { return do_is_equal(other); }
+   * @returns true if the two resources are equivalent
+   */
+  [[nodiscard]] bool is_equal(host_memory_resource const& other) const noexcept
+  {
+    return do_is_equal(other);
+  }
 
  private:
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Allocates memory on the host of size at least `bytes` bytes.
    *
-   * The returned storage is aligned to the specified `alignment` if supported,
-   * and to `alignof(std::max_align_t)` otherwise.
+   * The returned storage is aligned to the specified `alignment` if supported, and to
+   * `alignof(std::max_align_t)` otherwise.
    *
-   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be
-   * allocated.
+   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be allocated.
    *
    * @param bytes The size of the allocation
    * @param alignment Alignment of the allocation
    * @return void* Pointer to the newly allocated memory
-   *---------------------------------------------------------------------------**/
+   */
   virtual void* do_allocate(std::size_t bytes,
                             std::size_t alignment = alignof(std::max_align_t)) = 0;
 
-  /**---------------------------------------------------------------------------*
-   * @brief Deallocate memory pointed to by `p`.
+  /**
+   * @brief Deallocate memory pointed to by `ptr`.
    *
-   * `p` must have been returned by a prior call to `allocate(bytes,alignment)`
-   * on a `host_memory_resource` that compares equal to `*this`, and the storage
-   * it points to must not yet have been deallocated, otherwise behavior is
-   * undefined.
+   * `ptr` must have been returned by a prior call to `allocate(bytes,alignment)` on a
+   * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
+   * yet have been deallocated, otherwise behavior is undefined.
    *
    * @throws Nothing.
    *
-   * @param p Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
-   * @param alignment Alignment of the allocation. This must be equal to the
-   *value of `alignment` that was passed to the `allocate` call that returned
-   *`p`.
-   * @param stream Stream on which to perform deallocation
-   *---------------------------------------------------------------------------**/
-  virtual void do_deallocate(void* p,
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
+   *              that was passed to the `allocate` call that returned `ptr`.
+   * @param alignment Alignment of the allocation. This must be equal to the value of `alignment`
+   *                  that was passed to the `allocate` call that returned `ptr`.
+   */
+  virtual void do_deallocate(void* ptr,
                              std::size_t bytes,
                              std::size_t alignment = alignof(std::max_align_t)) = 0;
 
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Compare this resource to another.
    *
-   * Two host_memory_resources compare equal if and only if memory allocated
-   * from one host_memory_resource can be deallocated from the other and vice
-   * versa.
+   * Two host_memory_resources compare equal if and only if memory allocated from one
+   * host_memory_resource can be deallocated from the other and vice versa.
    *
-   * By default, simply checks if \p *this and \p other refer to the same
-   * object, i.e., does not check if they are two objects of the same class.
+   * By default, simply checks if `*this` and `other` refer to the same object, i.e., does not check
+   * whether they are two objects of the same class.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent
-   * @return false If the two resources are not equal
-   *---------------------------------------------------------------------------**/
-  virtual bool do_is_equal(host_memory_resource const& other) const noexcept
+   */
+  [[nodiscard]] virtual bool do_is_equal(host_memory_resource const& other) const noexcept
   {
     return this == &other;
   }
 };
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -24,10 +24,10 @@
 
 namespace rmm::mr {
 
-/**---------------------------------------------------------------------------*
- * @brief A `host_memory_resource` that uses the global `operator new` and
- * `operator delete` to allocate host memory.
- *---------------------------------------------------------------------------**/
+/**
+ * @brief A `host_memory_resource` that uses the global `operator new` and `operator delete` to
+ * allocate host memory.
+ */
 class new_delete_resource final : public host_memory_resource {
  public:
   new_delete_resource()                           = default;
@@ -38,19 +38,18 @@ class new_delete_resource final : public host_memory_resource {
   new_delete_resource& operator=(new_delete_resource&&) = default;
 
  private:
-  /**---------------------------------------------------------------------------*
+  /**
    * @brief Allocates memory on the host of size at least `bytes` bytes.
    *
-   * The returned storage is aligned to the specified `alignment` if supported,
-   * and to `alignof(std::max_align_t)` otherwise.
+   * The returned storage is aligned to the specified `alignment` if supported, and to
+   * `alignof(std::max_align_t)` otherwise.
    *
-   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be
-   * allocated.
+   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be allocated.
    *
    * @param bytes The size of the allocation
    * @param alignment Alignment of the allocation
-   * @return void* Pointer to the newly allocated memory
-   *---------------------------------------------------------------------------**/
+   * @return Pointer to the newly allocated memory
+   */
   void* do_allocate(std::size_t bytes,
                     std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
@@ -62,24 +61,21 @@ class new_delete_resource final : public host_memory_resource {
       bytes, alignment, [](std::size_t size) { return ::operator new(size); });
   }
 
-  /**---------------------------------------------------------------------------*
-   * @brief Deallocate memory pointed to by `p`.
+  /**
+   * @brief Deallocate memory pointed to by `ptr`.
    *
-   * `p` must have been returned by a prior call to `allocate(bytes,alignment)`
-   * on a `host_memory_resource` that compares equal to `*this`, and the storage
-   * it points to must not yet have been deallocated, otherwise behavior is
-   * undefined.
+   * `ptr` must have been returned by a prior call to `allocate(bytes,alignment)` on a
+   * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
+   * yet have been deallocated, otherwise behavior is undefined.
    *
    * @throws Nothing.
    *
-   * @param p Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
-   * @param alignment Alignment of the allocation. This must be equal to the
-   *value of `alignment` that was passed to the `allocate` call that returned
-   *`p`.
-   * @param stream Stream on which to perform deallocation
-   *---------------------------------------------------------------------------**/
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
+   *              that was passed to the `allocate` call that returned `ptr`.
+   * @param alignment Alignment of the allocation. This must be equal to the value of `alignment`
+   *                  that was passed to the `allocate` call that returned `ptr`.
+   */
   void do_deallocate(void* ptr,
                      std::size_t bytes,
                      std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
@@ -87,4 +83,5 @@ class new_delete_resource final : public host_memory_resource {
     detail::aligned_deallocate(ptr, bytes, alignment, [](void* ptr) { ::operator delete(ptr); });
   }
 };
+
 }  // namespace rmm::mr

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -22,8 +22,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace rmm {
-namespace mr {
+namespace rmm::mr {
 
 /**---------------------------------------------------------------------------*
  * @brief A `host_memory_resource` that uses the global `operator new` and
@@ -32,7 +31,7 @@ namespace mr {
 class new_delete_resource final : public host_memory_resource {
  public:
   new_delete_resource()                           = default;
-  ~new_delete_resource()                          = default;
+  ~new_delete_resource() override                 = default;
   new_delete_resource(new_delete_resource const&) = default;
   new_delete_resource(new_delete_resource&&)      = default;
   new_delete_resource& operator=(new_delete_resource const&) = default;
@@ -56,12 +55,11 @@ class new_delete_resource final : public host_memory_resource {
                     std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
     // If the requested alignment isn't supported, use default
-    auto align = (detail::is_supported_alignment(rmm::detail::alignment_type{alignment}))
-                   ? rmm::detail::alignment_type{alignment}
-                   : detail::RMM_DEFAULT_HOST_ALIGNMENT;
+    alignment =
+      (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
     return detail::aligned_allocate(
-      bytes, align, [](std::size_t size) { return ::operator new(size); });
+      bytes, alignment, [](std::size_t size) { return ::operator new(size); });
   }
 
   /**---------------------------------------------------------------------------*
@@ -82,12 +80,11 @@ class new_delete_resource final : public host_memory_resource {
    *`p`.
    * @param stream Stream on which to perform deallocation
    *---------------------------------------------------------------------------**/
-  void do_deallocate(void* p,
+  void do_deallocate(void* ptr,
                      std::size_t bytes,
                      std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
-    detail::aligned_deallocate(p, bytes, alignment, [](void* p) { ::operator delete(p); });
+    detail::aligned_deallocate(ptr, bytes, alignment, [](void* ptr) { ::operator delete(ptr); });
   }
 };
-}  // namespace mr
-}  // namespace rmm
+}  // namespace rmm::mr

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -56,11 +56,12 @@ class new_delete_resource final : public host_memory_resource {
                     std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
     // If the requested alignment isn't supported, use default
-    alignment =
-      (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
+    auto align = (detail::is_supported_alignment(rmm::detail::alignment_type{alignment}))
+                   ? rmm::detail::alignment_type{alignment}
+                   : detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
     return detail::aligned_allocate(
-      bytes, alignment, [](std::size_t size) { return ::operator new(size); });
+      bytes, align, [](std::size_t size) { return ::operator new(size); });
   }
 
   /**---------------------------------------------------------------------------*

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -62,10 +62,10 @@ class pinned_memory_resource final : public host_memory_resource {
       (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
     return detail::aligned_allocate(bytes, alignment, [](std::size_t size) {
-      void* p{nullptr};
-      auto status = cudaMallocHost(&p, size);
+      void* ptr{nullptr};
+      auto status = cudaMallocHost(&ptr, size);
       if (cudaSuccess != status) { throw std::bad_alloc{}; }
-      return p;
+      return ptr;
     });
   }
 

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -38,12 +38,13 @@ using exec_policy_t = std::unique_ptr<par_t, deleter_t>;
  * allocation.
  */
 [[deprecated("Use new exec_policy in rmm/exec_policy.hpp")]] inline exec_policy_t exec_policy(
-  cudaStream_t stream = 0)
+  cudaStream_t stream = nullptr)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   auto* alloc  = new rmm::mr::thrust_allocator<char>(cuda_stream_view{stream});
   auto deleter = [alloc](par_t* pointer) {
-    delete alloc;
-    delete pointer;
+    delete alloc;    // NOLINT(cppcoreguidelines-owning-memory)
+    delete pointer;  // NOLINT(cppcoreguidelines-owning-memory)
   };
 
   exec_policy_t policy{new par_t(*alloc), deleter};

--- a/python/setup.py
+++ b/python/setup.py
@@ -155,7 +155,7 @@ extensions += cythonize(
             ],
             libraries=["cuda", "cudart"],
             language="c++",
-            extra_compile_args=["-std=c++14"],
+            extra_compile_args=["-std=c++17"],
         )
     ],
     nthreads=nthreads,
@@ -178,7 +178,7 @@ extensions += cythonize(
             ],
             libraries=["cuda", "cudart"],
             language="c++",
-            extra_compile_args=["-std=c++14"],
+            extra_compile_args=["-std=c++17"],
         )
     ],
     nthreads=nthreads,

--- a/tests/byte_literals.hpp
+++ b/tests/byte_literals.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+
+namespace rmm::test {
+
+constexpr auto kilo{long{1} << 10};
+constexpr auto mega{long{1} << 20};
+constexpr auto giga{long{1} << 30};
+constexpr auto tera{long{1} << 40};
+constexpr auto peta{long{1} << 50};
+
+// user-defined Byte literals
+constexpr unsigned long long operator""_B(unsigned long long val) { return val; }
+constexpr unsigned long long operator""_KiB(unsigned long long const val) { return kilo * val; }
+constexpr unsigned long long operator""_MiB(unsigned long long const val) { return mega * val; }
+constexpr unsigned long long operator""_GiB(unsigned long long const val) { return giga * val; }
+constexpr unsigned long long operator""_TiB(unsigned long long const val) { return tera * val; }
+constexpr unsigned long long operator""_PiB(unsigned long long const val) { return peta * val; }
+
+}  // namespace rmm::test

--- a/tests/cuda_stream_pool_tests.cpp
+++ b/tests/cuda_stream_pool_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/cuda_stream_tests.cpp
+++ b/tests/cuda_stream_tests.cpp
@@ -47,6 +47,7 @@ TEST_F(CudaStreamTest, MoveConstructor)
   rmm::cuda_stream stream_a;
   auto const view_a         = stream_a.view();
   rmm::cuda_stream stream_b = std::move(stream_a);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_FALSE(stream_a.is_valid());  // Any other operations on stream_a are UB, may segfault
   EXPECT_EQ(stream_b, view_a);
 }

--- a/tests/cuda_stream_tests.cpp
+++ b/tests/cuda_stream_tests.cpp
@@ -47,7 +47,7 @@ TEST_F(CudaStreamTest, MoveConstructor)
   rmm::cuda_stream stream_a;
   auto const view_a         = stream_a.view();
   rmm::cuda_stream stream_b = std::move(stream_a);
-  // NOLINTNEXTLINE(bugprone-use-after-move)
+  // NOLINTNEXTLINE(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_FALSE(stream_a.is_valid());  // Any other operations on stream_a are UB, may segfault
   EXPECT_EQ(stream_b, view_a);
 }

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -154,6 +154,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   // Initialize buffer
   thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<char*>(buff.data()),
+                   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<char*>(buff.data()) + buff.size(),
                    0);
 
@@ -168,6 +169,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
 
   EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<char*>(buff.data()),
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<char*>(buff.data()) + buff.size(),
                             static_cast<char*>(buff_copy.data())));
 
@@ -179,6 +181,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
 
   EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char*>(buff.data()),
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
                             static_cast<signed char*>(buff_copy.data())));
 }
@@ -193,6 +196,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 
   thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char*>(buff.data()),
+                   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
   rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);
@@ -208,6 +212,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 
   EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char*>(buff.data()),
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
                             static_cast<signed char*>(buff_copy.data())));
 }
@@ -218,6 +223,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 
   thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char*>(buff.data()),
+                   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
   rmm::device_buffer buff_copy(buff, this->stream, &this->mr);
@@ -231,6 +237,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 
   EXPECT_TRUE(thrust::equal(rmm::exec_policy(buff_copy.stream()),
                             static_cast<signed char*>(buff.data()),
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
                             static_cast<signed char*>(buff_copy.data())));
 }
@@ -245,6 +252,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 
   thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char*>(buff.data()),
+                   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
   rmm::device_buffer buff_copy(buff, this->stream, &this->mr);
@@ -261,6 +269,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 
   EXPECT_TRUE(thrust::equal(rmm::exec_policy(buff_copy.stream()),
                             static_cast<signed char*>(buff.data()),
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
                             static_cast<signed char*>(buff_copy.data())));
 }
@@ -284,11 +293,11 @@ TYPED_TEST(DeviceBufferTest, MoveConstructor)
   EXPECT_EQ(mr, buff_new.memory_resource());
 
   // Original buffer should be empty
-  EXPECT_EQ(nullptr, buff.data());
-  EXPECT_EQ(0, buff.size());
-  EXPECT_EQ(0, buff.capacity());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
-  EXPECT_NE(nullptr, buff.memory_resource());
+  EXPECT_EQ(nullptr, buff.data());                     // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(0, buff.size());                           // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(0, buff.capacity());                       // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());  // NOLINT(bugprone-use-after-move)
+  EXPECT_NE(nullptr, buff.memory_resource());          // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
@@ -312,11 +321,11 @@ TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
   EXPECT_EQ(mr, buff_new.memory_resource());
 
   // Original buffer should be empty
-  EXPECT_EQ(nullptr, buff.data());
-  EXPECT_EQ(0, buff.size());
-  EXPECT_EQ(0, buff.capacity());
-  EXPECT_EQ(rmm::cuda_stream_view{}, buff.stream());
-  EXPECT_NE(nullptr, buff.memory_resource());
+  EXPECT_EQ(nullptr, buff.data());                    // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(0, buff.size());                          // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(0, buff.capacity());                      // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(rmm::cuda_stream_view{}, buff.stream());  // NOLINT(bugprone-use-after-move)
+  EXPECT_NE(nullptr, buff.memory_resource());         // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
@@ -399,6 +408,7 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
   thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char*>(buff.data()),
+                   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
 
@@ -422,6 +432,7 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
   EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char*>(buff.data()),
+                            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
                             static_cast<signed char*>(old_content.data())));
 }

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -27,9 +27,11 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
-#include <cuda_runtime_api.h>
 #include <thrust/equal.h>
 #include <thrust/sequence.h>
+
+#include <cuda_runtime_api.h>
+
 #include <cstddef>
 #include <random>
 

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -293,9 +293,10 @@ TYPED_TEST(DeviceBufferTest, MoveConstructor)
   EXPECT_EQ(mr, buff_new.memory_resource());
 
   // Original buffer should be empty
-  EXPECT_EQ(nullptr, buff.data());                     // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(0, buff.size());                           // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(0, buff.capacity());                       // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(nullptr,
+            buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+  EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(rmm::cuda_stream_default, buff.stream());  // NOLINT(bugprone-use-after-move)
   EXPECT_NE(nullptr, buff.memory_resource());          // NOLINT(bugprone-use-after-move)
 }
@@ -321,9 +322,10 @@ TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
   EXPECT_EQ(mr, buff_new.memory_resource());
 
   // Original buffer should be empty
-  EXPECT_EQ(nullptr, buff.data());                    // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(0, buff.size());                          // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(0, buff.capacity());                      // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(nullptr,
+            buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+  EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(rmm::cuda_stream_view{}, buff.stream());  // NOLINT(bugprone-use-after-move)
   EXPECT_NE(nullptr, buff.memory_resource());         // NOLINT(bugprone-use-after-move)
 }
@@ -349,7 +351,7 @@ TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
   EXPECT_EQ(mr, dest.memory_resource());
 
   // `from` should be empty
-  EXPECT_EQ(nullptr, src.data());
+  EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
   EXPECT_EQ(rmm::cuda_stream_default, src.stream());
@@ -377,7 +379,7 @@ TYPED_TEST(DeviceBufferTest, MoveAssignment)
   EXPECT_EQ(mr, dest.memory_resource());
 
   // `from` should be empty
-  EXPECT_EQ(nullptr, src.data());
+  EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
   EXPECT_EQ(rmm::cuda_stream_default, src.stream());
@@ -393,8 +395,8 @@ TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
   auto* mr      = buff.memory_resource();
   auto stream   = buff.stream();
 
-  buff = std::move(buff);  // self-move-assignment shouldn't modify the buffer
-  EXPECT_NE(nullptr, buff.data());
+  buff = std::move(buff);           // self-move-assignment shouldn't modify the buffer
+  EXPECT_NE(nullptr, buff.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(ptr, buff.data());
   EXPECT_EQ(size, buff.size());
   EXPECT_EQ(capacity, buff.capacity());

--- a/tests/device_scalar_tests.cpp
+++ b/tests/device_scalar_tests.cpp
@@ -30,10 +30,10 @@
 
 template <typename T>
 struct DeviceScalarTest : public ::testing::Test {
+  std::default_random_engine generator{};
   T value{};
   rmm::cuda_stream stream{};
   rmm::mr::device_memory_resource* mr{rmm::mr::get_current_device_resource()};
-  std::default_random_engine generator{};
 
   DeviceScalarTest() : value{random_value()} {}
 

--- a/tests/device_scalar_tests.cpp
+++ b/tests/device_scalar_tests.cpp
@@ -93,13 +93,14 @@ TYPED_TEST(DeviceScalarTest, MoveCtor)
   EXPECT_NE(nullptr, scalar.data());
   EXPECT_EQ(this->value, scalar.value(this->stream));
 
-  auto original_pointer = scalar.data();
-  auto original_value   = scalar.value(this->stream);
+  auto* original_pointer = scalar.data();
+  auto original_value    = scalar.value(this->stream);
 
   rmm::device_scalar<TypeParam> moved_to{std::move(scalar)};
   EXPECT_NE(nullptr, moved_to.data());
   EXPECT_EQ(moved_to.data(), original_pointer);
   EXPECT_EQ(moved_to.value(this->stream), original_value);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(nullptr, scalar.data());
 }
 

--- a/tests/device_uvector_tests.cpp
+++ b/tests/device_uvector_tests.cpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/device_uvector_tests.cpp
+++ b/tests/device_uvector_tests.cpp
@@ -65,8 +65,8 @@ TYPED_TEST(TypedUVectorTest, ResizeSmaller)
 {
   auto const original_size{12345};
   rmm::device_uvector<TypeParam> vec(original_size, this->stream());
-  auto original_data  = vec.data();
-  auto original_begin = vec.begin();
+  auto* original_data  = vec.data();
+  auto* original_begin = vec.begin();
 
   auto smaller_size = vec.size() - 1;
   vec.resize(smaller_size, this->stream());
@@ -86,8 +86,8 @@ TYPED_TEST(TypedUVectorTest, ResizeLarger)
 {
   auto const original_size{12345};
   rmm::device_uvector<TypeParam> vec(original_size, this->stream());
-  auto original_data  = vec.data();
-  auto original_begin = vec.begin();
+  auto* original_data  = vec.data();
+  auto* original_begin = vec.begin();
 
   auto larger_size = vec.size() + 1;
   vec.resize(larger_size, this->stream());
@@ -97,8 +97,8 @@ TYPED_TEST(TypedUVectorTest, ResizeLarger)
   EXPECT_EQ(vec.size(), larger_size);
   EXPECT_EQ(vec.capacity(), larger_size);
 
-  auto larger_data  = vec.data();
-  auto larger_begin = vec.begin();
+  auto* larger_data  = vec.data();
+  auto* larger_begin = vec.begin();
 
   // shrink_to_fit shouldn't have any effect
   vec.shrink_to_fit(this->stream());
@@ -127,7 +127,7 @@ TYPED_TEST(TypedUVectorTest, Release)
   auto const original_size{12345};
   rmm::device_uvector<TypeParam> vec(original_size, this->stream());
 
-  auto original_data = vec.data();
+  auto* original_data = vec.data();
 
   rmm::device_buffer storage = vec.release();
 

--- a/tests/device_uvector_tests.cpp
+++ b/tests/device_uvector_tests.cpp
@@ -158,7 +158,9 @@ TYPED_TEST(TypedUVectorTest, OOBGetElement)
 {
   auto const size{12345};
   rmm::device_uvector<TypeParam> vec(size, this->stream());
-  EXPECT_THROW(vec.element(vec.size() + 1, this->stream()), rmm::out_of_range);
+  // avoid error due to nodiscard function
+  auto foo = [&]() { return vec.element(vec.size() + 1, this->stream()); };
+  EXPECT_THROW(foo(), rmm::out_of_range);
 }
 
 TYPED_TEST(TypedUVectorTest, GetSetElement)

--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -220,8 +220,8 @@ TEST(Adaptor, STDOUT)
 
   auto const size{100};
 
-  auto* p = log_mr.allocate(size);
-  log_mr.deallocate(p, size);
+  auto* ptr = log_mr.allocate(size);
+  log_mr.deallocate(ptr, size);
 
   std::string output = testing::internal::GetCapturedStdout();
   std::string header = output.substr(0, output.find('\n'));
@@ -238,8 +238,8 @@ TEST(Adaptor, STDERR)
 
   auto const size{100};
 
-  auto* p = log_mr.allocate(size);
-  log_mr.deallocate(p, size);
+  auto* ptr = log_mr.allocate(size);
+  log_mr.deallocate(ptr, size);
 
   std::string output = testing::internal::GetCapturedStderr();
   std::string header = output.substr(0, output.find('\n'));

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -19,8 +19,7 @@
 
 #include <gtest/gtest.h>
 
-namespace rmm {
-namespace test {
+namespace rmm::test {
 namespace {
 
 using cuda_async_mr = rmm::mr::cuda_async_memory_resource;
@@ -38,24 +37,24 @@ TEST(PoolTest, ThrowIfNotSupported)
 #if defined(RMM_CUDA_MALLOC_ASYNC_SUPPORT)
 TEST(PoolTest, ExplicitInitialPoolSize)
 {
-  cuda_async_mr mr{100};
-  void* p;
-  EXPECT_NO_THROW(p = mr.allocate(100));
-  EXPECT_NO_THROW(mr.deallocate(p, 100));
+  const auto pool_init_size{100};
+  cuda_async_mr mr{pool_init_size};
+  void* ptr = mr.allocate(pool_init_size);
+  mr.deallocate(ptr, pool_init_size);
   RMM_CUDA_TRY(cudaDeviceSynchronize());
 }
 
 TEST(PoolTest, ExplicitReleaseThreshold)
 {
-  cuda_async_mr mr{100, 1000};
-  void* p;
-  EXPECT_NO_THROW(p = mr.allocate(100));
-  EXPECT_NO_THROW(mr.deallocate(p, 100));
+  const auto pool_init_size{100};
+  const auto pool_release_threshold{1000};
+  cuda_async_mr mr{pool_init_size, pool_release_threshold};
+  void* ptr = mr.allocate(pool_init_size);
+  mr.deallocate(ptr, pool_init_size);
   RMM_CUDA_TRY(cudaDeviceSynchronize());
 }
 
 #endif
 
 }  // namespace
-}  // namespace test
-}  // namespace rmm
+}  // namespace rmm::test

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -47,7 +47,7 @@ TEST(PoolTest, ExplicitInitialPoolSize)
 TEST(PoolTest, ExplicitReleaseThreshold)
 {
   const auto pool_init_size{100};
-  const auto pool_release_threshold{1000};
+  const auto pool_release_threshold = cuda_async_mr::release_threshold_size_type{1000};
   cuda_async_mr mr{pool_init_size, pool_release_threshold};
   void* ptr = mr.allocate(pool_init_size);
   mr.deallocate(ptr, pool_init_size);

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -47,7 +47,7 @@ TEST(PoolTest, ExplicitInitialPoolSize)
 TEST(PoolTest, ExplicitReleaseThreshold)
 {
   const auto pool_init_size{100};
-  const auto pool_release_threshold = cuda_async_mr::release_threshold_size_type{1000};
+  const auto pool_release_threshold{1000};
   cuda_async_mr mr{pool_init_size, pool_release_threshold};
   void* ptr = mr.allocate(pool_init_size);
   mr.deallocate(ptr, pool_init_size);

--- a/tests/mr/device/limiting_mr_tests.cpp
+++ b/tests/mr/device/limiting_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,65 +14,81 @@
  * limitations under the License.
  */
 
+#include "../../byte_literals.hpp"
+
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/limiting_resource_adaptor.hpp>
 
 #include <gtest/gtest.h>
-#include "mr_test.hpp"
 
-namespace rmm {
-namespace test {
+namespace rmm::test {
 namespace {
+
 using Limiting_adaptor = rmm::mr::limiting_resource_adaptor<rmm::mr::device_memory_resource>;
+
 TEST(LimitingTest, ThrowOnNullUpstream)
 {
-  auto construct_nullptr = []() { Limiting_adaptor mr{nullptr, 5_MiB}; };
+  auto const max_size{5_MiB};
+  auto construct_nullptr = []() { Limiting_adaptor mr{nullptr, max_size}; };
   EXPECT_THROW(construct_nullptr(), rmm::logic_error);
 }
 
 TEST(LimitingTest, TooBig)
 {
-  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), 1_MiB};
-  EXPECT_THROW(mr.allocate(5_MiB), rmm::bad_alloc);
+  auto const max_size{5_MiB};
+  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), max_size};
+  EXPECT_THROW(mr.allocate(max_size + 1), rmm::bad_alloc);
 }
 
 TEST(LimitingTest, UnderLimitDueToFrees)
 {
-  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), 10_MiB};
-  auto p1 = mr.allocate(4_MiB);
-  EXPECT_EQ(mr.get_allocated_bytes(), 4_MiB);
-  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 6_MiB);
-  auto p2 = mr.allocate(4_MiB);
-  EXPECT_EQ(mr.get_allocated_bytes(), 8_MiB);
-  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 2_MiB);
-  mr.deallocate(p1, 4_MiB);
-  EXPECT_EQ(mr.get_allocated_bytes(), 4_MiB);
-  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 6_MiB);
+  auto const max_size{10_MiB};
+  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), max_size};
+  auto const size1{4_MiB};
+  auto* ptr1           = mr.allocate(size1);
+  auto allocated_bytes = size1;
+  EXPECT_EQ(mr.get_allocated_bytes(), allocated_bytes);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), max_size - allocated_bytes);
+  auto* ptr2 = mr.allocate(size1);
+  allocated_bytes += size1;
+  EXPECT_EQ(mr.get_allocated_bytes(), allocated_bytes);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), max_size - allocated_bytes);
+  mr.deallocate(ptr1, size1);
+  allocated_bytes -= size1;
+  EXPECT_EQ(mr.get_allocated_bytes(), allocated_bytes);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), max_size - allocated_bytes);
   // note that we don't keep track of fragmentation or things like page size
   // so this should fill 100% of the memory even though it is probably over.
-  EXPECT_NO_THROW(mr.allocate(6_MiB));
-  EXPECT_EQ(mr.get_allocated_bytes(), 10_MiB);
+  auto const size2{6_MiB};
+  auto* ptr3 = mr.allocate(size2);
+  allocated_bytes += size2;
+  EXPECT_EQ(mr.get_allocated_bytes(), allocated_bytes);
   EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 0);
-  mr.deallocate(p2, 4_MiB);
+  mr.deallocate(ptr2, size1);
+  mr.deallocate(ptr3, size2);
 }
 
 TEST(LimitingTest, OverLimit)
 {
-  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), 10_MiB};
-  auto p1 = mr.allocate(4_MiB);
-  EXPECT_EQ(mr.get_allocated_bytes(), 4_MiB);
-  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 6_MiB);
-  auto p2 = mr.allocate(4_MiB);
-  EXPECT_EQ(mr.get_allocated_bytes(), 8_MiB);
-  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 2_MiB);
-  EXPECT_THROW(mr.allocate(3_MiB), rmm::bad_alloc);
-  EXPECT_EQ(mr.get_allocated_bytes(), 8_MiB);
-  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), 2_MiB);
-  mr.deallocate(p1, 4_MiB);
-  mr.deallocate(p2, 4_MiB);
+  auto const max_size{10_MiB};
+  Limiting_adaptor mr{rmm::mr::get_current_device_resource(), max_size};
+  auto const size1{4_MiB};
+  auto* ptr1           = mr.allocate(size1);
+  auto allocated_bytes = size1;
+  EXPECT_EQ(mr.get_allocated_bytes(), allocated_bytes);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), max_size - allocated_bytes);
+  auto* ptr2 = mr.allocate(size1);
+  allocated_bytes += size1;
+  EXPECT_EQ(mr.get_allocated_bytes(), allocated_bytes);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), max_size - allocated_bytes);
+  auto const size2{3_MiB};
+  EXPECT_THROW(mr.allocate(size2), rmm::bad_alloc);
+  EXPECT_EQ(mr.get_allocated_bytes(), allocated_bytes);
+  EXPECT_EQ(mr.get_allocation_limit() - mr.get_allocated_bytes(), max_size - allocated_bytes);
+  mr.deallocate(ptr1, 4_MiB);
+  mr.deallocate(ptr2, 4_MiB);
 }
 
 }  // namespace
-}  // namespace test
-}  // namespace rmm
+}  // namespace rmm::test

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -100,13 +100,14 @@ inline void test_allocate(rmm::mr::device_memory_resource* mr,
 inline void concurrent_allocations_are_different(rmm::mr::device_memory_resource* mr,
                                                  cuda_stream_view stream)
 {
-  void* p1 = mr->allocate(8_B, stream);
-  void* p2 = mr->allocate(8_B, stream);
+  const auto size{8_B};
+  void* ptr1 = mr->allocate(size, stream);
+  void* ptr2 = mr->allocate(size, stream);
 
-  EXPECT_NE(p1, p2);
+  EXPECT_NE(ptr1, ptr2);
 
-  mr->deallocate(p1, 8_B, stream);
-  mr->deallocate(p2, 8_B, stream);
+  mr->deallocate(ptr1, size, stream);
+  mr->deallocate(ptr2, size, stream);
 }
 
 inline void test_various_allocations(rmm::mr::device_memory_resource* mr, cuda_stream_view stream)

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <gtest/gtest.h>
+#include "../../byte_literals.hpp"
 
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
@@ -30,6 +30,8 @@
 #include <rmm/mr/device/owning_wrapper.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
+
+#include <gtest/gtest.h>
 
 #include <cuda_runtime_api.h>
 
@@ -60,14 +62,6 @@ inline bool is_device_memory(void* p)
   return (attributes.type == cudaMemoryTypeDevice) or (attributes.type == cudaMemoryTypeManaged);
 #endif
 }
-
-// some useful allocation sizes
-constexpr long operator""_B(unsigned long long const x) { return x; }
-constexpr long operator""_KiB(unsigned long long const x) { return x * (long{1} << 10); }
-constexpr long operator""_MiB(unsigned long long const x) { return x * (long{1} << 20); }
-constexpr long operator""_GiB(unsigned long long const x) { return x * (long{1} << 30); }
-constexpr long operator""_TiB(unsigned long long const x) { return x * (long{1} << 40); }
-constexpr long operator""_PiB(unsigned long long const x) { return x * (long{1} << 50); }
 
 struct allocation {
   void* p{nullptr};

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -20,21 +20,20 @@
 
 #include <gtest/gtest.h>
 
-namespace rmm {
-namespace test {
+namespace rmm::test {
 namespace {
 
-INSTANTIATE_TEST_CASE_P(ResourceTests,
-                        mr_test,
-                        ::testing::Values(mr_factory{"CUDA", &make_cuda},
+INSTANTIATE_TEST_SUITE_P(ResourceTests,
+                         mr_test,
+                         ::testing::Values(mr_factory{"CUDA", &make_cuda},
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
-                                          mr_factory{"CUDA_Async", &make_cuda_async},
+                                           mr_factory{"CUDA_Async", &make_cuda_async},
 #endif
-                                          mr_factory{"Managed", &make_managed},
-                                          mr_factory{"Pool", &make_pool},
-                                          mr_factory{"Arena", &make_arena},
-                                          mr_factory{"Binning", &make_binning}),
-                        [](auto const& info) { return info.param.name; });
+                                           mr_factory{"Managed", &make_managed},
+                                           mr_factory{"Pool", &make_pool},
+                                           mr_factory{"Arena", &make_arena},
+                                           mr_factory{"Binning", &make_binning}),
+                         [](auto const& info) { return info.param.name; });
 
 TEST(DefaultTest, CurrentDeviceResourceIsCUDA)
 {
@@ -46,8 +45,7 @@ TEST(DefaultTest, UseCurrentDeviceResource) { test_get_current_device_resource()
 
 TEST(DefaultTest, GetCurrentDeviceResource)
 {
-  rmm::mr::device_memory_resource* mr;
-  EXPECT_NO_THROW(mr = rmm::mr::get_current_device_resource());
+  auto* mr = rmm::mr::get_current_device_resource();
   EXPECT_NE(nullptr, mr);
   EXPECT_TRUE(mr->is_equal(rmm::mr::cuda_memory_resource{}));
 }
@@ -84,17 +82,17 @@ TEST_P(mr_test, RandomAllocations) { test_random_allocations(this->mr.get()); }
 
 TEST_P(mr_test, RandomAllocationsStream)
 {
-  test_random_allocations(this->mr.get(), 100, 5_MiB, this->stream);
+  test_random_allocations(this->mr.get(), default_num_allocations, default_max_size, this->stream);
 }
 
 TEST_P(mr_test, MixedRandomAllocationFree)
 {
-  test_mixed_random_allocation_free(this->mr.get(), 5_MiB, cuda_stream_view{});
+  test_mixed_random_allocation_free(this->mr.get(), default_max_size, cuda_stream_view{});
 }
 
 TEST_P(mr_test, MixedRandomAllocationFreeStream)
 {
-  test_mixed_random_allocation_free(this->mr.get(), 5_MiB, this->stream);
+  test_mixed_random_allocation_free(this->mr.get(), default_max_size, this->stream);
 }
 
 TEST_P(mr_test, GetMemInfo)
@@ -102,7 +100,7 @@ TEST_P(mr_test, GetMemInfo)
   if (this->mr->supports_get_mem_info()) {
     std::pair<std::size_t, std::size_t> mem_info;
     EXPECT_NO_THROW(mem_info = this->mr->get_mem_info(rmm::cuda_stream_view{}));
-    std::size_t allocation_size = 16 * 256;
+    const auto allocation_size{16 * 256};
     void* ptr{nullptr};
     EXPECT_NO_THROW(ptr = this->mr->allocate(allocation_size));
     EXPECT_NO_THROW(mem_info = this->mr->get_mem_info(rmm::cuda_stream_view{}));
@@ -111,5 +109,4 @@ TEST_P(mr_test, GetMemInfo)
   }
 }
 }  // namespace
-}  // namespace test
-}  // namespace rmm
+}  // namespace rmm::test

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -109,14 +109,20 @@ TEST_P(mr_test, MixedRandomAllocationFreeStream)
 TEST_P(mr_test, GetMemInfo)
 {
   if (this->mr->supports_get_mem_info()) {
-    this->mr->get_mem_info(rmm::cuda_stream_view{});
     const auto allocation_size{16 * 256};
-    void* ptr{nullptr};
-    ptr = this->mr->allocate(allocation_size);
     {
       auto const [free, total] = this->mr->get_mem_info(rmm::cuda_stream_view{});
       EXPECT_TRUE(free >= allocation_size);
     }
+
+    void* ptr{nullptr};
+    ptr = this->mr->allocate(allocation_size);
+
+    {
+      auto const [free, total] = this->mr->get_mem_info(rmm::cuda_stream_view{});
+      EXPECT_TRUE(free >= allocation_size);
+    }
+
     this->mr->deallocate(ptr, allocation_size);
   }
 }

--- a/tests/mr/device/polymorphic_allocator_tests.cpp
+++ b/tests/mr/device/polymorphic_allocator_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ TEST_F(allocator_test, custom_resource)
   EXPECT_EQ(allocator.resource(), &mr);
 }
 
-void test_conversion(rmm::mr::polymorphic_allocator<int>) {}
+void test_conversion(rmm::mr::polymorphic_allocator<int> /*unused*/) {}
+
 TEST_F(allocator_test, implicit_conversion)
 {
   rmm::mr::cuda_memory_resource mr;
@@ -106,9 +107,10 @@ TEST_F(allocator_test, rebind)
 TEST_F(allocator_test, allocate_deallocate)
 {
   rmm::mr::polymorphic_allocator<int> allocator{};
-  auto p = allocator.allocate(1000, stream);
-  EXPECT_NE(p, nullptr);
-  EXPECT_NO_THROW(allocator.deallocate(p, 1000, stream));
+  const auto size{1000};
+  auto* ptr = allocator.allocate(size, stream);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_NO_THROW(allocator.deallocate(ptr, size, stream));
 }
 
 }  // namespace

--- a/tests/mr/device/stream_allocator_adaptor_tests.cpp
+++ b/tests/mr/device/stream_allocator_adaptor_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-#include <memory>
-
-#include <gtest/gtest.h>
 #include <rmm/cuda_stream.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/polymorphic_allocator.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
 
 namespace {
 
@@ -34,7 +35,7 @@ TEST_F(allocator_test, factory)
 {
   using Adaptor = rmm::mr::stream_allocator_adaptor<decltype(allocator)>;
   auto adapted  = rmm::mr::make_stream_allocator_adaptor(allocator, stream);
-  static_assert((std::is_same<decltype(adapted), Adaptor>::value), "");
+  static_assert((std::is_same<decltype(adapted), Adaptor>::value));
   EXPECT_EQ(adapted.underlying_allocator(), allocator);
   EXPECT_EQ(adapted.stream(), stream);
 }
@@ -97,21 +98,21 @@ TEST_F(allocator_test, rebind)
 {
   auto adapted  = rmm::mr::make_stream_allocator_adaptor(allocator, stream);
   using Rebound = std::allocator_traits<decltype(adapted)>::rebind_alloc<double>;
-  static_assert((std::is_same<std::allocator_traits<Rebound>::value_type, double>::value), "");
+  static_assert((std::is_same<std::allocator_traits<Rebound>::value_type, double>::value));
   static_assert(
     std::is_same<Rebound,
-                 rmm::mr::stream_allocator_adaptor<rmm::mr::polymorphic_allocator<double>>>::value,
-    "");
+                 rmm::mr::stream_allocator_adaptor<rmm::mr::polymorphic_allocator<double>>>::value);
 
-  Rebound r{adapted};
+  Rebound rebound{adapted};
 }
 
 TEST_F(allocator_test, allocate_deallocate)
 {
   auto adapted = rmm::mr::make_stream_allocator_adaptor(allocator, stream);
-  auto p       = adapted.allocate(1000);
-  EXPECT_NE(p, nullptr);
-  EXPECT_NO_THROW(adapted.deallocate(p, 1000));
+  auto const size{1000};
+  auto* ptr = adapted.allocate(size);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_NO_THROW(adapted.deallocate(ptr, size));
 }
 
 }  // namespace

--- a/tests/mr/device/thrust_allocator_tests.cu
+++ b/tests/mr/device/thrust_allocator_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <rmm/device_vector.hpp>
-#include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 #include "mr_test.hpp"
 
-namespace rmm {
-namespace test {
+#include <rmm/device_vector.hpp>
+#include <rmm/mr/device/thrust_allocator_adaptor.hpp>
+
+#include <gtest/gtest.h>
+
+namespace rmm::test {
 namespace {
 
 struct allocator_test : public mr_test {
@@ -28,8 +29,9 @@ struct allocator_test : public mr_test {
 
 TEST_P(allocator_test, first)
 {
-  rmm::device_vector<int> ints(100, 1);
-  EXPECT_EQ(100, thrust::reduce(ints.begin(), ints.end()));
+  auto const num_ints{100};
+  rmm::device_vector<int> ints(num_ints, 1);
+  EXPECT_EQ(num_ints, thrust::reduce(ints.begin(), ints.end()));
 }
 
 INSTANTIATE_TEST_CASE_P(ThrustAllocatorTests,
@@ -39,6 +41,6 @@ INSTANTIATE_TEST_CASE_P(ThrustAllocatorTests,
                                           mr_factory{"Pool", &make_pool},
                                           mr_factory{"Binning", &make_binning}),
                         [](auto const& info) { return info.param.name; });
+
 }  // namespace
-}  // namespace test
-}  // namespace rmm
+}  // namespace rmm::test

--- a/tests/mr/device/tracking_mr_tests.cpp
+++ b/tests/mr/device/tracking_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
+#include "../../byte_literals.hpp"
+
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/tracking_resource_adaptor.hpp>
-#include "mr_test.hpp"
 
 #include <gtest/gtest.h>
 
-namespace rmm {
-namespace test {
+namespace rmm::test {
 namespace {
 
 using tracking_adaptor = rmm::mr::tracking_resource_adaptor<rmm::mr::device_memory_resource>;
+
+constexpr auto num_allocations{10};
+constexpr auto num_more_allocations{5};
+constexpr auto ten_MiB{10_MiB};
 
 TEST(TrackingTest, ThrowOnNullUpstream)
 {
@@ -45,11 +49,12 @@ TEST(TrackingTest, AllFreed)
 {
   tracking_adaptor mr{rmm::mr::get_current_device_resource()};
   std::vector<void*> allocations;
-  for (int i = 0; i < 10; ++i) {
-    allocations.push_back(mr.allocate(10_MiB));
+  allocations.reserve(num_allocations);
+  for (int i = 0; i < num_allocations; ++i) {
+    allocations.push_back(mr.allocate(ten_MiB));
   }
-  for (auto p : allocations) {
-    mr.deallocate(p, 10_MiB);
+  for (auto* alloc : allocations) {
+    mr.deallocate(alloc, ten_MiB);
   }
   EXPECT_EQ(mr.get_outstanding_allocations().size(), 0);
   EXPECT_EQ(mr.get_allocated_bytes(), 0);
@@ -59,16 +64,17 @@ TEST(TrackingTest, AllocationsLeftWithStacks)
 {
   tracking_adaptor mr{rmm::mr::get_current_device_resource(), true};
   std::vector<void*> allocations;
-  for (int i = 0; i < 10; ++i) {
-    allocations.push_back(mr.allocate(10_MiB));
+  allocations.reserve(num_allocations);
+  for (int i = 0; i < num_allocations; ++i) {
+    allocations.push_back(mr.allocate(ten_MiB));
   }
-  for (int i = 0; i < 10; i += 2) {
-    mr.deallocate(allocations[i], 10_MiB);
+  for (int i = 0; i < num_allocations; i += 2) {
+    mr.deallocate(allocations[i], ten_MiB);
   }
-  EXPECT_EQ(mr.get_outstanding_allocations().size(), 5);
-  EXPECT_EQ(mr.get_allocated_bytes(), 50_MiB);
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations / 2);
+  EXPECT_EQ(mr.get_allocated_bytes(), ten_MiB * (num_allocations / 2));
   auto const& outstanding_allocations = mr.get_outstanding_allocations();
-  EXPECT_EQ(outstanding_allocations.size(), 5);
+  EXPECT_EQ(outstanding_allocations.size(), num_allocations / 2);
   EXPECT_NE(outstanding_allocations.begin()->second.strace, nullptr);
 }
 
@@ -76,16 +82,18 @@ TEST(TrackingTest, AllocationsLeftWithoutStacks)
 {
   tracking_adaptor mr{rmm::mr::get_current_device_resource()};
   std::vector<void*> allocations;
-  for (int i = 0; i < 10; ++i) {
-    allocations.push_back(mr.allocate(10_MiB));
+  allocations.reserve(num_allocations);
+  for (int i = 0; i < num_allocations; ++i) {
+    allocations.push_back(mr.allocate(ten_MiB));
   }
-  for (int i = 0; i < 10; i += 2) {
-    mr.deallocate(allocations[i], 10_MiB);
+
+  for (int i = 0; i < num_allocations; i += 2) {
+    mr.deallocate(allocations[i], ten_MiB);
   }
-  EXPECT_EQ(mr.get_outstanding_allocations().size(), 5);
-  EXPECT_EQ(mr.get_allocated_bytes(), 50_MiB);
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations / 2);
+  EXPECT_EQ(mr.get_allocated_bytes(), ten_MiB * (num_allocations / 2));
   auto const& outstanding_allocations = mr.get_outstanding_allocations();
-  EXPECT_EQ(outstanding_allocations.size(), 5);
+  EXPECT_EQ(outstanding_allocations.size(), num_allocations / 2);
   EXPECT_EQ(outstanding_allocations.begin()->second.strace, nullptr);
 }
 
@@ -95,27 +103,27 @@ TEST(TrackingTest, MultiTracking)
   rmm::mr::set_current_device_resource(&mr);
 
   std::vector<std::shared_ptr<rmm::device_buffer>> allocations;
-  for (std::size_t i = 0; i < 10; ++i) {
+  for (std::size_t i = 0; i < num_allocations; ++i) {
     allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(10_MiB, rmm::cuda_stream_default));
+      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default));
   }
 
-  EXPECT_EQ(mr.get_outstanding_allocations().size(), 10);
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations);
 
   tracking_adaptor inner_mr{rmm::mr::get_current_device_resource()};
   rmm::mr::set_current_device_resource(&inner_mr);
 
-  for (std::size_t i = 0; i < 5; ++i) {
+  for (std::size_t i = 0; i < num_more_allocations; ++i) {
     allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(10_MiB, rmm::cuda_stream_default));
+      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default));
   }
 
   // Check the allocated bytes for both MRs
-  EXPECT_EQ(mr.get_outstanding_allocations().size(), 15);
-  EXPECT_EQ(inner_mr.get_outstanding_allocations().size(), 5);
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations + num_more_allocations);
+  EXPECT_EQ(inner_mr.get_outstanding_allocations().size(), num_more_allocations);
 
-  EXPECT_EQ(mr.get_allocated_bytes(), 150_MiB);
-  EXPECT_EQ(inner_mr.get_allocated_bytes(), 50_MiB);
+  EXPECT_EQ(mr.get_allocated_bytes(), ten_MiB * (num_allocations + num_more_allocations));
+  EXPECT_EQ(inner_mr.get_allocated_bytes(), ten_MiB * num_more_allocations);
 
   EXPECT_GT(mr.get_outstanding_allocations_str().size(), 0);
 
@@ -140,26 +148,26 @@ TEST(TrackingTest, NegativeInnerTracking)
   // memory pointer
   tracking_adaptor mr{rmm::mr::get_current_device_resource()};
   std::vector<void*> allocations;
-  for (std::size_t i = 0; i < 10; ++i) {
-    allocations.push_back(mr.allocate(10_MiB));
+  for (std::size_t i = 0; i < num_allocations; ++i) {
+    allocations.push_back(mr.allocate(ten_MiB));
   }
 
-  EXPECT_EQ(mr.get_outstanding_allocations().size(), 10);
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations);
 
   tracking_adaptor inner_mr{&mr};
 
   // Add more allocations
-  for (std::size_t i = 0; i < 5; ++i) {
-    allocations.push_back(inner_mr.allocate(10_MiB));
+  for (std::size_t i = 0; i < num_more_allocations; ++i) {
+    allocations.push_back(inner_mr.allocate(ten_MiB));
   }
 
   // Check the outstanding allocations
-  EXPECT_EQ(mr.get_outstanding_allocations().size(), 15);
-  EXPECT_EQ(inner_mr.get_outstanding_allocations().size(), 5);
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations + num_more_allocations);
+  EXPECT_EQ(inner_mr.get_outstanding_allocations().size(), num_more_allocations);
 
   // Deallocate all allocations using the inner_mr
-  for (std::size_t i = 0; i < allocations.size(); ++i) {
-    inner_mr.deallocate(allocations[i], 10_MiB);
+  for (auto& allocation : allocations) {
+    inner_mr.deallocate(allocation, ten_MiB);
   }
   allocations.clear();
 
@@ -172,13 +180,13 @@ TEST(TrackingTest, DeallocWrongBytes)
 {
   tracking_adaptor mr{rmm::mr::get_current_device_resource()};
   std::vector<void*> allocations;
-  for (std::size_t i = 0; i < 10; ++i) {
-    allocations.push_back(mr.allocate(10_MiB));
+  for (std::size_t i = 0; i < num_allocations; ++i) {
+    allocations.push_back(mr.allocate(ten_MiB));
   }
 
   // When deallocating, pass the wrong bytes to deallocate
-  for (std::size_t i = 0; i < allocations.size(); ++i) {
-    mr.deallocate(allocations[i], 5_MiB);
+  for (auto& allocation : allocations) {
+    mr.deallocate(allocation, ten_MiB / 2);
   }
   allocations.clear();
 
@@ -190,5 +198,4 @@ TEST(TrackingTest, DeallocWrongBytes)
 }
 
 }  // namespace
-}  // namespace test
-}  // namespace rmm
+}  // namespace rmm::test

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -158,10 +158,9 @@ TYPED_TEST(MRTest, RandomAllocations)
       EXPECT_TRUE(is_aligned(alloc.ptr));
     });
 
-  std::for_each(
-    allocations.begin(), allocations.end(), [generator, distribution, this](allocation& alloc) {
-      EXPECT_NO_THROW(this->mr->deallocate(alloc.ptr, alloc.size));
-    });
+  std::for_each(allocations.begin(), allocations.end(), [this](allocation& alloc) {
+    EXPECT_NO_THROW(this->mr->deallocate(alloc.ptr, alloc.size));
+  });
 }
 
 TYPED_TEST(MRTest, MixedRandomAllocationFree)

--- a/tests/mr/host/mr_tests.cpp
+++ b/tests/mr/host/mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,36 +14,33 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include "../../byte_literals.hpp"
 
+#include <rmm/detail/aligned.hpp>
 #include <rmm/mr/host/host_memory_resource.hpp>
 #include <rmm/mr/host/new_delete_resource.hpp>
 #include <rmm/mr/host/pinned_memory_resource.hpp>
 
 #include <cuda_runtime_api.h>
+
+#include <gtest/gtest.h>
+
 #include <cstddef>
 #include <deque>
 #include <random>
 
+namespace rmm::test {
 namespace {
-inline bool is_aligned(void* p, std::size_t alignment = alignof(std::max_align_t))
+inline bool is_aligned(void* ptr, std::size_t alignment = alignof(std::max_align_t))
 {
-  return (0 == reinterpret_cast<uintptr_t>(p) % alignment);
+  return rmm::detail::is_pointer_aligned(ptr, alignment);
 }
 
-inline void expect_aligned(void* p, std::size_t alignment)
-{
-  EXPECT_EQ(0, reinterpret_cast<uintptr_t>(p) % alignment);
-}
-
-/**---------------------------------------------------------------------------*
- * @brief Returns if a pointer points to a device memory or managed memory
- * allocation.
- *---------------------------------------------------------------------------**/
-inline bool is_device_memory(void* p)
+// Returns true if a pointer points to a device memory or managed memory allocation.
+inline bool is_device_memory(void* ptr)
 {
   cudaPointerAttributes attributes{};
-  if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) { return false; }
+  if (cudaSuccess != cudaPointerGetAttributes(&attributes, ptr)) { return false; }
 #if CUDART_VERSION < 10000  // memoryType is deprecated in CUDA 10
   return attributes.memoryType == cudaMemoryTypeDevice;
 #else
@@ -54,24 +51,23 @@ inline bool is_device_memory(void* p)
 /**
  * @brief Returns if a pointer `p` points to pinned host memory.
  */
-inline bool is_pinned_memory(void* p)
+inline bool is_pinned_memory(void* ptr)
 {
   cudaPointerAttributes attributes{};
-  if (cudaSuccess != cudaPointerGetAttributes(&attributes, p)) { return false; }
+  if (cudaSuccess != cudaPointerGetAttributes(&attributes, ptr)) { return false; }
   return attributes.type == cudaMemoryTypeHost;
 }
 
-static constexpr std::size_t size_word{4};
-static constexpr std::size_t size_kb{std::size_t{1} << 10};
-static constexpr std::size_t size_mb{std::size_t{1} << 20};
-static constexpr std::size_t size_gb{std::size_t{1} << 30};
-static constexpr std::size_t size_tb{std::size_t{1} << 40};
-static constexpr std::size_t size_pb{std::size_t{1} << 50};
+constexpr std::size_t size_word{4_B};
+constexpr std::size_t size_kb{1_KiB};
+constexpr std::size_t size_mb{1_MiB};
+constexpr std::size_t size_gb{1_GiB};
+constexpr std::size_t size_pb{1_PiB};
 
 struct allocation {
-  void* p{nullptr};
+  void* ptr{nullptr};
   std::size_t size{0};
-  allocation(void* _p, std::size_t _size) : p{_p}, size{_size} {}
+  allocation(void* ptr, std::size_t size) : ptr{ptr}, size{size} {}
   allocation() = default;
 };
 }  // namespace
@@ -81,7 +77,6 @@ struct MRTest : public ::testing::Test {
   std::unique_ptr<rmm::mr::host_memory_resource> mr;
 
   MRTest() : mr{new MemoryResourceType} {}
-  ~MRTest() = default;
 };
 
 using resources = ::testing::Types<rmm::mr::new_delete_resource, rmm::mr::pinned_memory_resource>;
@@ -92,56 +87,56 @@ TYPED_TEST(MRTest, SelfEquality) { EXPECT_TRUE(this->mr->is_equal(*this->mr)); }
 
 TYPED_TEST(MRTest, AllocateZeroBytes)
 {
-  void* p{nullptr};
-  EXPECT_NO_THROW(p = this->mr->allocate(0));
-  EXPECT_NO_THROW(this->mr->deallocate(p, 0));
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = this->mr->allocate(0));
+  EXPECT_NO_THROW(this->mr->deallocate(ptr, 0));
 }
 
 TYPED_TEST(MRTest, AllocateWord)
 {
-  void* p{nullptr};
-  EXPECT_NO_THROW(p = this->mr->allocate(size_word));
-  EXPECT_NE(nullptr, p);
-  EXPECT_TRUE(is_aligned(p));
-  EXPECT_FALSE(is_device_memory(p));
-  EXPECT_NO_THROW(this->mr->deallocate(p, size_word));
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = this->mr->allocate(size_word));
+  EXPECT_NE(nullptr, ptr);
+  EXPECT_TRUE(is_aligned(ptr));
+  EXPECT_FALSE(is_device_memory(ptr));
+  EXPECT_NO_THROW(this->mr->deallocate(ptr, size_word));
 }
 
 TYPED_TEST(MRTest, AllocateKB)
 {
-  void* p{nullptr};
-  EXPECT_NO_THROW(p = this->mr->allocate(size_kb));
-  EXPECT_NE(nullptr, p);
-  EXPECT_TRUE(is_aligned(p));
-  EXPECT_FALSE(is_device_memory(p));
-  EXPECT_NO_THROW(this->mr->deallocate(p, size_kb));
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = this->mr->allocate(size_kb));
+  EXPECT_NE(nullptr, ptr);
+  EXPECT_TRUE(is_aligned(ptr));
+  EXPECT_FALSE(is_device_memory(ptr));
+  EXPECT_NO_THROW(this->mr->deallocate(ptr, size_kb));
 }
 
 TYPED_TEST(MRTest, AllocateMB)
 {
-  void* p{nullptr};
-  EXPECT_NO_THROW(p = this->mr->allocate(size_mb));
-  EXPECT_NE(nullptr, p);
-  EXPECT_TRUE(is_aligned(p));
-  EXPECT_FALSE(is_device_memory(p));
-  EXPECT_NO_THROW(this->mr->deallocate(p, size_mb));
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = this->mr->allocate(size_mb));
+  EXPECT_NE(nullptr, ptr);
+  EXPECT_TRUE(is_aligned(ptr));
+  EXPECT_FALSE(is_device_memory(ptr));
+  EXPECT_NO_THROW(this->mr->deallocate(ptr, size_mb));
 }
 
 TYPED_TEST(MRTest, AllocateGB)
 {
-  void* p{nullptr};
-  EXPECT_NO_THROW(p = this->mr->allocate(size_gb));
-  EXPECT_NE(nullptr, p);
-  EXPECT_TRUE(is_aligned(p));
-  EXPECT_FALSE(is_device_memory(p));
-  EXPECT_NO_THROW(this->mr->deallocate(p, size_gb));
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = this->mr->allocate(size_gb));
+  EXPECT_NE(nullptr, ptr);
+  EXPECT_TRUE(is_aligned(ptr));
+  EXPECT_FALSE(is_device_memory(ptr));
+  EXPECT_NO_THROW(this->mr->deallocate(ptr, size_gb));
 }
 
 TYPED_TEST(MRTest, AllocateTooMuch)
 {
-  void* p{nullptr};
-  EXPECT_THROW(p = this->mr->allocate(size_pb), std::bad_alloc);
-  EXPECT_EQ(nullptr, p);
+  void* ptr{nullptr};
+  EXPECT_THROW(ptr = this->mr->allocate(size_pb), std::bad_alloc);
+  EXPECT_EQ(nullptr, ptr);
 }
 
 TYPED_TEST(MRTest, RandomAllocations)
@@ -156,16 +151,16 @@ TYPED_TEST(MRTest, RandomAllocations)
 
   // 100 allocations from [0,5MB)
   std::for_each(
-    allocations.begin(), allocations.end(), [&generator, &distribution, this](allocation& a) {
-      a.size = distribution(generator);
-      EXPECT_NO_THROW(a.p = this->mr->allocate(a.size));
-      EXPECT_NE(nullptr, a.p);
-      EXPECT_TRUE(is_aligned(a.p));
+    allocations.begin(), allocations.end(), [&generator, &distribution, this](allocation& alloc) {
+      alloc.size = distribution(generator);
+      EXPECT_NO_THROW(alloc.ptr = this->mr->allocate(alloc.size));
+      EXPECT_NE(nullptr, alloc.ptr);
+      EXPECT_TRUE(is_aligned(alloc.ptr));
     });
 
   std::for_each(
-    allocations.begin(), allocations.end(), [generator, distribution, this](allocation& a) {
-      EXPECT_NO_THROW(this->mr->deallocate(a.p, a.size));
+    allocations.begin(), allocations.end(), [generator, distribution, this](allocation& alloc) {
+      EXPECT_NO_THROW(this->mr->deallocate(alloc.ptr, alloc.size));
     });
 }
 
@@ -189,30 +184,27 @@ TYPED_TEST(MRTest, MixedRandomAllocationFree)
     std::size_t allocation_size = size_distribution(generator);
     EXPECT_NO_THROW(allocations.emplace_back(this->mr->allocate(allocation_size), allocation_size));
     auto new_allocation = allocations.back();
-    EXPECT_NE(nullptr, new_allocation.p);
-    EXPECT_TRUE(is_aligned(new_allocation.p));
+    EXPECT_NE(nullptr, new_allocation.ptr);
+    EXPECT_TRUE(is_aligned(new_allocation.ptr));
 
     bool const free_front{free_distribution(generator) == free_distribution.max()};
 
     if (free_front) {
       auto front = allocations.front();
-      EXPECT_NO_THROW(this->mr->deallocate(front.p, front.size));
+      EXPECT_NO_THROW(this->mr->deallocate(front.ptr, front.size));
       allocations.pop_front();
     }
   }
   // free any remaining allocations
-  for (auto a : allocations) {
-    EXPECT_NO_THROW(this->mr->deallocate(a.p, a.size));
+  for (auto alloc : allocations) {
+    EXPECT_NO_THROW(this->mr->deallocate(alloc.ptr, alloc.size));
     allocations.pop_front();
   }
 }
 
-static constexpr std::size_t MinTestedSize             = 32;
-static constexpr std::size_t MaxTestedSize             = 8 * 1024;
-static constexpr std::size_t TestedSizeStep            = 1;
-static constexpr std::size_t MinTestedAlignment        = 16;
-static constexpr std::size_t MaxTestedAlignment        = 4 * 1024;
-static constexpr std::size_t TestedAlignmentMultiplier = 2;
+static constexpr std::size_t MinTestedAlignment{16};
+static constexpr std::size_t MaxTestedAlignment{4096};
+static constexpr std::size_t TestedAlignmentMultiplier{2};
 static constexpr std::size_t NUM_TRIALS{100};
 
 TYPED_TEST(MRTest, AlignmentTest)
@@ -248,7 +240,7 @@ TYPED_TEST(MRTest, UnsupportedAlignmentTest)
       // alignment of `alignof(std::max_align_t)`
       auto const bad_alignment = alignment + 1;
       EXPECT_NO_THROW(ptr = this->mr->allocate(allocation_size, bad_alignment));
-      expect_aligned(ptr, alignof(std::max_align_t));
+      EXPECT_TRUE(is_aligned(ptr, alignof(std::max_align_t)));
       EXPECT_NO_THROW(this->mr->deallocate(ptr, allocation_size, bad_alignment));
     }
   }
@@ -257,8 +249,9 @@ TYPED_TEST(MRTest, UnsupportedAlignmentTest)
 TEST(PinnedResource, isPinned)
 {
   rmm::mr::pinned_memory_resource mr;
-  void* p{nullptr};
-  EXPECT_NO_THROW(p = mr.allocate(100));
-  EXPECT_TRUE(is_pinned_memory(p));
-  EXPECT_NO_THROW(mr.deallocate(p, 100));
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = mr.allocate(100));
+  EXPECT_TRUE(is_pinned_memory(ptr));
+  EXPECT_NO_THROW(mr.deallocate(ptr, 100));
 }
+}  // namespace rmm::test


### PR DESCRIPTION
Adds a .clang-tidy configuration file.   This does not add CI tests yet, but I wanted to get it ready to do so without forcing it on anyone. As-is, this PR will enable clang-tidy "yellow squiggles" if you use clangd in vscode.

Starting with these Checks:

```
Checks:          'clang-diagnostic-*,
                  clang-analyzer-*,
                  cppcoreguidelines-*,
                  modernize-*,
                  bugprone-*,
                  performance-*,
                  readability-*,
                  llvm-*,
                  -modernize-use-trailing-return-type'
``` 

Here is a list of warnings fixed

* readability-identifier-length
* cppcoreguidelines-special-member-functions
* modernize-use-nodiscard
* modernize-use-nullptr
* cppcoreguidelines-pro-type-cstyle-cast (ignore locally for CUDA-defined stream constants)
* performance-noexcept-move-constructor
* readability-function-cognitive-complexity
* readability-qualified-auto
* modernize-concat-nested-namespaces
* readability-isolate-declaration
* readability-redundant-member-init
* modernize-use-override
* modernize-avoid-c-arrays
* cppcoreguidelines-pro-bounds-array-to-pointer-decay
* cppcoreguidelines-pro-bounds-constant-array-index
* bugprone-narrowing-conversions
* readability-implicit-bool-conversion
* readability-redundant-smartptr-get
* llvm-else-after-return
* readability-uppercase-literal-suffix
* readability-braces-around-statements
* cppcoreguidelines-avoid-magic-numbers
* performance-unnecessary-value-param
* bugprone-macro-parentheses
* performance-faster-string-find

NOLINT lines have been added where fixes are unavailable, such as with necessary pointer arithmetic or `reinterpret_cast` calls.

I have a private branch of google test which adds NOLINT lines to suppress warnings caused by gtest's code. I plan to make a PR for this.

There are still a couple of outstanding warnings having to do with "easily swappable parameters" (e.g. when a function takes two sizes.  Fixing these requires breaking API changes. Alternatively we could suppress them.)