### PR TITLE
Use `lib` (not `lib64`) for libraries

### DIFF
--- a/conda/recipes/rmm/build.sh
+++ b/conda/recipes/rmm/build.sh
@@ -1,4 +1,4 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
 # Script assumes the script is executed from the root of the repo directory
-./build.sh -v clean rmm
+./build.sh -v clean rmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"


### PR DESCRIPTION
Previously some CMake files were getting installed with the `rmm` packages. These were installed because the library directory here did not line up with [the one used by `librmm`]( https://github.com/rapidsai/rmm/blob/97617ba826e89d69ff14457b1ede7d1478cbfa96/conda/recipes/librmm/build.sh#L3 ). This fixes that issue. Also should deduplicate any CMake files that are already included in `librmm` and drop them from `rmm`.

cc @robertmaynard @vyasr