### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/.github/workflows/branch-workflow.yaml
+++ b/.github/workflows/branch-workflow.yaml
@@ -13,20 +13,17 @@ concurrency:
 
 jobs:
   cpp-build:
-    name: C++ build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@main
     with:
       build_type: branch
   python-build:
-    name: Python build
     needs: cpp-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
     with:
       build_type: branch
   upload-conda:
-    name: Upload conda packages for branch builds
     needs: python-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@main

--- a/.github/workflows/nightly-workflow.yaml
+++ b/.github/workflows/nightly-workflow.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   cpp-build:
-    name: C++ build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@main
     with:
@@ -17,7 +16,6 @@ jobs:
       repo: rapidsai/rmm
       ref: ${{ inputs.REF }}
   cpp-tests:
-    name: C++ tests for PRs
     needs: cpp-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@main
@@ -26,7 +24,6 @@ jobs:
       repo: rapidsai/rmm
       ref: ${{ inputs.REF }}
   python-build:
-    name: Python build
     needs: cpp-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
@@ -35,7 +32,6 @@ jobs:
       repo: rapidsai/rmm
       ref: ${{ inputs.REF }}
   python-tests:
-    name: Python tests for PRs
     needs: python-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
@@ -44,7 +40,6 @@ jobs:
       repo: rapidsai/rmm
       ref: ${{ inputs.REF }}
   upload-conda:
-    name: Upload conda packages for branch builds
     needs: [python-tests, cpp-tests]
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@main

--- a/ci/upload_to_anaconda.sh
+++ b/ci/upload_to_anaconda.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
-
-rapids-upload-to-anaconda "${CPP_CHANNEL}"
-rapids-upload-to-anaconda "${PYTHON_CHANNEL}"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.