### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/conda/environments/rmm_dev_cuda10.1.yml
+++ b/conda/environments/rmm_dev_cuda10.1.yml
@@ -3,8 +3,8 @@ channels:
 - rapidsai
 - conda-forge
 dependencies:
-- clang=11.0.0
-- clang-tools=11.0.0
+- clang=11.1.0
+- clang-tools=11.1.0
 - cmake>=3.20.1
 - cmake-format=0.6.11
 - flake8=3.8.3

--- a/conda/environments/rmm_dev_cuda10.2.yml
+++ b/conda/environments/rmm_dev_cuda10.2.yml
@@ -3,8 +3,8 @@ channels:
 - rapidsai
 - conda-forge
 dependencies:
-- clang=11.0.0
-- clang-tools=11.0.0
+- clang=11.1.0
+- clang-tools=11.1.0
 - cmake>=3.20.1
 - cmake-format=0.6.11
 - flake8=3.8.3

--- a/conda/environments/rmm_dev_cuda11.0.yml
+++ b/conda/environments/rmm_dev_cuda11.0.yml
@@ -3,8 +3,8 @@ channels:
 - rapidsai
 - conda-forge
 dependencies:
-- clang=11.0.0
-- clang-tools=11.0.0
+- clang=11.1.0
+- clang-tools=11.1.0
 - cmake>=3.20.1
 - cmake-format=0.6.11
 - flake8=3.8.3

--- a/scripts/run-clang-format.py
+++ b/scripts/run-clang-format.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import tempfile
 
-EXPECTED_VERSION = "11.0.0"
+EXPECTED_VERSION = "11.1.0"
 VERSION_REGEX = re.compile(r"clang-format version ([0-9.]+)")
 # NOTE: populate this list with more top-level dirs as we add more of them
 # to the rmm repo


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.