### PR TITLE
Fix variable names in logging macro calls

### DIFF
--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -198,7 +198,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
    */
   void* do_allocate(std::size_t size, cuda_stream_view stream) override
   {
-    RMM_LOG_TRACE("[A][stream {:p}][{}B]", fmt::ptr(stream.value()), bytes);
+    RMM_LOG_TRACE("[A][stream {:p}][{}B]", fmt::ptr(stream.value()), size);
 
     if (size <= 0) { return nullptr; }
 
@@ -214,7 +214,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
 
     RMM_LOG_TRACE("[A][stream {:p}][{}B][{:p}]",
                   fmt::ptr(stream_event.stream),
-                  bytes,
+                  size,
                   fmt::ptr(block.pointer()));
 
     log_summary_trace();
@@ -233,7 +233,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
    */
   void do_deallocate(void* ptr, std::size_t size, cuda_stream_view stream) override
   {
-    RMM_LOG_TRACE("[D][stream {:p}][{}B][{:p}]", fmt::ptr(stream.value()), bytes, p);
+    RMM_LOG_TRACE("[D][stream {:p}][{}B][{:p}]", fmt::ptr(stream.value()), size, ptr);
 
     if (size <= 0 || ptr == nullptr) { return; }
 


### PR DESCRIPTION
Fixes #896 .

When variable names were changed to satisfy clang-tidy improvements, these were missed because the macros are compiled out unless higher logging levels are enabled on the compiler command line.