### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -8,3 +8,4 @@ release_drafter: true
 copy_prs: true
 rerun_tests: true
 recently_updated: true
+


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.