### PR TITLE
Revert changes overriding rapids-cmake repo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,6 @@
 
 cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
-# TODO(keith): REMOVE BEFORE MERGING
-set(rapids-cmake-repo "kkraus14/rapids-cmake")
-set(rapids-cmake-branch "spdlog_1.11_fmt")
-
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.04/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/RMM_RAPIDS.cmake)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -16,10 +16,6 @@ cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 set(rmm_version 23.04.00)
 
-# TODO(keith): REMOVE BEFORE MERGING
-set(rapids-cmake-repo "kkraus14/rapids-cmake")
-set(rapids-cmake-branch "spdlog_1.11_fmt")
-
 file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.04/RAPIDS.cmake
      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
 include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)


### PR DESCRIPTION
## Description
PR #1177 was merged a little too early when CI passed due to the presence of a `/merge` comment and sufficient approvals. This reverts a temporary change to the rapids-cmake repo that is no longer needed because https://github.com/rapidsai/rapids-cmake/pull/368 has been merged.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
