### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/recipes/librmm/build.sh
+++ b/conda/recipes/librmm/build.sh
@@ -1,0 +1,3 @@
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
+
+./build.sh -n -v clean librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"

--- a/conda/recipes/librmm/conda_build_config.yaml
+++ b/conda/recipes/librmm/conda_build_config.yaml
@@ -1,0 +1,5 @@
+cmake_version:
+  - ">=3.20.1"
+
+gtest_version:
+  - "=1.10.0"

--- a/conda/recipes/librmm/install_librmm.sh
+++ b/conda/recipes/librmm/install_librmm.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
-./build.sh -v librmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+cmake --install build

--- a/conda/recipes/librmm/install_librmm_tests.sh
+++ b/conda/recipes/librmm/install_librmm_tests.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
-# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
-./build.sh -n -v librmm tests benchmarks --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
 cmake --install build --component testing

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -1,16 +1,37 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.
+# Copyright (c) 2018-2022, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set cuda_version='.'.join(environ.get('CUDA', '9.2').split('.')[:2]) %}
 {% set cuda_major=cuda_version.split('.')[0] %}
-{% set cmake_version=">=3.20.1" %}
-{% set gtest_version="=1.10.0" %}
+{% set cuda_spec = ">=" + cuda_major ~ ",<" + (cuda_major | int + 1) ~ ".0a0" %} # i.e. >=11,<12.0a0
 
 package:
   name: librmm-split
 
 source:
   git_url: ../../..
+
+requirements:
+  build:
+    - cmake {{ cmake_version }}
+  host:
+    - cudatoolkit {{ cuda_version }}.*
+
+build:
+  script_env:
+    - CC
+    - CXX
+    - CUDAHOSTCXX
+    - PARALLEL_LEVEL
+    - CMAKE_GENERATOR
+    - CMAKE_C_COMPILER_LAUNCHER
+    - CMAKE_CXX_COMPILER_LAUNCHER
+    - CMAKE_CUDA_COMPILER_LAUNCHER
+    - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
+    - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
+    - SCCACHE_BUCKET=rapids-sccache
+    - SCCACHE_REGION=us-west-2
+    - SCCACHE_IDLE_TIMEOUT=32768
 
 outputs:
   - name: librmm
@@ -19,30 +40,14 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-      script_env: &script_env
-        - CC
-        - CXX
-        - CUDAHOSTCXX
-        - PARALLEL_LEVEL
-        - CMAKE_GENERATOR
-        - CMAKE_C_COMPILER_LAUNCHER
-        - CMAKE_CXX_COMPILER_LAUNCHER
-        - CMAKE_CUDA_COMPILER_LAUNCHER
-        - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
-        - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
-        - SCCACHE_BUCKET=rapids-sccache
-        - SCCACHE_REGION=us-west-2
-        - SCCACHE_IDLE_TIMEOUT=32768
       run_exports:
         - {{ pin_subpackage("librmm", max_pin="x.x") }}
     requirements:
       build:
         - cmake {{ cmake_version }}
-      host:
-        - cudatoolkit {{ cuda_version }}.*
       run:
+        - cudatoolkit {{ cuda_spec }}
         - spdlog>=1.8.5,<1.9
-        - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     test:
       commands:
         - test -f $PREFIX/include/rmm/thrust_rmm_allocator.h
@@ -87,14 +92,11 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-      script_env: *script_env
     requirements:
       build:
         - cmake {{ cmake_version }}
-      host:
-        - cudatoolkit {{ cuda_version }}.*
       run:
-        - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+        - cudatoolkit {{ cuda_spec }}
         - {{ pin_subpackage('librmm', exact=True) }}
         - gtest {{ gtest_version }}
         - gmock {{ gtest_version }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.