### PR TITLE
Make `pool_memory_resource::pool_size()` public

### DIFF
--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -129,6 +129,15 @@ class pool_memory_resource final
    */
   Upstream* get_upstream() const noexcept { return upstream_mr_; }
 
+  /**
+   * @brief Computes the size of the current pool
+   *
+   * Includes allocated as well as free memory.
+   *
+   * @return std::size_t The total size of the currently allocated pool.
+   */
+  [[nodiscard]] std::size_t pool_size() const noexcept { return current_pool_size_; }
+
  protected:
   using free_list  = detail::coalescing_free_list;
   using block_type = free_list::block_type;
@@ -337,15 +346,6 @@ class pool_memory_resource final
     return block_type{static_cast<char*>(ptr), size, (iter != upstream_blocks_.end())};
 #endif
   }
-
-  /**
-   * @brief Computes the size of the current pool
-   *
-   * Includes allocated as well as free memory.
-   *
-   * @return std::size_t The total size of the currently allocated pool.
-   */
-  [[nodiscard]] std::size_t pool_size() const noexcept { return current_pool_size_; }
 
   /**
    * @brief Free all memory allocated from the upstream memory_resource.

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -66,6 +66,7 @@ cdef extern from "rmm/mr/device/pool_memory_resource.hpp" \
             Upstream* upstream_mr,
             optional[size_t] initial_pool_size,
             optional[size_t] maximum_pool_size) except +
+        size_t pool_size()
 
 cdef extern from "rmm/mr/device/fixed_size_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
@@ -298,6 +299,10 @@ cdef class PoolMemoryResource(UpstreamResourceAdaptor):
             Maximum size in bytes, that the pool can grow to.
         """
         pass
+
+    def pool_size(self):
+        return (<pool_memory_resource[device_memory_resource]*>(
+            self.c_obj.get()))[0].pool_size()
 
 
 cdef class FixedSizeMemoryResource(UpstreamResourceAdaptor):

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -301,9 +301,10 @@ cdef class PoolMemoryResource(UpstreamResourceAdaptor):
         pass
 
     def pool_size(self):
-        return (<pool_memory_resource[device_memory_resource]*>(
-            self.c_obj.get()))[0].pool_size()
-
+        cdef pool_memory_resource[device_memory_resource]* c_mr = (
+            <pool_memory_resource[device_memory_resource]*>(self.get_mr())
+        )
+        return c_mr.pool_size()
 
 cdef class FixedSizeMemoryResource(UpstreamResourceAdaptor):
     def __cinit__(


### PR DESCRIPTION
It's useful to know how much memory RMM has "to itself" at any given time. When using a `pool_memory_resource`, being able to query the current pool size is the only way to know that.

This is to enable the use cases described in https://github.com/rapidsai/rmm/issues/956 (combined with a `CallbackMemoryResource`, for which I'll open a subsequent PR).