### PR TITLE
Make IPC handle export optional in cuda_async_memory_resource

### DIFF
--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -136,9 +136,9 @@ struct async_alloc {
   {
     int supported_handle_types_bitmask{};
 #if CUDART_VERSION >= 11030  // 11.3 introduced cudaDevAttrMemoryPoolSupportedHandleTypes
-    cudaDeviceGetAttribute(&supported_handle_types_bitmask,
-                           cudaDevAttrMemoryPoolSupportedHandleTypes,
-                           rmm::detail::current_device().value());
+    RMM_CUDA_TRY(cudaDeviceGetAttribute(&supported_handle_types_bitmask,
+                                        cudaDevAttrMemoryPoolSupportedHandleTypes,
+                                        rmm::detail::current_device().value()));
 #endif
     return (supported_handle_types_bitmask & handle_type) == handle_type;
   }

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -125,7 +125,7 @@ struct async_alloc {
    * @brief Check whether the specified `cudaMemAllocationHandleType` is supported on the present
    * CUDA driver/runtime version.
    *
-   * @note This query was introduced in CUDA 11.3 so on CUDA 11.2 this will only return true for
+   * @note This query was introduced in CUDA 11.3 so on CUDA 11.2 this function will only return true for
    * `cudaMemHandleTypeNone`.
    *
    * @param handle_type An IPC export handle type to check for support.

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -125,8 +125,8 @@ struct async_alloc {
    * @brief Check whether the specified `cudaMemAllocationHandleType` is supported on the present
    * CUDA driver/runtime version.
    *
-   * @note This query was introduced in CUDA 11.3 so on CUDA 11.2 this function will only return true for
-   * `cudaMemHandleTypeNone`.
+   * @note This query was introduced in CUDA 11.3 so on CUDA 11.2 this function will only return
+   * true for `cudaMemHandleTypeNone`.
    *
    * @param handle_type An IPC export handle type to check for support.
    * @return true if supported

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 #pragma once
+
+#include <rmm/cuda_device.hpp>
+
 #include <cuda_runtime_api.h>
+
 #include <dlfcn.h>
+
 #include <memory>
 #include <optional>
 
@@ -114,6 +119,28 @@ struct async_alloc {
       return result == cudaSuccess and cuda_pool_supported == 1;
     }()};
     return runtime_supports_pool and driver_supports_pool;
+  }
+
+  /**
+   * @brief Check whether the specified `cudaMemAllocationHandleType` is supported on the present
+   * CUDA driver/runtime version.
+   *
+   * @note This query was introduced in CUDA 11.3 so on CUDA 11.2 this will only return true for
+   * `cudaMemHandleTypeNone`.
+   *
+   * @param handle_type An IPC export handle type to check for support.
+   * @return true if supported
+   * @return false if unsupported
+   */
+  static bool is_export_handle_type_supported(cudaMemAllocationHandleType handle_type)
+  {
+    int supported_handle_types_bitmask{};
+#if CUDART_VERSION >= 11030  // 11.3 introduced cudaDevAttrMemoryPoolSupportedHandleTypes
+    cudaDeviceGetAttribute(&supported_handle_types_bitmask,
+                           cudaDevAttrMemoryPoolSupportedHandleTypes,
+                           rmm::detail::current_device().value());
+#endif
+    return (supported_handle_types_bitmask & handle_type) == handle_type;
   }
 
   template <typename... Args>

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -48,14 +48,13 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * Flags for specifying particular handle types
    */
   enum class allocation_handle_type {
-    none                  = 0x0, /**< Does not allow any export mechanism. > */
-    posix_file_descriptor = 0x1, /**< Allows a file descriptor to be used for exporting. Permitted
-                                    only on POSIX systems. (int) */
-    win32     = 0x2,             /**< Allows a Win32 NT handle to be used for exporting. (HANDLE) */
-    win32_kmt = 0x4 /**< Allows a Win32 KMT handle to be used for exporting. (D3DKMT_HANDLE) */
+    none                  = 0x0,  ///< Does not allow any export mechanism.
+    posix_file_descriptor = 0x1,  ///< Allows a file descriptor to be used for exporting. Permitted
+                                  ///< only on POSIX systems.
+    win32     = 0x2,              ///< Allows a Win32 NT handle to be used for exporting. (HANDLE)
+    win32_kmt = 0x4  ///< Allows a Win32 KMT handle to be used for exporting. (D3DKMT_HANDLE)
   };
 
-#ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   /**
    * @brief Constructs a cuda_async_memory_resource with the optionally specified initial pool size
    * and release threshold.
@@ -78,6 +77,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
                              thrust::optional<std::size_t> release_threshold             = {},
                              thrust::optional<allocation_handle_type> export_handle_type = {})
   {
+#ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     // Check if cudaMallocAsync Memory pool supported
     RMM_EXPECTS(rmm::detail::async_alloc::is_supported(),
                 "cudaMallocAsync not supported with this CUDA driver/runtime version");
@@ -119,17 +119,11 @@ class cuda_async_memory_resource final : public device_memory_resource {
     auto const pool_size = initial_pool_size.value_or(free / 2);
     auto* ptr            = do_allocate(pool_size, cuda_stream_default);
     do_deallocate(ptr, pool_size, cuda_stream_default);
-  }
 #else
-  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size             = {},
-                             thrust::optional<std::size_t> release_threshold             = {},
-                             thrust::optional<allocation_handle_type> export_handle_type = {})
-  {
     RMM_FAIL(
       "cudaMallocAsync not supported by the version of the CUDA Toolkit used for this build");
-  }
 #endif
+  }
 
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   /**

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -45,7 +45,14 @@ namespace rmm::mr {
 class cuda_async_memory_resource final : public device_memory_resource {
  public:
   /**
-   * Flags for specifying particular handle types
+   * @brief Flags for specifying memory allocation handle types.
+   *
+   * @note These values are exact copies from `cudaMemAllocationHandleType`. We need to
+   * define our own enum here because the earliest CUDA runtime version that supports asynchronous
+   * memory pools (CUDA 11.2) did not support these flags. So we need a placeholder that can be
+   * used consistently in the constructor of `cuda_async_memory_resource` with all versions of
+   * CUDA >= 11.2. See the `cudaMemAllocationHandleType` docs at
+   * https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html"
    */
   enum class allocation_handle_type {
     none                  = 0x0,  ///< Does not allow any export mechanism.

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -44,6 +44,17 @@ namespace rmm::mr {
  */
 class cuda_async_memory_resource final : public device_memory_resource {
  public:
+  /**
+   * Flags for specifying particular handle types
+   */
+  enum class allocation_handle_type {
+    none                  = 0x0, /**< Does not allow any export mechanism. > */
+    posix_file_descriptor = 0x1, /**< Allows a file descriptor to be used for exporting. Permitted
+                                    only on POSIX systems. (int) */
+    win32     = 0x2,             /**< Allows a Win32 NT handle to be used for exporting. (HANDLE) */
+    win32_kmt = 0x4 /**< Allows a Win32 KMT handle to be used for exporting. (D3DKMT_HANDLE) */
+  };
+
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   /**
    * @brief Constructs a cuda_async_memory_resource with the optionally specified initial pool size
@@ -63,9 +74,9 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * `cudaMemHandleTypeNone` for no IPC support.
    */
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size                  = {},
-                             thrust::optional<std::size_t> release_threshold                  = {},
-                             thrust::optional<cudaMemAllocationHandleType> export_handle_type = {})
+  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size             = {},
+                             thrust::optional<std::size_t> release_threshold             = {},
+                             thrust::optional<allocation_handle_type> export_handle_type = {})
   {
     // Check if cudaMallocAsync Memory pool supported
     RMM_EXPECTS(rmm::detail::async_alloc::is_supported(),
@@ -74,7 +85,8 @@ class cuda_async_memory_resource final : public device_memory_resource {
     // Construct explicit pool
     cudaMemPoolProps pool_props{};
     pool_props.allocType   = cudaMemAllocationTypePinned;
-    pool_props.handleTypes = export_handle_type.value_or(cudaMemHandleTypeNone);
+    pool_props.handleTypes = static_cast<cudaMemAllocationHandleType>(
+      export_handle_type.value_or(allocation_handle_type::none));
     RMM_EXPECTS(rmm::detail::async_alloc::is_export_handle_type_supported(pool_props.handleTypes),
                 "Requested IPC memory handle type not supported");
     pool_props.location.type = cudaMemLocationTypeDevice;
@@ -110,8 +122,9 @@ class cuda_async_memory_resource final : public device_memory_resource {
   }
 #else
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size = {},
-                             thrust::optional<std::size_t> release_threshold = {})
+  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size             = {},
+                             thrust::optional<std::size_t> release_threshold             = {},
+                             thrust::optional<allocation_handle_type> export_handle_type = {})
   {
     RMM_FAIL(
       "cudaMallocAsync not supported by the version of the CUDA Toolkit used for this build");

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -69,7 +69,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * @param release_threshold Optional release threshold size in bytes of the pool. If no value is
    * provided, the release threshold is set to the total amount of memory on the current device.
    * @param export_handle_type Optional `cudaMemAllocationHandleType` that allocations from this
-   * resource should support for interprocess communication (IPC). Default is
+   * resource should support interprocess communication (IPC). Default is
    * `cudaMemHandleTypeNone` for no IPC support.
    */
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -67,10 +67,16 @@ cdef extern from "rmm/mr/device/managed_memory_resource.hpp" \
 cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass cuda_async_memory_resource(device_memory_resource):
+        enum allocation_handle_type:
+            none,
+            posix_file_descriptor,
+            win32,
+            win32_kmt
+
         cuda_async_memory_resource(
             optional[size_t] initial_pool_size,
             optional[size_t] release_threshold,
-            optional[cudaMemAllocationHandleType] export_handle_type) except +
+            optional[allocation_handle_type] export_handle_type) except +
 
 cdef extern from "rmm/mr/device/pool_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
@@ -267,12 +273,12 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
             else optional[size_t](release_threshold)
         )
 
-        cdef optional[cudaMemAllocationHandleType] c_export_handle_type = (
-            optional[cudaMemAllocationHandleType](
-                cudaMemHandleTypePosixFileDescriptor
+        cdef optional[allocation_handle_type] c_export_handle_type = (
+            optional[allocation_handle_type](
+                posix_file_descriptor
             )
             if enable_ipc
-            else optional[cudaMemAllocationHandleType]()
+            else optional[allocation_handle_type]()
         )
 
         self.c_obj.reset(

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -249,15 +249,15 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         Release threshold in bytes. If the pool size grows beyond this
         value, unused memory held by the pool will be released at the
         next synchronization point.
-    enable_ipc: Boolean, optional
-        If True, enables export of Posix file descriptor handle for the memory
+    enable_ipc: bool, optional
+        If True, enables export of POSIX file descriptor handles for the memory
         allocated by this resource so that it can be used with CUDA IPC.
     """
     def __cinit__(
-            self,
-            initial_pool_size=None,
-            release_threshold=None,
-            enable_ipc=False
+        self,
+        initial_pool_size=None,
+        release_threshold=None,
+        enable_ipc=False
     ):
         cdef optional[size_t] c_initial_pool_size = (
             optional[size_t]()

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -238,9 +238,9 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         next synchronization point.
     """
     def __cinit__(
-            self, 
-            initial_pool_size=None, 
-            release_threshold=None, 
+            self,
+            initial_pool_size=None,
+            release_threshold=None,
             export_handle_type=None
     ):
         cdef optional[size_t] c_initial_pool_size = (

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -246,14 +246,14 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         value, unused memory held by the pool will be released at the
         next synchronization point.
     enable_ipc: Boolean, optional
-        If true, enables export of Posix file descriptor handle for the memory
+        If True, enables export of Posix file descriptor handle for the memory
         allocated by this resource so that it can be used with CUDA IPC.
     """
     def __cinit__(
             self,
             initial_pool_size=None,
             release_threshold=None,
-            enable_ipc=True
+            enable_ipc=False
     ):
         cdef optional[size_t] c_initial_pool_size = (
             optional[size_t]()

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -257,7 +257,7 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         self,
         initial_pool_size=None,
         release_threshold=None,
-        enable_ipc=False
+        enable_ipc=True
     ):
         cdef optional[size_t] c_initial_pool_size = (
             optional[size_t]()

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -237,7 +237,12 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         value, unused memory held by the pool will be released at the
         next synchronization point.
     """
-    def __cinit__(self, initial_pool_size=None, release_threshold=None, export_handle_type=None):
+    def __cinit__(
+            self, 
+            initial_pool_size=None, 
+            release_threshold=None, 
+            export_handle_type=None
+    ):
         cdef optional[size_t] c_initial_pool_size = (
             optional[size_t]()
             if initial_pool_size is None

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -24,7 +24,7 @@ from libcpp.memory cimport make_shared, make_unique, shared_ptr, unique_ptr
 from libcpp.string cimport string
 
 from cuda.cudart import cudaError_t
-from cuda.ccudart import cudaMemAllocationHandleType
+from cuda.ccudart cimport cudaMemAllocationHandleType, cudaMemHandleTypePosixFileDescriptor
 
 from rmm._cuda.gpu import CUDARuntimeError, getDevice, setDevice
 
@@ -62,7 +62,7 @@ cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
         cuda_async_memory_resource(
             optional[size_t] initial_pool_size,
             optional[size_t] release_threshold,
-            optional[bool] enable_ipc) except +
+            optional[cudaMemAllocationHandleType] export_handle_type) except +
 
 cdef extern from "rmm/mr/device/pool_memory_resource.hpp" \
         namespace "rmm::mr" nogil:

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -24,6 +24,7 @@ from libcpp.memory cimport make_shared, make_unique, shared_ptr, unique_ptr
 from libcpp.string cimport string
 
 from cuda.cudart import cudaError_t
+from cuda.cudart import cudaMemAllocationHandleType
 
 from rmm._cuda.gpu import CUDARuntimeError, getDevice, setDevice
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
@@ -57,8 +58,10 @@ cdef extern from "rmm/mr/device/managed_memory_resource.hpp" \
 cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass cuda_async_memory_resource(device_memory_resource):
-        cuda_async_memory_resource(optional[size_t] initial_pool_size,
-                                   optional[size_t] release_threshold) except +
+        cuda_async_memory_resource(
+            optional[size_t] initial_pool_size,
+            optional[size_t] release_threshold,
+            optional[cudaMemAllocationHandleType] export_handle_type) except +
 
 cdef extern from "rmm/mr/device/pool_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
@@ -234,7 +237,7 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         value, unused memory held by the pool will be released at the
         next synchronization point.
     """
-    def __cinit__(self, initial_pool_size=None, release_threshold=None):
+    def __cinit__(self, initial_pool_size=None, release_threshold=None, export_handle_type=None):
         cdef optional[size_t] c_initial_pool_size = (
             optional[size_t]()
             if initial_pool_size is None
@@ -247,10 +250,17 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
             else optional[size_t](release_threshold)
         )
 
+        cdef optional[cudaMemAllocationHandleType] c_export_handle_type = (
+            optional[cudaMemAllocationHandleType]()
+            if export_handle_type is None
+            else optional[export_handle_type](export_handle_type)
+        )
+
         self.c_obj.reset(
             new cuda_async_memory_resource(
                 c_initial_pool_size,
-                c_release_threshold
+                c_release_threshold,
+                c_export_handle_type
             )
         )
 

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -30,26 +30,6 @@ from rmm._cuda.gpu import CUDARuntimeError, getDevice, setDevice
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
 
 
-# NOTE: We can't use declarations of CUDA types from CUDA Python and
-# expect them to work with external code. So we declare them
-# ourselves.  See https://github.com/NVIDIA/cuda-python/issues/22 for
-# details.
-cdef extern from * nogil:
-    """
-    #include <cuda_runtime_api.h>
-
-    #if (CUDART_VERSION < 11030)
-    enum cudaMemAllocationHandleType {
-        cudaMemHandleTypePosixFileDescriptor = 0
-    };
-    #endif
-    """
-    int CUDART_VERSION
-
-    enum cudaMemAllocationHandleType:
-        cudaMemHandleTypePosixFileDescriptor
-
-
 # NOTE: Keep extern declarations in .pyx file as much as possible to avoid
 # leaking dependencies when importing RMM Cython .pxd files
 cdef extern from "thrust/optional.h" namespace "thrust" nogil:
@@ -84,6 +64,7 @@ cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
             optional[size_t] release_threshold,
             optional[allocation_handle_type] export_handle_type) except +
 
+# TODO: when we adopt Cython 3.0 use enum class
 cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
         namespace \
         "rmm::mr::cuda_async_memory_resource::allocation_handle_type" \

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -245,6 +245,9 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         Release threshold in bytes. If the pool size grows beyond this
         value, unused memory held by the pool will be released at the
         next synchronization point.
+    enable_ipc: Boolean, optional
+        If true, enables export of Posix file descriptor handle for the memory
+        allocated by this resource so that it can be used with CUDA IPC.
     """
     def __cinit__(
             self,
@@ -265,11 +268,9 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         )
 
         cdef optional[cudaMemAllocationHandleType] c_export_handle_type = (
-            optional[cudaMemAllocationHandleType]()
+            optional[cudaMemHandleTypePosixFileDescriptor]()
             if enable_ipc
-            else optional[cudaMemAllocationHandleType](
-                cudaMemHandleTypePosixFileDescriptor
-            )
+            else optional[cudaMemAllocationHandleType]()
         )
 
         self.c_obj.reset(

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -268,7 +268,9 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         )
 
         cdef optional[cudaMemAllocationHandleType] c_export_handle_type = (
-            optional[cudaMemHandleTypePosixFileDescriptor]()
+            optional[cudaMemAllocationHandleType](
+                cudaMemHandleTypePosixFileDescriptor
+            )
             if enable_ipc
             else optional[cudaMemAllocationHandleType]()
         )

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -24,9 +24,10 @@ from libcpp.memory cimport make_shared, make_unique, shared_ptr, unique_ptr
 from libcpp.string cimport string
 
 from cuda.cudart import cudaError_t
-from cuda.cudart import cudaMemAllocationHandleType
+from cuda.ccudart import cudaMemAllocationHandleType
 
 from rmm._cuda.gpu import CUDARuntimeError, getDevice, setDevice
+
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
 
 
@@ -61,7 +62,7 @@ cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
         cuda_async_memory_resource(
             optional[size_t] initial_pool_size,
             optional[size_t] release_threshold,
-            optional[cudaMemAllocationHandleType] export_handle_type) except +
+            optional[bool] enable_ipc) except +
 
 cdef extern from "rmm/mr/device/pool_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
@@ -241,7 +242,7 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
             self,
             initial_pool_size=None,
             release_threshold=None,
-            export_handle_type=None
+            enable_ipc=True
     ):
         cdef optional[size_t] c_initial_pool_size = (
             optional[size_t]()
@@ -257,8 +258,8 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
 
         cdef optional[cudaMemAllocationHandleType] c_export_handle_type = (
             optional[cudaMemAllocationHandleType]()
-            if export_handle_type is None
-            else optional[export_handle_type](export_handle_type)
+            if enable_ipc == True
+            else optional[cudaMemAllocationHandleType](cudaMemHandleTypePosixFileDescriptor)
         )
 
         self.c_obj.reset(

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -77,17 +77,23 @@ cdef extern from "rmm/mr/device/managed_memory_resource.hpp" \
 
 cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass cuda_async_memory_resource(device_memory_resource):
-        enum allocation_handle_type:
-            none,
-            posix_file_descriptor,
-            win32,
-            win32_kmt
 
+    cdef cppclass cuda_async_memory_resource(device_memory_resource):
         cuda_async_memory_resource(
             optional[size_t] initial_pool_size,
             optional[size_t] release_threshold,
             optional[allocation_handle_type] export_handle_type) except +
+
+cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
+        namespace \
+        "rmm::mr::cuda_async_memory_resource::allocation_handle_type" \
+        nogil:
+    enum allocation_handle_type \
+            "rmm::mr::cuda_async_memory_resource::allocation_handle_type":
+        none
+        posix_file_descriptor
+        win32
+        win32_kmt
 
 cdef extern from "rmm/mr/device/pool_memory_resource.hpp" \
         namespace "rmm::mr" nogil:

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -543,6 +543,21 @@ def test_cuda_async_memory_resource(dtype, nelem, alloc):
     not _CUDAMALLOC_ASYNC_SUPPORTED,
     reason="cudaMallocAsync not supported",
 )
+def test_cuda_async_memory_resource_ipc():
+    # Test that enabling IPC earlier than CUDA 11.3 raises a ValueError
+    if _driver_version < 11030 or _runtime_version < 11030:
+        with pytest.raises(ValueError):
+            mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
+    else:
+        mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
+        rmm.mr.set_current_device_resource(mr)
+        assert rmm.mr.get_current_device_resource_type() is type(mr)
+
+
+@pytest.mark.skipif(
+    not _CUDAMALLOC_ASYNC_SUPPORTED,
+    reason="cudaMallocAsync not supported",
+)
 @pytest.mark.parametrize("nelems", _nelems)
 def test_cuda_async_memory_resource_stream(nelems):
     # test that using CudaAsyncMemoryResource


### PR DESCRIPTION
posix handle export is not  supported currently in cudaMemPoolCreate on WSL2. This change makes the default to not export IPC handles (`cudaMemHandleTypeNone`), and allows setting a different handle type. 

In Python, `cuda_async_memory_resource` takes a new `enable_ipc` parameter which currently defaults to `False`, which is a breaking change. Defaulting to `False` was necessary because we can't check supported handle types on CUDA 11.2, only 11.3 and above. Also, the `True` path is currently written to only support Posix handles, so WSL2 is not supported. Also, IPC has some overheads on cudaMallocAsync pools which we may want to avoid.

Fixes #1029