### PR TITLE
rmm conda recipe needs to ensure all CMake files go to `lib`

### DIFF
--- a/conda/recipes/rmm/build.sh
+++ b/conda/recipes/rmm/build.sh
@@ -1,4 +1,4 @@
 # Copyright (c) 2018-2019, NVIDIA CORPORATION.
 
 # Script assumes the script is executed from the root of the repo directory
-./build.sh -v clean rmm
+./build.sh -v clean rmm  --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"


### PR DESCRIPTION
If we don't specify the `lib` directory, we will incorrectly get `lib64` when the host OS is RHEL/Centos.
