### PR TITLE
Update workflows for nightly tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
       - "branch-*"
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
-  workflow_call:
+  workflow_dispatch:
     inputs:
       branch:
         required: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/rmm
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
@@ -41,7 +40,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/rmm
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
@@ -51,7 +49,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@cuda-118
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/rmm
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: test
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       branch:
         required: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@cuda-118
     with:
       build_type: nightly
-      repo: rapidsai/rmm
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
@@ -28,7 +27,6 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@cuda-118
     with:
       build_type: nightly
-      repo: rapidsai/rmm
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}


### PR DESCRIPTION
## Description

Due to some limitations on the number of reusable workflows that can be used in a given GH Action workflow, I need to switch the nightly workflow files (`build.yaml` and `test.yaml`) to use `workflow_dispatch` instead of `workflow_call`.

Because of this switch, we can also remove the hardcoded `repo` field in `{build,test}.yaml`.


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
