### PR TITLE
Rename `librmm_tests` to `librmm-tests`

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -91,7 +91,7 @@ if [[ -z "$PROJECT_FLASH" || "$PROJECT_FLASH" == "0" ]]; then
     fi
 else
 
-    gpuci_mamba_retry install -c $WORKSPACE/ci/artifacts/rmm/cpu/.conda-bld/ librmm librmm_tests
+    gpuci_mamba_retry install -c $WORKSPACE/ci/artifacts/rmm/cpu/.conda-bld/ librmm librmm-tests
 
     TESTRESULTS_DIR=${WORKSPACE}/test-results
     mkdir -p ${TESTRESULTS_DIR}
@@ -101,7 +101,7 @@ else
     nvidia-smi
 
     gpuci_logger "Running googletests"
-    # run gtests from librmm_tests package
+    # run gtests from librmm-tests package
     for gt in "$CONDA_PREFIX/bin/gtests/librmm/"* ; do
         ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
         exitcode=$?

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -86,7 +86,7 @@ outputs:
       home: http://rapids.ai/
       license: Apache-2.0
       summary: librmm library
-  - name: librmm_tests
+  - name: librmm-tests
     version: {{ version }}
     script: install_librmm_tests.sh
     build:


### PR DESCRIPTION
This PR updates the `librmm_tests` package name to `librmm-tests`. Seems like `-` is the convention used on Anaconda.org.
