### PR TITLE
suppress spurious clang-tidy warnings in debug macros

### DIFF
--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -240,6 +240,7 @@ class out_of_range : public std::out_of_range {
       std::cerr << "CUDA Error detected. " << cudaGetErrorName(status__) << " " \
                 << cudaGetErrorString(status__) << std::endl;                   \
     }                                                                           \
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay) */   \
     assert(status__ == cudaSuccess);                                            \
   } while (0)
 #endif
@@ -257,6 +258,7 @@ class out_of_range : public std::out_of_range {
       RMM_LOG_CRITICAL(                                                                           \
         "[" __FILE__ ":" RMM_STRINGIFY(__LINE__) "] Assertion " RMM_STRINGIFY(_expr) " failed."); \
       rmm::logger().flush();                                                                      \
+      /* NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay) */                   \
       assert(success);                                                                            \
     }                                                                                             \
   } while (0)


### PR DESCRIPTION
Getting these clang-tidy warnings in debug build:
```console
/home/rou/src/rmm/include/rmm/cuda_stream.hpp:86:5: warning: do not implicitly decay an array into a pointer; consider using gsl::array_view or an explicit cast instead [cppcoreguidelines-pro-bounds-array-to-pointer-decay]
    RMM_LOGGING_ASSERT(is_valid());
    ^
/home/rou/src/rmm/include/rmm/detail/error.hpp:260:7: note: expanded from macro 'RMM_LOGGING_ASSERT'
      assert(success);                                                                            \
      ^
/usr/include/assert.h:95:51: note: expanded from macro 'assert'
      : __assert_fail (#expr, __FILE__, __LINE__, __ASSERT_FUNCTION))
                                                  ^
/usr/include/assert.h:129:30: note: expanded from macro '__ASSERT_FUNCTION'
#   define __ASSERT_FUNCTION    __extension__ __PRETTY_FUNCTION__
                                ^
```

Looks to be a pending issue with clang-tidy: https://reviews.llvm.org/D88833