### PR TITLE
Disable copy/move ctors and operator= from free_list classes

### DIFF
--- a/include/rmm/mr/device/detail/coalescing_free_list.hpp
+++ b/include/rmm/mr/device/detail/coalescing_free_list.hpp
@@ -171,6 +171,8 @@ struct coalescing_free_list : free_list<block> {
 
   coalescing_free_list(coalescing_free_list const&) = delete;
   coalescing_free_list& operator=(coalescing_free_list const&) = delete;
+  coalescing_free_list(coalescing_free_list&&)                 = delete;
+  coalescing_free_list& operator=(coalescing_free_list&&) = delete;
 
   /**
    * @brief Inserts a block into the `free_list` in the correct order, coalescing it with the

--- a/include/rmm/mr/device/detail/coalescing_free_list.hpp
+++ b/include/rmm/mr/device/detail/coalescing_free_list.hpp
@@ -169,6 +169,9 @@ struct coalescing_free_list : free_list<block> {
   coalescing_free_list()  = default;
   ~coalescing_free_list() = default;
 
+  coalescing_free_list(coalescing_free_list const&) = delete;
+  coalescing_free_list& operator=(coalescing_free_list const&) = delete;
+
   /**
    * @brief Inserts a block into the `free_list` in the correct order, coalescing it with the
    *        preceding and following blocks if either is contiguous.

--- a/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+++ b/include/rmm/mr/device/detail/fixed_size_free_list.hpp
@@ -31,6 +31,8 @@ struct fixed_size_free_list : free_list<block_base> {
 
   fixed_size_free_list(fixed_size_free_list const&) = delete;
   fixed_size_free_list& operator=(fixed_size_free_list const&) = delete;
+  fixed_size_free_list(fixed_size_free_list&&)                 = delete;
+  fixed_size_free_list& operator=(fixed_size_free_list&&) = delete;
 
   /**
    * @brief Construct a new free_list from range defined by input iterators

--- a/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+++ b/include/rmm/mr/device/detail/fixed_size_free_list.hpp
@@ -29,6 +29,9 @@ struct fixed_size_free_list : free_list<block_base> {
   fixed_size_free_list()  = default;
   ~fixed_size_free_list() = default;
 
+  fixed_size_free_list(fixed_size_free_list const&) = delete;
+  fixed_size_free_list& operator=(fixed_size_free_list const&) = delete;
+
   /**
    * @brief Construct a new free_list from range defined by input iterators
    *

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -63,6 +63,8 @@ class free_list {
 
   free_list(free_list const&) = delete;
   free_list& operator=(free_list const&) = delete;
+  free_list(free_list&&)                 = delete;
+  free_list& operator=(free_list&&) = delete;
 
   using block_type     = BlockType;
   using list_type      = ListType;

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -61,6 +61,9 @@ class free_list {
   free_list()          = default;
   virtual ~free_list() = default;
 
+  free_list(free_list const&) = delete;
+  free_list& operator=(free_list const&) = delete;
+
   using block_type     = BlockType;
   using list_type      = ListType;
   using size_type      = typename list_type::size_type;

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -164,7 +164,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
   void print_free_blocks() const
   {
     std::cout << "stream free blocks: ";
-    for (auto s : stream_free_blocks_) {
+    for (auto& s : stream_free_blocks_) {
       std::cout << "stream: " << s.first.stream << " event: " << s.first.event << " ";
       s.second.print();
       std::cout << std::endl;
@@ -311,7 +311,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
   block_type allocate_and_insert_remainder(block_type b, std::size_t size, free_list& blocks)
   {
     auto const [allocated, remainder] = this->underlying().allocate_from_block(b, size);
-    if (remainder.is_valid()) blocks.insert(remainder);
+    if (remainder.is_valid()) { blocks.insert(remainder); }
     return allocated;
   }
 
@@ -360,9 +360,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
    * stream/event than `stream_event`.
    *
    * If an appropriate block is found in a free list F associated with event E,
-   * `stream_event.stream` will be made to wait on event E. All other blocks in free list F will be
-   * moved to the free list associated with `stream_event.stream`. This results in coalescing with
-   * other blocks in that free list, hopefully reducing fragmentation.
+   * `stream_event.stream` will be made to wait on event E.
    *
    * @param size The requested size of the allocation.
    * @param stream_event The stream and associated event on which the allocation is being
@@ -380,7 +378,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
       ++next_it;  // Points to element after `it` to allow erasing `it` in the loop body
       auto other_event = it->first.event;
       if (other_event != stream_event.event) {
-        auto other_blocks = it->second;
+        free_list& other_blocks = it->second;
 
         block_type const b = [&]() {
           if (merge_first) {

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -103,6 +103,19 @@ inline void test_allocate(rmm::mr::device_memory_resource* mr,
   if (not stream.is_default()) stream.synchronize();
 }
 
+// Simple reproducer for https://github.com/rapidsai/rmm/issues/861
+inline void concurrent_allocations_are_different(rmm::mr::device_memory_resource* mr,
+                                                 cuda_stream_view stream)
+{
+  void* p1 = mr->allocate(8_B, stream);
+  void* p2 = mr->allocate(8_B, stream);
+
+  EXPECT_NE(p1, p2);
+
+  mr->deallocate(p1, 8_B, stream);
+  mr->deallocate(p2, 8_B, stream);
+}
+
 inline void test_various_allocations(rmm::mr::device_memory_resource* mr, cuda_stream_view stream)
 {
   // test allocating zero bytes on non-default stream


### PR DESCRIPTION
Fixes #861.

An implicit copy of `free_list` was being used instead of a reference, which led to duplicate allocations. This never manifested until after #851 because previously the locally modified copy of a free list was being merged into an MR-owned free list.  When we removed one of the places where we merged free lists, this copy resulted in the changes to free lists being lost. This only manifested in PTDS usage, but likely would also manifest in use cases with multiple non-default streams.