### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,9 +1,12 @@
-name: nightly-test
+name: nightly
 
 on:
   workflow_dispatch:
     inputs:
       branch:
+        required: true
+        type: string
+      date:
         required: true
         type: string
       sha:
@@ -18,6 +21,7 @@ jobs:
       build_type: nightly
       repo: rapidsai/rmm
       branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
   python-tests:
     secrets: inherit
@@ -26,4 +30,5 @@ jobs:
       build_type: nightly
       repo: rapidsai/rmm
       branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.