### PR TITLE
Use rapids-cmake 22.10 best practice for RAPIDS.cmake location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,11 @@
 
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
-     ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+if(NOT EXISTS ${CMAKE_BINARY_DIR}/RMM_RAPIDS.cmake)
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
+       ${CMAKE_BINARY_DIR}/RMM_RAPIDS.cmake)
+endif()
+include(${CMAKE_BINARY_DIR}/RMM_RAPIDS.cmake)
 
 include(rapids-cmake)
 include(rapids-cpm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,11 @@
 
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/RMM_RAPIDS.cmake)
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
-       ${CMAKE_BINARY_DIR}/RMM_RAPIDS.cmake)
+       ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)
 endif()
-include(${CMAKE_BINARY_DIR}/RMM_RAPIDS.cmake)
+include(${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)
 
 include(rapids-cmake)
 include(rapids-cpm)


### PR DESCRIPTION

## Description
Removes possibility of another projects RAPIDS.cmake being used, and removes need to always download a version.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
