### PR TITLE
Remove CUDA 11.0 from dependencies.yaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS an
 Compiler requirements:
 
 * `gcc`     version 9.3+
-* `nvcc`    version 11.0+
+* `nvcc`    version 11.2+
 * `cmake`   version 3.23.1+
 
 CUDA/GPU requirements:
 
-* CUDA 11.0+
+* CUDA 11.2+
 * NVIDIA driver 450.51+
 * Pascal architecture or better
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -48,10 +48,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "11.0"
-            packages:
-              - cudatoolkit=11.0
-          - matrix:
               cuda: "11.2"
             packages:
               - cudatoolkit=11.2


### PR DESCRIPTION
## Description
CUDA 11.0 is not supported in the 22.12 release. This PR removes it from the `dependencies.yaml` file.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
