### PR TITLE
Correct namespace usage in host memory resources

### DIFF
--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -51,13 +51,14 @@ class new_delete_resource final : public host_memory_resource {
    * @return Pointer to the newly allocated memory
    */
   void* do_allocate(std::size_t bytes,
-                    std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
+                    std::size_t alignment = rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
     // If the requested alignment isn't supported, use default
-    alignment =
-      (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
+    alignment = (rmm::detail::is_supported_alignment(alignment))
+                  ? alignment
+                  : rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
-    return detail::aligned_allocate(
+    return rmm::detail::aligned_allocate(
       bytes, alignment, [](std::size_t size) { return ::operator new(size); });
   }
 
@@ -78,9 +79,10 @@ class new_delete_resource final : public host_memory_resource {
    */
   void do_deallocate(void* ptr,
                      std::size_t bytes,
-                     std::size_t alignment = detail::RMM_DEFAULT_HOST_ALIGNMENT) override
+                     std::size_t alignment = rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
-    detail::aligned_deallocate(ptr, bytes, alignment, [](void* ptr) { ::operator delete(ptr); });
+    rmm::detail::aligned_deallocate(
+      ptr, bytes, alignment, [](void* ptr) { ::operator delete(ptr); });
   }
 };
 

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -58,10 +58,11 @@ class pinned_memory_resource final : public host_memory_resource {
     if (0 == bytes) { return nullptr; }
 
     // If the requested alignment isn't supported, use default
-    alignment =
-      (detail::is_supported_alignment(alignment)) ? alignment : detail::RMM_DEFAULT_HOST_ALIGNMENT;
+    alignment = (rmm::detail::is_supported_alignment(alignment))
+                  ? alignment
+                  : rmm::detail::RMM_DEFAULT_HOST_ALIGNMENT;
 
-    return detail::aligned_allocate(bytes, alignment, [](std::size_t size) {
+    return rmm::detail::aligned_allocate(bytes, alignment, [](std::size_t size) {
       void* ptr{nullptr};
       auto status = cudaMallocHost(&ptr, size);
       if (cudaSuccess != status) { throw std::bad_alloc{}; }
@@ -89,7 +90,7 @@ class pinned_memory_resource final : public host_memory_resource {
                      std::size_t alignment = alignof(std::max_align_t)) override
   {
     if (nullptr == ptr) { return; }
-    detail::aligned_deallocate(
+    rmm::detail::aligned_deallocate(
       ptr, bytes, alignment, [](void* ptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeHost(ptr)); });
   }
 };


### PR DESCRIPTION
Host memory resources were calling into detail as `detail::`, but due to relative namespacing, it was trying to look in `rmm::mr::host::detail::...`. Corrected these usages to `rmm::detail::...`