### PR TITLE
Forward-merge branch-23.02 to branch-23.04

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
           - id: trailing-whitespace
           - id: end-of-file-fixer
     - repo: https://github.com/PyCQA/isort
-      rev: 5.10.1
+      rev: 5.12.0
       hooks:
           - id: isort
             args: ["--config-root=python/", "--resolve-all-configs"]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.02` that creates a PR to keep `branch-23.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.