### PR TITLE
Clarify using RMM with other Python libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,11 @@ allocations by setting the CuPy CUDA allocator to
 >>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
 ```
 
+
+**Note:** This only configures cuPy to use current RMM resource for allocations. 
+It does not initialize nor change the current resource, e.g., enabling a memory pool. 
+See [here](#memoryresource-objects) for more information on how this can be done.
+
 ### Using RMM with Numba
 
 You can configure Numba to use RMM for memory allocations using the
@@ -704,3 +709,7 @@ This can be done in two ways:
   >>> import rmm
   >>> cuda.set_memory_manager(rmm.RMMNumbaManager)
   ```
+
+**Note:** This only configures Numba to use current RMM resource for allocations. 
+It does not initialize nor change the current resource, e.g., enabling a memory pool. 
+See [here](#memoryresource-objects) for more information on how this can be done.

--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ allocations by setting the CuPy CUDA allocator to
 ```
 
 
-**Note:** This only configures cuPy to use current RMM resource for allocations. 
+**Note:** This only configures CuPy to use the current RMM resource for allocations. 
 It does not initialize nor change the current resource, e.g., enabling a memory pool. 
 See [here](#memoryresource-objects) for more information on how this can be done.
 
@@ -710,6 +710,6 @@ This can be done in two ways:
   >>> cuda.set_memory_manager(rmm.RMMNumbaManager)
   ```
 
-**Note:** This only configures Numba to use current RMM resource for allocations. 
+**Note:** This only configures Numba to use the current RMM resource for allocations. 
 It does not initialize nor change the current resource, e.g., enabling a memory pool. 
 See [here](#memoryresource-objects) for more information on how this can be done.

--- a/README.md
+++ b/README.md
@@ -712,4 +712,4 @@ This can be done in two ways:
 
 **Note:** This only configures Numba to use the current RMM resource for allocations. 
 It does not initialize nor change the current resource, e.g., enabling a memory pool. 
-See [here](#memoryresource-objects) for more information on how this can be done.
+See [here](#memoryresource-objects) for more information on changing the current memory resource.

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ allocations by setting the CuPy CUDA allocator to
 
 **Note:** This only configures CuPy to use the current RMM resource for allocations. 
 It does not initialize nor change the current resource, e.g., enabling a memory pool. 
-See [here](#memoryresource-objects) for more information on how this can be done.
+See [here](#memoryresource-objects) for more information on changing the current memory resource.
 
 ### Using RMM with Numba
 


### PR DESCRIPTION
Based on an internal question, clarified the README docs on what the APIs for enabling cuPy/Numba to use RMM simply inherit whatever the state of RMM is as opposed to modify the state (like enabling a memory pool).

