### PR TITLE
Enable `codecov`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,31 +12,31 @@ concurrency:
 jobs:
   pr-builder:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@codecov-test
   checks:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@codecov-test
   conda-cpp-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@codecov-test
     with:
       build_type: pull-request
   conda-cpp-tests:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@codecov-test
     with:
       build_type: pull-request
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@codecov-test
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@codecov-test
     with:
       build_type: pull-request

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,31 +12,31 @@ concurrency:
 jobs:
   pr-builder:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@codecov-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@main
   checks:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@codecov-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@main
   conda-cpp-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@codecov-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-matrix-build.yaml@main
     with:
       build_type: pull-request
   conda-cpp-tests:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@codecov-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@main
     with:
       build_type: pull-request
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@codecov-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-matrix-build.yaml@main
     with:
       build_type: pull-request
   conda-python-tests:
     needs: conda-python-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@codecov-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@main
     with:
       build_type: pull-request

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -9,7 +9,7 @@ rapids-logger "Create checks conda environment"
 rapids-dependency-file-generator \
   --output conda \
   --file_key checks \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" > env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n checks
 conda activate checks

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -8,7 +8,7 @@ conda activate base
 rapids-dependency-file-generator \
   --output conda \
   --file_key test_cpp \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*}" > env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test
 conda activate test

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -21,8 +21,8 @@ rapids-mamba-retry install \
   -c "${CPP_CHANNEL}" \
   librmm librmm-tests
 
-TESTRESULTS_DIR=test-results
-mkdir -p ${TESTRESULTS_DIR}
+RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
+mkdir -p "${RAPIDS_TESTS_DIR}"
 SUITEERROR=0
 
 rapids-logger "Check GPU usage"
@@ -32,7 +32,7 @@ set +e
 
 rapids-logger "Running googletests"
 for gt in "$CONDA_PREFIX/bin/gtests/librmm/"* ; do
-    ${gt} --gtest_output=xml:${TESTRESULTS_DIR}/
+    ${gt} --gtest_output=xml:${RAPIDS_TESTS_DIR}/
     exitcode=$?
     if (( ${exitcode} != 0 )); then
         SUITEERROR=${exitcode}

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -39,7 +39,8 @@ set +e
 rapids-logger "pytest rmm"
 pytest \
   --cache-clear \
-  --junitxml="${RAPIDS_TESTS_DIR}/junit-rmm.xml" -v \
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-rmm.xml" \
+  -v \
   --cov-config=.coveragerc \
   --cov=rmm \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/rmm-coverage.xml" \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -8,7 +8,7 @@ rapids-logger "Create test conda environment"
 rapids-dependency-file-generator \
   --output conda \
   --file_key test_python \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" > env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test
 conda activate test

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -24,8 +24,9 @@ rapids-mamba-retry install \
   -c "${PYTHON_CHANNEL}" \
   rmm librmm
 
-TESTRESULTS_DIR="${PWD}/test-results"
-mkdir -p "${TESTRESULTS_DIR}"
+RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
+RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
+mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 SUITEERROR=0
 
 rapids-logger "Check GPU usage"
@@ -36,7 +37,14 @@ cd python
 set +e
 
 rapids-logger "pytest rmm"
-pytest --cache-clear --junitxml="${TESTRESULTS_DIR}/junit-rmm.xml" -v --cov-config=.coveragerc --cov=rmm --cov-report=xml:python/rmm-coverage.xml --cov-report term
+pytest \
+  --cache-clear \
+  --junitxml="${RAPIDS_TESTS_DIR}/junit-rmm.xml" -v \
+  --cov-config=.coveragerc \
+  --cov=rmm \
+  --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/rmm-coverage.xml" \
+  --cov-report term
+
 exitcode=$?
 if (( ${exitcode} != 0 )); then
     SUITEERROR=${exitcode}


### PR DESCRIPTION
## Description

This PR enables `codecov` for GitHub Actions for `rmm`. The `codecov` results can be placed in the directory defined by the `RAPIDS_COVERAGE_DIR` variable, which is set in our shared workflows.

Additionally, this PR configures the unit test results to be placed in the directory defined by the `RAPIDS_TESTS_DIR` variable, which is also set in our shared workflows.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
