### PR TITLE
Enable sccache for python build

### DIFF
--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -18,6 +18,16 @@ build:
   script_env:
     - RMM_BUILD_NO_GPU_TEST
     - VERSION_SUFFIX
+    - CMAKE_C_COMPILER_LAUNCHER
+    - CMAKE_CXX_COMPILER_LAUNCHER
+    - CMAKE_CUDA_COMPILER_LAUNCHER
+    - SCCACHE_S3_KEY_PREFIX=rmm-aarch64 # [aarch64]
+    - SCCACHE_S3_KEY_PREFIX=rmm-linux64 # [linux64]
+    - SCCACHE_BUCKET=rapids-sccache
+    - SCCACHE_REGION=us-west-2
+    - SCCACHE_IDLE_TIMEOUT=32768
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
   ignore_run_exports_from:
     - {{ compiler('cuda') }}
 


### PR DESCRIPTION
This PR enables `sccache` for python builds