### PR TITLE
Update `build.yaml` workflow to reduce verbosity

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -39,7 +39,7 @@ popd
 
 if [[ "${RAPIDS_BUILD_TYPE}" == "branch" ]]; then
   rapids-logger "Upload Docs to S3"
-  aws s3 sync --only-show-errors --delete doxygen/html "s3://rapidsai-docs/librmm/${VERSION_NUMBER}/html"
-  aws s3 sync --only-show-errors --delete python/docs/_html "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/html"
-  aws s3 sync --only-show-errors --delete python/docs/_text "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/txt"
+  aws s3 sync --no-progress --delete doxygen/html "s3://rapidsai-docs/librmm/${VERSION_NUMBER}/html"
+  aws s3 sync --no-progress --delete python/docs/_html "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/html"
+  aws s3 sync --no-progress --delete python/docs/_text "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/txt"
 fi

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -39,7 +39,7 @@ popd
 
 if [[ "${RAPIDS_BUILD_TYPE}" == "branch" ]]; then
   rapids-logger "Upload Docs to S3"
-  aws s3 sync --delete doxygen/html "s3://rapidsai-docs/librmm/${VERSION_NUMBER}/html"
-  aws s3 sync --delete python/docs/_html "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/html"
-  aws s3 sync --delete python/docs/_text "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/txt"
+  aws s3 sync --only-show-errors --delete doxygen/html "s3://rapidsai-docs/librmm/${VERSION_NUMBER}/html"
+  aws s3 sync --only-show-errors --delete python/docs/_html "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/html"
+  aws s3 sync --only-show-errors --delete python/docs/_text "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/txt"
 fi


### PR DESCRIPTION
This PR adds the `--only-show-errors` flag to reduce verbose output from the `s3 sync` commands.