### PR TITLE
Add `cudatoolkit` versions to `dependencies.yaml`

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -21,6 +21,10 @@ cd $WORKSPACE
 export GPUCI_CONDA_RETRY_MAX=1
 export GPUCI_CONDA_RETRY_SLEEP=30
 
+# Workaround to keep Jenkins builds working
+# until we migrate fully to GitHub Actions
+export RAPIDS_CUDA_VERSION="${CUDA}"
+
 # If nightly build, append current YYMMDD to version
 if [[ "$BUILD_MODE" = "branch" && "$SOURCE_BRANCH" = branch-* ]] ; then
   export VERSION_SUFFIX=`date +%y%m%d`

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -27,6 +27,10 @@ export CUDA_MAJOR_VER=$(echo "${CUDA_VERSION}" | cut -f 1 -d.)
 export CUDA_MINOR_VER=$(echo "${CUDA_VERSION}" | cut -f 2 -d.)
 export CUDA_REL="${CUDA_MAJOR_VER}.${CUDA_MINOR_VER}"
 
+# Workaround to keep Jenkins builds working
+# until we migrate fully to GitHub Actions
+export RAPIDS_CUDA_VERSION="${CUDA}"
+
 # Get latest tag and number of commits since tag
 export GIT_DESCRIBE_TAG=`git describe --abbrev=0 --tags`
 export GIT_DESCRIBE_NUMBER=`git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count`

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -5,6 +5,14 @@ set -euo pipefail
 . /opt/conda/etc/profile.d/conda.sh
 conda activate base
 
+rapids-dependency-file-generator \
+  --generate conda \
+  --file_key test_cpp \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*}" > env.yaml
+
+rapids-mamba-retry env create --force -f env.yaml -n test
+conda activate test
+
 rapids-print-env
 
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -7,7 +7,7 @@ rapids-logger "Create test conda environment"
 
 rapids-dependency-file-generator \
   --generate conda \
-  --file_key test \
+  --file_key test_python \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" > env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,13 +10,18 @@ files:
       - cudatoolkit
       - develop
       - run
-      - test
-  test:
+      - test_cpp
+      - test_python
+  test_python:
     generate: none
     includes:
       - cudatoolkit
       - py_version
-      - test
+      - test_python
+  test_cpp:
+    generate: none
+    includes:
+      - cudatoolkit
   checks:
     generate: none
     includes:
@@ -43,7 +48,7 @@ dependencies:
         - flake8=3.8.3
         - gcovr>=5.0
         - isort=5.10.1
-      test:
+      test_python:
         - pytest
         - pytest-cov
     specific:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,14 +7,16 @@ files:
       arch: [x86_64]
     includes:
       - build
+      - cudatoolkit
       - develop
       - run
       - test
   test:
     generate: none
     includes:
-      - test
+      - cudatoolkit
       - py_version
+      - test
   checks:
     generate: none
     includes:
@@ -70,10 +72,22 @@ dependencies:
         py_version:
           - python=3.9
       - matrix:
+          cuda: "11.0"
+        cudatoolkit:
+          - cudatoolkit=11.0
+      - matrix:
+          cuda: "11.2"
+        cudatoolkit:
+          - cudatoolkit=11.2
+      - matrix:
+          cuda: "11.4"
+        cudatoolkit:
+          - cudatoolkit=11.4
+      - matrix:
           cuda: "11.5"
-        build:
+        cudatoolkit:
           - cudatoolkit=11.5
       - matrix:
           cuda: "11.6"
-        build:
+        cudatoolkit:
           - cudatoolkit=11.6


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR adds a new list of dependencies called `cudatoolkit`, which are used to ensure that the proper `cudatoolkit` version is installed when creating test environments in `ci/test_{cpp,python}.sh`.

It also bifurcates the existing `test` environment into `test_cpp` and `test_python` since some of the `test_python` dependencies aren't relevant for the C++ tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
