### PR TITLE
Remove cuda event deadlocking issues in device mr tests

### DIFF
--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -183,7 +183,7 @@ void allocate_loop(rmm::mr::device_memory_resource* mr,
                    cudaEvent_t& event,
                    rmm::cuda_stream_view stream)
 {
-  constexpr std::size_t max_size{1_KiB};
+  constexpr std::size_t max_size{1_MiB};
 
   std::default_random_engine generator;
   std::uniform_int_distribution<std::size_t> size_distribution(1, max_size);
@@ -227,7 +227,7 @@ void test_allocate_free_different_threads(rmm::mr::device_memory_resource* mr,
                                           rmm::cuda_stream_view streamA,
                                           rmm::cuda_stream_view streamB)
 {
-  constexpr std::size_t num_allocations{3};
+  constexpr std::size_t num_allocations{100};
 
   std::mutex mtx;
   std::condition_variable allocations_ready;

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -218,7 +218,6 @@ void deallocate_loop(rmm::mr::device_memory_resource* mr,
     allocations.pop_front();
     mr->deallocate(alloc.ptr, alloc.size, stream);
     lk.unlock();
-    cv.notify_one();
   }
 
   // Work around for threads going away before cudaEvent has finished async processing

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -217,7 +217,6 @@ void deallocate_loop(rmm::mr::device_memory_resource* mr,
     allocation alloc = allocations.front();
     allocations.pop_front();
     mr->deallocate(alloc.ptr, alloc.size, stream);
-    lock.unlock();
   }
 
   // Work around for threads going away before cudaEvent has finished async processing

--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -217,7 +217,7 @@ void deallocate_loop(rmm::mr::device_memory_resource* mr,
     allocation alloc = allocations.front();
     allocations.pop_front();
     mr->deallocate(alloc.ptr, alloc.size, stream);
-    lk.unlock();
+    lock.unlock();
   }
 
   // Work around for threads going away before cudaEvent has finished async processing


### PR DESCRIPTION
We fixed both deadlocking issues due to a assumption that std::mutex would have fair scheduling, and work around deadlocks found in cuda event created in very short lived threads ( < 10ms ).

