### PR TITLE
`build.sh`: accept `--help`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -100,7 +100,7 @@ function ensureCMakeRan {
     fi
 }
 
-if hasArg -h; then
+if hasArg -h || hasArg --help; then
     echo "${HELP}"
     exit 0
 fi


### PR DESCRIPTION
Currently, the `--help` argument isn't supported:
```
$ ./build.sh --help
Invalid option or formatting, check --help: --help
```