### PR TITLE
Update `conda` recipes for Enhanced Compatibility effort

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -46,7 +46,7 @@ gpuci_mamba_retry install -y \
                   "cudatoolkit=$CUDA_REL" \
                   "rapids-build-env=${MINOR_VERSION}.*"
 
-# https://docs.rapids.ai/maintainers/depmgmt/ 
+# https://docs.rapids.ai/maintainers/depmgmt/
 # conda remove --force rapids-build-env
 # gpuci_mamba_retry install "your-pkg=1.0.0"
 
@@ -121,10 +121,10 @@ else
     gpuci_mamba_retry install -c $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ "$CONDA_FILE"
 
     export LIBRMM_BUILD_DIR="$WORKSPACE/ci/artifacts/rmm/cpu/conda_work/build"
-    
+
     gpuci_logger "Building rmm"
     "$WORKSPACE/build.sh" -v rmm
-    
+
     gpuci_logger "pytest rmm"
     py.test --cache-clear --junitxml=${WORKSPACE}/test-results/junit-rmm.xml -v --cov-config=.coveragerc --cov=rmm --cov-report=xml:${WORKSPACE}/python/rmm-coverage.xml --cov-report term
     exitcode=$?

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -110,8 +110,11 @@ else
     done
 
     cd $WORKSPACE/python
-    
-    CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*.tar.bz2"`
+
+    CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*has_cma*.tar.bz2"`
+    if [[ "$CUDA" == "11.0" ]]; then
+        CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*no_cma*.tar.bz2"`
+    fi
     CONDA_FILE=`basename "$CONDA_FILE" .tar.bz2` #get filename without extension
     CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install
     gpuci_logger "Installing $CONDA_FILE"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -23,7 +23,9 @@ export HOME=$WORKSPACE
 cd $WORKSPACE
 
 # Determine CUDA release version
-export CUDA_REL=${CUDA_VERSION%.*}
+export CUDA_MAJOR_VER=$(echo "${CUDA_VERSION}" | cut -f 1 -d.)
+export CUDA_MINOR_VER=$(echo "${CUDA_VERSION}" | cut -f 2 -d.)
+export CUDA_REL="${CUDA_MAJOR_VER}.${CUDA_MINOR_VER}"
 
 # Get latest tag and number of commits since tag
 export GIT_DESCRIBE_TAG=`git describe --abbrev=0 --tags`
@@ -111,9 +113,9 @@ else
 
     cd $WORKSPACE/python
 
-    CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*has_cma*.tar.bz2"`
-    if [[ "$CUDA" == "11.0" ]]; then
-        CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*no_cma*.tar.bz2"`
+    CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*no_cma*.tar.bz2"`
+    if [[ "$CUDA_MAJOR_VER" -ge 11 ]] && [[ "$CUDA_MINOR_VER" -ge 2 ]]; then
+        CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*has_cma*.tar.bz2"`
     fi
     CONDA_FILE=`basename "$CONDA_FILE" .tar.bz2` #get filename without extension
     CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install

--- a/conda/recipes/librmm/build.sh
+++ b/conda/recipes/librmm/build.sh
@@ -1,4 +1,4 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh -v clean librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+./build.sh -v clean librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\" ${BUILD_FLAGS}

--- a/conda/recipes/librmm/conda_build_config.yaml
+++ b/conda/recipes/librmm/conda_build_config.yaml
@@ -1,3 +1,3 @@
 cudaMallocAsync:
-  - true
-  - false
+  - has_cma
+  - no_cma

--- a/conda/recipes/librmm/conda_build_config.yaml
+++ b/conda/recipes/librmm/conda_build_config.yaml
@@ -1,0 +1,3 @@
+cudaMallocAsync:
+  - true
+  - false

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -3,6 +3,9 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
+{% set build_flags="" if cudaMallocAsync else "--no-async" %}
+{% set build_str_modifier="has_cma" if cudaMallocAsync else "no_cma" %}
+
 package:
   name: librmm
   version: {{ version }}
@@ -12,7 +15,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_str_modifier }}
   script_env:
     - CC
     - CXX
@@ -26,6 +29,7 @@ build:
     - CMAKE_C_COMPILER_LAUNCHER
     - CMAKE_CXX_COMPILER_LAUNCHER
     - CMAKE_CUDA_COMPILER_LAUNCHER
+    - BUILD_FLAGS="{{ build_flags }}"
   run_exports:
     - {{ pin_subpackage("librmm", max_pin="x.x") }}
 
@@ -35,8 +39,12 @@ requirements:
   host:
     - cudatoolkit {{ cuda_version }}.*
   run:
-    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - spdlog>=1.8.5,<1.9
+{% if cudaMallocAsync %}
+    - {{ pin_compatible('cudatoolkit', max_pin='x', lower_bound='11.2') }} # cudatoolkit >=11.2,<12.0.0
+{% else %}
+    - {{ pin_compatible('cudatoolkit', upper_bound='11.2', lower_bound='11.0') }} # cudatoolkit >=11.0,<11.2
+{% endif %}
 
 test:
   commands:

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -2,6 +2,7 @@
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 package:
   name: librmm
   version: {{ version }}
@@ -11,7 +12,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
@@ -34,7 +35,7 @@ requirements:
   host:
     - cudatoolkit {{ cuda_version }}.*
   run:
-    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
+    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - spdlog>=1.8.5,<1.9
 
 test:

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -3,8 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
-{% set build_flags="" if cudaMallocAsync else "--no-async" %}
-{% set build_str_modifier="has_cma" if cudaMallocAsync else "no_cma" %}
+{% set build_flags="" if cudaMallocAsync == "has_cma" else "--no-cudamallocasync" %}
 
 package:
   name: librmm
@@ -15,7 +14,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ build_str_modifier }}
+  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}_{{ cudaMallocAsync }}
   script_env:
     - CC
     - CXX
@@ -40,7 +39,7 @@ requirements:
     - cudatoolkit {{ cuda_version }}.*
   run:
     - spdlog>=1.8.5,<1.9
-{% if cudaMallocAsync %}
+{% if cudaMallocAsync == "has_cma" %}
     - {{ pin_compatible('cudatoolkit', max_pin='x', lower_bound='11.2') }} # cudatoolkit >=11.2,<12.0.0
 {% else %}
     - {{ pin_compatible('cudatoolkit', upper_bound='11.2', lower_bound='11.0') }} # cudatoolkit >=11.0,<11.2

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -3,6 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set py_version=environ.get('CONDA_PY', 35) %}
 {% set cuda_version='.'.join(environ.get('CUDA', '10.1').split('.')[:2]) %}
+{% set cuda_major=cuda_version.split('.')[0] %}
 
 package:
   name: rmm
@@ -13,7 +14,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda_{{ cuda_version }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: cuda_{{ cuda_major }}_py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - RMM_BUILD_NO_GPU_TEST
     - VERSION_SUFFIX
@@ -33,7 +34,7 @@ requirements:
     - python
     - numba >=0.49
     - numpy
-    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
+    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
 
 test:
   commands:


### PR DESCRIPTION
This PR updates the `conda` recipe build strings and `cudatoolkit` version specifications as part of the Enhanced Compatibility efforts.

### `rmm` Changes 

The build strings in the `conda` recipe have been updated to only include the major CUDA version (i.e. `librmm-21.12.00a-cuda11_gc781527_12.tar.bz2`) and the `cudatoolkit` version specifications will now be formatted like `cudatoolkit >=x,<y.0a0` (i.e. `cudatoolkit >=11,<12.0a0`).

Moving forward, we'll build the packages with a single CUDA version (i.e. `11.5`) and test them in environments with different CUDA versions (i.e. `11.0`, `11.2`, `11.4`, etc.).


### `librmm` Changes

A `conda_build_config.yaml` file has been added to the `librmm` recipe folder so that two variants of `librmm` are built: one with and one without `cudaMallocAsync` support. A new environment variable, `BUILD_FLAGS`, is passed through to `conda/recipes/librmm/build.sh` and is set according to the `cudaMallocAsync` variant value in the recipe. Finally, a build string modifier of either `no_cma` or `has_cma` is appended to the build string which is used to determine which package should be installed in `ci/gpu/build.sh`.