### PR TITLE
Fix return value docs for supports_get_mem_info

### DIFF
--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -104,7 +104,7 @@ class binning_memory_resource final : public device_memory_resource {
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
-   * @return bool true if the resource supports get_mem_info, false otherwise.
+   * @return false
    */
   [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -124,7 +124,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
-   * @return true
+   * @return false
    */
   [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -100,7 +100,7 @@ class fixed_size_memory_resource
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
-   * @return bool true if the resource supports get_mem_info, false otherwise.
+   * @return false
    */
   [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -47,7 +47,7 @@ class managed_memory_resource final : public device_memory_resource {
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
-   * @return bool true if the resource supports get_mem_info, false otherwise.
+   * @return true
    */
   [[nodiscard]] bool supports_get_mem_info() const noexcept override { return true; }
 

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -138,7 +138,7 @@ class owning_wrapper : public device_memory_resource {
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
-   * @return true if the upstream resource supports get_mem_info, false otherwise.
+   * @return true if the wrapped resource supports get_mem_info, false otherwise.
    */
   [[nodiscard]] bool supports_get_mem_info() const noexcept override
   {


### PR DESCRIPTION
Fixes #880 

Fixes the documentation of return value of `supports_get_mem_info` in several memory resources.