### PR TITLE
Remove `setup.py` from `update-release.sh` script

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -32,8 +32,6 @@ function sed_runner() {
 sed_runner 's/'"  VERSION .*"'/'"  VERSION ${NEXT_FULL_TAG}"'/g' CMakeLists.txt
 sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cmake"'/g' CMakeLists.txt
 
-sed_runner 's/version=.*/version=\"'"${NEXT_FULL_TAG}"'\",/g' python/setup.py
-
 sed_runner 's/'"PROJECT_NUMBER         = .*"'/'"PROJECT_NUMBER         = ${NEXT_SHORT_TAG}"'/g' doxygen/Doxyfile
 
 sed_runner 's/'"version =.*"'/'"version = \"${NEXT_SHORT_TAG}\""'/g' python/docs/conf.py


### PR DESCRIPTION
Since `setup.py` [uses versioneer](https://github.com/rapidsai/rmm/blob/91dd10e55688295f654f619f6da7e62dc4c7a403/python/setup.py#L230), this PR removes the line from `update-release.sh` that updates `setup.py`.
