### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/tests/mr/device/mr_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_multithreaded_tests.cpp
@@ -179,6 +179,7 @@ void allocate_loop(rmm::mr::device_memory_resource* mr,
                    std::size_t num_allocations,
                    std::list<allocation>& allocations,
                    std::mutex& mtx,
+                   std::condition_variable& allocations_ready,
                    cudaEvent_t& event,
                    rmm::cuda_stream_view stream)
 {
@@ -195,27 +196,32 @@ void allocate_loop(rmm::mr::device_memory_resource* mr,
       RMM_CUDA_TRY(cudaEventRecord(event, stream.value()));
       allocations.emplace_back(ptr, size);
     }
+    allocations_ready.notify_one();
   }
+  // Work around for threads going away before cudaEvent has finished async processing
+  cudaEventSynchronize(event);
 }
 
 void deallocate_loop(rmm::mr::device_memory_resource* mr,
                      std::size_t num_allocations,
                      std::list<allocation>& allocations,
                      std::mutex& mtx,
+                     std::condition_variable& allocations_ready,
                      cudaEvent_t& event,
                      rmm::cuda_stream_view stream)
 {
-  for (std::size_t i = 0; i < num_allocations;) {
-    std::lock_guard<std::mutex> lock(mtx);
-    if (allocations.empty()) { continue; }
-    i++;
+  for (std::size_t i = 0; i < num_allocations; i++) {
+    std::unique_lock lock(mtx);
+    allocations_ready.wait(lock, [&allocations] { return !allocations.empty(); });
     RMM_CUDA_TRY(cudaStreamWaitEvent(stream.value(), event));
     allocation alloc = allocations.front();
     allocations.pop_front();
     mr->deallocate(alloc.ptr, alloc.size, stream);
   }
-}
 
+  // Work around for threads going away before cudaEvent has finished async processing
+  cudaEventSynchronize(event);
+}
 void test_allocate_free_different_threads(rmm::mr::device_memory_resource* mr,
                                           rmm::cuda_stream_view streamA,
                                           rmm::cuda_stream_view streamB)
@@ -223,6 +229,7 @@ void test_allocate_free_different_threads(rmm::mr::device_memory_resource* mr,
   constexpr std::size_t num_allocations{100};
 
   std::mutex mtx;
+  std::condition_variable allocations_ready;
   std::list<allocation> allocations;
   cudaEvent_t event;
 
@@ -233,6 +240,7 @@ void test_allocate_free_different_threads(rmm::mr::device_memory_resource* mr,
                        num_allocations,
                        std::ref(allocations),
                        std::ref(mtx),
+                       std::ref(allocations_ready),
                        std::ref(event),
                        streamA);
 
@@ -241,6 +249,7 @@ void test_allocate_free_different_threads(rmm::mr::device_memory_resource* mr,
                        num_allocations,
                        std::ref(allocations),
                        std::ref(mtx),
+                       std::ref(allocations_ready),
                        std::ref(event),
                        streamB);
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.