### PR TITLE
Update `librmm` `conda` outputs

### DIFF
--- a/conda/recipes/librmm/build.sh
+++ b/conda/recipes/librmm/build.sh
@@ -1,3 +1,0 @@
-# Copyright (c) 2018-2019, NVIDIA CORPORATION.
-
-./build.sh -n -v clean librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"

--- a/conda/recipes/librmm/install_librmm.sh
+++ b/conda/recipes/librmm/install_librmm.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
-cmake --install build
+./build.sh -v librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"

--- a/conda/recipes/librmm/install_librmm_tests.sh
+++ b/conda/recipes/librmm/install_librmm_tests.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
+./build.sh -n -v librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
 cmake --install build --component testing

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -12,26 +12,6 @@ package:
 source:
   git_url: ../../..
 
-requirements:
-  build:
-    - cmake {{ cmake_version }}
-
-build:
-  script_env:
-    - CC
-    - CXX
-    - CUDAHOSTCXX
-    - PARALLEL_LEVEL
-    - CMAKE_GENERATOR
-    - CMAKE_C_COMPILER_LAUNCHER
-    - CMAKE_CXX_COMPILER_LAUNCHER
-    - CMAKE_CUDA_COMPILER_LAUNCHER
-    - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
-    - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
-    - SCCACHE_BUCKET=rapids-sccache
-    - SCCACHE_REGION=us-west-2
-    - SCCACHE_IDLE_TIMEOUT=32768
-
 outputs:
   - name: librmm
     version: {{ version }}
@@ -39,6 +19,20 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+      script_env: &script_env
+        - CC
+        - CXX
+        - CUDAHOSTCXX
+        - PARALLEL_LEVEL
+        - CMAKE_GENERATOR
+        - CMAKE_C_COMPILER_LAUNCHER
+        - CMAKE_CXX_COMPILER_LAUNCHER
+        - CMAKE_CUDA_COMPILER_LAUNCHER
+        - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
+        - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
+        - SCCACHE_BUCKET=rapids-sccache
+        - SCCACHE_REGION=us-west-2
+        - SCCACHE_IDLE_TIMEOUT=32768
       run_exports:
         - {{ pin_subpackage("librmm", max_pin="x.x") }}
     requirements:
@@ -93,6 +87,7 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+      script_env: *script_env
     requirements:
       build:
         - cmake {{ cmake_version }}


### PR DESCRIPTION
This PR is a continuation of #978. Initially I thought we'd be able to do a single top-level build with `build.sh` and then simply run `cmake --install...` for the `Outputs` entries. However, I think this would require us to duplicate the `requirements` for each `Outputs` package in the top-level build, which doesn't seem like a good practice. Instead, this PR changes the recipe to build and install the relevant CMake components during each package's individual build steps.

The environment variables are copied between package builds using a [YAML anchor](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/).