### PR TITLE
Disable opportunistic reuse in async mr when cuda driver < 11.5

### DIFF
--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -106,10 +106,10 @@ class cuda_async_memory_resource final : public device_memory_resource {
     RMM_ASSERT_CUDA_SUCCESS(cudaMemPoolDestroy(pool_handle()));
 #endif
   }
-  cuda_async_memory_resource(cuda_async_memory_resource const&) = delete;
-  cuda_async_memory_resource(cuda_async_memory_resource&&)      = delete;
+  cuda_async_memory_resource(cuda_async_memory_resource const&)            = delete;
+  cuda_async_memory_resource(cuda_async_memory_resource&&)                 = delete;
   cuda_async_memory_resource& operator=(cuda_async_memory_resource const&) = delete;
-  cuda_async_memory_resource& operator=(cuda_async_memory_resource&&) = delete;
+  cuda_async_memory_resource& operator=(cuda_async_memory_resource&&)      = delete;
 
   /**
    * @brief Is cudaMallocAsync supported with this cuda runtime/driver version?
@@ -125,12 +125,19 @@ class cuda_async_memory_resource final : public device_memory_resource {
       return runtime_version >= min_async_version;
     }()};
     static auto driver_supports_pool{[] {
+      int cuda_pool_supported{};
+      auto result = cudaDeviceGetAttribute(&cuda_pool_supported,
+                                           cudaDevAttrMemoryPoolsSupported,
+                                           rmm::detail::current_device().value());
+
       int driver_version{};
       RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
       // CUDA drivers before 11.5 have known incompatibilities with the async allocator.
       // See https://github.com/NVIDIA/spark-rapids/issues/4710.
       constexpr auto min_async_version{11050};
-      return driver_version >= min_async_version;
+
+      return result == cudaSuccess and cuda_pool_supported == 1 and
+             driver_version >= min_async_version;
     }()};
     return runtime_supports_pool and driver_supports_pool;
 #else


### PR DESCRIPTION
With https://github.com/NVIDIA/spark-rapids/issues/4710 we found some issues with the async pool that may cause memory errors with older drivers. This was confirmed with the cuda team. For driver version < 11.5, we'll disable `cudaMemPoolReuseAllowOpportunistic`.

@abellina 