### PR TITLE
Replace `to_device` with `DeviceBuffer.to_device`

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ DeviceBuffers can also be created by copying data from host memory:
 >>> import rmm
 >>> import numpy as np
 >>> a = np.array([1, 2, 3], dtype='float64')
->>> buf = rmm.to_device(a.tobytes())
+>>> buf = rmm.DeviceBuffer.to_device(a.tobytes())
 >>> buf.size
 24
 ```


### PR DESCRIPTION
As well as in the basic python docs, `to_device` was also
explicitly referenced in the README. Follows up #902 which
missed this reference.
