### PR TITLE
RMM shouldn't install thrust

### DIFF
--- a/cmake/thirdparty/get_thrust.cmake
+++ b/cmake/thirdparty/get_thrust.cmake
@@ -16,12 +16,10 @@
 function(find_and_configure_thrust)
 
   include(${rapids-cmake-dir}/cpm/thrust.cmake)
-  rapids_cpm_thrust(
-    NAMESPACE rmm)
+  rapids_cpm_thrust(NAMESPACE rmm)
 
-  # We don't list the export set information in rapids_cpm_thrust
-  # as we don't want to install Thrust as part of rmm install process.
-  # Doing so would stop consumers such as cudf from using patched
+  # We don't list the export set information in rapids_cpm_thrust as we don't want to install Thrust
+  # as part of rmm install process. Doing so would stop consumers such as cudf from using patched
   # versions, which they require for improved build times.
   rapids_export_package(BUILD Thrust rmm-exports)
   rapids_export_package(INSTALL Thrust rmm-exports)

--- a/cmake/thirdparty/get_thrust.cmake
+++ b/cmake/thirdparty/get_thrust.cmake
@@ -17,9 +17,14 @@ function(find_and_configure_thrust)
 
   include(${rapids-cmake-dir}/cpm/thrust.cmake)
   rapids_cpm_thrust(
-    NAMESPACE rmm
-    BUILD_EXPORT_SET rmm-exports
-    INSTALL_EXPORT_SET rmm-exports)
+    NAMESPACE rmm)
+
+  # We don't list the export set information in rapids_cpm_thrust
+  # as we don't want to install Thrust as part of rmm install process.
+  # Doing so would stop consumers such as cudf from using patched
+  # versions, which they require for improved build times.
+  rapids_export_package(BUILD Thrust rmm-exports)
+  rapids_export_package(INSTALL Thrust rmm-exports)
 
 endfunction()
 


### PR DESCRIPTION
When we merged https://github.com/rapidsai/rmm/pull/854 we enabled the installation of Thrust as part of RMM install. This causes downstream issues as projects like cuDF want to use a patched version to improve compile times.

Since RMM is header only we don't need to ensure our consumers use the same Thrust version, so we can skip installing it.
