### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Compiler requirements:
 
 * `gcc`     version 9.3+
 * `nvcc`    version 11.0+
-* `cmake`   version 3.20.1+
+* `cmake`   version 3.23.1+
 
 CUDA/GPU requirements:
 

--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -7,7 +7,7 @@ dependencies:
 - black=22.3.0
 - clang-tools=11.1.0
 - clang=11.1.0
-- cmake>=3.20.1,!=3.23.0
+- cmake>=3.23.1
 - cmakelang=0.6.13
 - cuda-python>=11.5,<11.7.1
 - cudatoolkit=11.5

--- a/conda/environments/all_cuda-116_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-116_arch-x86_64.yaml
@@ -7,7 +7,7 @@ dependencies:
 - black=22.3.0
 - clang-tools=11.1.0
 - clang=11.1.0
-- cmake>=3.20.1,!=3.23.0
+- cmake>=3.23.1
 - cmakelang=0.6.13
 - cuda-python>=11.6,<11.7.1
 - cudatoolkit=11.6

--- a/conda/recipes/librmm/conda_build_config.yaml
+++ b/conda/recipes/librmm/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.20.1,!=3.23.0"
+  - ">=3.23.1"
 
 gtest_version:
   - "=1.10.0"

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -23,7 +23,7 @@ build:
 
 requirements:
   build:
-    - cmake>=3.20.1,!=3.23.0
+    - cmake>=3.23.1
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -21,7 +21,7 @@ dependencies:
   conda_and_requirements:
     common:
       build:
-        - cmake>=3.20.1,!=3.23.0
+        - cmake>=3.23.1
         - cython>=0.29,<0.30
         - python>=3.8,<3.10
         - scikit-build>=0.13.1

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -12,7 +12,7 @@
 # the License.
 # =============================================================================
 
-cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 set(rmm_version 22.10.00)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,7 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.20.1,!=3.23.0",
+    "cmake>=3.23.1",
     "ninja",
     "cuda-python>=11.5,<11.7.1",
 ]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.