### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -14,14 +14,16 @@ source:
 requirements:
   build:
     - cmake {{ cmake_version }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }} {{ cuda_version }}
+    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
   host:
     - cudatoolkit {{ cuda_version }}.*
 
 build:
   script_env:
-    - CC
-    - CXX
-    - CUDAHOSTCXX
     - PARALLEL_LEVEL
     - CMAKE_GENERATOR
     - CMAKE_C_COMPILER_LAUNCHER
@@ -42,6 +44,9 @@ outputs:
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       run_exports:
         - {{ pin_subpackage("librmm", max_pin="x.x") }}
+      ignore_run_exports_from:
+        - nvcc_linux-64 # [linux64]
+        - nvcc_linux-aarch64 # [aarch64]
     requirements:
       build:
         - cmake {{ cmake_version }}
@@ -92,6 +97,9 @@ outputs:
     build:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+      ignore_run_exports_from:
+        - nvcc_linux-64 # [linux64]
+        - nvcc_linux-aarch64 # [aarch64]
     requirements:
       build:
         - cmake {{ cmake_version }}

--- a/conda/recipes/rmm/conda_build_config.yaml
+++ b/conda/recipes/rmm/conda_build_config.yaml
@@ -7,11 +7,5 @@ cxx_compiler_version:
 cuda_compiler:
   - nvcc
 
-cmake_version:
-  - ">=3.20.1,!=3.23.0"
-
-gtest_version:
-  - "=1.10.0"
-
 sysroot_version:
   - "2.17"

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -18,27 +18,29 @@ build:
   script_env:
     - RMM_BUILD_NO_GPU_TEST
     - VERSION_SUFFIX
-    - CC
-    - CXX
-    - CUDAHOSTCXX
 
 requirements:
-  host:
-    - python
-    - librmm {{ version }}
-    - setuptools
-    - cython>=0.29,<0.30
+  build:
     - cmake>=3.20.1,!=3.23.0
-    - scikit-build>=0.13.1
-    - spdlog>=1.8.5,<2.0.0a0
-    - cudatoolkit {{ cuda_version }}.*
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }} {{ cuda_version }}
+    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
+  host:
     - cuda-python >=11.5,<12.0
-  run:
+    - cudatoolkit {{ cuda_version }}.*
+    - cython >=0.29,<0.30
+    - librmm {{ version }}.*
     - python
+    - scikit-build>=0.13.1
+    - setuptools
+    - spdlog>=1.8.5,<2.0.0a0
+  run:
+    - cuda-python >=11.5,<12.0
     - numba >=0.49
     - numpy >=1.19
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
-    - cuda-python >=11.5,<12.0
 
 test:
   imports:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.