### PR TITLE
Add the ability to register and unregister reinitialization hooks

### DIFF
--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -22,8 +22,10 @@ from rmm.rmm import (
     RMMNumbaManager,
     _numba_memory_manager,
     is_initialized,
+    register_reinitialize_hook,
     reinitialize,
     rmm_cupy_allocator,
+    unregister_reinitialize_hook,
 )
 
 __version__ = get_versions()["version"]

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -87,8 +87,8 @@ def reinitialize(
     corresponding to each device.
     """
     [
-        hook(*args, **kwargs)
-        for (hook, args, kwargs) in reversed(_reinitialize_hooks)
+        func(*args, **kwargs)
+        for (func, args, kwargs) in reversed(_reinitialize_hooks)
     ]
     rmm.mr._initialize(
         pool_allocator=pool_allocator,

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -242,9 +242,17 @@ def rmm_cupy_allocator(nbytes):
 
 def register_reinitialize_hook(func, *args, **kwargs):
     """
-    Register a hook to be called by `rmm.reinitialize()`.
+    Add a function to the list of functions that will be called before
+    `rmm.reinitialize()`.
 
     Hooks are called in the *reverse* order they are registered.
+
+    Parameters
+    ----------
+    func: callable
+        Function to be called before `rmm.reinitialize()`
+    args, kwargs
+        Positional and keyword arguments to bepassed to `func`
     """
     _reinitialize_hooks[func] = (args, kwargs)
     return func
@@ -252,7 +260,8 @@ def register_reinitialize_hook(func, *args, **kwargs):
 
 def unregister_reinitialize_hook(func):
     """
-    Remove func from the list of hooks to be called by `rmm.reinitialize()`.
+    Remove `func` from the list of functions that will be called before
+    `rmm.reinitialize()`.
     """
     _reinitialize_hooks.pop(func, None)
     return func

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ctypes
-from itertools import filterfalse
 
 from cuda.cuda import CUdeviceptr, cuIpcGetMemHandle
 from numba import config, cuda
@@ -252,7 +251,7 @@ def register_reinitialize_hook(func, *args, **kwargs):
     reinitialized, thus ensuring that the relevant device memory
     resource can be deallocated.
 
-    Hooks are called in the *reverse* order they are registered.  This
+    Hooks are called in the *reverse* order they are registered. This
     is useful, for example, when a library registers multiple hooks
     and needs them to run in a specific order for cleanup to be safe.
     Hooks cannot rely on being registered in a particular order
@@ -261,7 +260,7 @@ def register_reinitialize_hook(func, *args, **kwargs):
 
     Parameters
     ----------
-    func: callable
+    func : callable
         Function to be called before :py:func:`~rmm.reinitialize()`
     args, kwargs
         Positional and keyword arguments to be passed to `func`
@@ -280,6 +279,4 @@ def unregister_reinitialize_hook(func):
     be removed from the list of hooks.
     """
     global _reinitialize_hooks
-    _reinitialize_hooks = list(
-        filterfalse(lambda x: x[0] == func, _reinitialize_hooks)
-    )
+    _reinitialize_hooks = [x for x in _reinitialize_hooks if x[0] != func]

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -88,7 +88,7 @@ def reinitialize(
     """
     [
         hook(*args, **kwargs)
-        for (hook, (args, kwargs)) in reversed(_reinitialize_hooks.items())
+        for (hook, args, kwargs) in reversed(_reinitialize_hooks)
     ]
     rmm.mr._initialize(
         pool_allocator=pool_allocator,

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -245,14 +245,19 @@ def register_reinitialize_hook(func, *args, **kwargs):
     Add a function to the list of functions ("hooks") that will be
     called before :py:func:`~rmm.reinitialize()`.
 
-    A library may register hooks to perform any necessary cleanup
-    before RMM is reinitialized. For example, a library with an
-    internal cache of objects that use device memory allocated by RMM
-    can register a hook to release those references before RMM is
+    A user or library may register hooks to perform any necessary
+    cleanup before RMM is reinitialized. For example, a library with
+    an internal cache of objects that use device memory allocated by
+    RMM can register a hook to release those references before RMM is
     reinitialized, thus ensuring that the relevant device memory
     resource can be deallocated
 
-    Hooks are called in the *reverse* order they are registered.
+    Hooks are called in the *reverse* order they are registered.  This
+    is useful, for example, when a library registers multiple hooks
+    and needs them to run in a specific order for cleanup to be safe.
+    Hooks cannot rely on being registered in a particular order
+    relative to hooks registered by other packages, since that is
+    determined by package import ordering.
 
     Parameters
     ----------

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -246,6 +246,10 @@ def register_reinitialize_hook(func, *args, **kwargs):
     Add a function to the list of functions that will be called before
     `rmm.reinitialize()`.
 
+    Typically, a library will use this function to register hooks that
+    are responsible for deleting any remaining internal references to
+    objects using device memory allocated by RMM.
+
     Hooks are called in the *reverse* order they are registered.
 
     Parameters

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -765,3 +765,38 @@ def test_custom_mr(capsys):
 
     captured = capsys.readouterr()
     assert captured.out == "Allocating 256 bytes\nDeallocating 256 bytes\n"
+
+
+def test_reinitialize_hooks(capsys):
+    def one():
+        print("one")
+
+    def two():
+        print("two")
+
+    def three(s):
+        print(s)
+
+    rmm.register_reinitialize_hook(one)
+    rmm.register_reinitialize_hook(two)
+    rmm.register_reinitialize_hook(three, "four")
+
+    rmm.reinitialize()
+    captured = capsys.readouterr()
+    assert captured.out == "four\ntwo\none\n"
+
+    rmm.unregister_reinitialize_hook(one)
+    rmm.unregister_reinitialize_hook(two)
+    rmm.unregister_reinitialize_hook(three)
+
+    rmm.register_reinitialize_hook(one)
+    rmm.register_reinitialize_hook(two)
+    rmm.unregister_reinitialize_hook(one)
+
+    rmm.reinitialize()
+    captured = capsys.readouterr()
+    assert captured.out == "two\n"
+
+    rmm.unregister_reinitialize_hook(one)
+    rmm.unregister_reinitialize_hook(two)
+    rmm.unregister_reinitialize_hook(three)

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -818,7 +818,7 @@ def test_reinit_hooks_register_twice(make_reinit_hook, capsys):
     assert captured.out == "two\nthree\ntwo\none\n"
 
 
-def test_register_reinit_hook_twice(reinit_hooks, capsys):
+def test_reinit_hooks_unregister_twice_registered(make_reinit_hook, capsys):
     # unregistering a twice-registered function
     # should unregister both instances:
     def func_with_arg(x):
@@ -828,6 +828,7 @@ def test_register_reinit_hook_twice(reinit_hooks, capsys):
     make_reinit_hook(lambda: print("two"))
     make_reinit_hook(func_with_arg, "three")
 
+    rmm.unregister_reinitialize_hook(func_with_arg)
     rmm.reinitialize()
     captured = capsys.readouterr()
     assert captured.out == "two\n"


### PR DESCRIPTION
This PR introduces the ability to register one or more "hooks" that will be invoked before each call to `rmm.reinitialize()`.

The motivation is to allow downstream libraries to register hooks that are responsible for deleting any internal objects that that keep references to an RMM memory resource. In particular, this is useful for https://github.com/rapidsai/cudf/pull/11246.
