### PR TITLE
[gpuCI] Forward-merge branch-21.10 to branch-21.12 [skip gpuci]

### DIFF
--- a/cmake/thirdparty/get_spdlog.cmake
+++ b/cmake/thirdparty/get_spdlog.cmake
@@ -16,13 +16,12 @@
 function(find_and_configure_spdlog)
 
   include(${rapids-cmake-dir}/cpm/spdlog.cmake)
-  rapids_cpm_spdlog()
+  rapids_cpm_spdlog(INSTALL_EXPORT_SET rmm-exports)
 
   if(spdlog_ADDED)
     install(TARGETS spdlog_header_only EXPORT rmm-exports)
   else()
     rapids_export_package(BUILD spdlog rmm-exports)
-    rapids_export_package(INSTALL spdlog rmm-exports)
   endif()
 endfunction()
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.10` that creates a PR to keep `branch-21.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.