### PR TITLE
Parameterize exception type caught by failure_callback_resource_adaptor

### DIFF
--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -49,7 +49,8 @@ using failure_callback_t = std::function<bool(std::size_t, void*)>;
  * resource in order to satisfy allocation requests.
  *
  * The callback function takes an allocation size and a callback argument and returns
- * a bool representing whether to retry the allocation (true) or re-throw the caught exception (false).
+ * a bool representing whether to retry the allocation (true) or re-throw the caught exception
+ * (false).
  *
  * When implementing a callback function for allocation retry, care must be taken to avoid an
  * infinite loop. The following example makes sure to only retry the allocation once:

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -35,12 +35,11 @@ namespace rmm::mr {
  *     `bool failure_callback_t(std::size_t bytes, std::exception const& error, void* callback_arg)`
  *
  * The callback function is passed three parameters: `bytes` is the size of the failed memory
- * allocation, error is the exception thrown by the upstream memory resource for the allocation,
- * and `arg` is the extra argument passed to the constructor of the
+ * allocation and `arg` is the extra argument passed to the constructor of the
  * `failure_callback_resource_adaptor`. The callback function returns a Boolean where true means to
  * retry the memory allocation and false means to re-throw the exception.
  */
-using failure_callback_t = std::function<bool(std::size_t, std::exception const&, void*)>;
+using failure_callback_t = std::function<bool(std::size_t, void*)>;
 
 /**
  * @brief A device memory resource that calls a callback function when allocations
@@ -59,7 +58,7 @@ using failure_callback_t = std::function<bool(std::size_t, std::exception const&
  * using failure_callback_adaptor =
  *   rmm::mr::failure_callback_resource_adaptor<rmm::mr::device_memory_resource>;
  *
- * bool failure_handler(std::size_t bytes, std::exception const& error, void* arg)
+ * bool failure_handler(std::size_t bytes, void* arg)
  * {
  *   bool& retried = *reinterpret_cast<bool*>(arg);
  *   if (!retried) {
@@ -162,7 +161,7 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
         ret = upstream_->allocate(bytes, stream);
         break;
       } catch (exception_type const& e) {
-        if (!callback_(bytes, e, callback_arg_)) { throw; }
+        if (!callback_(bytes, callback_arg_)) { throw; }
       }
     }
     return ret;

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -41,7 +41,7 @@ namespace rmm::mr {
  * where true means to retry the memory allocation and false means to throw a
  * `rmm::bad_alloc` exception.
  */
-using failure_callback_t = std::function<bool(std::size_t, void*)>;
+using failure_callback_t = std::function<bool(std::size_t, std::exception const&, void*)>;
 
 /**
  * @brief A device memory resource that calls a callback function when allocations
@@ -164,7 +164,7 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
         ret = upstream_->allocate(bytes, stream);
         break;
       } catch (exception_type const& e) {
-        if (!callback_(bytes, callback_arg_)) { throw; }
+        if (!callback_(bytes, e, callback_arg_)) { throw; }
       }
     }
     return ret;

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -32,9 +32,9 @@ namespace rmm::mr {
  * or re-throw the exception.
  *
  * The callback function signature is:
- *     `bool failure_callback_t(std::size_t bytes, std::exception const& error, void* callback_arg)`
+ *     `bool failure_callback_t(std::size_t bytes, void* callback_arg)`
  *
- * The callback function is passed three parameters: `bytes` is the size of the failed memory
+ * The callback function is passed two parameters: `bytes` is the size of the failed memory
  * allocation and `arg` is the extra argument passed to the constructor of the
  * `failure_callback_resource_adaptor`. The callback function returns a Boolean where true means to
  * retry the memory allocation and false means to re-throw the exception.
@@ -48,8 +48,8 @@ using failure_callback_t = std::function<bool(std::size_t, void*)>;
  * An instance of this resource must be constructed with an existing, upstream
  * resource in order to satisfy allocation requests.
  *
- * The callback function takes an allocation size, an exception, and a callback argument and returns
- * a bool representing whether to retry the allocation (true) or throw `std::bad_alloc` (false).
+ * The callback function takes an allocation size and a callback argument and returns
+ * a bool representing whether to retry the allocation (true) or re-throw the caught exception (false).
  *
  * When implementing a callback function for allocation retry, care must be taken to avoid an
  * infinite loop. The following example makes sure to only retry the allocation once:

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -27,42 +27,39 @@ namespace rmm::mr {
 /**
  * @brief Callback function type used by failure_callback_resource_adaptor
  *
- * The resource adaptor calls this function when a memory allocation throws a
- * `std::bad_alloc` exception. The function decides whether the resource adaptor
- * should try to allocate the memory again or re-throw the `std::bad_alloc`
- * exception.
+ * The resource adaptor calls this function when a memory allocation throws a specified exception
+ * type. The function decides whether the resource adaptor should try to allocate the memory again
+ * or re-throw the exception.
  *
  * The callback function signature is:
- *     `bool failure_callback_t(std::size_t bytes, void* callback_arg)`
+ *     `bool failure_callback_t(std::size_t bytes, std::exception const& error, void* callback_arg)`
  *
- * The callback function will be passed two parameters: `bytes` is the size of the
- * failed memory allocation, and `arg` is the extra argument passed to the constructor
- * of the `failure_callback_resource_adaptor`. The callback function returns a Boolean
- * where true means to retry the memory allocation and false means to throw a
- * `rmm::bad_alloc` exception.
+ * The callback function is passed three parameters: `bytes` is the size of the failed memory
+ * allocation, error is the exception thrown by the upstream memory resource for the allocation,
+ * and `arg` is the extra argument passed to the constructor of the
+ * `failure_callback_resource_adaptor`. The callback function returns a Boolean where true means to
+ * retry the memory allocation and false means to re-throw the exception.
  */
 using failure_callback_t = std::function<bool(std::size_t, std::exception const&, void*)>;
 
 /**
  * @brief A device memory resource that calls a callback function when allocations
- * throws `std::bad_alloc`.
+ * throw a specified exception type.
  *
  * An instance of this resource must be constructed with an existing, upstream
  * resource in order to satisfy allocation requests.
  *
- * The callback function takes an allocation size and a callback argument and returns
- * a bool representing whether to retry the allocation (true) or throw `std::bad_alloc`
- * (false).
+ * The callback function takes an allocation size, an exception, and a callback argument and returns
+ * a bool representing whether to retry the allocation (true) or throw `std::bad_alloc` (false).
  *
- * When implementing a callback function for allocation retry, care must be taken to
- * avoid an infinite loop. In the following example, we make sure to only retry the allocation
- * once:
+ * When implementing a callback function for allocation retry, care must be taken to avoid an
+ * infinite loop. The following example makes sure to only retry the allocation once:
  *
  * @code{c++}
  * using failure_callback_adaptor =
  *   rmm::mr::failure_callback_resource_adaptor<rmm::mr::device_memory_resource>;
  *
- * bool failure_handler(std::size_t bytes, void* arg)
+ * bool failure_handler(std::size_t bytes, std::exception const& error, void* arg)
  * {
  *   bool& retried = *reinterpret_cast<bool*>(arg);
  *   if (!retried) {
@@ -85,10 +82,11 @@ using failure_callback_t = std::function<bool(std::size_t, std::exception const&
  * @tparam Upstream The type of the upstream resource used for allocation/deallocation.
  * @tparam ExceptionType The type of exception that this adaptor should respond to
  */
-template <typename Upstream, typename ExceptionType = rmm::bad_alloc>
+template <typename Upstream, typename ExceptionType = rmm::out_of_memory>
 class failure_callback_resource_adaptor final : public device_memory_resource {
  public:
   using exception_type = ExceptionType;  ///< The type of exception this object catches/throws
+
   /**
    * @brief Construct a new `failure_callback_resource_adaptor` using `upstream` to satisfy
    * allocation requests.

--- a/tests/mr/device/failure_callback_mr_tests.cpp
+++ b/tests/mr/device/failure_callback_mr_tests.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "../../byte_literals.hpp"
+#include "rmm/cuda_stream_view.hpp"
+#include "rmm/mr/device/device_memory_resource.hpp"
 
 #include <cstddef>
 #include <rmm/detail/error.hpp>
@@ -26,28 +28,91 @@
 namespace rmm::test {
 namespace {
 
+template <typename ExceptionType = rmm::bad_alloc>
 using failure_callback_adaptor =
-  rmm::mr::failure_callback_resource_adaptor<rmm::mr::device_memory_resource>;
+  rmm::mr::failure_callback_resource_adaptor<rmm::mr::device_memory_resource, ExceptionType>;
 
 bool failure_handler(std::size_t bytes, void* arg)
 {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   bool& retried = *reinterpret_cast<bool*>(arg);
   if (!retried) {
     retried = true;
     return true;  // First time we request an allocation retry
-  } else {
-    return false;  // Second time we let the adaptor throw std::bad_alloc
   }
+  return false;  // Second time we let the adaptor throw std::bad_alloc
 }
 
 TEST(FailureCallbackTest, RetryAllocationOnce)
 {
   bool retried{false};
-  failure_callback_adaptor mr{rmm::mr::get_current_device_resource(), failure_handler, &retried};
-  rmm::mr::set_current_device_resource(&mr);
+  failure_callback_adaptor<> mr{rmm::mr::get_current_device_resource(), failure_handler, &retried};
   EXPECT_EQ(retried, false);
   EXPECT_THROW(mr.allocate(512_GiB), std::bad_alloc);
   EXPECT_EQ(retried, true);
+}
+
+template <typename ExceptionType>
+class always_throw_memory_resource final : public mr::device_memory_resource {
+ private:
+  void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
+  {
+    throw ExceptionType{"foo"};
+  }
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override{};
+  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
+    cuda_stream_view stream) const override
+  {
+    return {0, 0};
+  }
+
+  [[nodiscard]] bool supports_streams() const noexcept override { return false; }
+  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
+};
+
+TEST(FailureCallbackTest, DifferentExceptionTypes)
+{
+  always_throw_memory_resource<rmm::bad_alloc> bad_alloc_mr;
+  always_throw_memory_resource<rmm::out_of_memory> oom_mr;
+
+  EXPECT_THROW(bad_alloc_mr.allocate(1_MiB), rmm::bad_alloc);
+  EXPECT_THROW(oom_mr.allocate(1_MiB), rmm::out_of_memory);
+
+  // Wrap a bad_alloc-catching callback adaptor around an MR that always throws bad_alloc:
+  // Should retry once and then re-throw bad_alloc
+  {
+    bool retried{false};
+    failure_callback_adaptor<rmm::bad_alloc> bad_alloc_callback_mr{
+      &bad_alloc_mr, failure_handler, &retried};
+
+    EXPECT_EQ(retried, false);
+    EXPECT_THROW(bad_alloc_callback_mr.allocate(1_MiB), rmm::bad_alloc);
+    EXPECT_EQ(retried, true);
+  }
+
+  // Wrap a out_of_memory-catching callback adaptor around an MR that always throws out_of_memory:
+  // Should retry once and then re-throw out_of_memory
+  {
+    bool retried{false};
+
+    failure_callback_adaptor<rmm::out_of_memory> oom_callback_mr{
+      &oom_mr, failure_handler, &retried};
+    EXPECT_EQ(retried, false);
+    EXPECT_THROW(oom_callback_mr.allocate(1_MiB), rmm::out_of_memory);
+    EXPECT_EQ(retried, true);
+  }
+
+  // Wrap a out_of_memory-catching callback adaptor around an MR that always throws bad_alloc:
+  // Should not catch the bad_alloc exception
+  {
+    bool retried{false};
+
+    failure_callback_adaptor<rmm::out_of_memory> oom_callback_mr{
+      &bad_alloc_mr, failure_handler, &retried};
+    EXPECT_EQ(retried, false);
+    EXPECT_THROW(oom_callback_mr.allocate(1_MiB), rmm::bad_alloc);  // bad_alloc passes through
+    EXPECT_EQ(retried, false);  // Does not catch / retry on anything except OOM
+  }
 }
 
 }  // namespace

--- a/tests/mr/device/failure_callback_mr_tests.cpp
+++ b/tests/mr/device/failure_callback_mr_tests.cpp
@@ -32,7 +32,7 @@ template <typename ExceptionType = rmm::bad_alloc>
 using failure_callback_adaptor =
   rmm::mr::failure_callback_resource_adaptor<rmm::mr::device_memory_resource, ExceptionType>;
 
-bool failure_handler(std::size_t /*bytes*/, std::exception const& /*error*/, void* arg)
+bool failure_handler(std::size_t /*bytes*/, void* arg)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   bool& retried = *reinterpret_cast<bool*>(arg);

--- a/tests/mr/device/failure_callback_mr_tests.cpp
+++ b/tests/mr/device/failure_callback_mr_tests.cpp
@@ -32,7 +32,7 @@ template <typename ExceptionType = rmm::bad_alloc>
 using failure_callback_adaptor =
   rmm::mr::failure_callback_resource_adaptor<rmm::mr::device_memory_resource, ExceptionType>;
 
-bool failure_handler(std::size_t bytes, void* arg)
+bool failure_handler(std::size_t /*bytes*/, std::exception const& /*error*/, void* arg)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
   bool& retried = *reinterpret_cast<bool*>(arg);


### PR DESCRIPTION
#892 added `failure_callback_resource_adaptor` which provides the ability to respond to memory allocation failures. However, it was hard-coded to catch (and rethrow) `std::bad_alloc` exceptions.  This PR makes the type of exception the adaptor catches a template parameter, to provide greater flexibility. The default exception type is now `rmm::out_of_memory` since we expect this to be the common use case.

Also a few changes to fix clang-tidy warnings.