### PR TITLE
Make IPC handle export optional in cuda_async_memory_resource

### DIFF
--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 #pragma once
+
+#include <rmm/cuda_device.hpp>
+
 #include <cuda_runtime_api.h>
+
 #include <dlfcn.h>
+
 #include <memory>
 #include <optional>
 
@@ -114,6 +119,28 @@ struct async_alloc {
       return result == cudaSuccess and cuda_pool_supported == 1;
     }()};
     return runtime_supports_pool and driver_supports_pool;
+  }
+
+  /**
+   * @brief Check whether the specified `cudaMemAllocationHandleType` is supported on the present
+   * CUDA driver/runtime version.
+   *
+   * @note This query was introduced in CUDA 11.3 so on CUDA 11.2 this function will only return
+   * true for `cudaMemHandleTypeNone`.
+   *
+   * @param handle_type An IPC export handle type to check for support.
+   * @return true if supported
+   * @return false if unsupported
+   */
+  static bool is_export_handle_type_supported(cudaMemAllocationHandleType handle_type)
+  {
+    int supported_handle_types_bitmask{};
+#if CUDART_VERSION >= 11030  // 11.3 introduced cudaDevAttrMemoryPoolSupportedHandleTypes
+    RMM_CUDA_TRY(cudaDeviceGetAttribute(&supported_handle_types_bitmask,
+                                        cudaDevAttrMemoryPoolSupportedHandleTypes,
+                                        rmm::detail::current_device().value()));
+#endif
+    return (supported_handle_types_bitmask & handle_type) == handle_type;
   }
 
   template <typename... Args>

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -25,7 +25,14 @@ from libcpp.string cimport string
 
 from cuda.cudart import cudaError_t
 
-from rmm._cuda.gpu import CUDARuntimeError, getDevice, setDevice
+from rmm._cuda.gpu import (
+    CUDARuntimeError,
+    driverGetVersion,
+    getDevice,
+    runtimeGetVersion,
+    setDevice,
+)
+
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
 
 
@@ -56,9 +63,24 @@ cdef extern from "rmm/mr/device/managed_memory_resource.hpp" \
 
 cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
+
     cdef cppclass cuda_async_memory_resource(device_memory_resource):
-        cuda_async_memory_resource(optional[size_t] initial_pool_size,
-                                   optional[size_t] release_threshold) except +
+        cuda_async_memory_resource(
+            optional[size_t] initial_pool_size,
+            optional[size_t] release_threshold,
+            optional[allocation_handle_type] export_handle_type) except +
+
+# TODO: when we adopt Cython 3.0 use enum class
+cdef extern from "rmm/mr/device/cuda_async_memory_resource.hpp" \
+        namespace \
+        "rmm::mr::cuda_async_memory_resource::allocation_handle_type" \
+        nogil:
+    enum allocation_handle_type \
+            "rmm::mr::cuda_async_memory_resource::allocation_handle_type":
+        none
+        posix_file_descriptor
+        win32
+        win32_kmt
 
 cdef extern from "rmm/mr/device/pool_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
@@ -233,8 +255,16 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         Release threshold in bytes. If the pool size grows beyond this
         value, unused memory held by the pool will be released at the
         next synchronization point.
+    enable_ipc: bool, optional
+        If True, enables export of POSIX file descriptor handles for the memory
+        allocated by this resource so that it can be used with CUDA IPC.
     """
-    def __cinit__(self, initial_pool_size=None, release_threshold=None):
+    def __cinit__(
+        self,
+        initial_pool_size=None,
+        release_threshold=None,
+        enable_ipc=False
+    ):
         cdef optional[size_t] c_initial_pool_size = (
             optional[size_t]()
             if initial_pool_size is None
@@ -247,10 +277,29 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
             else optional[size_t](release_threshold)
         )
 
+        # IPC export handle support query is only possibly on CUDA 11.3 or
+        # later, so IPC not supported on earlier versions
+        if enable_ipc:
+            driver_version = driverGetVersion()
+            runtime_version = runtimeGetVersion()
+            if (driver_version <= 11020 or runtime_version <= 11020):
+                raise ValueError(
+                    "enable_ipc=True is not supported on CUDA <= 11.2."
+                )
+
+        cdef optional[allocation_handle_type] c_export_handle_type = (
+            optional[allocation_handle_type](
+                posix_file_descriptor
+            )
+            if enable_ipc
+            else optional[allocation_handle_type]()
+        )
+
         self.c_obj.reset(
             new cuda_async_memory_resource(
                 c_initial_pool_size,
-                c_release_threshold
+                c_release_threshold,
+                c_export_handle_type
             )
         )
 

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -543,6 +543,21 @@ def test_cuda_async_memory_resource(dtype, nelem, alloc):
     not _CUDAMALLOC_ASYNC_SUPPORTED,
     reason="cudaMallocAsync not supported",
 )
+def test_cuda_async_memory_resource_ipc():
+    # Test that enabling IPC earlier than CUDA 11.3 raises a ValueError
+    if _driver_version < 11030 or _runtime_version < 11030:
+        with pytest.raises(ValueError):
+            mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
+    else:
+        mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
+        rmm.mr.set_current_device_resource(mr)
+        assert rmm.mr.get_current_device_resource_type() is type(mr)
+
+
+@pytest.mark.skipif(
+    not _CUDAMALLOC_ASYNC_SUPPORTED,
+    reason="cudaMallocAsync not supported",
+)
 @pytest.mark.parametrize("nelems", _nelems)
 def test_cuda_async_memory_resource_stream(nelems):
     # test that using CudaAsyncMemoryResource


### PR DESCRIPTION
Posix handle export is not supported currently in cudaMemPoolCreate on WSL2. This change makes the default to not export IPC handles (cudaMemHandleTypeNone), and allows setting a different handle type.

In Python, cuda_async_memory_resource takes a new enable_ipc parameter which currently defaults to False, which is a breaking change. Defaulting to False was necessary because we can't check supported handle types on CUDA 11.2, only 11.3 and above. Also, the True path is currently written to only support Posix handles, so WSL2 is not supported. Also, IPC has some overheads on cudaMallocAsync pools which we may want to avoid.

Fixes #1029

(Reverts rapidsai/rmm#1049, which was a revert of #1030)