### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ conda install -c nvidia -c rapidsai -c conda-forge \
 We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD
 of our latest development branch.
 
-Note: RMM is supported only on Linux, and with Python versions 3.7 and later.
+Note: RMM is supported only on Linux, and only tested with Python versions 3.8 and 3.9.
+
 
 Note: The RMM package from Conda requires building with GCC 9 or later. Otherwise, your application may fail to build.
 

--- a/conda/environments/rmm_dev_cuda11.5.yml
+++ b/conda/environments/rmm_dev_cuda11.5.yml
@@ -10,7 +10,7 @@ dependencies:
 - flake8=3.8.3
 - black=19.10
 - isort=5.6.4
-- python>=3.7,<3.9
+- python>=3.8,<3.10
 - numba>=0.49
 - numpy
 - cffi>=1.10.0

--- a/conda/environments/rmm_dev_cuda11.6.yml
+++ b/conda/environments/rmm_dev_cuda11.6.yml
@@ -10,7 +10,7 @@ dependencies:
 - flake8=3.8.3
 - black=19.10
 - isort=5.6.4
-- python>=3.7,<3.9
+- python>=3.8,<3.10
 - numba>=0.49
 - numpy
 - cffi>=1.10.0

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -54,4 +54,4 @@ packages = find:
 install_requires =
     numpy
     numba>=0.49
-python_requires = >=3.7,<3.9
+python_requires = >=3.8

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,8 +18,8 @@ setup(
         "Topic :: Scientific/Engineering",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     # Include the separately-compiled shared library
     extras_require={"test": ["pytest", "pytest-xdist"]},


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.