### PR TITLE
Run rapids-dependency-file-generator via pre-commit

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,13 +25,14 @@ jobs:
   checks:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@branch-23.04
+    with:
+      enable_check_generated_files: false
   conda-cpp-build:
     needs: checks
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@branch-23.04
     with:
       build_type: pull-request
-      enable_check_generated_files: false
   conda-cpp-tests:
     needs: conda-cpp-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,6 +31,7 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@branch-23.04
     with:
       build_type: pull-request
+      enable_check_generated_files: false
   conda-cpp-tests:
     needs: conda-cpp-build
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
       hooks:
           - id: trailing-whitespace
           - id: end-of-file-fixer
+    - repo: https://github.com/vyasr/dependency-file-generator
+      rev: feat/pre_commit_hook
+      hooks:
+          - id: rapids-dependency-file-generator
     - repo: https://github.com/PyCQA/isort
       rev: 5.12.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,10 @@ repos:
           - id: trailing-whitespace
           - id: end-of-file-fixer
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.2.0
+      rev: v1.4.0
       hooks:
           - id: rapids-dependency-file-generator
+          - args: ["--clean"]
     - repo: https://github.com/PyCQA/isort
       rev: 5.12.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.3.0
       hooks:
           - id: trailing-whitespace
           - id: end-of-file-fixer
-    - repo: https://github.com/vyasr/dependency-file-generator
-      rev: feat/pre_commit_hook
+    - repo: https://github.com/rapidsai/dependency-file-generator
+      rev: v1.2.0
       hooks:
           - id: rapids-dependency-file-generator
     - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       rev: v1.4.0
       hooks:
           - id: rapids-dependency-file-generator
-          - args: ["--clean"]
+            args: ["--clean"]
     - repo: https://github.com/PyCQA/isort
       rev: 5.12.0
       hooks:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This feature is enabled by the most recent release of dfg. This changes also allows us to disable the dfg CI check as it is now redundant.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
