### PR TITLE
Add bindings for cuPointerGetAttribute

### DIFF
--- a/python/rmm/_cuda/10.1/gpu.pxi
+++ b/python/rmm/_cuda/10.1/gpu.pxi
@@ -380,6 +380,33 @@ cdef extern from "cuda.h" nogil:
     CUresult cuGetErrorName(CUresult error, const char** pStr)
     CUresult cuGetErrorString(CUresult error, const char** pStr)
 
+    ctypedef unsigned int CUdeviceptr
+
+    cpdef enum CUpointer_attribute "CUpointer_attribute_enum":
+        CU_POINTER_ATTRIBUTE_CONTEXT = 1
+        CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2
+        CU_POINTER_ATTRIBUTE_DEVICE_POINTER = 3
+        CU_POINTER_ATTRIBUTE_HOST_POINTER = 4
+        CU_POINTER_ATTRIBUTE_P2P_TOKENS = 5
+        CU_POINTER_ATTRIBUTE_SYNC_MEMOPS = 6
+        CU_POINTER_ATTRIBUTE_BUFFER_ID = 7
+        CU_POINTER_ATTRIBUTE_IS_MANAGED = 8
+        CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL = 9
+        CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE = 10
+        CU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
+        CU_POINTER_ATTRIBUTE_RANGE_SIZE = 12
+        CU_POINTER_ATTRIBUTE_MAPPED = 13
+        CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES = 14
+        CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE = 15
+        CU_POINTER_ATTRIBUTE_ACCESS_FLAGS = 16
+        CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE = 17
+
+    CUresult cuPointerGetAttribute (
+        void* data,
+        CUpointer_attribute attribute,
+        CUdeviceptr ptr
+    )
+
 cdef extern from "cuda_runtime_api.h" nogil:
 
     cudaError_t cudaDriverGetVersion(int* driverVersion)

--- a/python/rmm/_cuda/10.2/gpu.pxi
+++ b/python/rmm/_cuda/10.2/gpu.pxi
@@ -384,6 +384,34 @@ cdef extern from "cuda.h" nogil:
     CUresult cuGetErrorName(CUresult error, const char** pStr)
     CUresult cuGetErrorString(CUresult error, const char** pStr)
 
+    ctypedef unsigned int CUdeviceptr
+
+    cpdef enum CUpointer_attribute "CUpointer_attribute_enum":
+        CU_POINTER_ATTRIBUTE_CONTEXT = 1
+        CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2
+        CU_POINTER_ATTRIBUTE_DEVICE_POINTER = 3
+        CU_POINTER_ATTRIBUTE_HOST_POINTER = 4
+        CU_POINTER_ATTRIBUTE_P2P_TOKENS = 5
+        CU_POINTER_ATTRIBUTE_SYNC_MEMOPS = 6
+        CU_POINTER_ATTRIBUTE_BUFFER_ID = 7
+        CU_POINTER_ATTRIBUTE_IS_MANAGED = 8
+        CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL = 9
+        CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE = 10
+        CU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
+        CU_POINTER_ATTRIBUTE_RANGE_SIZE = 12
+        CU_POINTER_ATTRIBUTE_MAPPED = 13
+        CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES = 14
+        CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE = 15
+        CU_POINTER_ATTRIBUTE_ACCESS_FLAGS = 16
+        CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE = 17
+
+    CUresult cuPointerGetAttribute (
+        void* data,
+        CUpointer_attribute attribute,
+        CUdeviceptr ptr
+    )
+
+
 cdef extern from "cuda_runtime_api.h" nogil:
 
     cudaError_t cudaDriverGetVersion(int* driverVersion)

--- a/python/rmm/_cuda/11.x/gpu.pxi
+++ b/python/rmm/_cuda/11.x/gpu.pxi
@@ -390,6 +390,33 @@ cdef extern from "cuda.h" nogil:
     CUresult cuGetErrorName(CUresult error, const char** pStr)
     CUresult cuGetErrorString(CUresult error, const char** pStr)
 
+    ctypedef unsigned int CUdeviceptr
+
+    cpdef enum CUpointer_attribute "CUpointer_attribute_enum":
+        CU_POINTER_ATTRIBUTE_CONTEXT = 1
+        CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2
+        CU_POINTER_ATTRIBUTE_DEVICE_POINTER = 3
+        CU_POINTER_ATTRIBUTE_HOST_POINTER = 4
+        CU_POINTER_ATTRIBUTE_P2P_TOKENS = 5
+        CU_POINTER_ATTRIBUTE_SYNC_MEMOPS = 6
+        CU_POINTER_ATTRIBUTE_BUFFER_ID = 7
+        CU_POINTER_ATTRIBUTE_IS_MANAGED = 8
+        CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL = 9
+        CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE = 10
+        CU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
+        CU_POINTER_ATTRIBUTE_RANGE_SIZE = 12
+        CU_POINTER_ATTRIBUTE_MAPPED = 13
+        CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES = 14
+        CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE = 15
+        CU_POINTER_ATTRIBUTE_ACCESS_FLAGS = 16
+
+    CUresult cuPointerGetAttribute (
+        void* data,
+        CUpointer_attribute attribute,
+        CUdeviceptr ptr
+    )
+
+
 cdef extern from "cuda_runtime_api.h" nogil:
 
     cudaError_t cudaDriverGetVersion(int* driverVersion)

--- a/python/rmm/_cuda/gpu.pyx
+++ b/python/rmm/_cuda/gpu.pyx
@@ -1,6 +1,9 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
+from libc.stdint cimport int32_t, uintptr_t
+
 from rmm._cuda.gpu cimport (
+    CUpointer_attribute,
     CUresult,
     cudaDeviceAttr,
     cudaDeviceGetAttribute,
@@ -199,3 +202,32 @@ def deviceGetName(int device):
     if status != 0:
         raise CUDADriverError(status)
     return device_name.decode()
+
+
+def pointerGetAttribute(uintptr_t ptr, CUpointer_attribute attribute):
+    """
+    Return the specified attribute for the device pointer `ptr`.
+
+    Parameters
+    ----------
+    ptr: int
+        Device pointer
+    attribute: CUpointer_attribute
+        The attribute to return
+
+    Notes
+    -----
+    Currently, only the attribute CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL
+    is supported.
+    """
+    if attribute != CUpointer_attribute.CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL:
+        raise ValueError(f"Unsupported attribute {attribute}")
+    cdef int c_ordinal
+    cdef  CUresult status = cuPointerGetAttribute(
+        <void*>(&c_ordinal),
+        attribute,
+        ptr
+    )
+    if status != 0:
+        raise CUDADriverError(status)
+    return <uintptr_t> c_ordinal


### PR DESCRIPTION
This function is needed to get the device ID associated with the memory allocation for a `cudf.Buffer`. I didn't add support for all the enum values, as we can soon replace our custom CUDA bindings with the official CUDA Python ones.