### PR TITLE
Enable constructing DeviceBuffers using a non-default memory resource and correctly manage memory resource lifetime in DeviceBuffer

### DIFF
--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -17,15 +17,23 @@ from libcpp.memory cimport unique_ptr
 
 from rmm._cuda.stream cimport Stream
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
-from rmm._lib.memory_resource cimport DeviceMemoryResource
+from rmm._lib.memory_resource cimport (
+    DeviceMemoryResource,
+    device_memory_resource,
+)
 
 
 cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
     cdef cppclass device_buffer:
         device_buffer()
         device_buffer(size_t size, cuda_stream_view stream) except +
+        device_buffer(size_t size, cuda_stream_view stream,
+                      device_memory_resource* mr) except +
         device_buffer(const void* source_data,
                       size_t size, cuda_stream_view stream) except +
+        device_buffer(const void* source_data,
+                      size_t size, cuda_stream_view stream,
+                      device_memory_resource* mr) except +
         void resize(size_t new_size, cuda_stream_view stream) except +
         void shrink_to_fit(cuda_stream_view stream) except +
         void* data()

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -716,3 +716,10 @@ def test_dev_buf_circle_ref_dealloc():
     # deallocate `dbuf1` (which needs the MR alive), a segfault occurs.
 
     gc.collect()
+
+
+def test_device_buffer_nondefault_mr():
+    # test creating a DeviceBuffer with a non-default memory resource
+    dbuf = rmm.DeviceBuffer(size=100_000, mr=rmm.mr.CudaMemoryResource())
+    del dbuf
+    gc.collect()


### PR DESCRIPTION
Closes #944 