### PR TITLE
Temporarily disable warnings for unknown pragmas

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -45,9 +45,9 @@ function(ConfigureBench BENCH_NAME)
     target_compile_definitions(${TEST_NAME} PUBLIC "RMM_DISABLE_CUDA_MALLOC_ASYNC")
   endif()
 
-  target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
-                                              -Wno-error=deprecated-declarations
-                                              -Wno-unknown-pragmas>)
+  target_compile_options(
+    ${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
+                         -Wno-error=deprecated-declarations -Wno-unknown-pragmas>)
   if(DISABLE_DEPRECATION_WARNING)
     target_compile_options(
       ${BENCH_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -46,7 +46,8 @@ function(ConfigureBench BENCH_NAME)
   endif()
 
   target_compile_options(${BENCH_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror
-                                              -Wno-error=deprecated-declarations>)
+                                              -Wno-error=deprecated-declarations
+                                              -Wno-unknown-pragmas>)
   if(DISABLE_DEPRECATION_WARNING)
     target_compile_options(
       ${BENCH_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-deprecated-declarations>)


### PR DESCRIPTION
CUB 1.15 has uses an unprotected `#pragma nv_exec_check_disable` which makes includes of thrust headers from .cpp files fail if `-Werror` is enabled (or warn if it is not set)

This PR is a temporary workaround. It just adds -Wno-unknown-pragmas to the command line for building benchmark .cpp files. 