### PR TITLE
Pin max version of `cuda-python` to `11.7`

### DIFF
--- a/conda/environments/rmm_dev_cuda11.5.yml
+++ b/conda/environments/rmm_dev_cuda11.5.yml
@@ -20,4 +20,4 @@ dependencies:
 - spdlog>=1.8.5,<1.9
 - cython>=0.29,<0.30
 - gcovr>=5.0
-- cuda-python>=11.5,<12.0
+- cuda-python>=11.5,<11.7.1

--- a/conda/environments/rmm_dev_cuda11.6.yml
+++ b/conda/environments/rmm_dev_cuda11.6.yml
@@ -20,4 +20,4 @@ dependencies:
 - spdlog>=1.8.5,<1.9
 - cython>=0.29,<0.30
 - gcovr>=5.0
-- cuda-python>=11.6,<12.0
+- cuda-python>=11.6,11.7.1

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - {{ compiler('cuda') }} {{ cuda_version }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
-    - cuda-python >=11.5,<12.0
+    - cuda-python >=11.5,<11.7.1
     - cudatoolkit {{ cuda_version }}.*
     - cython >=0.29,<0.30
     - librmm {{ version }}.*
@@ -38,7 +38,7 @@ requirements:
     - setuptools
     - spdlog>=1.8.5,<2.0.0a0
   run:
-    - cuda-python >=11.5,<12.0
+    - cuda-python >=11.5,<11.7.1
     - numba >=0.49
     - numpy >=1.19
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ requires = [
     "scikit-build>=0.13.1",
     "cmake>=3.20.1,!=3.23.0",
     "ninja",
-    "cuda-python>=11.5,<12.0",
+    "cuda-python>=11.5,<11.7.1",
 ]
 
 [tool.black]

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -52,7 +52,7 @@ skip=
 [options]
 packages = find:
 install_requires =
-    cuda-python>=11.5,<12.0
+    cuda-python>=11.5,<11.7.1
     numpy>=1.19
     numba>=0.49
 python_requires = >=3.8

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,6 +34,10 @@ setup(
         )
     },
     cmdclass=versioneer.get_cmdclass(),
-    install_requires=["cuda-python>=11.5,<12.0", "numpy>=1.19", "numba>=0.49"],
+    install_requires=[
+        "cuda-python>=11.5,<11.7.1",
+        "numpy>=1.19",
+        "numba>=0.49",
+    ],
     zip_safe=False,
 )


### PR DESCRIPTION
This PR pins max version of `cuda-python` to `11.7`

This is a back port of #1062.