### PR TITLE
Support using THRUST_WRAPPED_NAMESPACE

### DIFF
--- a/include/rmm/detail/thrust_namespace.h
+++ b/include/rmm/detail/thrust_namespace.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <thrust/detail/config.h> // namespace macros
+
 #ifdef THRUST_WRAPPED_NAMESPACE
 
 // Ensure the namespace exist before we import it
@@ -24,6 +26,9 @@ namespace THRUST_WRAPPED_NAMESPACE {
 namespace thrust {
 }
 }  // namespace THRUST_WRAPPED_NAMESPACE
-using namespace THRUST_WRAPPED_NAMESPACE;
+
+namespace rmm {
+  using namespace THRUST_WRAPPED_NAMESPACE;
+}
 
 #endif

--- a/include/rmm/detail/thrust_namespace.h
+++ b/include/rmm/detail/thrust_namespace.h
@@ -21,9 +21,9 @@
 // Ensure the namespace exist before we import it
 // so that this include can occur before thrust includes
 namespace THRUST_WRAPPED_NAMESPACE {
-    namespace thrust {
-    }
+namespace thrust {
 }
+}  // namespace THRUST_WRAPPED_NAMESPACE
 using namespace THRUST_WRAPPED_NAMESPACE;
 
 #endif

--- a/include/rmm/detail/thrust_namespace.h
+++ b/include/rmm/detail/thrust_namespace.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <thrust/detail/config.h> // namespace macros
+#include <thrust/detail/config.h>  // namespace macros
 
 #ifdef THRUST_WRAPPED_NAMESPACE
 
@@ -28,7 +28,7 @@ namespace thrust {
 }  // namespace THRUST_WRAPPED_NAMESPACE
 
 namespace rmm {
-  using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 }
 
 #endif

--- a/include/rmm/detail/thrust_namespace.h
+++ b/include/rmm/detail/thrust_namespace.h
@@ -17,5 +17,13 @@
 #pragma once
 
 #ifdef THRUST_WRAPPED_NAMESPACE
+
+// Ensure the namespace exist before we import it
+// so that this include can occur before thrust includes
+namespace THRUST_WRAPPED_NAMESPACE {
+    namespace thrust {
+    }
+}
 using namespace THRUST_WRAPPED_NAMESPACE;
+
 #endif

--- a/include/rmm/detail/thrust_namespace.h
+++ b/include/rmm/detail/thrust_namespace.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,6 @@
 
 #pragma once
 
-#include <rmm/mr/device/thrust_allocator_adaptor.hpp>
-
-#include <thrust/device_vector.h>
-#include <rmm/detail/thrust_namespace.h>
-
-namespace rmm {
-/**
- * @brief Alias for a thrust::device_vector that uses RMM for memory allocation.
- *
- */
-template <typename T>
-using device_vector = thrust::device_vector<T, rmm::mr::thrust_allocator<T>>;
-
-}  // namespace rmm
+#ifdef THRUST_WRAPPED_NAMESPACE
+using namespace THRUST_WRAPPED_NAMESPACE;
+#endif

--- a/include/rmm/device_vector.hpp
+++ b/include/rmm/device_vector.hpp
@@ -18,9 +18,8 @@
 
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
-#include <thrust/device_vector.h>
-
 #include <rmm/detail/thrust_namespace.h>
+#include <thrust/device_vector.h>
 
 namespace rmm {
 /**

--- a/include/rmm/device_vector.hpp
+++ b/include/rmm/device_vector.hpp
@@ -19,6 +19,7 @@
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
 #include <thrust/device_vector.h>
+
 #include <rmm/detail/thrust_namespace.h>
 
 namespace rmm {

--- a/include/rmm/device_vector.hpp
+++ b/include/rmm/device_vector.hpp
@@ -20,7 +20,7 @@
 
 #include <thrust/device_vector.h>
 #ifdef THRUST_WRAPPED_NAMESPACE
- using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 #endif
 
 namespace rmm {

--- a/include/rmm/device_vector.hpp
+++ b/include/rmm/device_vector.hpp
@@ -19,6 +19,9 @@
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
 #include <thrust/device_vector.h>
+#ifdef THRUST_WRAPPED_NAMESPACE
+ using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 
 namespace rmm {
 /**

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -24,10 +24,9 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
+#include <rmm/detail/thrust_namespace.h>
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
-
-#include <rmm/detail/thrust_namespace.h>
 
 namespace rmm {
 

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -26,6 +26,7 @@
 
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
+
 #include <rmm/detail/thrust_namespace.h>
 
 namespace rmm {

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -26,6 +26,9 @@
 
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
+#ifdef THRUST_WRAPPED_NAMESPACE
+ using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 
 namespace rmm {
 

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -26,9 +26,7 @@
 
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
-#ifdef THRUST_WRAPPED_NAMESPACE
-using namespace THRUST_WRAPPED_NAMESPACE;
-#endif
+#include <rmm/detail/thrust_namespace.h>
 
 namespace rmm {
 

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -27,7 +27,7 @@
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
 #ifdef THRUST_WRAPPED_NAMESPACE
- using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 #endif
 
 namespace rmm {

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -25,7 +25,7 @@
 
 #include <thrust/optional.h>
 #ifdef THRUST_WRAPPED_NAMESPACE
- using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 #endif
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -24,9 +24,7 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/optional.h>
-#ifdef THRUST_WRAPPED_NAMESPACE
-using namespace THRUST_WRAPPED_NAMESPACE;
-#endif
+#include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -23,9 +23,8 @@
 #include <rmm/mr/device/cuda_async_view_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-#include <thrust/optional.h>
-
 #include <rmm/detail/thrust_namespace.h>
+#include <thrust/optional.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -24,6 +24,7 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/optional.h>
+
 #include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -24,6 +24,9 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/optional.h>
+#ifdef THRUST_WRAPPED_NAMESPACE
+ using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -23,9 +23,7 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/optional.h>
-#ifdef THRUST_WRAPPED_NAMESPACE
-using namespace THRUST_WRAPPED_NAMESPACE;
-#endif
+#include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -23,6 +23,7 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/optional.h>
+
 #include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -23,6 +23,9 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <thrust/optional.h>
+#ifdef THRUST_WRAPPED_NAMESPACE
+ using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -24,7 +24,7 @@
 
 #include <thrust/optional.h>
 #ifdef THRUST_WRAPPED_NAMESPACE
- using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 #endif
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -22,9 +22,8 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-#include <thrust/optional.h>
-
 #include <rmm/detail/thrust_namespace.h>
+#include <thrust/optional.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -23,6 +23,7 @@
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+
 #include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -23,6 +23,9 @@
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+#ifdef THRUST_WRAPPED_NAMESPACE
+ using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -23,9 +23,7 @@
 
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
-#ifdef THRUST_WRAPPED_NAMESPACE
-using namespace THRUST_WRAPPED_NAMESPACE;
-#endif
+#include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -21,10 +21,9 @@
 #include <rmm/mr/device/detail/fixed_size_free_list.hpp>
 #include <rmm/mr/device/detail/stream_ordered_memory_resource.hpp>
 
+#include <rmm/detail/thrust_namespace.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
-
-#include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -24,7 +24,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #ifdef THRUST_WRAPPED_NAMESPACE
- using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 #endif
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -27,6 +27,9 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/optional.h>
+#ifdef THRUST_WRAPPED_NAMESPACE
+ using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -24,11 +24,10 @@
 #include <rmm/mr/device/detail/stream_ordered_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
+#include <rmm/detail/thrust_namespace.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/optional.h>
-
-#include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -27,6 +27,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/optional.h>
+
 #include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -28,7 +28,7 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/optional.h>
 #ifdef THRUST_WRAPPED_NAMESPACE
- using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 #endif
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -27,9 +27,7 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/optional.h>
-#ifdef THRUST_WRAPPED_NAMESPACE
-using namespace THRUST_WRAPPED_NAMESPACE;
-#endif
+#include <rmm/detail/thrust_namespace.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -22,6 +22,7 @@
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
+
 #include <rmm/detail/thrust_namespace.h>
 
 namespace rmm::mr {

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -22,9 +22,7 @@
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
-#ifdef THRUST_WRAPPED_NAMESPACE
-using namespace THRUST_WRAPPED_NAMESPACE;
-#endif
+#include <rmm/detail/thrust_namespace.h>
 
 namespace rmm::mr {
 /**

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -22,6 +22,9 @@
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
+#ifdef THRUST_WRAPPED_NAMESPACE
+ using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 
 namespace rmm::mr {
 /**

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -19,11 +19,10 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 
+#include <rmm/detail/thrust_namespace.h>
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
-
-#include <rmm/detail/thrust_namespace.h>
 
 namespace rmm::mr {
 /**

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -23,7 +23,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
 #ifdef THRUST_WRAPPED_NAMESPACE
- using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 #endif
 
 namespace rmm::mr {

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -21,9 +21,7 @@
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
 #include <thrust/execution_policy.h>
-#ifdef THRUST_WRAPPED_NAMESPACE
-using namespace THRUST_WRAPPED_NAMESPACE;
-#endif
+#include <rmm/detail/thrust_namespace.h>
 
 namespace rmm {
 

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -22,7 +22,7 @@
 
 #include <thrust/execution_policy.h>
 #ifdef THRUST_WRAPPED_NAMESPACE
- using namespace THRUST_WRAPPED_NAMESPACE;
+using namespace THRUST_WRAPPED_NAMESPACE;
 #endif
 
 namespace rmm {

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -21,6 +21,9 @@
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
 #include <thrust/execution_policy.h>
+#ifdef THRUST_WRAPPED_NAMESPACE
+ using namespace THRUST_WRAPPED_NAMESPACE;
+#endif
 
 namespace rmm {
 

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -20,9 +20,8 @@
 #include <rmm/device_vector.hpp>
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
-#include <thrust/execution_policy.h>
-
 #include <rmm/detail/thrust_namespace.h>
+#include <thrust/execution_policy.h>
 
 namespace rmm {
 

--- a/include/rmm/thrust_rmm_allocator.h
+++ b/include/rmm/thrust_rmm_allocator.h
@@ -21,6 +21,7 @@
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
 #include <thrust/execution_policy.h>
+
 #include <rmm/detail/thrust_namespace.h>
 
 namespace rmm {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,11 @@ function(ConfigureTest TEST_NAME)
   string(REGEX REPLACE "_TEST$" "_PTDS_TEST" PTDS_TEST_NAME "${TEST_NAME}")
   ConfigureTestInternal("${PTDS_TEST_NAME}" ${ARGN})
   target_compile_definitions("${PTDS_TEST_NAME}" PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
+
+  # Test with custom thrust namespace
+  string(REGEX REPLACE "_TEST$" "_NAMESPACE_TEST" NS_TEST_NAME "${TEST_NAME}")
+  ConfigureTestInternal("${NS_TEST_NAME}" ${ARGN})
+  target_compile_definitions("${NS_TEST_NAME}" PUBLIC THRUST_WRAPPED_NAMESPACE=rmm_thrust)
 endfunction()
 
 # test sources

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -29,7 +29,7 @@
 
 #include <thrust/equal.h>
 #include <thrust/sequence.h>
-namespace testing{
+namespace testing {
 namespace thrust = THRUST_NS_QUALIFIER;
 }
 using namespace testing;

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -29,6 +29,10 @@
 
 #include <thrust/equal.h>
 #include <thrust/sequence.h>
+namespace testing{
+namespace thrust = THRUST_NS_QUALIFIER;
+}
+using namespace testing;
 
 #include <cuda_runtime_api.h>
 


### PR DESCRIPTION
Allows rmm to be used in the presence of `THRUST_WRAPPED_NAMESPACE` which changes the namespace location of all thrust types.
