### PR TITLE
Update `librmm` recipe to output `librmm_tests` package

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -26,11 +26,6 @@ if [[ "$BUILD_MODE" = "branch" && "$SOURCE_BRANCH" = branch-* ]] ; then
   export VERSION_SUFFIX=`date +%y%m%d`
 fi
 
-# Set sccache as CMake compiler
-export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
-export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
-export CMAKE_C_COMPILER_LAUNCHER="sccache"
-
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/ci/cpu/upload.sh
+++ b/ci/cpu/upload.sh
@@ -31,19 +31,19 @@ fi
 gpuci_logger "Starting conda uploads"
 
 if [[ "$BUILD_LIBRMM" == "1" && "$UPLOAD_LIBRMM" == "1" ]]; then
-  export LIBRMM_FILE=$(conda build --croot ${CONDA_BLD_DIR} conda/recipes/librmm --output)
-  test -e ${LIBRMM_FILE}
-  echo "Upload librmm"
-  echo ${LIBRMM_FILE}
-  gpuci_retry anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --skip-existing ${LIBRMM_FILE} --no-progress
+  export LIBRMM_FILES=$(conda build --croot ${CONDA_BLD_DIR} conda/recipes/librmm --output)
+  while read -r LIBRMM_FILE; do
+    test -e ${LIBRMM_FILE}
+    echo "Upload librmm file: ${LIBRMM_FILE}"
+    gpuci_retry anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --skip-existing ${LIBRMM_FILE} --no-progress
+  done <<< "${LIBRMM_FILES}"
 fi
 
 if [[ "$BUILD_RMM" == "1" && "$UPLOAD_RMM" == "1" ]]; then
   export RMM_FILES=$(conda build --croot ${CONDA_BLD_DIR} conda/recipes/rmm --python=$PYTHON --output)
   while read -r RMM_FILE; do
     test -e ${RMM_FILE}
-    echo "Upload rmm"
-    echo ${RMM_FILE}
+    echo "Upload rmm file: ${RMM_FILE}"
     gpuci_retry anaconda -t ${MY_UPLOAD_KEY} upload -u ${CONDA_USERNAME:-rapidsai} ${LABEL_OPTION} --skip-existing ${RMM_FILE} --no-progress
   done <<< "${RMM_FILES}"
 fi

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -39,8 +39,6 @@ export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 gpuci_logger "Get env"
 env
 
-set -x
-
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -32,11 +32,6 @@ export GIT_DESCRIBE_TAG=`git describe --abbrev=0 --tags`
 export GIT_DESCRIBE_NUMBER=`git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
-# Set sccache as CMake compiler
-export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"
-export CMAKE_CXX_COMPILER_LAUNCHER="sccache"
-export CMAKE_C_COMPILER_LAUNCHER="sccache"
-
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -39,6 +39,8 @@ export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 gpuci_logger "Get env"
 env
 
+set -x
+
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids

--- a/conda/recipes/librmm/build.sh
+++ b/conda/recipes/librmm/build.sh
@@ -1,8 +1,3 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
-# This assumes the script is executed from the root of the repo directory
-if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
-  ./build.sh -v clean librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
-else
-  ./build.sh -v clean librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
-fi
+./build.sh -n -v clean librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"

--- a/conda/recipes/librmm/install_librmm.sh
+++ b/conda/recipes/librmm/install_librmm.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cmake --install build

--- a/conda/recipes/librmm/install_librmm_tests.sh
+++ b/conda/recipes/librmm/install_librmm_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cmake --install build --component testing

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -3,82 +3,107 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
+{% set cmake_version=">=3.20.1" %}
+{% set gtest_version="=1.10.0" %}
 
 package:
-  name: librmm
-  version: {{ version }}
+  name: librmm-split
 
 source:
   git_url: ../../..
 
+requirements:
+  build:
+    - cmake {{ cmake_version }}
+
 build:
-  number: {{ GIT_DESCRIBE_NUMBER }}
-  string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - CC
     - CXX
     - CUDAHOSTCXX
     - PARALLEL_LEVEL
-    - VERSION_SUFFIX
     - CMAKE_GENERATOR
     - CMAKE_C_COMPILER_LAUNCHER
     - CMAKE_CXX_COMPILER_LAUNCHER
     - CMAKE_CUDA_COMPILER_LAUNCHER
-    - PROJECT_FLASH
     - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
     - SCCACHE_BUCKET=rapids-sccache
     - SCCACHE_REGION=us-west-2
     - SCCACHE_IDLE_TIMEOUT=32768
-  run_exports:
-    - {{ pin_subpackage("librmm", max_pin="x.x") }}
 
-requirements:
-  build:
-    - cmake >=3.20.1
-  host:
-    - cudatoolkit {{ cuda_version }}.*
-  run:
-    - spdlog>=1.8.5,<1.9
-    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
-
-test:
-  commands:
-    - test -f $PREFIX/include/rmm/thrust_rmm_allocator.h
-    - test -f $PREFIX/include/rmm/logger.hpp
-    - test -f $PREFIX/include/rmm/cuda_stream.hpp
-    - test -f $PREFIX/include/rmm/cuda_stream_view.hpp
-    - test -f $PREFIX/include/rmm/cuda_stream_pool.hpp
-    - test -f $PREFIX/include/rmm/device_uvector.hpp
-    - test -f $PREFIX/include/rmm/device_scalar.hpp
-    - test -f $PREFIX/include/rmm/device_buffer.hpp
-    - test -f $PREFIX/include/rmm/detail/aligned.hpp
-    - test -f $PREFIX/include/rmm/detail/error.hpp
-    - test -f $PREFIX/include/rmm/detail/exec_check_disable.hpp
-    - test -f $PREFIX/include/rmm/mr/device/detail/arena.hpp
-    - test -f $PREFIX/include/rmm/mr/device/detail/free_list.hpp
-    - test -f $PREFIX/include/rmm/mr/device/detail/coalescing_free_list.hpp
-    - test -f $PREFIX/include/rmm/mr/device/detail/fixed_size_free_list.hpp
-    - test -f $PREFIX/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/arena_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/binning_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/cuda_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/device_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/fixed_size_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/limiting_resource_adaptor.hpp
-    - test -f $PREFIX/include/rmm/mr/device/logging_resource_adaptor.hpp
-    - test -f $PREFIX/include/rmm/mr/device/managed_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/owning_wrapper.hpp
-    - test -f $PREFIX/include/rmm/mr/device/per_device_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/pool_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
-    - test -f $PREFIX/include/rmm/mr/device/thrust_allocator_adaptor.hpp
-    - test -f $PREFIX/include/rmm/mr/host/host_memory_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/host/new_delete_resource.hpp
-    - test -f $PREFIX/include/rmm/mr/host/pinned_memory_resource.hpp
-
-about:
-  home: http://rapids.ai/
-  license: Apache-2.0
-  # license_file: LICENSE
-  summary: librmm library
+outputs:
+  - name: librmm
+    version: {{ version }}
+    script: install_librmm.sh
+    build:
+      number: {{ GIT_DESCRIBE_NUMBER }}
+      string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+      run_exports:
+        - {{ pin_subpackage("librmm", max_pin="x.x") }}
+    requirements:
+      build:
+        - cmake {{ cmake_version }}
+      host:
+        - cudatoolkit {{ cuda_version }}.*
+      run:
+        - spdlog>=1.8.5,<1.9
+        - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    test:
+      commands:
+        - test -f $PREFIX/include/rmm/thrust_rmm_allocator.h
+        - test -f $PREFIX/include/rmm/logger.hpp
+        - test -f $PREFIX/include/rmm/cuda_stream.hpp
+        - test -f $PREFIX/include/rmm/cuda_stream_view.hpp
+        - test -f $PREFIX/include/rmm/cuda_stream_pool.hpp
+        - test -f $PREFIX/include/rmm/device_uvector.hpp
+        - test -f $PREFIX/include/rmm/device_scalar.hpp
+        - test -f $PREFIX/include/rmm/device_buffer.hpp
+        - test -f $PREFIX/include/rmm/detail/aligned.hpp
+        - test -f $PREFIX/include/rmm/detail/error.hpp
+        - test -f $PREFIX/include/rmm/detail/exec_check_disable.hpp
+        - test -f $PREFIX/include/rmm/mr/device/detail/arena.hpp
+        - test -f $PREFIX/include/rmm/mr/device/detail/free_list.hpp
+        - test -f $PREFIX/include/rmm/mr/device/detail/coalescing_free_list.hpp
+        - test -f $PREFIX/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+        - test -f $PREFIX/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/arena_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/binning_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/cuda_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/device_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/fixed_size_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/limiting_resource_adaptor.hpp
+        - test -f $PREFIX/include/rmm/mr/device/logging_resource_adaptor.hpp
+        - test -f $PREFIX/include/rmm/mr/device/managed_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/owning_wrapper.hpp
+        - test -f $PREFIX/include/rmm/mr/device/per_device_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/pool_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+        - test -f $PREFIX/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+        - test -f $PREFIX/include/rmm/mr/host/host_memory_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/host/new_delete_resource.hpp
+        - test -f $PREFIX/include/rmm/mr/host/pinned_memory_resource.hpp
+    about:
+      home: http://rapids.ai/
+      license: Apache-2.0
+      summary: librmm library
+  - name: librmm_tests
+    version: {{ version }}
+    script: install_librmm_tests.sh
+    build:
+      number: {{ GIT_DESCRIBE_NUMBER }}
+      string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+    requirements:
+      build:
+        - cmake {{ cmake_version }}
+      host:
+        - cudatoolkit {{ cuda_version }}.*
+      run:
+        - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+        - {{ pin_subpackage('librmm', exact=True) }}
+        - gtest {{ gtest_version }}
+        - gmock {{ gtest_version }}
+    about:
+      home: http://rapids.ai/
+      license: Apache-2.0
+      summary: librmm test & benchmark executables


### PR DESCRIPTION
This PR updates the `librmm` recipe to include a new output, `librmm_tests`. `librmm_tests` is a `conda` package that includes all of the binaries for `librmm`'s tests and benchmarks. This PR is a prerequisite for deprecating Project Flash.

This also updates the CI scripts to use the new package for tests.