### PR TITLE
Add device_uvector::reserve and device_buffer::reserve

### DIFF
--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -261,8 +261,8 @@ class device_buffer {
       auto tmp            = device_buffer{new_capacity, stream, _mr};
       auto const old_size = size();
       RMM_CUDA_TRY(
-        cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, this->stream().value()));
-      std::swap(tmp, *this);
+        cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, stream.value()));
+      *this = std::move(tmp);
       _size = old_size;
     }
   }
@@ -302,8 +302,8 @@ class device_buffer {
     } else {
       auto tmp = device_buffer{new_size, stream, _mr};
       RMM_CUDA_TRY(
-        cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, this->stream().value()));
-      std::swap(tmp, *this);
+        cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, stream.value()));
+      *this = std::move(tmp);
     }
   }
 

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -260,8 +260,7 @@ class device_buffer {
     if (new_capacity > capacity()) {
       auto tmp            = device_buffer{new_capacity, stream, _mr};
       auto const old_size = size();
-      RMM_CUDA_TRY(
-        cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, stream.value()));
+      RMM_CUDA_TRY(cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, stream.value()));
       *this = std::move(tmp);
       _size = old_size;
     }
@@ -301,8 +300,7 @@ class device_buffer {
       _size = new_size;
     } else {
       auto tmp = device_buffer{new_size, stream, _mr};
-      RMM_CUDA_TRY(
-        cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, stream.value()));
+      RMM_CUDA_TRY(cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, stream.value()));
       *this = std::move(tmp);
     }
   }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -237,6 +237,39 @@ class device_buffer {
   }
 
   /**
+   * @brief Increase the capacity of the device memory allocation
+   *
+   * If the requested `new_capacity` is less than or equal to `capacity()`, no
+   * action is taken.
+   *
+   * If `new_capacity` is larger than `capacity()`, a new allocation is made on
+   * `stream` to satisfy `new_capacity`, and the contents of the old allocation are
+   * copied on `stream` to the new allocation. The old allocation is then freed.
+   * The bytes from `[size(), new_capacity)` are uninitialized.
+   *
+   * @throws rmm::bad_alloc If creating the new allocation fails
+   * @throws rmm::cuda_error if the copy from the old to new allocation
+   * fails
+   *
+   * @param new_capacity The requested new capacity, in bytes
+   * @param stream The stream to use for allocation and copy
+   */
+  void reserve(std::size_t new_capacity, cuda_stream_view stream)
+  {
+    set_stream(stream);
+    if (new_capacity > capacity()) {
+      void* const new_data = _mr->allocate(new_capacity, this->stream());
+      auto const old_size  = size();
+      RMM_CUDA_TRY(
+        cudaMemcpyAsync(new_data, data(), size(), cudaMemcpyDefault, this->stream().value()));
+      deallocate_async();
+      _data     = new_data;
+      _size     = old_size;
+      _capacity = new_capacity;
+    }
+  }
+
+  /**
    * @brief Resize the device memory allocation
    *
    * If the requested `new_size` is less than or equal to `capacity()`, no
@@ -256,7 +289,7 @@ class device_buffer {
    *
    * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error if the copy from the old to new allocation
-   *fails
+   * fails
    *
    * @param new_size The requested new size, in bytes
    * @param stream The stream to use for allocation and copy

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -357,7 +357,7 @@ class device_uvector {
    * If `new_capacity <= capacity()`, no action is taken.
    *
    * If `new_capacity > capacity()`, a new allocation of size `new_capacity` is created, and the
-   * first `size()` elements from the current allocation are copied there as if by mempcy. Finally,
+   * first `size()` elements from the current allocation are copied there as if by memcpy. Finally,
    * the old allocation is freed and replaced by the new allocation.
    *
    * @param new_capacity The desired capacity (number of elements)
@@ -377,7 +377,7 @@ class device_uvector {
    * memory is allocated nor copied. `shrink_to_fit()` may be used to force deallocation of unused
    * memory.
    *
-   * If `new_size > capacity()`, elements are copied as if by mempcy to a new allocation.
+   * If `new_size > capacity()`, elements are copied as if by memcpy to a new allocation.
    *
    * The invariant `size() <= capacity()` holds.
    *

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -352,6 +352,23 @@ class device_uvector {
   }
 
   /**
+   * @brief Increases the capacity of the vector to `new_capacity` elements.
+   *
+   * If `new_capacity <= capacity()`, no action is taken.
+   *
+   * If `new_capacity > capacity()`, a new allocation of size `new_capacity` is created, and the
+   * first `size()` elements from the current allocation are copied there as if by mempcy. Finally,
+   * the old allocation is freed and replaced by the new allocation.
+   *
+   * @param new_capacity The desired capacity (number of elements)
+   * @param stream The stream on which to perform the allocation/copy (if any)
+   */
+  void reserve(std::size_t new_capacity, cuda_stream_view stream)
+  {
+    _storage.reserve(elements_to_bytes(new_capacity), stream);
+  }
+
+  /**
    * @brief Resizes the vector to contain `new_size` elements.
    *
    * If `new_size > size()`, the additional elements are uninitialized.

--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -26,6 +26,7 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         device_buffer(size_t size, cuda_stream_view stream) except +
         device_buffer(const void* source_data,
                       size_t size, cuda_stream_view stream) except +
+        void reserve(size_t new_capacity, cuda_stream_view stream) except +
         void resize(size_t new_size, cuda_stream_view stream) except +
         void shrink_to_fit(cuda_stream_view stream) except +
         void* data()
@@ -57,6 +58,7 @@ cdef class DeviceBuffer:
     cpdef bytes tobytes(self, Stream stream=*)
 
     cdef size_t c_size(self) except *
+    cpdef void reserve(self, size_t new_capacity, Stream stream=*) except *
     cpdef void resize(self, size_t new_size, Stream stream=*) except *
     cpdef size_t capacity(self) except *
     cdef void* c_data(self) except *

--- a/python/rmm/_lib/device_buffer.pyx
+++ b/python/rmm/_lib/device_buffer.pyx
@@ -288,6 +288,11 @@ cdef class DeviceBuffer:
     cdef size_t c_size(self) except *:
         return self.c_obj.get()[0].size()
 
+    cpdef void reserve(self,
+                       size_t new_capacity,
+                       Stream stream=DEFAULT_STREAM) except *:
+        self.c_obj.get()[0].reserve(new_capacity, stream.view())
+
     cpdef void resize(self,
                       size_t new_size,
                       Stream stream=DEFAULT_STREAM) except *:

--- a/python/rmm/_lib/device_uvector.pxd
+++ b/python/rmm/_lib/device_uvector.pxd
@@ -29,6 +29,7 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         ) except +
         T front_element(cuda_stream_view s) except +
         T back_element(cuda_stream_view s) except +
+        void reserve(size_t new_capacity, cuda_stream_view stream) except +
         void resize(size_t new_size, cuda_stream_view stream) except +
         void shrink_to_fit(cuda_stream_view stream) except +
         device_buffer release()

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -458,6 +458,31 @@ TYPED_TEST(DeviceBufferTest, ResizeBigger)
   EXPECT_NE(old_data, buff.data());
 }
 
+TYPED_TEST(DeviceBufferTest, ReserveSmaller)
+{
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, &this->mr);
+  auto* const old_data    = buff.data();
+  auto const old_capacity = buff.capacity();
+  auto const new_capacity = buff.capacity() - 1;
+  buff.reserve(new_capacity, rmm::cuda_stream_default);
+  EXPECT_EQ(this->size, buff.size());
+  EXPECT_EQ(old_capacity, buff.capacity());
+  // Reserving smaller means the allocation is unchanged
+  EXPECT_EQ(old_data, buff.data());
+}
+
+TYPED_TEST(DeviceBufferTest, ReserveBigger)
+{
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, &this->mr);
+  auto* const old_data    = buff.data();
+  auto const new_capacity = buff.capacity() + 1;
+  buff.reserve(new_capacity, rmm::cuda_stream_default);
+  EXPECT_EQ(this->size, buff.size());
+  EXPECT_EQ(new_capacity, buff.capacity());
+  // Reserving bigger means the data should point to a new allocation
+  EXPECT_NE(old_data, buff.data());
+}
+
 TYPED_TEST(DeviceBufferTest, SetGetStream)
 {
   rmm::device_buffer buff(this->size, rmm::cuda_stream_default, &this->mr);

--- a/tests/device_uvector_tests.cpp
+++ b/tests/device_uvector_tests.cpp
@@ -119,6 +119,42 @@ TYPED_TEST(TypedUVectorTest, ResizeLarger)
   EXPECT_EQ(vec.begin(), larger_begin);
 }
 
+TYPED_TEST(TypedUVectorTest, ReserveSmaller)
+{
+  auto const original_size{12345};
+  rmm::device_uvector<TypeParam> vec(original_size, this->stream());
+  auto* const original_data    = vec.data();
+  auto* const original_begin   = vec.begin();
+  auto const original_capacity = vec.capacity();
+
+  auto const smaller_capacity = vec.capacity() - 1;
+  vec.reserve(smaller_capacity, this->stream());
+
+  EXPECT_EQ(vec.data(), original_data);
+  EXPECT_EQ(vec.begin(), original_begin);
+  EXPECT_EQ(vec.size(), original_size);
+  EXPECT_EQ(vec.capacity(), original_capacity);
+}
+
+TYPED_TEST(TypedUVectorTest, ReserveLarger)
+{
+  auto const original_size{12345};
+  rmm::device_uvector<TypeParam> vec(original_size, this->stream());
+  vec.set_element(0, 1, this->stream());
+  auto* const original_data  = vec.data();
+  auto* const original_begin = vec.begin();
+
+  auto const larger_capacity = vec.capacity() + 1;
+  vec.reserve(larger_capacity, this->stream());
+
+  EXPECT_NE(vec.data(), original_data);
+  EXPECT_NE(vec.begin(), original_begin);
+  EXPECT_EQ(vec.size(), original_size);
+  EXPECT_EQ(vec.capacity(), larger_capacity);
+  // The element should be copied
+  EXPECT_EQ(vec.element(0, this->stream()), 1);
+}
+
 TYPED_TEST(TypedUVectorTest, ResizeToZero)
 {
   auto const original_size{12345};


### PR DESCRIPTION
I am building a parser that outputs variable-sized blocks of data. To collect them, I would like to use pre-allocated `device_uvector`s, using `size()` to keep track of how much memory is already in use. Setting the capacity and size manually works at the moment by calling `vec.resize(capacity, stream); vec.resize(size, stream);` on an empty vector, but this seems unnecessarily complicated. Since `device_uvector` otherwise already closely matches the `std::vector` interface, I want to propose adding `reserve` to the interface.

TODO:
- [x] Add to Python interface