### PR TITLE
Fix `bash` command for running tests

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -91,7 +91,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     fi
 else
 
-    gpuci_mamba_retry install -c $WORKSPACE/ci/artifacts/rmm/cpu/.conda-bld/ librmm librmm_tests
+    gpuci_mamba_retry install -y -c $WORKSPACE/ci/artifacts/rmm/cpu/.conda-bld/ librmm_tests
 
     TESTRESULTS_DIR=${WORKSPACE}/test-results
     mkdir -p ${TESTRESULTS_DIR}

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -102,7 +102,7 @@ else
 
     gpuci_logger "Running googletests"
     # run gtests from librmm_tests package
-    for gt in "$CONDA_PREFIX/bin/gtests/librmm/*" ; do
+    for gt in "$CONDA_PREFIX/bin/gtests/librmm/"* ; do
         ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
         exitcode=$?
         if (( ${exitcode} != 0 )); then


### PR DESCRIPTION
Previously, the `bash` loop that's responsible for running `librmm`'s unit tests had incorrect quotes around the expression, which prevented shell expansion from occurring. This PR moves the quotes so that it doesn't include the `*` character.

Once the `*` was removed from the quotes, it caused more tests to be run, some of which aren't compatible on CUDA < 11.2. So this PR also adds a JSON array, `ASYNC_TESTS_TO_SKIP`, of test names that should be skipped on older CUDA versions.