### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,12 @@ RMM can be installed with Conda ([miniconda](https://conda.io/miniconda.html), o
 [Anaconda distribution](https://www.anaconda.com/download)) from the `rapidsai` channel:
 
 ```bash
+# for CUDA 11.5
+conda install -c rapidsai -c conda-forge -c nvidia \
+    rmm cudatoolkit=11.5
 # for CUDA 11.2
-conda install -c nvidia -c rapidsai -c conda-forge \
+conda install -c rapidsai -c conda-forge -c nvidia \
     rmm cudatoolkit=11.2
-# for CUDA 11.1
-conda install -c nvidia -c rapidsai -c conda-forge \
-    rmm cudatoolkit=11.1
-# for CUDA 11.0
-conda install -c nvidia -c rapidsai -c conda-forge \
-    rmm cudatoolkit=11.0
 ```
 
 We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD

--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - clang=11.1.0
 - cmake>=3.23.1
 - cmakelang=0.6.13
-- cuda-python>=11.5,<11.7.1
+- cuda-python>=11.7.1,<12.0
 - cudatoolkit=11.5
 - cython>=0.29,<0.30
 - flake8=3.8.3

--- a/conda/environments/all_cuda-116_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-116_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - clang=11.1.0
 - cmake>=3.23.1
 - cmakelang=0.6.13
-- cuda-python>=11.6,<11.7.1
+- cuda-python>=11.7.1,<12.0
 - cudatoolkit=11.6
 - cython>=0.29,<0.30
 - flake8=3.8.3

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - {{ compiler('cuda') }} {{ cuda_version }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
-    - cuda-python >=11.5,<11.7.1
+    - cuda-python >=11.7.1,<12.0
     - cudatoolkit {{ cuda_version }}.*
     - cython >=0.29,<0.30
     - librmm {{ version }}.*
@@ -38,7 +38,7 @@ requirements:
     - setuptools
     - spdlog>=1.8.5,<2.0.0a0
   run:
-    - cuda-python >=11.5,<11.7.1
+    - cuda-python >=11.7.1,<12.0
     - numba >=0.49
     - numpy >=1.19
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -55,11 +55,11 @@ dependencies:
       - matrix:
           cuda: "11.5"
         build:
-          - cuda-python>=11.5,<11.7.1
+          - cuda-python>=11.7.1,<12.0
       - matrix:
           cuda: "11.6"
         build:
-          - cuda-python>=11.6,<11.7.1
+          - cuda-python>=11.7.1,<12.0
   - output_types: [conda]
     common:
       build:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ requires = [
     "scikit-build>=0.13.1",
     "cmake>=3.23.1",
     "ninja",
-    "cuda-python>=11.5,<11.7.1",
+    "cuda-python>=11.7.1,<12.0"
 ]
 
 [tool.black]

--- a/python/rmm/_cuda/gpu.py
+++ b/python/rmm/_cuda/gpu.py
@@ -142,7 +142,7 @@ def getDeviceProperties(device: int):
 
 def deviceGetName(device: int):
     """
-    Returns an identifer string for the device.
+    Returns an identifier string for the device.
 
     Parameters
     ----------

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -314,16 +314,8 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
             else optional[size_t](release_threshold)
         )
 
-        # IPC export handle support query is only possibly on CUDA 11.3 or
-        # later, so IPC not supported on earlier versions
-        if enable_ipc:
-            driver_version = driverGetVersion()
-            runtime_version = runtimeGetVersion()
-            if (driver_version <= 11020 or runtime_version <= 11020):
-                raise ValueError(
-                    "enable_ipc=True is not supported on CUDA <= 11.2."
-                )
-
+        # If IPC memory handles are not supported, the constructor below will
+        # raise an error from C++.
         cdef optional[allocation_handle_type] c_export_handle_type = (
             optional[allocation_handle_type](
                 posix_file_descriptor

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -544,12 +544,28 @@ def test_cuda_async_memory_resource(dtype, nelem, alloc):
     reason="cudaMallocAsync not supported",
 )
 def test_cuda_async_memory_resource_ipc():
-    # Test that enabling IPC earlier than CUDA 11.3 raises a ValueError
-    if _driver_version < 11030 or _runtime_version < 11030:
-        with pytest.raises(ValueError):
-            mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
-    else:
+    # TODO: We don't have a great way to check if IPC is supported in Python,
+    # without using the C++ function
+    # rmm::detail::async_alloc::is_export_handle_type_supported. We can't
+    # accurately test driver and runtime versions for this via Python because
+    # cuda-python always has the IPC handle enum defined (which normally
+    # requires a CUDA 11.3 runtime) and the cuda-compat package in Docker
+    # containers prevents us from assuming that the driver we see actually
+    # supports IPC handles even if its reported version is new enough (we may
+    # see a newer driver than what is present on the host). We can only know
+    # the expected behavior by checking the C++ function mentioned above, which
+    # is then a redundant check because the CudaAsyncMemoryResource constructor
+    # follows the same logic. Therefore, we cannot easily ensure this test
+    # passes in certain expected configurations -- we can only ensure that if
+    # it fails, it fails in a predictable way.
+    try:
         mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
+    except RuntimeError as e:
+        # CUDA 11.3 is required for IPC memory handle support
+        assert str(e).endswith(
+            "Requested IPC memory handle type not supported"
+        )
+    else:
         rmm.mr.set_current_device_resource(mr)
         assert rmm.mr.get_current_device_resource_type() is type(mr)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.