### PR TITLE
Propagate exceptions raised in Python callback functions

### DIFF
--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -50,8 +50,7 @@ cdef CppExcept translate_python_except_to_cpp(err: BaseException):
     """
     if isinstance(err, MemoryError):
         return CppExcept(0, str.encode(str(err)))
-    if isinstance(err, BaseException):
-        return CppExcept(-1, str.encode(str(err)))
+    return CppExcept(-1, str.encode(str(err)))
 
 # Implementation of `throw_cpp_except()`, which throws a given `CppExcept`.
 # This function MUST be called without the GIL otherwise the thrown C++

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -21,6 +21,7 @@ from libc.stdint cimport int8_t, int64_t, uintptr_t
 from libcpp cimport bool
 from libcpp.cast cimport dynamic_cast
 from libcpp.memory cimport make_shared, make_unique, shared_ptr, unique_ptr
+from libcpp.pair cimport pair
 from libcpp.string cimport string
 
 from cuda.cudart import cudaError_t
@@ -34,6 +35,42 @@ from rmm._cuda.gpu import (
 )
 
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
+
+# Transparent handle of a C++ exception
+ctypedef pair[int, string] CppExcept
+
+cdef CppExcept translate_python_except_to_cpp(err: BaseException):
+    """Translate a Python exception into a C++ exception handle
+
+    The returned exception handle can then be thrown by `throw_cpp_except()`,
+    which MUST be done without holding the GIL.
+
+    This is useful when C++ calls a Python function and needs to catch or
+    propagate exceptions.
+    """
+    if isinstance(err, MemoryError):
+        return CppExcept(0, str.encode(str(err)))
+    if isinstance(err, BaseException):
+        return CppExcept(-1, str.encode(str(err)))
+
+# Implementation of `throw_cpp_except()`, which throws a given `CppExcept`.
+# This function MUST be called without the GIL otherwise the thrown C++
+# exception are tanslated back into a Python exception.
+cdef extern from *:
+    """
+    #include <stdexcept>
+    #include <utility>
+
+    void throw_cpp_except(std::pair<int, std::string> res) {
+        switch(res.first) {
+            case 0:
+                throw rmm::out_of_memory(res.second);
+            default:
+                throw std::runtime_error(res.second);
+        }
+    }
+    """
+    void throw_cpp_except(CppExcept) nogil
 
 
 # NOTE: Keep extern declarations in .pyx file as much as possible to avoid
@@ -523,8 +560,14 @@ cdef void* _allocate_callback_wrapper(
     size_t nbytes,
     cuda_stream_view stream,
     void* ctx
-) with gil:
-    return <void*><uintptr_t>((<object>ctx)(nbytes))
+) nogil:
+    cdef CppExcept err
+    with gil:
+        try:
+            return <void*><uintptr_t>((<object>ctx)(nbytes))
+        except BaseException as e:
+            err = translate_python_except_to_cpp(e)
+    throw_cpp_except(err)
 
 cdef void _deallocate_callback_wrapper(
     void* ptr,

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -55,7 +55,7 @@ cdef CppExcept translate_python_except_to_cpp(err: BaseException):
 
 # Implementation of `throw_cpp_except()`, which throws a given `CppExcept`.
 # This function MUST be called without the GIL otherwise the thrown C++
-# exception are tanslated back into a Python exception.
+# exception are translated back into a Python exception.
 cdef extern from *:
     """
     #include <stdexcept>

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -712,6 +712,18 @@ def test_failure_callback_resource_adaptor():
     assert retried[0]
 
 
+def test_failure_callback_resource_adaptor_error():
+    def callback(nbytes: int) -> bool:
+        raise RuntimeError("MyError")
+
+    cuda_mr = rmm.mr.CudaMemoryResource()
+    mr = rmm.mr.FailureCallbackResourceAdaptor(cuda_mr, callback)
+    rmm.mr.set_current_device_resource(mr)
+
+    with pytest.raises(RuntimeError, match="MyError"):
+        rmm.DeviceBuffer(size=int(1e11))
+
+
 def test_dev_buf_circle_ref_dealloc():
     rmm.mr.set_current_device_resource(rmm.mr.CudaMemoryResource())
 


### PR DESCRIPTION
## Description
Currently, we ignore Python exceptions raised in callback functions called by resources such as `CallbackMemoryResource`. This is because Cython doesn't automatically translate Python exceptions into C++ exceptions (even though Cython does translate C++ exceptions into Python automatically).

To address this issue, we now translate Python exceptions raised in the callback function into a C++ exception manually. Next, we remove Cython's [automatic C++ to Python exception translation](https://cython.readthedocs.io/en/stable/src/userguide/wrapping_CPlusPlus.html#exceptions) by **not** using the `except +` declaration. Thus, when the callback raises an exception, the caller (a memory resource implemented in C++) can catch and/or propagate the exception.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
