### PR TITLE
Add `gdb` pretty-printers for rmm types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,13 @@ endif()
 
 include(CPack)
 
+# optionally assemble Thrust pretty-printers
+if(Thrust_SOURCE_DIR)
+  file(READ ${Thrust_SOURCE_DIR}/scripts/gdb-pretty-printers.py THRUST_PRETTY_PRINTER_CONTENT)
+  file(READ ${PROJECT_SOURCE_DIR}/scripts/gdb-pretty-printers.py RMM_PRETTY_PRINTER_CONTENT)
+  file(WRITE ${PROJECT_BINARY_DIR}/scripts/gdb-pretty-printers.py "${THRUST_PRETTY_PRINTER_CONTENT}${RMM_PRETTY_PRINTER_CONTENT}")
+endif()
+
 # install export targets
 install(TARGETS rmm EXPORT rmm-exports)
 install(DIRECTORY include/rmm/ DESTINATION include/rmm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,7 @@ include(CPack)
 
 # optionally assemble Thrust pretty-printers
 if(Thrust_SOURCE_DIR)
-  file(READ ${Thrust_SOURCE_DIR}/scripts/gdb-pretty-printers.py THRUST_PRETTY_PRINTER_CONTENT)
-  file(READ ${PROJECT_SOURCE_DIR}/scripts/gdb-pretty-printers.py RMM_PRETTY_PRINTER_CONTENT)
-  file(WRITE ${PROJECT_BINARY_DIR}/scripts/gdb-pretty-printers.py "${THRUST_PRETTY_PRINTER_CONTENT}${RMM_PRETTY_PRINTER_CONTENT}")
+  configure_file(scripts/load-pretty-printers.in load-pretty-printers @ONLY)
 endif()
 
 # install export targets

--- a/scripts/gdb-pretty-printers.py
+++ b/scripts/gdb-pretty-printers.py
@@ -16,14 +16,14 @@
 import gdb
 
 
-if not "ThrustVectorPrinter" in locals():
-    raise Exception("This file expects the Thrust pretty-printers to be loaded already. "
+if "ThrustVectorPrinter" not in locals():
+    raise NameError("This file expects the Thrust pretty-printers to be loaded already. "
                     "Either load them manually, or use the generated load-pretty-printers "
                     "script in the build directory")
 
 
-class HostIterator():
-    """Iterates over arrays in host memory"""
+class HostIterator:
+    """Iterates over arrays in host memory."""
 
     def __init__(self, start, size):
         self.item = start
@@ -43,8 +43,8 @@ class HostIterator():
         return (f"[{count}]", elt)
 
 
-class DeviceIterator():
-    """Iterates over arrays in device memory by copying chunks into host memory"""
+class DeviceIterator:
+    """Iterates over arrays in device memory by copying chunks into host memory."""
 
     def __init__(self, start, size):
         self.exec = exec
@@ -97,7 +97,7 @@ class DeviceIterator():
 
 
 class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
-    """Print a rmm::device_uvector"""
+    """Print a rmm::device_uvector."""
 
     def __init__(self, val):
         self.val = val
@@ -110,8 +110,7 @@ class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
         return DeviceIterator(self.pointer, self.size)        
 
     def to_string(self):
-        typename = str(self.val.type)
-        return (f"{typename} of length {self.size}, capacity {self.capacity}")
+        return (f"{self.val.type} of length {self.size}, capacity {self.capacity}")
 
     def display_hint(self):
         return "array"

--- a/scripts/gdb-pretty-printers.py
+++ b/scripts/gdb-pretty-printers.py
@@ -16,12 +16,6 @@
 import gdb
 
 
-if "ThrustVectorPrinter" not in locals():
-    raise NameError("This file expects the Thrust pretty-printers to be loaded already. "
-                    "Either load them manually, or use the generated load-pretty-printers "
-                    "script in the build directory")
-
-
 class HostIterator:
     """Iterates over arrays in host memory."""
 

--- a/scripts/gdb-pretty-printers.py
+++ b/scripts/gdb-pretty-printers.py
@@ -18,8 +18,8 @@ import gdb
 
 if not 'ThrustVectorPrinter' in locals():
     raise Exception("This file expects the Thrust pretty-printers to be loaded already. "
-                    "Either load them manually, or use the generated gdb-pretty-printers.py "
-                    "in the build directory")
+                    "Either load them manually, or use the generated load-pretty-printers "
+                    "script in the build directory")
 
 
 class HostIterator(Iterator):
@@ -38,8 +38,8 @@ class HostIterator(Iterator):
             raise StopIteration
         elt = self.item.dereference()
         count = self.count
-        self.item = self.item + 1
-        self.count = self.count + 1
+        self.item += 1
+        self.count += 1
         return ('[%d]' % count, elt)
 
 
@@ -90,11 +90,11 @@ class DeviceIterator(Iterator):
             raise StopIteration
         self.update_buffer()
         elt = self.buffer_item.dereference()
-        self.buffer_item = self.buffer_item + 1
-        self.buffer_count = self.buffer_count + 1
+        self.buffer_item += 1
+        self.buffer_count += 1
         count = self.count
-        self.item = self.item + 1
-        self.count = self.count + 1
+        self.item += 1
+        self.count += 1
         return ('[%d]' % count, elt)
 
 

--- a/scripts/gdb-pretty-printers.py
+++ b/scripts/gdb-pretty-printers.py
@@ -16,137 +16,138 @@
 import gdb
 
 
-if not 'ThrustVectorPrinter' in dir():
-    print("This file expects the Thrust pretty-printers to be loaded already. "
-          "Either load them manually, or use the generated gdb-pretty-printers.py "
-          "in the build directory")
-else:
-    class HostIterator(Iterator):
-        """Iterates over arrays in host memory"""
-
-        def __init__(self, start, size):
-            self.item = start
-            self.size = size
-            self.count = 0
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            if self.count >= self.size:
-                raise StopIteration
-            elt = self.item.dereference()
-            count = self.count
-            self.item = self.item + 1
-            self.count = self.count + 1
-            return ('[%d]' % count, elt)
+if not 'ThrustVectorPrinter' in locals():
+    raise Exception("This file expects the Thrust pretty-printers to be loaded already. "
+                    "Either load them manually, or use the generated gdb-pretty-printers.py "
+                    "in the build directory")
 
 
-    class DeviceIterator(Iterator):
-        """Iterates over arrays in device memory by copying chunks into host memory"""
+class HostIterator(Iterator):
+    """Iterates over arrays in host memory"""
 
-        def __init__(self, start, size):
-            self.exec = exec
-            self.item = start
-            self.size = size
-            self.count = 0
-            self.buffer = None
-            self.sizeof = self.item.dereference().type.sizeof
-            self.buffer_start = 0
-            # At most 1 MB or size, at least 1
-            self.buffer_size = min(size, max(1, 2 ** 20 // self.sizeof))
-            self.buffer = gdb.parse_and_eval(
-                '(void*)malloc(%s)' % (self.buffer_size * self.sizeof))
-            self.buffer.fetch_lazy()
-            self.buffer_count = self.buffer_size
-            self.update_buffer()
+    def __init__(self, start, size):
+        self.item = start
+        self.size = size
+        self.count = 0
 
-        def update_buffer(self):
-            if self.buffer_count >= self.buffer_size:
-                self.buffer_item = gdb.parse_and_eval(
-                    hex(self.buffer)).cast(self.item.type)
-                self.buffer_count = 0
-                self.buffer_start = self.count
-                device_addr = hex(self.item.dereference().address)
-                buffer_addr = hex(self.buffer)
-                size = min(self.buffer_size, self.size -
-                            self.buffer_start) * self.sizeof
-                status = gdb.parse_and_eval(
-                    '(cudaError)cudaMemcpy(%s, %s, %d, cudaMemcpyDeviceToHost)' % (buffer_addr, device_addr, size))
-                if status != 0:
-                    raise gdb.MemoryError(
-                        'memcpy from device failed: %s' % status)
+    def __iter__(self):
+        return self
 
-        def __del__(self):
-            gdb.parse_and_eval('(void)free(%s)' %
-                                hex(self.buffer)).fetch_lazy()
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            if self.count >= self.size:
-                raise StopIteration
-            self.update_buffer()
-            elt = self.buffer_item.dereference()
-            self.buffer_item = self.buffer_item + 1
-            self.buffer_count = self.buffer_count + 1
-            count = self.count
-            self.item = self.item + 1
-            self.count = self.count + 1
-            return ('[%d]' % count, elt)
+    def __next__(self):
+        if self.count >= self.size:
+            raise StopIteration
+        elt = self.item.dereference()
+        count = self.count
+        self.item = self.item + 1
+        self.count = self.count + 1
+        return ('[%d]' % count, elt)
 
 
-    class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
-        """Print a rmm::device_uvector"""
+class DeviceIterator(Iterator):
+    """Iterates over arrays in device memory by copying chunks into host memory"""
 
-        def __init__(self, val):
-            self.val = val
-            el_type = val.type.template_argument(0)
-            self.pointer = val['_storage']['_data'].cast(el_type.pointer())
-            self.size = int(val['_storage']['_size']) // el_type.sizeof
-            self.capacity = int(val['_storage']['_capacity']) // el_type.sizeof
+    def __init__(self, start, size):
+        self.exec = exec
+        self.item = start
+        self.size = size
+        self.count = 0
+        self.buffer = None
+        self.sizeof = self.item.dereference().type.sizeof
+        self.buffer_start = 0
+        # At most 1 MB or size, at least 1
+        self.buffer_size = min(size, max(1, 2 ** 20 // self.sizeof))
+        self.buffer = gdb.parse_and_eval(
+            '(void*)malloc(%s)' % (self.buffer_size * self.sizeof))
+        self.buffer.fetch_lazy()
+        self.buffer_count = self.buffer_size
+        self.update_buffer()
 
-        def children(self):
-            return DeviceIterator(self.pointer, self.size)        
+    def update_buffer(self):
+        if self.buffer_count >= self.buffer_size:
+            self.buffer_item = gdb.parse_and_eval(
+                hex(self.buffer)).cast(self.item.type)
+            self.buffer_count = 0
+            self.buffer_start = self.count
+            device_addr = hex(self.item.dereference().address)
+            buffer_addr = hex(self.buffer)
+            size = min(self.buffer_size, self.size -
+                        self.buffer_start) * self.sizeof
+            status = gdb.parse_and_eval(
+                '(cudaError)cudaMemcpy(%s, %s, %d, cudaMemcpyDeviceToHost)' % (buffer_addr, device_addr, size))
+            if status != 0:
+                raise gdb.MemoryError(
+                    'memcpy from device failed: %s' % status)
 
-        def to_string(self):
-            typename = str(self.val.type)
-            return ('%s of length %d, capacity %d' % (typename, self.size, self.capacity))
+    def __del__(self):
+        gdb.parse_and_eval('(void)free(%s)' %
+                            hex(self.buffer)).fetch_lazy()
 
-        def display_hint(self):
-            return 'array'
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.count >= self.size:
+            raise StopIteration
+        self.update_buffer()
+        elt = self.buffer_item.dereference()
+        self.buffer_item = self.buffer_item + 1
+        self.buffer_count = self.buffer_count + 1
+        count = self.count
+        self.item = self.item + 1
+        self.count = self.count + 1
+        return ('[%d]' % count, elt)
 
 
-    # Workaround to avoid using the pretty printer on things like std::vector<int>::iterator
-    def is_template_type_not_alias(typename):
-        loc = typename.find('<')
-        if loc is None:
+class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
+    """Print a rmm::device_uvector"""
+
+    def __init__(self, val):
+        self.val = val
+        el_type = val.type.template_argument(0)
+        self.pointer = val['_storage']['_data'].cast(el_type.pointer())
+        self.size = int(val['_storage']['_size']) // el_type.sizeof
+        self.capacity = int(val['_storage']['_capacity']) // el_type.sizeof
+
+    def children(self):
+        return DeviceIterator(self.pointer, self.size)        
+
+    def to_string(self):
+        typename = str(self.val.type)
+        return ('%s of length %d, capacity %d' % (typename, self.size, self.capacity))
+
+    def display_hint(self):
+        return 'array'
+
+
+# Workaround to avoid using the pretty printer on things like std::vector<int>::iterator
+def is_template_type_not_alias(typename):
+    loc = typename.find('<')
+    if loc is None:
+        return False
+    depth = 0
+    for char in typename[typename.find('<'):-1]:
+        if char == '<':
+            depth += 1
+        if char == '>':
+            depth -= 1
+        if depth == 0:
             return False
-        depth = 0
-        for char in typename[typename.find('<'):-1]:
-            if char == '<':
-                depth += 1
-            if char == '>':
-                depth -= 1
-            if depth == 0:
-                return False
-        return True
+    return True
 
 
-    def template_match(typename, template_name):
-        return typename.startswith(template_name + "<") and typename.endswith(">")
+def template_match(typename, template_name):
+    return typename.startswith(template_name + "<") and typename.endswith(">")
 
 
-    def lookup_rmm_type(val):
-        if not str(val.type.unqualified()).startswith('rmm::'):
-            return None
-        suffix = str(val.type.unqualified())[5:]
-        if not is_template_type_not_alias(suffix):
-            return None
-        if template_match(suffix, 'device_uvector'):
-            return RmmDeviceUVectorPrinter(val)
+def lookup_rmm_type(val):
+    if not str(val.type.unqualified()).startswith('rmm::'):
         return None
+    suffix = str(val.type.unqualified())[5:]
+    if not is_template_type_not_alias(suffix):
+        return None
+    if template_match(suffix, 'device_uvector'):
+        return RmmDeviceUVectorPrinter(val)
+    return None
 
 
-    gdb.pretty_printers.append(lookup_rmm_type)
+gdb.pretty_printers.append(lookup_rmm_type)

--- a/scripts/gdb-pretty-printers.py
+++ b/scripts/gdb-pretty-printers.py
@@ -13,140 +13,140 @@
 # limitations under the License.
 #
 
-import sys
 import gdb
 
 
-if "@RMM_PRETTY_PRINTER@" != "1":
-    sys.exit("This file is only a template, use gdb-pretty-printer.py in the CMake build directory instead.")
+if not 'ThrustVectorPrinter' in dir():
+    print("This file expects the Thrust pretty-printers to be loaded already. "
+          "Either load them manually, or use the generated gdb-pretty-printers.py "
+          "in the build directory")
+else:
+    class HostIterator(Iterator):
+        """Iterates over arrays in host memory"""
+
+        def __init__(self, start, size):
+            self.item = start
+            self.size = size
+            self.count = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.count >= self.size:
+                raise StopIteration
+            elt = self.item.dereference()
+            count = self.count
+            self.item = self.item + 1
+            self.count = self.count + 1
+            return ('[%d]' % count, elt)
 
 
-class HostIterator(Iterator):
-    """Iterates over arrays in host memory"""
+    class DeviceIterator(Iterator):
+        """Iterates over arrays in device memory by copying chunks into host memory"""
 
-    def __init__(self, start, size):
-        self.item = start
-        self.size = size
-        self.count = 0
+        def __init__(self, start, size):
+            self.exec = exec
+            self.item = start
+            self.size = size
+            self.count = 0
+            self.buffer = None
+            self.sizeof = self.item.dereference().type.sizeof
+            self.buffer_start = 0
+            # At most 1 MB or size, at least 1
+            self.buffer_size = min(size, max(1, 2 ** 20 // self.sizeof))
+            self.buffer = gdb.parse_and_eval(
+                '(void*)malloc(%s)' % (self.buffer_size * self.sizeof))
+            self.buffer.fetch_lazy()
+            self.buffer_count = self.buffer_size
+            self.update_buffer()
 
-    def __iter__(self):
-        return self
+        def update_buffer(self):
+            if self.buffer_count >= self.buffer_size:
+                self.buffer_item = gdb.parse_and_eval(
+                    hex(self.buffer)).cast(self.item.type)
+                self.buffer_count = 0
+                self.buffer_start = self.count
+                device_addr = hex(self.item.dereference().address)
+                buffer_addr = hex(self.buffer)
+                size = min(self.buffer_size, self.size -
+                            self.buffer_start) * self.sizeof
+                status = gdb.parse_and_eval(
+                    '(cudaError)cudaMemcpy(%s, %s, %d, cudaMemcpyDeviceToHost)' % (buffer_addr, device_addr, size))
+                if status != 0:
+                    raise gdb.MemoryError(
+                        'memcpy from device failed: %s' % status)
 
-    def __next__(self):
-        if self.count >= self.size:
-            raise StopIteration
-        elt = self.item.dereference()
-        count = self.count
-        self.item = self.item + 1
-        self.count = self.count + 1
-        return ('[%d]' % count, elt)
+        def __del__(self):
+            gdb.parse_and_eval('(void)free(%s)' %
+                                hex(self.buffer)).fetch_lazy()
 
+        def __iter__(self):
+            return self
 
-class DeviceIterator(Iterator):
-    """Iterates over arrays in device memory by copying chunks into host memory"""
-
-    def __init__(self, start, size):
-        self.exec = exec
-        self.item = start
-        self.size = size
-        self.count = 0
-        self.buffer = None
-        self.sizeof = self.item.dereference().type.sizeof
-        self.buffer_start = 0
-        # At most 1 MB or size, at least 1
-        self.buffer_size = min(size, max(1, 2 ** 20 // self.sizeof))
-        self.buffer = gdb.parse_and_eval(
-            '(void*)malloc(%s)' % (self.buffer_size * self.sizeof))
-        self.buffer.fetch_lazy()
-        self.buffer_count = self.buffer_size
-        self.update_buffer()
-
-    def update_buffer(self):
-        if self.buffer_count >= self.buffer_size:
-            self.buffer_item = gdb.parse_and_eval(
-                hex(self.buffer)).cast(self.item.type)
-            self.buffer_count = 0
-            self.buffer_start = self.count
-            device_addr = hex(self.item.dereference().address)
-            buffer_addr = hex(self.buffer)
-            size = min(self.buffer_size, self.size -
-                        self.buffer_start) * self.sizeof
-            status = gdb.parse_and_eval(
-                '(cudaError)cudaMemcpy(%s, %s, %d, cudaMemcpyDeviceToHost)' % (buffer_addr, device_addr, size))
-            if status != 0:
-                raise gdb.MemoryError(
-                    'memcpy from device failed: %s' % status)
-
-    def __del__(self):
-        gdb.parse_and_eval('(void)free(%s)' %
-                            hex(self.buffer)).fetch_lazy()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self.count >= self.size:
-            raise StopIteration
-        self.update_buffer()
-        elt = self.buffer_item.dereference()
-        self.buffer_item = self.buffer_item + 1
-        self.buffer_count = self.buffer_count + 1
-        count = self.count
-        self.item = self.item + 1
-        self.count = self.count + 1
-        return ('[%d]' % count, elt)
+        def __next__(self):
+            if self.count >= self.size:
+                raise StopIteration
+            self.update_buffer()
+            elt = self.buffer_item.dereference()
+            self.buffer_item = self.buffer_item + 1
+            self.buffer_count = self.buffer_count + 1
+            count = self.count
+            self.item = self.item + 1
+            self.count = self.count + 1
+            return ('[%d]' % count, elt)
 
 
-class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
-    """Print a rmm::device_uvector"""
+    class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
+        """Print a rmm::device_uvector"""
 
-    def __init__(self, val):
-        self.val = val
-        el_type = val.type.template_argument(0)
-        self.pointer = val['_storage']['_data'].cast(el_type.pointer())
-        self.size = int(val['_storage']['_size']) // el_type.sizeof
-        self.capacity = int(val['_storage']['_capacity']) // el_type.sizeof
+        def __init__(self, val):
+            self.val = val
+            el_type = val.type.template_argument(0)
+            self.pointer = val['_storage']['_data'].cast(el_type.pointer())
+            self.size = int(val['_storage']['_size']) // el_type.sizeof
+            self.capacity = int(val['_storage']['_capacity']) // el_type.sizeof
 
-    def children(self):
-        return DeviceIterator(self.pointer, self.size)        
+        def children(self):
+            return DeviceIterator(self.pointer, self.size)        
 
-    def to_string(self):
-        typename = str(self.val.type)
-        return ('%s of length %d, capacity %d' % (typename, self.size, self.capacity))
+        def to_string(self):
+            typename = str(self.val.type)
+            return ('%s of length %d, capacity %d' % (typename, self.size, self.capacity))
 
-    def display_hint(self):
-        return 'array'
+        def display_hint(self):
+            return 'array'
 
 
-# Workaround to avoid using the pretty printer on things like std::vector<int>::iterator
-def is_template_type_not_alias(typename):
-    loc = typename.find('<')
-    if loc is None:
-        return False
-    depth = 0
-    for char in typename[typename.find('<'):-1]:
-        if char == '<':
-            depth += 1
-        if char == '>':
-            depth -= 1
-        if depth == 0:
+    # Workaround to avoid using the pretty printer on things like std::vector<int>::iterator
+    def is_template_type_not_alias(typename):
+        loc = typename.find('<')
+        if loc is None:
             return False
-    return True
+        depth = 0
+        for char in typename[typename.find('<'):-1]:
+            if char == '<':
+                depth += 1
+            if char == '>':
+                depth -= 1
+            if depth == 0:
+                return False
+        return True
 
 
-def template_match(typename, template_name):
-    return typename.startswith(template_name + "<") and typename.endswith(">")
+    def template_match(typename, template_name):
+        return typename.startswith(template_name + "<") and typename.endswith(">")
 
 
-def lookup_rmm_type(val):
-    if not str(val.type.unqualified()).startswith('rmm::'):
+    def lookup_rmm_type(val):
+        if not str(val.type.unqualified()).startswith('rmm::'):
+            return None
+        suffix = str(val.type.unqualified())[5:]
+        if not is_template_type_not_alias(suffix):
+            return None
+        if template_match(suffix, 'device_uvector'):
+            return RmmDeviceUVectorPrinter(val)
         return None
-    suffix = str(val.type.unqualified())[5:]
-    if not is_template_type_not_alias(suffix):
-        return None
-    if template_match(suffix, 'device_uvector'):
-        return RmmDeviceUVectorPrinter(val)
-    return None
 
 
-gdb.pretty_printers.append(lookup_rmm_type)
+    gdb.pretty_printers.append(lookup_rmm_type)

--- a/scripts/gdb-pretty-printers.py
+++ b/scripts/gdb-pretty-printers.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import gdb
+import sys
+
+if sys.version_info[0] > 2:
+    Iterator = object
+else:
+    # "Polyfill" for Python2 Iterator interface
+    class Iterator:
+        def next(self):
+            return self.__next__()
+
+
+class HostIterator(Iterator):
+    """Iterates over arrays in host memory"""
+
+    def __init__(self, start, size):
+        self.item = start
+        self.size = size
+        self.count = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.count >= self.size:
+            raise StopIteration
+        elt = self.item.dereference()
+        count = self.count
+        self.item = self.item + 1
+        self.count = self.count + 1
+        return ('[%d]' % count, elt)
+
+
+class DeviceIterator(Iterator):
+    """Iterates over arrays in device memory by copying chunks into host memory"""
+
+    def __init__(self, start, size):
+        self.exec = exec
+        self.item = start
+        self.size = size
+        self.count = 0
+        self.buffer = None
+        self.sizeof = self.item.dereference().type.sizeof
+        self.buffer_start = 0
+        # At most 1 MB or size, at least 1
+        self.buffer_size = min(size, max(1, 2 ** 20 // self.sizeof))
+        self.buffer = gdb.parse_and_eval(
+            '(void*)malloc(%s)' % (self.buffer_size * self.sizeof))
+        self.buffer.fetch_lazy()
+        self.buffer_count = self.buffer_size
+        self.update_buffer()
+
+    def update_buffer(self):
+        if self.buffer_count >= self.buffer_size:
+            self.buffer_item = gdb.parse_and_eval(
+                hex(self.buffer)).cast(self.item.type)
+            self.buffer_count = 0
+            self.buffer_start = self.count
+            device_addr = hex(self.item.dereference().address)
+            buffer_addr = hex(self.buffer)
+            size = min(self.buffer_size, self.size -
+                        self.buffer_start) * self.sizeof
+            status = gdb.parse_and_eval(
+                '(cudaError)cudaMemcpy(%s, %s, %d, cudaMemcpyDeviceToHost)' % (buffer_addr, device_addr, size))
+            if status != 0:
+                raise gdb.MemoryError(
+                    'memcpy from device failed: %s' % status)
+
+    def __del__(self):
+        gdb.parse_and_eval('(void)free(%s)' %
+                            hex(self.buffer)).fetch_lazy()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.count >= self.size:
+            raise StopIteration
+        self.update_buffer()
+        elt = self.buffer_item.dereference()
+        self.buffer_item = self.buffer_item + 1
+        self.buffer_count = self.buffer_count + 1
+        count = self.count
+        self.item = self.item + 1
+        self.count = self.count + 1
+        return ('[%d]' % count, elt)
+
+
+class ThrustVectorPrinter(gdb.printing.PrettyPrinter):
+    """Print a thrust::*_vector"""
+
+    def __init__(self, val):
+        self.val = val
+        self.pointer = val['m_storage']['m_begin']['m_iterator']
+        self.size = int(val['m_size'])
+        self.capacity = int(val['m_storage']['m_size'])
+        self.is_device = False
+        if str(self.pointer.type).startswith("thrust::device_ptr"):
+            self.pointer = self.pointer['m_iterator']
+            self.is_device = True
+
+    def children(self):
+        if self.is_device:
+            return DeviceIterator(self.pointer, self.size)
+        else:
+            return HostIterator(self.pointer, self.size)
+
+    def to_string(self):
+        typename = str(self.val.type)
+        return ('%s of length %d, capacity %d' % (typename, self.size, self.capacity))
+
+    def display_hint(self):
+        return 'array'
+
+
+class ThrustReferencePrinter(gdb.printing.PrettyPrinter):
+    """Print a thrust::device_reference"""
+
+    def __init__(self, val):
+        self.val = val
+        self.pointer = val['ptr']['m_iterator']
+        self.type = self.pointer.dereference().type
+        sizeof = self.type.sizeof
+        self.buffer = gdb.parse_and_eval('(void*)malloc(%s)' % sizeof)
+        device_addr = hex(self.pointer)
+        buffer_addr = hex(self.buffer)
+        status = gdb.parse_and_eval('(cudaError)cudaMemcpy(%s, %s, %d, cudaMemcpyDeviceToHost)' % (
+            buffer_addr, device_addr, sizeof))
+        if status != 0:
+            raise gdb.MemoryError('memcpy from device failed: %s' % status)
+        self.buffer_val = gdb.parse_and_eval(
+            hex(self.buffer)).cast(self.pointer.type).dereference()
+
+    def __del__(self):
+        gdb.parse_and_eval('(void)free(%s)' % hex(self.buffer)).fetch_lazy()
+
+    def children(self):
+        return []
+
+    def to_string(self):
+        typename = str(self.val.type)
+        return ('(%s) @%s: %s' % (typename, self.pointer, self.buffer_val))
+
+    def display_hint(self):
+        return None
+
+
+class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
+    """Print a rmm::device_uvector"""
+
+    def __init__(self, val):
+        self.val = val
+        el_type = val.type.template_argument(0)
+        self.pointer = val['_storage']['_data'].cast(el_type.pointer())
+        self.size = int(val['_storage']['_size']) // el_type.sizeof
+        self.capacity = int(val['_storage']['_capacity']) // el_type.sizeof
+
+    def children(self):
+        return DeviceIterator(self.pointer, self.size)        
+
+    def to_string(self):
+        typename = str(self.val.type)
+        return ('%s of length %d, capacity %d' % (typename, self.size, self.capacity))
+
+    def display_hint(self):
+        return 'array'
+
+
+# Workaround to avoid using the pretty printer on things like std::vector<int>::iterator
+def is_template_type_not_alias(typename):
+    loc = typename.find('<')
+    if loc is None:
+        return False
+    depth = 0
+    for char in typename[typename.find('<'):-1]:
+        if char == '<':
+            depth += 1
+        if char == '>':
+            depth -= 1
+        if depth == 0:
+            return False
+    return True
+
+
+def template_match(typename, template_name):
+    return typename.startswith(template_name + "<") and typename.endswith(">")
+
+
+def lookup_rmm_type(val):
+    if not str(val.type.unqualified()).startswith('rmm::'):
+        return None
+    suffix = str(val.type.unqualified())[5:]
+    if not is_template_type_not_alias(suffix):
+        return None
+    if template_match(suffix, 'device_uvector'):
+        return RmmDeviceUVectorPrinter(val)
+    return None
+
+
+def lookup_thrust_type(val):
+    if not str(val.type.unqualified()).startswith('thrust::'):
+        return None
+    suffix = str(val.type.unqualified())[8:]
+    if not is_template_type_not_alias(suffix):
+        return None
+    if template_match(suffix, 'host_vector') or template_match(suffix, 'device_vector'):
+        return ThrustVectorPrinter(val)
+    elif int(gdb.VERSION.split(".")[0]) >= 10 and template_match(suffix, 'device_reference'):
+        return ThrustReferencePrinter(val)
+    return None
+
+
+gdb.pretty_printers.append(lookup_rmm_type)
+gdb.pretty_printers.append(lookup_thrust_type)

--- a/scripts/gdb-pretty-printers.py
+++ b/scripts/gdb-pretty-printers.py
@@ -16,7 +16,7 @@
 import gdb
 
 
-if not 'ThrustVectorPrinter' in locals():
+if not "ThrustVectorPrinter" in locals():
     raise Exception("This file expects the Thrust pretty-printers to be loaded already. "
                     "Either load them manually, or use the generated load-pretty-printers "
                     "script in the build directory")
@@ -102,9 +102,9 @@ class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
     def __init__(self, val):
         self.val = val
         el_type = val.type.template_argument(0)
-        self.pointer = val['_storage']['_data'].cast(el_type.pointer())
-        self.size = int(val['_storage']['_size']) // el_type.sizeof
-        self.capacity = int(val['_storage']['_capacity']) // el_type.sizeof
+        self.pointer = val["_storage"]["_data"].cast(el_type.pointer())
+        self.size = int(val["_storage"]["_size"]) // el_type.sizeof
+        self.capacity = int(val["_storage"]["_capacity"]) // el_type.sizeof
 
     def children(self):
         return DeviceIterator(self.pointer, self.size)        
@@ -114,19 +114,19 @@ class RmmDeviceUVectorPrinter(gdb.printing.PrettyPrinter):
         return (f"{typename} of length {self.size}, capacity {self.capacity}")
 
     def display_hint(self):
-        return 'array'
+        return "array"
 
 
 # Workaround to avoid using the pretty printer on things like std::vector<int>::iterator
 def is_template_type_not_alias(typename):
-    loc = typename.find('<')
+    loc = typename.find("<")
     if loc is None:
         return False
     depth = 0
     for char in typename[loc:-1]:
-        if char == '<':
+        if char == "<":
             depth += 1
-        if char == '>':
+        if char == ">":
             depth -= 1
         if depth == 0:
             return False
@@ -138,12 +138,12 @@ def template_match(typename, template_name):
 
 
 def lookup_rmm_type(val):
-    if not str(val.type.unqualified()).startswith('rmm::'):
+    if not str(val.type.unqualified()).startswith("rmm::"):
         return None
     suffix = str(val.type.unqualified())[5:]
     if not is_template_type_not_alias(suffix):
         return None
-    if template_match(suffix, 'device_uvector'):
+    if template_match(suffix, "device_uvector"):
         return RmmDeviceUVectorPrinter(val)
     return None
 

--- a/scripts/load-pretty-printers.in
+++ b/scripts/load-pretty-printers.in
@@ -1,0 +1,2 @@
+source @Thrust_SOURCE_DIR@/scripts/gdb-pretty-printers.py
+source @PROJECT_SOURCE_DIR@/scripts/gdb-pretty-printers.py


### PR DESCRIPTION
## Description
This PR adds a pretty-printer for `device_uvector` and pulls in Thrust pretty-printers that were added in https://github.com/NVIDIA/thrust/pull/1631. CMake provides a convenience script to load all of the pretty-printers, to resolve the duplication concerns raised in https://github.com/rapidsai/cudf/pull/11499.

Example output:
<details>

```
$ gdb -q gtests/DEVICE_UVECTOR_TEST
Reading symbols from gtests/DEVICE_UVECTOR_TEST...
(gdb) b cudaMalloc
Function "cudaMalloc" not defined.
Make breakpoint pending on future shared library load? (y or [n]) y
Breakpoint 1 (cudaMalloc) pending.
(gdb) run
Starting program: /home/nfs/tribizel/rapids/rmm/build/cuda-11.5.0/feature__pretty-printers/debug/gtests/DEVICE_UVECTOR_TEST 
warning: Error disabling address space randomization: Operation not permitted
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/x86_64-linux-gnu/libthread_db.so.1".
Running main() from gmock_main.cc
[==========] Running 95 tests from 5 test suites.
[----------] Global test environment set-up.
[----------] 19 tests from TypedUVectorTest/0, where TypeParam = signed char
[ RUN      ] TypedUVectorTest/0.MemoryResource
[New Thread 0x7f741efc1000 (LWP 86147)]

Thread 1 "DEVICE_UVECTOR_" hit Breakpoint 1, 0x00007f7426dddc80 in cudaMalloc () from /home/nfs/tribizel/rapids/compose/etc/conda/cuda_11.5/envs/rapids/lib/libcudart.so.11.0
(gdb) c
Continuing.
[New Thread 0x7f741e7c0000 (LWP 86148)]
[       OK ] TypedUVectorTest/0.MemoryResource (999 ms)
[ RUN      ] TypedUVectorTest/0.ZeroSizeConstructor
[       OK ] TypedUVectorTest/0.ZeroSizeConstructor (0 ms)
[ RUN      ] TypedUVectorTest/0.NonZeroSizeConstructor

Thread 1 "DEVICE_UVECTOR_" hit Breakpoint 1, 0x00007f7426dddc80 in cudaMalloc () from /home/nfs/tribizel/rapids/compose/etc/conda/cuda_11.5/envs/rapids/lib/libcudart.so.11.0
(gdb) finish
Run till exit from #0  0x00007f7426dddc80 in cudaMalloc () from /home/nfs/tribizel/rapids/compose/etc/conda/cuda_11.5/envs/rapids/lib/libcudart.so.11.0
rmm::mr::cuda_memory_resource::do_allocate (bytes=<optimized out>, this=<optimized out>) at /home/nfs/tribizel/rapids/rmm/include/rmm/mr/device/cuda_memory_resource.hpp:70
70          RMM_CUDA_TRY_ALLOC(cudaMalloc(&ptr, bytes));
(gdb) finish
Run till exit from #0  rmm::mr::cuda_memory_resource::do_allocate (bytes=<optimized out>, this=<optimized out>) at /home/nfs/tribizel/rapids/rmm/include/rmm/mr/device/cuda_memory_resource.hpp:70
0x00005587874feef0 in rmm::device_buffer::allocate_async (bytes=12345, this=0x7ffefebb46b0) at /home/nfs/tribizel/rapids/rmm/include/rmm/device_buffer.hpp:418
418         _data     = (bytes > 0) ? memory_resource()->allocate(bytes, stream()) : nullptr;
Value returned is $1 = (void *) 0x7f73ff000000
(gdb) finish
Run till exit from #0  0x00005587874feef0 in rmm::device_buffer::allocate_async (bytes=12345, this=0x7ffefebb46b0) at /home/nfs/tribizel/rapids/rmm/include/rmm/device_buffer.hpp:418
TypedUVectorTest_NonZeroSizeConstructor_Test<signed char>::TestBody (this=<optimized out>) at /home/nfs/tribizel/rapids/rmm/tests/device_uvector_tests.cpp:55
55        EXPECT_EQ(vec.size(), size);
(gdb) print vec
$2 = {_storage = {_data = 0x7f73ff000000, _size = 12345, _capacity = 12345, _stream = {stream_ = 0x0}, _mr = 0x558787561008 <rmm::mr::detail::initial_resource()::mr>}}
(gdb) source load-pretty-printers 
(gdb) print vec
$3 = rmm::device_uvector<signed char> of length 12345, capacity 12345 = {0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 
  0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 
  0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 
  0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 
  0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 
  0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 
  0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000', 0 '\000'...}
(gdb) 
```

</details>

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
