### PR TITLE
Align __version__ with wheel version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -24,9 +24,7 @@ if "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE" in os.environ:
 
 setup(
     name="rmm" + os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default=""),
-    version=os.getenv(
-        "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE", default=versioneer.get_version()
-    ),
+    version=versioneer.get_version(),
     description="rmm - RAPIDS Memory Manager",
     url="https://github.com/rapidsai/rmm",
     author="NVIDIA Corporation",

--- a/python/setup.py
+++ b/python/setup.py
@@ -7,6 +7,20 @@ from skbuild import setup
 
 import versioneer
 
+if "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE" in os.environ:
+    # borrow a similar hack from dask-cuda: https://github.com/rapidsai/dask-cuda/blob/b3ed9029a1ad02a61eb7fbd899a5a6826bb5cfac/setup.py#L12-L31
+    orig_get_versions = versioneer.get_versions
+
+    version_override = os.environ.get("RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE", "")
+
+    def get_versions():
+        data = orig_get_versions()
+        if version_override != "":
+            data["version"] = version_override
+        return data
+
+    versioneer.get_versions = get_versions
+
 setup(
     name="rmm" + os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default=""),
     version=os.getenv(

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,10 +8,11 @@ from skbuild import setup
 import versioneer
 
 if "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE" in os.environ:
-    # borrow a similar hack from dask-cuda: https://github.com/rapidsai/dask-cuda/blob/b3ed9029a1ad02a61eb7fbd899a5a6826bb5cfac/setup.py#L12-L31
     orig_get_versions = versioneer.get_versions
 
-    version_override = os.environ.get("RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE", "")
+    version_override = os.environ.get(
+        "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE", ""
+    )
 
     def get_versions():
         data = orig_get_versions()

--- a/python/setup.py
+++ b/python/setup.py
@@ -10,14 +10,11 @@ import versioneer
 if "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE" in os.environ:
     orig_get_versions = versioneer.get_versions
 
-    version_override = os.environ.get(
-        "RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE", ""
-    )
+    version_override = os.environ["RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE"]
 
     def get_versions():
         data = orig_get_versions()
-        if version_override != "":
-            data["version"] = version_override
+        data["version"] = version_override
         return data
 
     versioneer.get_versions = get_versions


### PR DESCRIPTION
In the pip wheels, the versioneer version is overwritten with an env var, `RAPIDS_PY_WHEEL_VERSIONEER_OVERRIDE` in the setup.py version.

However, the `__version__` metadata of the package doesn't match this override. This fix propagates the override to `__version__` also.