### PR TITLE
Remove `IncludeCategories` from `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -72,15 +72,6 @@ ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks: Preserve
-IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentPPDirectives: None


### PR DESCRIPTION
It was recently noticed that the `IncludeCategories`:
```
IncludeCategories:
  - Regex:           '^<ext/.*\.h>'
    Priority:        2
  - Regex:           '^<.*\.h>'
    Priority:        1
  - Regex:           '^<.*'
    Priority:        2
  - Regex:           '.*'
    Priority:        3
```
In the `.clang-format` are not really necessary as `ext` has no meaning in RAPIDS. This PR removes these.