### PR TITLE
Build benchmarks in RMM CI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,17 +20,19 @@ REPODIR=$(cd $(dirname $0); pwd)
 
 VALIDARGS="clean librmm rmm -v -g -n -s --ptds --no-cudamallocasync -h"
 HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [--ptds] [--no-cudamallocasync] [--cmake-args=\"<args>\"] [-h]
-   clean  - remove all existing build artifacts and configuration (start over)
-   librmm - build and install the librmm C++ code
-   rmm    - build and install the rmm Python package
-   -v     - verbose build mode
-   -g     - build for debug
-   -n     - no install step
-   -s     - statically link against cudart
-   --ptds - enable per-thread default stream
-   --no-cudamallocasync  - disable CUDA malloc async support
-   --cmake-args=\\\"<args>\\\"   - pass arbitrary list of CMake configuration options (escape all quotes in argument)
-   -h     - print this text
+   clean                       - remove all existing build artifacts and configuration (start over)
+   librmm                      - build and install the librmm C++ code
+   rmm                         - build and install the rmm Python package
+   benchmarks                  - build benchmarks
+   tests                       - build tests
+   -v                          - verbose build mode
+   -g                          - build for debug
+   -n                          - no install step
+   -s                          - statically link against cudart
+   --ptds                      - enable per-thread default stream
+   --no-cudamallocasync        - disable CUDA malloc async support
+   --cmake-args=\\\"<args>\\\" - pass arbitrary list of CMake configuration options (escape all quotes in argument)
+   -h                          - print this text
 
    default action (no args) is to build and install 'librmm' and 'rmm' targets
 "
@@ -94,6 +96,8 @@ function ensureCMakeRan {
               -DPER_THREAD_DEFAULT_STREAM="${PER_THREAD_DEFAULT_STREAM}" \
               -DCUDA_MALLOC_ASYNC_SUPPORT="${CUDA_MALLOC_ASYNC_SUPPORT}" \
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+              -DBUILD_TESTS=${BUILD_TESTS} \
+              -DBUILD_BENCHMARKS=${BUILD_BENCHMARKS} \
               ${CMAKE_ARGS}
         RAN_CMAKE=1
     fi
@@ -162,9 +166,7 @@ fi
 if (( NUMARGS == 0 )) || hasArg librmm; then
     ensureCMakeRan
     echo "building librmm..."
-    cmake --build "${LIBRMM_BUILD_DIR}" -j${PARALLEL_LEVEL} ${VERBOSE_FLAG} \
-        -DBUILD_TESTS=${BUILD_TESTS} \
-        -DBUILD_BENCHMARKS=${BUILD_BENCHMARKS}
+    cmake --build "${LIBRMM_BUILD_DIR}" -j${PARALLEL_LEVEL} ${VERBOSE_FLAG}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         echo "installing librmm..."
         cmake --build "${LIBRMM_BUILD_DIR}" --target install -v ${VERBOSE_FLAG}

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean librmm rmm -v -g -n -s --ptds --no-cudamallocasync -h"
+VALIDARGS="clean librmm rmm -v -g -n -s --ptds --no-cudamallocasync -h tests benchmarks"
 HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [--ptds] [--no-cudamallocasync] [--cmake-args=\"<args>\"] [-h]
    clean                       - remove all existing build artifacts and configuration (start over)
    librmm                      - build and install the librmm C++ code

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,8 @@ BUILD_DIRS="${LIBRMM_BUILD_DIR} ${RMM_BUILD_DIR}"
 VERBOSE_FLAG=""
 BUILD_TYPE=Release
 INSTALL_TARGET=install
+BUILD_BENCHMARKS=OFF
+BUILD_TESTS=OFF
 CUDA_STATIC_RUNTIME=OFF
 PER_THREAD_DEFAULT_STREAM=OFF
 CUDA_MALLOC_ASYNC_SUPPORT=ON
@@ -125,6 +127,12 @@ fi
 if hasArg -n; then
     INSTALL_TARGET=""
 fi
+if hasArg benchmarks; then
+    BUILD_BENCHMARKS=ON
+fi
+if hasArg tests; then
+    BUILD_TESTS=ON
+fi
 if hasArg -s; then
     CUDA_STATIC_RUNTIME=ON
 fi
@@ -154,7 +162,9 @@ fi
 if (( NUMARGS == 0 )) || hasArg librmm; then
     ensureCMakeRan
     echo "building librmm..."
-    cmake --build "${LIBRMM_BUILD_DIR}" -j${PARALLEL_LEVEL} ${VERBOSE_FLAG}
+    cmake --build "${LIBRMM_BUILD_DIR}" -j${PARALLEL_LEVEL} ${VERBOSE_FLAG} \
+        -DBUILD_TESTS=${BUILD_TESTS} \
+        -DBUILD_BENCHMARKS=${BUILD_BENCHMARKS}
     if [[ ${INSTALL_TARGET} != "" ]]; then
         echo "installing librmm..."
         cmake --build "${LIBRMM_BUILD_DIR}" --target install -v ${VERBOSE_FLAG}

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -68,7 +68,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     ################################################################################
 
     gpuci_logger "Build and install librmm and rmm"
-    "$WORKSPACE/build.sh" -v clean librmm rmm
+    "$WORKSPACE/build.sh" -v clean librmm rmm benchmarks tests
 
     ################################################################################
     # Test - librmm

--- a/conda/recipes/librmm/build.sh
+++ b/conda/recipes/librmm/build.sh
@@ -1,4 +1,8 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh -v clean librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
+  ./build.sh -v clean librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+else
+  ./build.sh -v clean librmm tests --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+fi

--- a/conda/recipes/librmm/build.sh
+++ b/conda/recipes/librmm/build.sh
@@ -4,5 +4,5 @@
 if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
   ./build.sh -v clean librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
 else
-  ./build.sh -v clean librmm tests --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+  ./build.sh -v clean librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
 fi

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -27,6 +27,7 @@ build:
     - CMAKE_C_COMPILER_LAUNCHER
     - CMAKE_CXX_COMPILER_LAUNCHER
     - CMAKE_CUDA_COMPILER_LAUNCHER
+    - PROJECT_FLASH
   run_exports:
     - {{ pin_subpackage("librmm", max_pin="x.x") }}
 


### PR DESCRIPTION
Fixes #940

Adds options to build tests and benchmarks to build.sh, and uses them in ci/gpu/build.sh