### PR TITLE
Headers that use `std::thread` now include <thread>

### DIFF
--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <map>
 #include <shared_mutex>
+#include <thread>
 
 namespace rmm::mr {
 

--- a/tests/mr/device/arena_mr_tests.cpp
+++ b/tests/mr/device/arena_mr_tests.cpp
@@ -28,6 +28,9 @@
 
 #include <sys/stat.h>
 
+#include <thread>
+#include <vector>
+
 namespace rmm::test {
 
 namespace {


### PR DESCRIPTION
Fixes #937
