### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
 
-#Always upload RMM Python package
+#Always upload RMM packages
 export UPLOAD_RMM=1
-
-#Build librmm once per CUDA
-if [[ "$PYTHON" == "3.8" ]]; then
-    export UPLOAD_LIBRMM=1
-else
-    export UPLOAD_LIBRMM=0
-fi
+export UPLOAD_LIBRMM=1
 
 if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     #If project flash is not activate, always build both


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.