### PR TITLE
Use script rather than environment variable to modify package names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,8 +74,7 @@ jobs:
       package-name: rmm
       package-dir: python
       skbuild-configure-options: "-DRMM_BUILD_WHEELS=ON"
-      uses-versioneer: false
-      uses-dynamic-name: false
+      uses-setup-env-vars: false
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,7 @@ jobs:
       package-dir: python
       skbuild-configure-options: "-DRMM_BUILD_WHEELS=ON"
       uses-versioneer: false
+      uses-dynamic-name: false
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,13 +62,14 @@ jobs:
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@branch-23.04
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@static_wheel_name
     with:
       build_type: pull-request
       package-dir: python
       package-name: rmm
       skbuild-configure-options: "-DRMM_BUILD_WHEELS=ON"
       uses-versioneer: false
+      uses-dynamic-name: false
   wheel-tests:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,7 +62,7 @@ jobs:
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@static_wheel_name
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@branch-23.04
     with:
       build_type: pull-request
       package-dir: python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,8 +68,7 @@ jobs:
       package-dir: python
       package-name: rmm
       skbuild-configure-options: "-DRMM_BUILD_WHEELS=ON"
-      uses-versioneer: false
-      uses-dynamic-name: false
+      uses-setup-env-vars: false
   wheel-tests:
     needs: wheel-build
     secrets: inherit

--- a/ci/release/apply_wheel_modifications.sh
+++ b/ci/release/apply_wheel_modifications.sh
@@ -4,7 +4,7 @@
 # Usage: bash apply_wheel_modifications.sh <new_version>
 
 VERSION=${1}
-CUDA_SUFFIX=${1}
+CUDA_SUFFIX=${2}
 
 sed -i "s/__version__ = .*/__version__ = \"${VERSION}\"/g" python/rmm/__init__.py
 sed -i "s/version=.*,/version=\"${VERSION}\",/g" python/setup.py

--- a/ci/release/apply_wheel_modifications.sh
+++ b/ci/release/apply_wheel_modifications.sh
@@ -4,6 +4,9 @@
 # Usage: bash apply_wheel_modifications.sh <new_version>
 
 VERSION=${1}
+CUDA_SUFFIX=${1}
 
 sed -i "s/__version__ = .*/__version__ = \"${VERSION}\"/g" python/rmm/__init__.py
 sed -i "s/version=.*,/version=\"${VERSION}\",/g" python/setup.py
+
+sed -i "s/name=\"rmm\",/name=\"rmm-${CUDA_SUFFIX}\"/g" python/setup.py

--- a/ci/release/apply_wheel_modifications.sh
+++ b/ci/release/apply_wheel_modifications.sh
@@ -9,4 +9,4 @@ CUDA_SUFFIX=${2}
 sed -i "s/__version__ = .*/__version__ = \"${VERSION}\"/g" python/rmm/__init__.py
 sed -i "s/version=.*,/version=\"${VERSION}\",/g" python/setup.py
 
-sed -i "s/name=\"rmm\",/name=\"rmm-${CUDA_SUFFIX}\"/g" python/setup.py
+sed -i "s/name=\"rmm\",/name=\"rmm${CUDA_SUFFIX}\"/g" python/setup.py

--- a/ci/release/apply_wheel_modifications.sh
+++ b/ci/release/apply_wheel_modifications.sh
@@ -9,4 +9,4 @@ CUDA_SUFFIX=${2}
 sed -i "s/__version__ = .*/__version__ = \"${VERSION}\"/g" python/rmm/__init__.py
 sed -i "s/version=.*,/version=\"${VERSION}\",/g" python/setup.py
 
-sed -i "s/name=\"rmm\",/name=\"rmm${CUDA_SUFFIX}\"/g" python/setup.py
+sed -i "s/name=\"rmm\",/name=\"rmm${CUDA_SUFFIX}\",/g" python/setup.py

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 from skbuild import setup
 
 setup(
-    name="rmm" + os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default=""),
+    name="rmm",
     version="23.04.00",
     description="rmm - RAPIDS Memory Manager",
     url="https://github.com/rapidsai/rmm",

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2019-2022, NVIDIA CORPORATION.
 
-import os
-
 from setuptools import find_packages
 from skbuild import setup
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The package name defined in setup.py needs to be modified for wheels to reflect the CUDA version that the wheel was built for. Currently that modification is done via an environment variable that is pulled in setup.py code. This changeset replaces that approach with a direct modification using a script (similar to what is done for versions in #1190) to facilitate moving towards static project metadata specification via pyproject.toml.

This PR depends on https://github.com/rapidsai/shared-action-workflows/pull/45.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
