### PR TITLE
Reduce error handling verbosity in CI tests scripts

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+
 set -euo pipefail
 
 rapids-logger "Create test conda environment"

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -36,5 +36,5 @@ for gt in "$CONDA_PREFIX/bin/gtests/librmm/"* ; do
     ${gt} --gtest_output=xml:${RAPIDS_TESTS_DIR}/
 done
 
-echo "Test script exiting with value: $EXITCODE"
+rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
-
-# Any failing command will set EXITCODE to non-zero
-set -e           # abort the script on error, this will change for running tests (see below)
-set -o pipefail  # piped commands propagate their error
-set -E           # ERR traps are inherited by subcommands
+set -euo pipefail
 trap "EXITCODE=1" ERR
 
 . /opt/conda/etc/profile.d/conda.sh
@@ -33,9 +29,6 @@ EXITCODE=0
 rapids-logger "Check GPU usage"
 nvidia-smi
 
-# Do not abort the script on error from this point on. This allows all tests to
-# run regardless of pass/fail, but relies on the ERR trap above to manage the
-# EXITCODE for the script.
 set +e
 
 rapids-logger "Running googletests"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 set -euo pipefail
-trap "EXITCODE=1" ERR
 
 . /opt/conda/etc/profile.d/conda.sh
 conda activate base
@@ -24,11 +23,12 @@ rapids-mamba-retry install \
 
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}"
-EXITCODE=0
 
 rapids-logger "Check GPU usage"
 nvidia-smi
 
+EXITCODE=0
+trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "Running googletests"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
 set -euo pipefail
-trap "EXITCODE=1" ERR
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
@@ -28,13 +27,14 @@ rapids-mamba-retry install \
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
-EXITCODE=0
 
 rapids-logger "Check GPU usage"
 nvidia-smi
 
 cd python
 
+EXITCODE=0
+trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "pytest rmm"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # Copyright (c) 2020-2023, NVIDIA CORPORATION.
-
-# Any failing command will set EXITCODE to non-zero
-set -e           # abort the script on error, this will change for running tests (see below)
-set -o pipefail  # piped commands propagate their error
-set -E           # ERR traps are inherited by subcommands
+set -euo pipefail
 trap "EXITCODE=1" ERR
 
 rapids-logger "Create test conda environment"
@@ -39,9 +35,6 @@ nvidia-smi
 
 cd python
 
-# Do not abort the script on error from this point on. This allows all tests to
-# run regardless of pass/fail, but relies on the ERR trap above to manage the
-# EXITCODE for the script.
 set +e
 
 rapids-logger "pytest rmm"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -47,5 +47,5 @@ pytest \
   --cov-report=xml:"${RAPIDS_COVERAGE_DIR}/rmm-coverage.xml" \
   --cov-report term
 
-echo "Test script exiting with value: $EXITCODE"
+rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
This PR adds a less verbose [trap method](https://github.com/rapidsai/cugraph/blob/f2b081075704aabc789603e14ce552eac3fbe692/ci/test.sh#L19), for error handling to help ensure that we capture all potential error codes in our test scripts, and works as follows:

- setting an environment variable, EXITCODE, with a default value of 0
- setting a trap statement triggered by ERR signals which will set EXITCODE=1 when any commands return a non-zero exit code


cc @ajschmidt8 