### PR TITLE
Use `ninja` in GitHub Actions

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source rapids-env-update
 
+export CMAKE_GENERATOR=Ninja
+
 rapids-print-env
 
 rapids-logger "Begin cpp build"

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source rapids-env-update
 
+export CMAKE_GENERATOR=Ninja
+
 rapids-print-env
 
 rapids-logger "Begin py build"


### PR DESCRIPTION
## Description

This PR adds an environment variable to ensure that CMake uses `ninja` as its build system, which was the behavior in Jenkins.




## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
