### PR TITLE
Relax test for async memory pool IPC handle support

### DIFF
--- a/python/rmm/_cuda/gpu.py
+++ b/python/rmm/_cuda/gpu.py
@@ -142,7 +142,7 @@ def getDeviceProperties(device: int):
 
 def deviceGetName(device: int):
     """
-    Returns an identifer string for the device.
+    Returns an identifier string for the device.
 
     Parameters
     ----------

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -314,16 +314,8 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
             else optional[size_t](release_threshold)
         )
 
-        # IPC export handle support query is only possibly on CUDA 11.3 or
-        # later, so IPC not supported on earlier versions
-        if enable_ipc:
-            driver_version = driverGetVersion()
-            runtime_version = runtimeGetVersion()
-            if (driver_version <= 11020 or runtime_version <= 11020):
-                raise ValueError(
-                    "enable_ipc=True is not supported on CUDA <= 11.2."
-                )
-
+        # If IPC memory handles are not supported, the constructor below will
+        # raise an error from C++.
         cdef optional[allocation_handle_type] c_export_handle_type = (
             optional[allocation_handle_type](
                 posix_file_descriptor

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -544,6 +544,20 @@ def test_cuda_async_memory_resource(dtype, nelem, alloc):
     reason="cudaMallocAsync not supported",
 )
 def test_cuda_async_memory_resource_ipc():
+    # TODO: We don't have a great way to check if IPC is supported in Python,
+    # without using the C++ function
+    # rmm::detail::async_alloc::is_export_handle_type_supported. We can't
+    # accurately test driver and runtime versions for this via Python because
+    # cuda-python always has the IPC handle enum defined (which normally
+    # requires a CUDA 11.3 runtime) and the cuda-compat package in Docker
+    # containers prevents us from assuming that the driver we see actually
+    # supports IPC handles even if its reported version is new enough (we may
+    # see a newer driver than what is present on the host). We can only know
+    # the expected behavior by checking the C++ function mentioned above, which
+    # is then a redundant check because the CudaAsyncMemoryResource constructor
+    # follows the same logic. Therefore, we cannot easily ensure this test
+    # passes in certain expected configurations -- we can only ensure that if
+    # it fails, it fails in a predictable way.
     try:
         mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
     except RuntimeError as e:

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -544,12 +544,12 @@ def test_cuda_async_memory_resource(dtype, nelem, alloc):
     reason="cudaMallocAsync not supported",
 )
 def test_cuda_async_memory_resource_ipc():
-    # Test that enabling IPC earlier than CUDA 11.3 raises a ValueError
-    if _driver_version < 11030 or _runtime_version < 11030:
-        with pytest.raises(ValueError):
-            mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
-    else:
+    try:
         mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
+    except ValueError as e:
+        # CUDA 11.3 is required for IPC memory handle support
+        assert str(e) == "Requested IPC memory handle type not supported"
+    else:
         rmm.mr.set_current_device_resource(mr)
         assert rmm.mr.get_current_device_resource_type() is type(mr)
 

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -562,7 +562,9 @@ def test_cuda_async_memory_resource_ipc():
         mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
     except RuntimeError as e:
         # CUDA 11.3 is required for IPC memory handle support
-        assert str(e) == "Requested IPC memory handle type not supported"
+        assert str(e).endswith(
+            "Requested IPC memory handle type not supported"
+        )
     else:
         rmm.mr.set_current_device_resource(mr)
         assert rmm.mr.get_current_device_resource_type() is type(mr)

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -546,7 +546,7 @@ def test_cuda_async_memory_resource(dtype, nelem, alloc):
 def test_cuda_async_memory_resource_ipc():
     try:
         mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
-    except ValueError as e:
+    except RuntimeError as e:
         # CUDA 11.3 is required for IPC memory handle support
         assert str(e) == "Requested IPC memory handle type not supported"
     else:


### PR DESCRIPTION
## Description
Replaces #1121. This PR resolves an inconsistency in the Python tests for IPC handle support. This issue has existed for at least a few months but the failure was not noticed in our nightly CI until switching to GitHub Actions. The core problem was that we were checking driver versions to determine support for IPC handles, which turned out to be a bad course of action. Instead, we should rely on checking for the feature support directly, with `cudart.cudaDeviceGetAttribute(cudart.cudaDeviceAttr.cudaDevAttrMemoryPoolSupportedHandleTypes, device_id)`. This is handled by the C++ code in rmm, and we now defer to that logic in Python tests.

After some collaborative debugging, we found that our CI runners with driver 450 (CUDA 11.0) and newer CUDA toolkit versions like 11.4 and 11.5 were reporting the driver version incorrectly, and returned a value equal to the container's runtime version. This appears to stem from the same issue reported in https://github.com/NVIDIA/nvidia-docker/issues/1515 and https://github.com/NVIDIA/libnvidia-container/issues/138. This seems to be due to how the `cuda-compat` package injects (forward?) compatibility support into containers. Both the driver and runtime claimed to be new enough to support IPC handles, which require CUDA 11.3, despite the driver being older than 11.3. This meant that the attempt to use an IPC handle was rejected by the C++ code at runtime and the Python test failed. The Python code no longer attempts to determine if IPC should be supported according to driver/runtime versions, because this is not valid for all the configurations in CI. Creating a valid check for IPC handle support in the Python layer is complicated, due to Docker driver version issues mentioned above, so we just ensure the test fails in a predictable way if the driver/runtime do not support IPC.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
