### PR TITLE
[REVIEW] Switch to common `js` file and defer loading it

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -199,5 +199,7 @@ autoclass_content = "init"
 
 def setup(app):
     app.add_js_file("copybutton_pydocs.js")
-    app.add_css_file("params.css")
     app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
+    app.add_js_file(
+        "https://docs.rapids.ai/assets/js/custom.js", loading_method="defer"
+    )


### PR DESCRIPTION
## Description
This PR switches docs to use the custom common js code merged here: https://github.com/rapidsai/docs/pull/286

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
