### PR TITLE
Ensure consistent spdlog dependency target no matter the source

### DIFF
--- a/cmake/thirdparty/get_spdlog.cmake
+++ b/cmake/thirdparty/get_spdlog.cmake
@@ -24,8 +24,7 @@ function(find_and_configure_spdlog)
       BUILD spdlog
       EXPORT_SET spdlog
       GLOBAL_TARGETS spdlog spdlog_header_only
-      NAMESPACE spdlog::
-      )
+      NAMESPACE spdlog::)
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
     rapids_export_find_package_root(BUILD spdlog [=[${CMAKE_CURRENT_LIST_DIR}]=] rmm-exports)
   endif()

--- a/cmake/thirdparty/get_spdlog.cmake
+++ b/cmake/thirdparty/get_spdlog.cmake
@@ -17,11 +17,17 @@ function(find_and_configure_spdlog)
 
   include(${rapids-cmake-dir}/cpm/spdlog.cmake)
   rapids_cpm_spdlog(INSTALL_EXPORT_SET rmm-exports)
+  rapids_export_package(BUILD spdlog rmm-exports)
 
   if(spdlog_ADDED)
-    install(TARGETS spdlog_header_only EXPORT rmm-exports)
-  else()
-    rapids_export_package(BUILD spdlog rmm-exports)
+    rapids_export(
+      BUILD spdlog
+      EXPORT_SET spdlog
+      GLOBAL_TARGETS spdlog spdlog_header_only
+      NAMESPACE spdlog::
+      )
+    include("${rapids-cmake-dir}/export/find_package_root.cmake")
+    rapids_export_find_package_root(BUILD spdlog [=[${CMAKE_CURRENT_LIST_DIR}]=] rmm-exports)
   endif()
 endfunction()
 


### PR DESCRIPTION
## Description
This removes the difference in targets generated for rmm depending on if spdlog is found on the machine, compared to being built as part of rmm.

Now in all cases rmm targets depend on `spdlog::spdlog_header_only` and never `rmm::spdlog_header_only`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
