### PR TITLE
Remove `rmm` installation from `librmm` tests`

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -11,7 +11,7 @@ CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 rapids-mamba-retry install \
   -c "${CPP_CHANNEL}" \
-  rmm librmm librmm-tests
+  librmm librmm-tests
 
 TESTRESULTS_DIR=test-results
 mkdir -p ${TESTRESULTS_DIR}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR removes the `rmm` conda package installation for `rmm` tests since it shouldn't be needed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
