### PR TITLE
Upgrade to spdlog 1.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       hooks:
           - id: black
             args: ["--config=python/pyproject.toml"]
-    - repo: https://gitlab.com/pycqa/flake8
+    - repo: https://github.com/PyCQA/flake8
       rev: 3.8.3
       hooks:
           - id: flake8

--- a/conda/environments/all_cuda-115_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-115_arch-x86_64.yaml
@@ -22,5 +22,5 @@ dependencies:
 - pytest-cov
 - python>=3.8,<3.10
 - scikit-build>=0.13.1
-- spdlog>=1.8.5,<1.9
+- spdlog=1.10
 name: all_cuda-115_arch-x86_64

--- a/conda/environments/all_cuda-116_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-116_arch-x86_64.yaml
@@ -22,5 +22,5 @@ dependencies:
 - pytest-cov
 - python>=3.8,<3.10
 - scikit-build>=0.13.1
-- spdlog>=1.8.5,<1.9
+- spdlog=1.10
 name: all_cuda-116_arch-x86_64

--- a/conda/recipes/librmm/conda_build_config.yaml
+++ b/conda/recipes/librmm/conda_build_config.yaml
@@ -13,5 +13,8 @@ cmake_version:
 gtest_version:
   - "=1.10.0"
 
+spdlog_version:
+  - "1.10"
+
 sysroot_version:
   - "2.17"

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -53,7 +53,7 @@ outputs:
         - cmake {{ cmake_version }}
       run:
         - cudatoolkit {{ cuda_spec }}
-        - spdlog>=1.8.5,<1.9
+        - spdlog {{ spdlog_version }}
     test:
       commands:
         - test -f $PREFIX/include/rmm/thrust_rmm_allocator.h

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -48,7 +48,6 @@ requirements:
     - python
     - scikit-build>=0.13.1
     - setuptools
-    - spdlog>=1.8.5,<2.0.0a0
   run:
     - cuda-python >=11.7.1,<12.0
     - numba >=0.49

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -43,7 +43,7 @@ dependencies:
           - scikit-build>=0.13.1
       - output_types: conda
         packages:
-          - spdlog>=1.8.5,<1.9
+          - spdlog=1.10
   cudatoolkit:
     specific:
       - output_types: conda


### PR DESCRIPTION
## Description

Updates spdlog dependency to 1.10 to match the conda-forge pinning. Depends on https://github.com/rapidsai/rapids-cmake/pull/312

Also updates the flake8 pre-commit hook location since it's migrated from gitlab to github.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
