### PR TITLE
Fix signed/unsigned comparison warning

### DIFF
--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -324,7 +324,8 @@ class device_buffer {
    */
   [[nodiscard]] std::int64_t ssize() const noexcept
   {
-    assert(size() < std::numeric_limits<int64_t>::max() && "Size overflows signed integer");
+    assert(size() < static_cast<std::size_t>(std::numeric_limits<int64_t>::max()) &&
+           "Size overflows signed integer");
     return static_cast<int64_t>(size());
   }
 


### PR DESCRIPTION
After #966 builds with full warnings enabled as errors could fail with the following error:
```
/miniconda3/envs/cudf_dev/include/rmm/device_buffer.hpp: In member function ‘int64_t rmm::device_buffer::ssize() const’:
/home/jlowe/miniconda3/envs/cudf_dev/include/rmm/device_buffer.hpp:327:19: error: comparison of integer expressions of different signedness: ‘std::size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Werror=sign-compare]
  327 |     assert(size() < std::numeric_limits<int64_t>::max() && "Size overflows signed integer");
      |            ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

This fixes the warning by casting the numerical limit to `std::size_t` before comparing.