### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -7,7 +7,7 @@ dependencies:
 - black=22.3.0
 - clang-tools=11.1.0
 - clang=11.1.0
-- cmake>=3.23.1
+- cmake>=3.23.1,!=3.25.0
 - cmakelang=0.6.13
 - cuda-python>=11.7.1,<12.0
 - cudatoolkit=11.5

--- a/conda/environments/all_cuda-116_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-116_arch-x86_64.yaml
@@ -7,7 +7,7 @@ dependencies:
 - black=22.3.0
 - clang-tools=11.1.0
 - clang=11.1.0
-- cmake>=3.23.1
+- cmake>=3.23.1,!=3.25.0
 - cmakelang=0.6.13
 - cuda-python>=11.7.1,<12.0
 - cudatoolkit=11.6

--- a/conda/recipes/librmm/conda_build_config.yaml
+++ b/conda/recipes/librmm/conda_build_config.yaml
@@ -8,7 +8,7 @@ cuda_compiler:
   - nvcc
 
 cmake_version:
-  - ">=3.23.1"
+  - ">=3.23.1,!=3.25.0"
 
 gtest_version:
   - "=1.10.0"

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -34,7 +34,7 @@ build:
 
 requirements:
   build:
-    - cmake>=3.23.1
+    - cmake>=3.23.1,!=3.25.0
     - ninja
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -35,7 +35,7 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - cmake>=3.23.1
+          - cmake>=3.23.1,!=3.25.0
           - cuda-python>=11.7.1,<12.0
           - cython>=0.29,<0.30
           - ninja

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,7 @@ requires = [
     "setuptools",
     "cython>=0.29,<0.30",
     "scikit-build>=0.13.1",
-    "cmake>=3.23.1",
+    "cmake>=3.23.1,!=3.25.0",
     "ninja",
     "cuda-python>=11.7.1,<12.0"
 ]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.