### PR TITLE
Fix conda recipes for conda compilers

### DIFF
--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -17,8 +17,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
-    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
-    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
+    - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cudatoolkit {{ cuda_version }}.*
 
@@ -45,8 +44,7 @@ outputs:
       run_exports:
         - {{ pin_subpackage("librmm", max_pin="x.x") }}
       ignore_run_exports_from:
-        - nvcc_linux-64 # [linux64]
-        - nvcc_linux-aarch64 # [aarch64]
+        - {{ compiler('cuda') }}
     requirements:
       build:
         - cmake {{ cmake_version }}
@@ -98,8 +96,7 @@ outputs:
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
-        - nvcc_linux-64 # [linux64]
-        - nvcc_linux-aarch64 # [aarch64]
+        - {{ compiler('cuda') }}
     requirements:
       build:
         - cmake {{ cmake_version }}

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -18,6 +18,8 @@ build:
   script_env:
     - RMM_BUILD_NO_GPU_TEST
     - VERSION_SUFFIX
+  ignore_run_exports_from:
+    - {{ compiler('cuda') }}
 
 requirements:
   build:
@@ -25,8 +27,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
-    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
-    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
+    - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cuda-python >=11.5,<12.0
     - cudatoolkit {{ cuda_version }}.*


### PR DESCRIPTION
- Simplify recipes using `{{ target_platform }}` for `sysroot` package and `compiler()` function in `ignore_run_exports_from`
- Add missisng `ignore_run_exports_from` to `rmm`