### PR TITLE
Update `librmm` `conda` recipe

### DIFF
--- a/conda/recipes/librmm/build.sh
+++ b/conda/recipes/librmm/build.sh
@@ -1,3 +1,3 @@
-# Copyright (c) 2018-2019, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 ./build.sh -n -v clean librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"

--- a/conda/recipes/librmm/build.sh
+++ b/conda/recipes/librmm/build.sh
@@ -1,0 +1,3 @@
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.
+
+./build.sh -n -v clean librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"

--- a/conda/recipes/librmm/conda_build_config.yaml
+++ b/conda/recipes/librmm/conda_build_config.yaml
@@ -1,0 +1,5 @@
+cmake_version:
+  - ">=3.20.1"
+
+gtest_version:
+  - "=1.10.0"

--- a/conda/recipes/librmm/install_librmm.sh
+++ b/conda/recipes/librmm/install_librmm.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
-./build.sh -v librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+cmake --install build

--- a/conda/recipes/librmm/install_librmm_tests.sh
+++ b/conda/recipes/librmm/install_librmm_tests.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
-./build.sh -n -v librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
 cmake --install build --component testing

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -3,6 +3,7 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
+{% set cuda_spec = ">=" + cuda_major ~ ",<" + (cuda_major | int + 1) ~ ".0a0" %} # i.e. >=11,<12.0a0
 
 package:
   name: librmm-split
@@ -13,6 +14,8 @@ source:
 requirements:
   build:
     - cmake {{ cmake_version }}
+  host:
+    - cudatoolkit {{ cuda_version }}.*
 
 build:
   script_env:
@@ -42,11 +45,9 @@ outputs:
     requirements:
       build:
         - cmake {{ cmake_version }}
-      host:
-        - cudatoolkit {{ cuda_version }}.*
       run:
+        - cudatoolkit {{ cuda_spec }}
         - spdlog>=1.8.5,<1.9
-        - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     test:
       commands:
         - test -f $PREFIX/include/rmm/thrust_rmm_allocator.h
@@ -94,10 +95,8 @@ outputs:
     requirements:
       build:
         - cmake {{ cmake_version }}
-      host:
-        - cudatoolkit {{ cuda_version }}.*
       run:
-        - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+        - cudatoolkit {{ cuda_spec }}
         - {{ pin_subpackage('librmm', exact=True) }}
         - gtest {{ gtest_version }}
         - gmock {{ gtest_version }}

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -12,6 +12,26 @@ package:
 source:
   git_url: ../../..
 
+requirements:
+  build:
+    - cmake {{ cmake_version }}
+
+build:
+  script_env:
+    - CC
+    - CXX
+    - CUDAHOSTCXX
+    - PARALLEL_LEVEL
+    - CMAKE_GENERATOR
+    - CMAKE_C_COMPILER_LAUNCHER
+    - CMAKE_CXX_COMPILER_LAUNCHER
+    - CMAKE_CUDA_COMPILER_LAUNCHER
+    - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
+    - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
+    - SCCACHE_BUCKET=rapids-sccache
+    - SCCACHE_REGION=us-west-2
+    - SCCACHE_IDLE_TIMEOUT=32768
+
 outputs:
   - name: librmm
     version: {{ version }}
@@ -19,20 +39,6 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-      script_env: &script_env
-        - CC
-        - CXX
-        - CUDAHOSTCXX
-        - PARALLEL_LEVEL
-        - CMAKE_GENERATOR
-        - CMAKE_C_COMPILER_LAUNCHER
-        - CMAKE_CXX_COMPILER_LAUNCHER
-        - CMAKE_CUDA_COMPILER_LAUNCHER
-        - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
-        - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
-        - SCCACHE_BUCKET=rapids-sccache
-        - SCCACHE_REGION=us-west-2
-        - SCCACHE_IDLE_TIMEOUT=32768
       run_exports:
         - {{ pin_subpackage("librmm", max_pin="x.x") }}
     requirements:
@@ -87,7 +93,6 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-      script_env: *script_env
     requirements:
       build:
         - cmake {{ cmake_version }}

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -3,8 +3,6 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
-{% set cmake_version=">=3.20.1" %}
-{% set gtest_version="=1.10.0" %}
 
 package:
   name: librmm-split


### PR DESCRIPTION
This PR updates the `librmm` `conda` recipe with some learnings from https://github.com/rapidsai/cudf/pull/10326.

Namely that the top-level `build.sh` script is the only feasible approach for consolidating the recipes.

The implication of these changes is that any shared libraries used in the top-level build must now manually be specified as `run` dependencies of the corresponding `outputs` package. To help reduce the amount of duplication of version specifications for these packages, dependency versions can be specified in `conda/recipes/librmm/conda_build_config.yaml`. The exception here is the version spec used for `cudatoolkit` since that comes from an environment variable in the CI process.