### PR TITLE
Replace `ccache` with `sccache`

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -9,6 +9,7 @@ set -e
 export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
 export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 export CMAKE_GENERATOR="Ninja"
+export CONDA_BLD_DIR="$WORKSPACE/.conda-bld"
 
 # Set home to the job's workspace
 export HOME=$WORKSPACE
@@ -66,20 +67,23 @@ conda config --set ssl_verify False
 if [[ "$BUILD_LIBRMM" == "1" ]]; then
   gpuci_logger "Build conda pkg for librmm"
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
-    gpuci_conda_retry build --no-build-id conda/recipes/librmm --python=$PYTHON
+    gpuci_conda_retry build conda/recipes/librmm --python=$PYTHON
   else
-    gpuci_conda_retry build --no-build-id --dirty --no-remove-work-dir conda/recipes/librmm
+    gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} --dirty --no-remove-work-dir conda/recipes/librmm
+    mkdir -p ${CONDA_BLD_DIR}/librmm
+    mv ${CONDA_BLD_DIR}/work/ ${CONDA_BLD_DIR}/librmm/work
   fi
 fi
 
 if [[ "$BUILD_RMM" == "1" ]]; then
   gpuci_logger "Build conda pkg for rmm"
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
-    gpuci_conda_retry build --no-build-id conda/recipes/rmm --python=$PYTHON
+    gpuci_conda_retry build conda/recipes/rmm --python=$PYTHON
   else
-    gpuci_conda_retry build --no-build-id --dirty --no-remove-work-dir \
-      -c $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ conda/recipes/rmm
-
+    gpuci_conda_retry build --no-build-id --croot ${CONDA_BLD_DIR} --dirty --no-remove-work-dir \
+      -c $WORKSPACE/ci/artifacts/rmm/cpu/.conda-bld/ conda/recipes/rmm
+    mkdir -p ${CONDA_BLD_DIR}/rmm
+    mv ${CONDA_BLD_DIR}/work/ ${CONDA_BLD_DIR}/rmm/work
   fi
 fi
 

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -66,18 +66,18 @@ conda config --set ssl_verify False
 if [[ "$BUILD_LIBRMM" == "1" ]]; then
   gpuci_logger "Build conda pkg for librmm"
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
-    gpuci_conda_retry build conda/recipes/librmm --python=$PYTHON
+    gpuci_conda_retry build --no-build-id conda/recipes/librmm --python=$PYTHON
   else
-    gpuci_conda_retry build --dirty --no-remove-work-dir conda/recipes/librmm
+    gpuci_conda_retry build --no-build-id --dirty --no-remove-work-dir conda/recipes/librmm
   fi
 fi
 
 if [[ "$BUILD_RMM" == "1" ]]; then
   gpuci_logger "Build conda pkg for rmm"
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
-    gpuci_conda_retry build conda/recipes/rmm --python=$PYTHON
+    gpuci_conda_retry build --no-build-id conda/recipes/rmm --python=$PYTHON
   else
-    gpuci_conda_retry build --dirty --no-remove-work-dir \
+    gpuci_conda_retry build --no-build-id --dirty --no-remove-work-dir \
       -c $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ conda/recipes/rmm
 
   fi

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -66,7 +66,6 @@ conda config --set ssl_verify False
 
 if [[ "$BUILD_LIBRMM" == "1" ]]; then
   gpuci_logger "Build conda pkg for librmm"
-  sccache --zero-stats
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     gpuci_conda_retry build conda/recipes/librmm --python=$PYTHON
   else

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -66,6 +66,7 @@ conda config --set ssl_verify False
 
 if [[ "$BUILD_LIBRMM" == "1" ]]; then
   gpuci_logger "Build conda pkg for librmm"
+  sccache --zero-stats
   if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     gpuci_conda_retry build conda/recipes/librmm --python=$PYTHON
   else
@@ -73,6 +74,8 @@ if [[ "$BUILD_LIBRMM" == "1" ]]; then
     mkdir -p ${CONDA_BLD_DIR}/librmm
     mv ${CONDA_BLD_DIR}/work/ ${CONDA_BLD_DIR}/librmm/work
   fi
+  gpuci_logger "sccache stats"
+  sccache --show-stats
 fi
 
 if [[ "$BUILD_RMM" == "1" ]]; then

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -25,6 +25,11 @@ if [[ "$BUILD_MODE" = "branch" && "$SOURCE_BRANCH" = branch-* ]] ; then
   export VERSION_SUFFIX=`date +%y%m%d`
 fi
 
+# Set sccache as CMake compiler
+export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
+export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
+export CMAKE_C_COMPILER_LAUNCHER="sccache"
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -118,11 +118,11 @@ else
 
     cd $WORKSPACE/python
 
-    CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ -name "librmm*.tar.bz2"`
+    CONDA_FILE=`find $WORKSPACE/ci/artifacts/rmm/cpu/.conda-bld/ -name "librmm*.tar.bz2"`
     CONDA_FILE=`basename "$CONDA_FILE" .tar.bz2` #get filename without extension
     CONDA_FILE=${CONDA_FILE//-/=} #convert to conda install
     gpuci_logger "Installing $CONDA_FILE"
-    gpuci_mamba_retry install -c $WORKSPACE/ci/artifacts/rmm/cpu/conda-bld/ "$CONDA_FILE"
+    gpuci_mamba_retry install -c $WORKSPACE/ci/artifacts/rmm/cpu/.conda-bld/ "$CONDA_FILE"
 
     export LIBRMM_BUILD_DIR="$WORKSPACE/ci/artifacts/rmm/cpu/conda_work/build"
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -32,6 +32,11 @@ export GIT_DESCRIBE_TAG=`git describe --abbrev=0 --tags`
 export GIT_DESCRIBE_NUMBER=`git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
+# Set sccache as CMake compiler
+export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
+export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
+export CMAKE_C_COMPILER_LAUNCHER="sccache"
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -20,14 +20,16 @@ build:
     - CUDAHOSTCXX
     - PARALLEL_LEVEL
     - VERSION_SUFFIX
-    - CCACHE_DIR
-    - CCACHE_NOHASHDIR
-    - CCACHE_COMPILERCHECK
     - CMAKE_GENERATOR
     - CMAKE_C_COMPILER_LAUNCHER
     - CMAKE_CXX_COMPILER_LAUNCHER
     - CMAKE_CUDA_COMPILER_LAUNCHER
     - PROJECT_FLASH
+    - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
+    - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
+    - SCCACHE_BUCKET=rapids-sccache
+    - SCCACHE_REGION=us-west-2
+    - SCCACHE_IDLE_TIMEOUT=32768
   run_exports:
     - {{ pin_subpackage("librmm", max_pin="x.x") }}
 


### PR DESCRIPTION
This PR replaces `ccache` with `sccache`. The reason for the replacement is to reduce the complexity involved in the CI backend to manually move around `ccache` tarballs.