### PR TITLE
Use numba to get CUDA runtime version.

### DIFF
--- a/python/rmm/_cuda/gpu.py
+++ b/python/rmm/_cuda/gpu.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
-from cuda import cuda, cudart
 import numba.cuda
+from cuda import cuda, cudart
 
 
 class CUDARuntimeError(RuntimeError):
@@ -82,7 +82,8 @@ def runtimeGetVersion():
     This calls numba.cuda.runtime.get_version() rather than cuda-python due to
     current limitations in cuda-python.
     """
-    # TODO: Replace this with `cuda.cudart.cudaRuntimeGetVersion()` when the limitation is fixed.
+    # TODO: Replace this with `cuda.cudart.cudaRuntimeGetVersion()` when the
+    # limitation is fixed.
     major, minor = numba.cuda.runtime.get_version()
     return major * 1000 + minor * 10
 

--- a/python/rmm/_cuda/gpu.py
+++ b/python/rmm/_cuda/gpu.py
@@ -82,7 +82,7 @@ def runtimeGetVersion():
     This calls numba.cuda.runtime.get_version() rather than cuda-python due to
     current limitations in cuda-python.
     """
-
+    # TODO: Replace this with `cuda.cudart.cudaRuntimeGetVersion()` when the limitation is fixed.
     major, minor = numba.cuda.runtime.get_version()
     return major * 1000 + minor * 10
 

--- a/python/rmm/_cuda/gpu.py
+++ b/python/rmm/_cuda/gpu.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
 from cuda import cuda, cudart
+import numba.cuda
 
 
 class CUDARuntimeError(RuntimeError):
@@ -78,13 +79,12 @@ def runtimeGetVersion():
     The version is returned as (1000 major + 10 minor). For example,
     CUDA 9.2 would be represented by 9020.
 
-    This function automatically raises CUDARuntimeError with error message
-    and status code.
+    This calls numba.cuda.runtime.get_version() rather than cuda-python due to
+    current limitations in cuda-python.
     """
-    status, version = cudart.cudaRuntimeGetVersion()
-    if status != cudart.cudaError_t.cudaSuccess:
-        raise CUDARuntimeError(status)
-    return version
+
+    major, minor = numba.cuda.runtime.get_version()
+    return major * 1000 + minor * 10
 
 
 def getDeviceCount():


### PR DESCRIPTION
This PR uses `numba` to fetch the CUDA runtime version, rather than cuda-python.

The current [implementation](https://github.com/NVIDIA/cuda-python/blob/746b773c91e1ede708fe9a584b8cdb1c0f32b51d/cuda/_lib/ccudart/ccudart.pyx#L79-L82) of cuda-python's `cuda.cudart.cudaRuntimeGetVersion()` [hard-codes the runtime version](https://github.com/NVIDIA/cuda-python/blob/746b773c91e1ede708fe9a584b8cdb1c0f32b51d/cuda/_lib/ccudart/utils.pyx#L37), rather than querying the runtime for its version. This is a known limitation that may not be resolved in the near term. cc: @vzhurba01