### PR TITLE
CI: Remove specification of manual stage for check_style.sh script.

### DIFF
--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -20,4 +20,4 @@ mkdir -p $(dirname ${RAPIDS_CMAKE_FORMAT_FILE})
 wget -O ${RAPIDS_CMAKE_FORMAT_FILE} ${FORMAT_FILE_URL}
 
 # Run pre-commit checks
-pre-commit run --hook-stage manual --all-files --show-diff-on-failure
+pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## Description
Do not explicitly specify to run the "manual" stage when running pre-commits as part of the ci/check_style.sh script.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
