### PR TITLE
Prepare upload scripts for Python 3.7 removal

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -4,7 +4,7 @@
 export UPLOAD_RMM=1
 
 #Build librmm once per CUDA
-if [[ "$PYTHON" == "3.7" ]]; then
+if [[ "$PYTHON" == "3.8" ]]; then
     export UPLOAD_LIBRMM=1
 else
     export UPLOAD_LIBRMM=0


### PR DESCRIPTION
As we will remove Python 3.7, we need to update the Python version in the upload scripts