### PR TITLE
Simplify CMake linting with cmake-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,18 +25,26 @@ repos:
             name: flake8-cython
             args: ["--config=python/.flake8.cython"]
             types: [cython]
-    - repo: https://github.com/cheshirekow/cmake-format-precommit
-      rev: v0.6.11
+    - repo: local
       hooks:
-          - id: cmake-format
-            name: cmake-format
-            args: ["--config-files", "cmake/config.json", "--in-place", "--"]
-            types: [file]  # override `types: [cmake]`
-            files: \.(cmake(\.in)?)$|CMakeLists\.txt
-          - id: cmake-lint
-            args: ["--config-files", "cmake/config.json", "--"]
-            types: [file]  # override `types: [cmake]`
-            files: \.(cmake(\.in)?)$|CMakeLists\.txt
+            - id: cmake-format
+              name: cmake-format
+              entry: bash scripts/run-cmake-format.sh cmake-format
+              language: python
+              types: [cmake]
+              # Note that pre-commit autoupdate does not update the versions
+              # of dependencies, so we'll have to update this manually.
+              additional_dependencies:
+                - cmake-format==0.6.11
+            - id: cmake-lint
+              name: cmake-lint
+              entry: bash scripts/run-cmake-format.sh cmake-lint
+              language: python
+              types: [cmake]
+              # Note that pre-commit autoupdate does not update the versions
+              # of dependencies, so we'll have to update this manually.
+              additional_dependencies:
+                - cmake-format==0.6.11
 
 default_language_version:
     python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       hooks:
             - id: cmake-format
               name: cmake-format
-              entry: bash scripts/run-cmake-format.sh cmake-format
+              entry: ./scripts/run-cmake-format.sh cmake-format
               language: python
               types: [cmake]
               # Note that pre-commit autoupdate does not update the versions
@@ -38,7 +38,7 @@ repos:
                 - cmake-format==0.6.11
             - id: cmake-lint
               name: cmake-lint
-              entry: bash scripts/run-cmake-format.sh cmake-lint
+              entry: ./scripts/run-cmake-format.sh cmake-lint
               language: python
               types: [cmake]
               # Note that pre-commit autoupdate does not update the versions

--- a/scripts/run-cmake-format.sh
+++ b/scripts/run-cmake-format.sh
@@ -40,7 +40,7 @@ if ! [ ${status} -eq 0 ]; then
 fi
 
 DEFAULT_FORMAT_FILE_LOCATIONS=(
-  "${RMM_ROOT}/_deps/rapids-cmake-src/cmake-format-rapids-cmake.json",
+  "${RMM_ROOT}/_deps/rapids-cmake-src/cmake-format-rapids-cmake.json"
 )
 
 if [ -z ${RAPIDS_CMAKE_FORMAT_FILE:+PLACEHOLDER} ]; then

--- a/scripts/run-cmake-format.sh
+++ b/scripts/run-cmake-format.sh
@@ -25,22 +25,24 @@
 
 status=0
 if [ -z ${RMM_ROOT:+PLACEHOLDER} ]; then
-    RMM_ROOT=$(git rev-parse --show-toplevel 2>&1)/build
+    RMM_BUILD_DIR=$(git rev-parse --show-toplevel 2>&1)/build
     status=$?
+else
+    RMM_BUILD_DIR=${RMM_ROOT}
 fi
 
 if ! [ ${status} -eq 0 ]; then
-    if [[ ${RMM_ROOT} == *"not a git repository"* ]]; then
+    if [[ ${RMM_BUILD_DIR} == *"not a git repository"* ]]; then
         echo "This script must be run inside the rmm repository, or the RMM_ROOT environment variable must be set."
     else
         echo "Script failed with unknown error attempting to determine project root:"
-        echo ${RMM_ROOT}
+        echo ${RMM_BUILD_DIR}
     fi
     exit 1
 fi
 
 DEFAULT_FORMAT_FILE_LOCATIONS=(
-  "${RMM_ROOT}/_deps/rapids-cmake-src/cmake-format-rapids-cmake.json"
+  "${RMM_BUILD_DIR}/_deps/rapids-cmake-src/cmake-format-rapids-cmake.json"
 )
 
 if [ -z ${RAPIDS_CMAKE_FORMAT_FILE:+PLACEHOLDER} ]; then

--- a/scripts/run-cmake-format.sh
+++ b/scripts/run-cmake-format.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# This script is a wrapper for cmakelang that may be used with pre-commit. The
+# wrapping is necessary because RAPIDS libraries split configuration for
+# cmakelang linters between a local config file and a second config file that's
+# shared across all of RAPIDS via rapids-cmake. In order to keep it up to date
+# this file is only maintained in one place (the rapids-cmake repo) and
+# pulled down during builds. We need a way to invoke CMake linting commands
+# without causing pre-commit failures (which could block local commits or CI),
+# while also being sufficiently flexible to allow users to maintain the config
+# file independently of a build directory.
+#
+# This script provides the minimal functionality to enable those use cases. It
+# searches in a number of predefined locations for the rapids-cmake config file
+# and exits gracefully if the file is not found. If a user wishes to specify a
+# config file at a nonstandard location, they may do so by setting the
+# environment variable RAPIDS_CMAKE_FORMAT_FILE.
+# 
+# This script can be invoked directly anywhere within the project repository.
+# Alternatively, it may be invoked as a pre-commit hook via
+# `pre-commit run (cmake-format)|(cmake-lint)`.
+#
+# Usage:
+# bash run-cmake-format.sh {cmake-format,cmake-lint} infile [infile ...]
+
+status=0
+if [ -z ${RMM_ROOT:+PLACEHOLDER} ]; then
+    RMM_ROOT=$(git rev-parse --show-toplevel 2>&1)/build
+    status=$?
+fi
+
+if ! [ ${status} -eq 0 ]; then
+    if [[ ${RMM_ROOT} == *"not a git repository"* ]]; then
+        echo "This script must be run inside the rmm repository, or the RMM_ROOT environment variable must be set."
+    else
+        echo "Script failed with unknown error attempting to determine project root:"
+        echo ${RMM_ROOT}
+    fi
+    exit 1
+fi
+
+DEFAULT_FORMAT_FILE_LOCATIONS=(
+  "${RMM_ROOT}/_deps/rapids-cmake-src/cmake-format-rapids-cmake.json",
+)
+
+if [ -z ${RAPIDS_CMAKE_FORMAT_FILE:+PLACEHOLDER} ]; then
+    for file_path in ${DEFAULT_FORMAT_FILE_LOCATIONS[@]}; do
+        if [ -f ${file_path} ]; then
+            RAPIDS_CMAKE_FORMAT_FILE=${file_path}
+            break
+        fi
+    done
+fi
+
+if [ -z ${RAPIDS_CMAKE_FORMAT_FILE:+PLACEHOLDER} ]; then
+  echo "The rapids-cmake cmake-format configuration file was not found at any of the default search locations: "
+  echo ""
+  ( IFS=$'\n'; echo "${DEFAULT_FORMAT_FILE_LOCATIONS[*]}" )
+  echo ""
+  echo "Try setting the environment variable RAPIDS_CMAKE_FORMAT_FILE to the path to the config file."
+  exit 0
+else
+  echo "Using format file ${RAPIDS_CMAKE_FORMAT_FILE}"
+fi
+
+if [[ $1 == "cmake-format" ]]; then
+  cmake-format -i --config-files cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2}
+elif [[ $1 == "cmake-lint" ]]; then
+  cmake-lint --config-files cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2}
+fi


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to RMM :) Please read these instructions and 
replace them with your description.

First, if you need some help or want to chat to the core developers, please
visit https://rapids.ai/community.html for links to our Google Group and other
communication channels.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made and/or
   features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

4. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

5. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just adds delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against the release or master branch they should be resolved 
   by merging master into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR adds a script to find the cmake-format-rapids-cmake.json file in a standard location and run the cmake-format or cmake-lint programs with that config file. The script fails gracefully when the file cannot be found and is therefore suitable for use as a pre-commit hook in scenarios where no build directory (containing the config file) exists yet. A corresponding pre-commit configuration is added here as well, replacing the old cmake-format hook which did not use the rapids-cmake config file.

Resolves #903.