### PR TITLE
Move clang dependency to conda develop packages.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -30,7 +30,6 @@ dependencies:
         - numpy>=1.19
       develop:
         - black=22.3.0
-        - clang=11.1.0
         - cmakelang=0.6.13
         - flake8=3.8.3
         - gcovr>=5.0
@@ -52,6 +51,7 @@ dependencies:
       build:
         - spdlog>=1.8.5,<1.9
       develop:
+        - clang=11.1.0
         - clang-tools=11.1.0
     specific:
       - matrix:


### PR DESCRIPTION
## Description
This moves the `clang` package to the `conda` section instead of `conda_and_requirements`, since it is not pip-installable (the `clang` package on PyPI is not the same thing).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
