### PR TITLE
Fix doxygen formatting for set_stream.

### DIFF
--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -381,7 +381,7 @@ class device_buffer {
    *
    * If no other rmm::device_buffer method that allocates memory is called
    * after this call with a different stream argument, then @p stream
-   * will be used for deallocation in the `rmm::device_uvector destructor.
+   * will be used for deallocation in the `rmm::device_uvector` destructor.
    * However, if either of `resize()` or `shrink_to_fit()` is called after this,
    * the later stream parameter will be stored and used in the destructor.
    */


### PR DESCRIPTION
## Description
This PR fixes doxygen formatting for `set_stream`. I looked over the rest of the `device_buffer` docs and didn't see any other issues.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
