### PR TITLE
Specify include_package_data to setup

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -5,4 +5,5 @@ from skbuild import setup
 
 setup(
     packages=find_packages(include=["rmm", "rmm.*"]),
+    include_package_data=True,
 )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
For pure setuptools-based builds, the `include_package_data` option historically defaulted to False. With newer projects, i.e. with projects containing a pyproject.toml file, it defaults to True. However, for projects using scikit-build this setting must be provided explicitly to the `setup` function (not in the config file) to allow scikit-build to intercept the argument and use it in the preprocessing it does before invoking `setuptools.setup`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
