### PR TITLE
Use CUDA 11.2+ features via dlopen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ target_include_directories(rmm INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOUR
 if(CUDA_STATIC_RUNTIME)
   message(STATUS "RMM: Enabling static linking of cudart")
   target_link_libraries(rmm INTERFACE CUDA::cudart_static)
+  target_compile_definitions(rmm INTERFACE RMM_STATIC_CUDART)
 else()
   target_link_libraries(rmm INTERFACE CUDA::cudart)
 endif()

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 #pragma once
+#include <cuda_runtime_api.h>
 #include <dlfcn.h>
 #include <memory>
-#include <cuda_runtime_api.h>
 
 namespace rmm::detail {
 
@@ -39,7 +39,7 @@ struct dynamic_load_runtime {
       const std::string libname_ver = "libcudart.so." + std::to_string(major) + ".0";
       const std::string libname     = "libcudart.so";
 
-      auto ptr = ::dlopen(libname_ver.c_str(), RTLD_LAZY);
+      auto* ptr = ::dlopen(libname_ver.c_str(), RTLD_LAZY);
       if (!ptr) { ::dlopen(libname.c_str(), RTLD_LAZY); }
       if (!ptr) { return false; }
 
@@ -57,7 +57,7 @@ struct dynamic_load_runtime {
     if (!open_cuda_runtime()) { return nullptr; }
     auto* handle = ::dlsym(cuda_runtime_lib.get(), func_name);
     if (!handle) { return nullptr; }
-    auto function_ptr = reinterpret_cast<cudart_func_ptr<Args...>>(handle);
+    auto* function_ptr = reinterpret_cast<cudart_func_ptr<Args...>>(handle);
     return function_ptr;
   }
 };
@@ -73,7 +73,6 @@ struct dynamic_load_runtime {
 struct async_alloc {
   static bool is_supported()
   {
-
 #if defined(RMM_STATIC_CUDART)
     static bool runtime_supports_pool = (CUDART_VERSION >= 11020);
 #else

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -53,7 +53,6 @@ struct dynamic_load_runtime {
   static cudart_func_ptr<Args...> function(const char* func_name)
   {
     auto* runtime = open_cuda_runtime();
-    if (!runtime) { return nullptr; }
     auto* handle = ::dlsym(runtime, func_name);
     if (!handle) { return nullptr; }
     auto* function_ptr = reinterpret_cast<cudart_func_ptr<Args...>>(handle);

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -62,7 +62,7 @@ struct dynamic_load_runtime {
 
 #if CUDART_VERSION >= 11020  // 11.2 introduced cudaMallocAsync
 /**
- * @brief `async_alloc` bind to the Stream Ordered Memory Allocator functions
+ * @brief Bind to the stream-ordered memory allocator functions
  * at runtime.
  *
  * This allows RMM users to compile/link against CUDA 11.2+ and run with

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -75,7 +75,7 @@ struct async_alloc {
     static bool runtime_supports_pool = (CUDART_VERSION >= 11020);
 #else
     static bool runtime_supports_pool =
-      dynamic_load_runtime::function<dynamic_load_runtime::funcion_sig<void*, cudaStream_t>>(
+      dynamic_load_runtime::function<dynamic_load_runtime::function_sig<void*, cudaStream_t>>(
         "cudaFreeAsync") != nullptr;
 #endif
 

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -96,7 +96,7 @@ struct async_alloc {
 #else
     static bool runtime_supports_pool =
       dynamic_load_runtime::function<dynamic_load_runtime::function_sig<void*, cudaStream_t>>(
-        "cudaFreeAsync") != nullptr;
+        "cudaFreeAsync").has_value();
 #endif
 
     static auto driver_supports_pool{[] {

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -16,8 +16,8 @@
 #pragma once
 #include <cuda_runtime_api.h>
 #include <dlfcn.h>
-#include <optional>
 #include <memory>
+#include <optional>
 
 namespace rmm::detail {
 
@@ -75,7 +75,7 @@ struct dynamic_load_runtime {
   static cudaError_t name(Args... args)                                        \
   {                                                                            \
     static const auto func = dynamic_load_runtime::function<signature>(#name); \
-    if(func) { return (*func)(args...); }                                      \
+    if (func) { return (*func)(args...); }                                     \
     RMM_FAIL("Failed to find #name function in libcudart.so");                 \
   }
 #endif

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -62,14 +62,19 @@ struct dynamic_load_runtime {
 };
 
 #if defined(RMM_STATIC_CUDART)
+// clang-format off
 #define RMM_CUDART_API_WRAPPER(name, signature)                               \
   template <typename... Args>                                                 \
   static cudaError_t name(Args... args)                                       \
   {                                                                           \
+    _Pragma("GCC diagnostic push")                                            \
+    _Pragma("GCC diagnostic ignored \"-Waddress\"")                           \
     static_assert(static_cast<signature>(::name),                             \
                   "Failed to find #name function with arguments #signature"); \
+    _Pragma("GCC diagnostic pop")                                             \
     return ::name(args...);                                                   \
   }
+// clang-format on
 #else
 #define RMM_CUDART_API_WRAPPER(name, signature)                                \
   template <typename... Args>                                                  \

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -47,7 +47,7 @@ struct dynamic_load_runtime {
   }
 
   template <typename... Args>
-  using funcion_sig = std::add_pointer_t<cudaError_t(Args...)>;
+  using function_sig = std::add_pointer_t<cudaError_t(Args...)>;
 
   template <typename signature>
   static signature function(const char* func_name)

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -65,7 +65,7 @@ struct dynamic_load_runtime {
  * @brief `async_alloc` bind to the Stream Ordered Memory Allocator functions
  * at runtime.
  *
- * This allows us rmm users to compile/link against CUDA 11.2+ and run with
+ * This allows RMM users to compile/link against CUDA 11.2+ and run with
  * < CUDA 11.2 runtime as these functions are found at call time
  */
 struct async_alloc {

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -49,15 +49,15 @@ struct dynamic_load_runtime {
   }
 
   template <typename... Args>
-  using function_return_type = std::add_pointer_t<cudaError_t(Args...)>;
+  using cudart_func_ptr = std::add_pointer_t<cudaError_t(Args...)>;
 
   template <typename... Args>
-  static function_return_type<Args...> function(const char* func_name)
+  static cudart_func_ptr<Args...> function(const char* func_name)
   {
     if (!open_cuda_runtime()) { return nullptr; }
     auto* handle = ::dlsym(cuda_runtime_lib.get(), func_name);
     if (!handle) { return nullptr; }
-    auto function_ptr = reinterpret_cast<function_return_type<Args...>>(handle);
+    auto function_ptr = reinterpret_cast<cudart_func_ptr<Args...>>(handle);
     return function_ptr;
   }
 };

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -50,7 +50,7 @@ struct dynamic_load_runtime {
   using funcion_sig = std::add_pointer_t<cudaError_t(Args...)>;
 
   template <typename signature>
-  static funcion_sig function(const char* func_name)
+  static signature function(const char* func_name)
   {
     auto* runtime = get_cuda_runtime_handle();
     auto* handle  = ::dlsym(runtime, func_name);

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -108,7 +108,7 @@ struct async_alloc {
   }
 
   template <typename... Args>
-  using cudart_sig = dynamic_load_runtime::funcion_sig<Args...>;
+  using cudart_sig = dynamic_load_runtime::function_sig<Args...>;
 
   using cudaMemPoolCreate_sig = cudart_sig<cudaMemPool_t*, const cudaMemPoolProps*>;
   RMM_CUDART_API_WRAPPER(cudaMemPoolCreate, cudaMemPoolCreate_sig);

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -55,7 +55,7 @@ struct dynamic_load_runtime {
   {
     auto* runtime = get_cuda_runtime_handle();
     auto* handle  = ::dlsym(runtime, func_name);
-    if (!handle) { return nullptr; }
+    if (!handle) { return std::nullopt; }
     auto* function_ptr = reinterpret_cast<signature>(handle);
     return std::optional<signature>(function_ptr);
   }

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -62,12 +62,13 @@ struct dynamic_load_runtime {
 };
 
 #if defined(RMM_STATIC_CUDART)
-#define RMM_CUDART_API_WRAPPER(name, signature)              \
-  template <typename... Args>                                \
-  static cudaError_t name(Args... args)                      \
-  {                                                          \
-    static const auto func = static_cast<signature>(::name); \
-    return func(args...);                                    \
+#define RMM_CUDART_API_WRAPPER(name, signature)                               \
+  template <typename... Args>                                                 \
+  static cudaError_t name(Args... args)                                       \
+  {                                                                           \
+    static_assert(static_cast<signature>(::name),                             \
+                  "Failed to find #name function with arguments #signature"); \
+    return ::name(args...);                                                   \
   }
 #else
 #define RMM_CUDART_API_WRAPPER(name, signature)                                \

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -66,7 +66,7 @@ struct dynamic_load_runtime {
  * at runtime.
  *
  * This allows RMM users to compile/link against CUDA 11.2+ and run with
- * < CUDA 11.2 runtime as these functions are found at call time
+ * < CUDA 11.2 runtime as these functions are found at call time.
  */
 struct async_alloc {
   static bool is_supported()

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <dlfcn.h>
+#include <memory>
+
+namespace rmm::detail {
+
+/**
+ * @brief `dynamic_load_runtime` loads the cuda runtime library at runtime
+ *
+ * By loading the cudart library at runtime we can use functions that
+ * are added in newer minor versions of the cuda runtime.
+ */
+struct dynamic_load_runtime {
+  static constexpr auto dlclose_destructor = [](void* handle) { ::dlclose(handle); };
+  inline static std::unique_ptr<void, decltype(dlclose_destructor)> cuda_runtime_lib{
+    nullptr, dlclose_destructor};
+
+  static bool open_cuda_runtime()
+  {
+    if (!cuda_runtime_lib) {
+      ::dlerror();
+      const int major               = CUDART_VERSION / 1000;
+      const std::string libname_ver = "libcudart.so." + std::to_string(major) + ".0";
+      const std::string libname     = "libcudart.so";
+
+      auto ptr = ::dlopen(libname_ver.c_str(), RTLD_LAZY);
+      if (!ptr) { ::dlopen(libname.c_str(), RTLD_LAZY); }
+      if (!ptr) { return false; }
+
+      cuda_runtime_lib.reset(ptr);
+    }
+    return true;
+  }
+
+  template <typename... Args>
+  using function_return_type = std::add_pointer_t<cudaError_t(Args...)>;
+
+  template <typename... Args>
+  static function_return_type<Args...> function(const char* func_name)
+  {
+    if (!open_cuda_runtime()) { return nullptr; }
+    auto* handle = ::dlsym(cuda_runtime_lib.get(), func_name);
+    if (!handle) { return nullptr; }
+    auto function_ptr = reinterpret_cast<function_return_type<Args...>>(handle);
+    return function_ptr;
+  }
+};
+
+
+/**
+ * @brief `async_alloc` bind to the Stream Ordered Memory Allocator functions
+ * at runtime.
+ *
+ * This allows us rmm users to compile/link against CUDA 11.2+ and run with
+ * < CUDA 11.2 runtime as these functions are found at call time
+ */
+struct async_alloc {
+
+  static bool is_supported()
+  {
+#if defined(RMM_STATIC_CUDART)
+    static bool has_support = (CUDART_VERSION >= 11020);
+#else
+    static bool has_support = dynamic_load_runtime::function<void*>("cudaFreeAsync") != nullptr;
+#endif
+    return has_support;
+  }
+
+#if defined(RMM_STATIC_CUDART)
+  #define RMM_SYNC_ALLOC_WRAPPER(name)\
+  template <typename... Args> \
+  static cudaError_t name(Args... args) { \
+    return ::name(args...); \
+  }
+#else
+  #define RMM_SYNC_ALLOC_WRAPPER(name)\
+  template <typename... Args> \
+  static cudaError_t name(Args... args) { \
+    static const auto func = dynamic_load_runtime::function<Args...>(#name); \
+    return func(args...); \
+  }
+#endif
+
+  RMM_SYNC_ALLOC_WRAPPER(cudaMemPoolCreate);
+  RMM_SYNC_ALLOC_WRAPPER(cudaMemPoolSetAttribute);
+  RMM_SYNC_ALLOC_WRAPPER(cudaMemPoolDestroy);
+  RMM_SYNC_ALLOC_WRAPPER(cudaMallocFromPoolAsync);
+  RMM_SYNC_ALLOC_WRAPPER(cudaFreeAsync);
+};
+}  // namespace rmm::detail

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -53,7 +53,7 @@ struct dynamic_load_runtime {
   static cudart_func_ptr<Args...> function(const char* func_name)
   {
     auto* runtime = open_cuda_runtime();
-    auto* handle = ::dlsym(runtime, func_name);
+    auto* handle  = ::dlsym(runtime, func_name);
     if (!handle) { return nullptr; }
     auto* function_ptr = reinterpret_cast<cudart_func_ptr<Args...>>(handle);
     return function_ptr;

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -90,11 +90,12 @@ struct async_alloc {
   }
 
 #if defined(RMM_STATIC_CUDART)
-#define RMM_SYNC_ALLOC_WRAPPER(name, signature) \
-  template <typename... Args>                   \
-  static cudaError_t name(Args... args)         \
-  {                                             \
-    return ::name(args...);                     \
+#define RMM_SYNC_ALLOC_WRAPPER(name, signature)              \
+  template <typename... Args>                                \
+  static cudaError_t name(Args... args)                      \
+  {                                                          \
+    static const auto func = static_cast<signature>(::name); \
+    return func(args...);                                    \
   }
 #else
 #define RMM_SYNC_ALLOC_WRAPPER(name, signature)                                \

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -96,7 +96,8 @@ struct async_alloc {
 #else
     static bool runtime_supports_pool =
       dynamic_load_runtime::function<dynamic_load_runtime::function_sig<void*, cudaStream_t>>(
-        "cudaFreeAsync").has_value();
+        "cudaFreeAsync")
+        .has_value();
 #endif
 
     static auto driver_supports_pool{[] {

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -27,7 +27,7 @@ namespace rmm::detail {
  * are added in newer minor versions of the cuda runtime.
  */
 struct dynamic_load_runtime {
-  static void* open_cuda_runtime()
+  static void* get_cuda_runtime_handle()
   {
     auto close_cudart = [](void* handle) { ::dlclose(handle); };
     auto open_cudart  = []() {
@@ -52,7 +52,7 @@ struct dynamic_load_runtime {
   template <typename... Args>
   static cudart_func_ptr<Args...> function(const char* func_name)
   {
-    auto* runtime = open_cuda_runtime();
+    auto* runtime = get_cuda_runtime_handle();
     auto* handle  = ::dlsym(runtime, func_name);
     if (!handle) { return nullptr; }
     auto* function_ptr = reinterpret_cast<cudart_func_ptr<Args...>>(handle);

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -75,7 +75,7 @@ struct dynamic_load_runtime {
   static cudaError_t name(Args... args)                                        \
   {                                                                            \
     static const auto func = dynamic_load_runtime::function<signature>(#name); \
-    if(func) { return func.value(args...); }                                   \
+    if(func) { return (*func)(args...); }                                      \
     RMM_FAIL("Failed to find #name function in libcudart.so");                 \
   }
 #endif

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -82,8 +82,8 @@ class cuda_async_memory_resource final : public device_memory_resource {
     constexpr auto min_async_version{11050};
     if (driver_version < min_async_version) {
       int disabled{0};
-      RMM_CUDA_TRY(
-        cudaMemPoolSetAttribute(cuda_pool_handle_, cudaMemPoolReuseAllowOpportunistic, &disabled));
+      RMM_CUDA_TRY(rmm::detail::async_alloc::cudaMemPoolSetAttribute(
+        cuda_pool_handle_, cudaMemPoolReuseAllowOpportunistic, &disabled));
     }
 
     auto const [free, total] = rmm::detail::available_device_memory();

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -63,7 +63,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     // Check if cudaMallocAsync Memory pool supported
-    RMM_EXPECTS(is_supported(),
+    RMM_EXPECTS(rmm::detail::async_alloc::is_supported(),
                 "cudaMallocAsync not supported with this CUDA driver/runtime version");
 
     // Construct explicit pool
@@ -111,27 +111,6 @@ class cuda_async_memory_resource final : public device_memory_resource {
   cuda_async_memory_resource(cuda_async_memory_resource&&)      = delete;
   cuda_async_memory_resource& operator=(cuda_async_memory_resource const&) = delete;
   cuda_async_memory_resource& operator=(cuda_async_memory_resource&&) = delete;
-
-  /**
-   * @brief Is cudaMallocAsync supported with this cuda runtime/driver version?
-   * @return true if both the cuda runtime and driver are newer than 11.2
-   */
-  static bool is_supported()
-  {
-#if defined(RMM_CUDA_MALLOC_ASYNC_SUPPORT)
-    static auto runtime_supports_pool = rmm::detail::async_alloc::is_supported();
-    static auto driver_supports_pool{[] {
-      int cuda_pool_supported{};
-      auto result = cudaDeviceGetAttribute(&cuda_pool_supported,
-                                           cudaDevAttrMemoryPoolsSupported,
-                                           rmm::detail::current_device().value());
-      return result == cudaSuccess and cuda_pool_supported == 1;
-    }()};
-    return runtime_supports_pool and driver_supports_pool;
-#else
-    return false;
-#endif
-  }
 
   /**
    * @brief Query whether the resource supports use of non-null CUDA streams for

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -104,7 +104,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
   ~cuda_async_memory_resource() override
   {
 #if defined(RMM_CUDA_MALLOC_ASYNC_SUPPORT)
-    RMM_ASSERT_CUDA_SUCCESS(cudaMemPoolDestroy(pool_handle()));
+    RMM_ASSERT_CUDA_SUCCESS(rmm::detail::async_alloc::cudaMemPoolDestroy(pool_handle()));
 #endif
   }
   cuda_async_memory_resource(cuda_async_memory_resource const&) = delete;

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -28,7 +28,7 @@ class AsyncMRTest : public ::testing::Test {
  protected:
   void SetUp() override
   {
-    if (!rmm::mr::cuda_async_memory_resource::is_supported()) {
+    if (!rmm::detail::async_alloc::is_supported()) {
       GTEST_SKIP() << "Skipping tests since cudaMallocAsync not supported with this CUDA "
                    << "driver/runtime version";
     }

--- a/tests/mr/device/mr_test.hpp
+++ b/tests/mr/device/mr_test.hpp
@@ -252,7 +252,7 @@ inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>
 
 inline auto make_cuda_async()
 {
-  if (rmm::mr::cuda_async_memory_resource::is_supported()) {
+  if (rmm::detail::async_alloc::is_supported()) {
     return std::make_shared<rmm::mr::cuda_async_memory_resource>();
   }
   return std::shared_ptr<rmm::mr::cuda_async_memory_resource>{nullptr};


### PR DESCRIPTION
By binding to the cudart 11.2 functions at runtime we remove the requirement that these symbols exist, therefore allowing
RMM to be compiled with 11.2+ and used with 11.0 or 11.1.

