### PR TITLE
Defer importing packages for third-party allocation hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,16 +691,18 @@ resources
 MemoryResources are highly configurable and can be composed together in different ways.
 See `help(rmm.mr)` for more information.
 
-### Using RMM with CuPy
+## Using RMM with third-party libraries
+
+#### Using RMM with CuPy
 
 You can configure [CuPy](https://cupy.dev/) to use RMM for memory
 allocations by setting the CuPy CUDA allocator to
 `rmm_cupy_allocator`:
 
 ```python
->>> import rmm
+>>> from rmm.allocators.cupy import rmm_cupy_allocator
 >>> import cupy
->>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+>>> cupy.cuda.set_allocator(rmm_cupy_allocator)
 ```
 
 
@@ -718,15 +720,15 @@ This can be done in two ways:
 1. Setting the environment variable `NUMBA_CUDA_MEMORY_MANAGER`:
 
   ```python
-  $ NUMBA_CUDA_MEMORY_MANAGER=rmm python (args)
+  $ NUMBA_CUDA_MEMORY_MANAGER=rmm.allocators.numba python (args)
   ```
 
 2. Using the `set_memory_manager()` function provided by Numba:
 
   ```python
   >>> from numba import cuda
-  >>> import rmm
-  >>> cuda.set_memory_manager(rmm.RMMNumbaManager)
+  >>> from rmm.allocators.numba import RMMNumbaManager
+  >>> cuda.set_memory_manager(RMMNumbaManager)
   ```
 
 **Note:** This only configures Numba to use the current RMM resource for allocations.
@@ -741,10 +743,11 @@ RMM-managed pool:
 
 ```python
 import rmm
+from rmm.allocators.torch import rmm_torch_allocator
 import torch
 
 rmm.reinitialize(pool_allocator=True)
-torch.cuda.memory.change_current_allocator(rmm.rmm_torch_allocator)
+torch.cuda.memory.change_current_allocator(rmm_torch_allocator)
 ```
 
 PyTorch and RMM will now share the same memory pool.
@@ -753,13 +756,14 @@ You can, of course, use a custom memory resource with PyTorch as well:
 
 ```python
 import rmm
+from rmm.allocators.torch import rmm_torch_allocator
 import torch
 
 # note that you can configure PyTorch to use RMM either before or
 # after changing RMM's memory resource.  PyTorch will use whatever
 # memory resource is configured to be the "current" memory resource at
 # the time of allocation.
-torch.cuda.change_current_allocator(rmm.rmm_torch_allocator)
+torch.cuda.change_current_allocator(rmm_torch_allocator)
 
 # configure RMM to use a managed memory resource, wrapped with a
 # statistics resource adaptor that can report information about the

--- a/python/docs/api.rst
+++ b/python/docs/api.rst
@@ -17,3 +17,21 @@ Memory Resources
    :members:
    :undoc-members:
    :show-inheritance:
+
+Memory Allocators
+-----------------
+
+.. automodule:: rmm.allocators.cupy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: rmm.allocators.numba
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: rmm.allocators.torch
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/docs/basics.md
+++ b/python/docs/basics.md
@@ -131,21 +131,31 @@ resources
 MemoryResources are highly configurable and can be composed together in different ways.
 See `help(rmm.mr)` for more information.
 
-### Using RMM with CuPy
+## Using RMM with third-party libraries
+
+A number of libraries provide hooks to control their device
+allocations. RMM provides implementations of these for
+[CuPy](https://cupy.dev),
+[numba](https://numba.readthedocs.io/en/stable/), and [PyTorch](https://pytorch.org) in the
+`rmm.allocators` submodule. All these approaches configure the library
+to use whichever the _current_ RMM memory resource is for device
+allocations.
+
+#### Using RMM with CuPy
 
 You can configure [CuPy](https://cupy.dev/) to use RMM for memory
 allocations by setting the CuPy CUDA allocator to
-`rmm_cupy_allocator`:
+`rmm.allocators.cupy.rmm_cupy_allocator`:
 
 ```python
->>> import rmm
+>>> from rmm.allocators.cupy import rmm_cupy_allocator
 >>> import cupy
->>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+>>> cupy.cuda.set_allocator(rmm_cupy_allocator)
 ```
 
 ### Using RMM with Numba
 
-You can configure Numba to use RMM for memory allocations using the
+You can configure [Numba](https://numba.readthedocs.io/en/stable/) to use RMM for memory allocations using the
 Numba [EMM Plugin](https://numba.readthedocs.io/en/stable/cuda/external-memory.html#setting-emm-plugin).
 
 This can be done in two ways:
@@ -153,13 +163,27 @@ This can be done in two ways:
 1. Setting the environment variable `NUMBA_CUDA_MEMORY_MANAGER`:
 
   ```bash
-  $ NUMBA_CUDA_MEMORY_MANAGER=rmm python (args)
+  $ NUMBA_CUDA_MEMORY_MANAGER=rmm.allocators.numba python (args)
   ```
 
 2. Using the `set_memory_manager()` function provided by Numba:
 
   ```python
   >>> from numba import cuda
-  >>> import rmm
-  >>> cuda.set_memory_manager(rmm.RMMNumbaManager)
+  >>> from rmm.allocators.numba import RMMNumbaManager
+  >>> cuda.set_memory_manager(RMMNumbaManager)
   ```
+
+### Using RMM with PyTorch
+
+You can configure
+[PyTorch](https://pytorch.org/docs/stable/notes/cuda.html) to use RMM
+for memory allocations using their by configuring the current
+allocator.
+
+```python
+from rmm.allocators.torch import rmm_torch_allocator
+import torch
+
+torch.cuda.memory.change_current_allocator(rmm_torch_allocator)
+```

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -14,16 +14,15 @@
 
 from rmm import mr
 from rmm._lib.device_buffer import DeviceBuffer
+from rmm.allocators.cupy import rmm_cupy_allocator
+from rmm.allocators.numba import RMMNumbaManager, _numba_memory_manager
+from rmm.allocators.torch import rmm_torch_allocator
 from rmm.mr import disable_logging, enable_logging, get_log_filenames
 from rmm.rmm import (
     RMMError,
-    RMMNumbaManager,
-    _numba_memory_manager,
     is_initialized,
     register_reinitialize_hook,
     reinitialize,
-    rmm_cupy_allocator,
-    rmm_torch_allocator,
     unregister_reinitialize_hook,
 )
 
@@ -39,6 +38,7 @@ __all__ = [
     "register_reinitialize_hook",
     "reinitialize",
     "rmm_cupy_allocator",
+    "rmm_torch_allocator",
     "unregister_reinitialize_hook",
 ]
 

--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -14,9 +14,6 @@
 
 from rmm import mr
 from rmm._lib.device_buffer import DeviceBuffer
-from rmm.allocators.cupy import rmm_cupy_allocator
-from rmm.allocators.numba import RMMNumbaManager, _numba_memory_manager
-from rmm.allocators.torch import rmm_torch_allocator
 from rmm.mr import disable_logging, enable_logging, get_log_filenames
 from rmm.rmm import (
     RMMError,
@@ -29,7 +26,6 @@ from rmm.rmm import (
 __all__ = [
     "DeviceBuffer",
     "RMMError",
-    "RMMNumbaManager",
     "disable_logging",
     "enable_logging",
     "get_log_filenames",
@@ -37,8 +33,6 @@ __all__ = [
     "mr",
     "register_reinitialize_hook",
     "reinitialize",
-    "rmm_cupy_allocator",
-    "rmm_torch_allocator",
     "unregister_reinitialize_hook",
 ]
 

--- a/python/rmm/_cuda/gpu.py
+++ b/python/rmm/_cuda/gpu.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
 
-import numba.cuda
 from cuda import cuda, cudart
 
 
@@ -84,6 +83,8 @@ def runtimeGetVersion():
     """
     # TODO: Replace this with `cuda.cudart.cudaRuntimeGetVersion()` when the
     # limitation is fixed.
+    import numba.cuda
+
     major, minor = numba.cuda.runtime.get_version()
     return major * 1000 + minor * 10
 

--- a/python/rmm/allocators/cupy.py
+++ b/python/rmm/allocators/cupy.py
@@ -26,7 +26,7 @@ def rmm_cupy_allocator(nbytes):
 
     Examples
     --------
-    >>> import rmm
+    >>> from rmm.allocators.cupy import rmm_cupy_allocator
     >>> import cupy
     >>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
     """

--- a/python/rmm/allocators/cupy.py
+++ b/python/rmm/allocators/cupy.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from rmm import _lib as librmm
+from rmm._cuda.stream import Stream
+
+try:
+    import cupy
+except ImportError:
+    cupy = None
+
+
+def rmm_cupy_allocator(nbytes):
+    """
+    A CuPy allocator that makes use of RMM.
+
+    Examples
+    --------
+    >>> import rmm
+    >>> import cupy
+    >>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+    """
+    if cupy is None:
+        raise ModuleNotFoundError("No module named 'cupy'")
+
+    stream = Stream(obj=cupy.cuda.get_current_stream())
+    buf = librmm.device_buffer.DeviceBuffer(size=nbytes, stream=stream)
+    dev_id = -1 if buf.ptr else cupy.cuda.device.get_device_id()
+    mem = cupy.cuda.UnownedMemory(
+        ptr=buf.ptr, size=buf.size, owner=buf, device_id=dev_id
+    )
+    ptr = cupy.cuda.memory.MemoryPointer(mem, 0)
+
+    return ptr

--- a/python/rmm/allocators/numba.py
+++ b/python/rmm/allocators/numba.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ctypes
+
+from cuda.cuda import CUdeviceptr, cuIpcGetMemHandle
+from numba import config, cuda
+from numba.cuda import HostOnlyCUDAMemoryManager, IpcHandle, MemoryPointer
+
+from rmm import _lib as librmm
+
+
+def _make_emm_plugin_finalizer(handle, allocations):
+    """
+    Factory to make the finalizer function.
+    We need to bind *handle* and *allocations* into the actual finalizer, which
+    takes no args.
+    """
+
+    def finalizer():
+        """
+        Invoked when the MemoryPointer is freed
+        """
+        # At exit time (particularly in the Numba test suite) allocations may
+        # have already been cleaned up by a call to Context.reset() for the
+        # context, even if there are some DeviceNDArrays and their underlying
+        # allocations lying around. Finalizers then get called by weakref's
+        # atexit finalizer, at which point allocations[handle] no longer
+        # exists. This is harmless, except that a traceback is printed just
+        # prior to exit (without abnormally terminating the program), but is
+        # worrying for the user. To avoid the traceback, we check if
+        # allocations is already empty.
+        #
+        # In the case where allocations is not empty, but handle is not in
+        # allocations, then something has gone wrong - so we only guard against
+        # allocations being completely empty, rather than handle not being in
+        # allocations.
+        if allocations:
+            del allocations[handle]
+
+    return finalizer
+
+
+class RMMNumbaManager(HostOnlyCUDAMemoryManager):
+    """
+    External Memory Management Plugin implementation for Numba. Provides
+    on-device allocation only.
+
+    See https://numba.readthedocs.io/en/stable/cuda/external-memory.html for
+    details of the interface being implemented here.
+    """
+
+    def initialize(self):
+        # No special initialization needed to use RMM within a given context.
+        pass
+
+    def memalloc(self, size):
+        """
+        Allocate an on-device array from the RMM pool.
+        """
+        buf = librmm.DeviceBuffer(size=size)
+        ctx = self.context
+
+        if config.CUDA_USE_NVIDIA_BINDING:
+            ptr = CUdeviceptr(int(buf.ptr))
+        else:
+            # expect ctypes bindings in numba
+            ptr = ctypes.c_uint64(int(buf.ptr))
+
+        finalizer = _make_emm_plugin_finalizer(int(buf.ptr), self.allocations)
+
+        # self.allocations is initialized by the parent, HostOnlyCUDAManager,
+        # and cleared upon context reset, so although we insert into it here
+        # and delete from it in the finalizer, we need not do any other
+        # housekeeping elsewhere.
+        self.allocations[int(buf.ptr)] = buf
+
+        return MemoryPointer(ctx, ptr, size, finalizer=finalizer)
+
+    def get_ipc_handle(self, memory):
+        """
+        Get an IPC handle for the MemoryPointer memory with offset modified by
+        the RMM memory pool.
+        """
+        start, end = cuda.cudadrv.driver.device_extents(memory)
+
+        if config.CUDA_USE_NVIDIA_BINDING:
+            _, ipchandle = cuIpcGetMemHandle(start)
+            offset = int(memory.handle) - int(start)
+        else:
+            ipchandle = (ctypes.c_byte * 64)()  # IPC handle is 64 bytes
+            cuda.cudadrv.driver.driver.cuIpcGetMemHandle(
+                ctypes.byref(ipchandle),
+                start,
+            )
+            offset = memory.handle.value - start
+        source_info = cuda.current_context().device.get_device_identity()
+
+        return IpcHandle(
+            memory, ipchandle, memory.size, source_info, offset=offset
+        )
+
+    def get_memory_info(self):
+        raise NotImplementedError()
+
+    @property
+    def interface_version(self):
+        return 1
+
+
+# Enables the use of RMM for Numba via an environment variable setting,
+# NUMBA_CUDA_MEMORY_MANAGER=rmm. See:
+# https://numba.readthedocs.io/en/stable/cuda/external-memory.html#environment-variable
+_numba_memory_manager = RMMNumbaManager

--- a/python/rmm/allocators/torch.py
+++ b/python/rmm/allocators/torch.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    from torch.cuda.memory import CUDAPluggableAllocator
+except ImportError:
+    rmm_torch_allocator = None
+else:
+    import rmm._lib.torch_allocator
+
+    _alloc_free_lib_path = rmm._lib.torch_allocator.__file__
+    rmm_torch_allocator = CUDAPluggableAllocator(
+        _alloc_free_lib_path,
+        alloc_fn_name="allocate",
+        free_fn_name="deallocate",
+    )

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import rmm
+from . import mr
 
 
 # Utility Functions
@@ -78,7 +78,7 @@ def reinitialize(
     for func, args, kwargs in reversed(_reinitialize_hooks):
         func(*args, **kwargs)
 
-    rmm.mr._initialize(
+    mr._initialize(
         pool_allocator=pool_allocator,
         managed_memory=managed_memory,
         initial_pool_size=initial_pool_size,
@@ -93,7 +93,7 @@ def is_initialized():
     """
     Returns True if RMM has been initialized, False otherwise.
     """
-    return rmm.mr.is_initialized()
+    return mr.is_initialized()
 
 
 def register_reinitialize_hook(func, *args, **kwargs):

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import rmm
-from rmm import _lib as librmm
-from rmm._cuda.stream import Stream
-from rmm.allocators.cupy import rmm_cupy_allocator  # noqa: F401
-from rmm.allocators.numba import (  # noqa: F401
-    RMMNumbaManager,
-    _numba_memory_manager,
-)
-from rmm.allocators.torch import rmm_torch_allocator  # noqa: F401
 
 
 # Utility Functions

--- a/python/rmm/rmm.py
+++ b/python/rmm/rmm.py
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import ctypes
-
-from cuda.cuda import CUdeviceptr, cuIpcGetMemHandle
-from numba import config, cuda
-from numba.cuda import HostOnlyCUDAMemoryManager, IpcHandle, MemoryPointer
-
 import rmm
 from rmm import _lib as librmm
 from rmm._cuda.stream import Stream
+from rmm.allocators.cupy import rmm_cupy_allocator  # noqa: F401
+from rmm.allocators.numba import (  # noqa: F401
+    RMMNumbaManager,
+    _numba_memory_manager,
+)
+from rmm.allocators.torch import rmm_torch_allocator  # noqa: F401
 
 
 # Utility Functions
@@ -102,154 +102,6 @@ def is_initialized():
     Returns True if RMM has been initialized, False otherwise.
     """
     return rmm.mr.is_initialized()
-
-
-class RMMNumbaManager(HostOnlyCUDAMemoryManager):
-    """
-    External Memory Management Plugin implementation for Numba. Provides
-    on-device allocation only.
-
-    See https://numba.readthedocs.io/en/stable/cuda/external-memory.html for
-    details of the interface being implemented here.
-    """
-
-    def initialize(self):
-        # No special initialization needed to use RMM within a given context.
-        pass
-
-    def memalloc(self, size):
-        """
-        Allocate an on-device array from the RMM pool.
-        """
-        buf = librmm.DeviceBuffer(size=size)
-        ctx = self.context
-
-        if config.CUDA_USE_NVIDIA_BINDING:
-            ptr = CUdeviceptr(int(buf.ptr))
-        else:
-            # expect ctypes bindings in numba
-            ptr = ctypes.c_uint64(int(buf.ptr))
-
-        finalizer = _make_emm_plugin_finalizer(int(buf.ptr), self.allocations)
-
-        # self.allocations is initialized by the parent, HostOnlyCUDAManager,
-        # and cleared upon context reset, so although we insert into it here
-        # and delete from it in the finalizer, we need not do any other
-        # housekeeping elsewhere.
-        self.allocations[int(buf.ptr)] = buf
-
-        return MemoryPointer(ctx, ptr, size, finalizer=finalizer)
-
-    def get_ipc_handle(self, memory):
-        """
-        Get an IPC handle for the MemoryPointer memory with offset modified by
-        the RMM memory pool.
-        """
-        start, end = cuda.cudadrv.driver.device_extents(memory)
-
-        if config.CUDA_USE_NVIDIA_BINDING:
-            _, ipchandle = cuIpcGetMemHandle(start)
-            offset = int(memory.handle) - int(start)
-        else:
-            ipchandle = (ctypes.c_byte * 64)()  # IPC handle is 64 bytes
-            cuda.cudadrv.driver.driver.cuIpcGetMemHandle(
-                ctypes.byref(ipchandle),
-                start,
-            )
-            offset = memory.handle.value - start
-        source_info = cuda.current_context().device.get_device_identity()
-
-        return IpcHandle(
-            memory, ipchandle, memory.size, source_info, offset=offset
-        )
-
-    def get_memory_info(self):
-        raise NotImplementedError()
-
-    @property
-    def interface_version(self):
-        return 1
-
-
-def _make_emm_plugin_finalizer(handle, allocations):
-    """
-    Factory to make the finalizer function.
-    We need to bind *handle* and *allocations* into the actual finalizer, which
-    takes no args.
-    """
-
-    def finalizer():
-        """
-        Invoked when the MemoryPointer is freed
-        """
-        # At exit time (particularly in the Numba test suite) allocations may
-        # have already been cleaned up by a call to Context.reset() for the
-        # context, even if there are some DeviceNDArrays and their underlying
-        # allocations lying around. Finalizers then get called by weakref's
-        # atexit finalizer, at which point allocations[handle] no longer
-        # exists. This is harmless, except that a traceback is printed just
-        # prior to exit (without abnormally terminating the program), but is
-        # worrying for the user. To avoid the traceback, we check if
-        # allocations is already empty.
-        #
-        # In the case where allocations is not empty, but handle is not in
-        # allocations, then something has gone wrong - so we only guard against
-        # allocations being completely empty, rather than handle not being in
-        # allocations.
-        if allocations:
-            del allocations[handle]
-
-    return finalizer
-
-
-# Enables the use of RMM for Numba via an environment variable setting,
-# NUMBA_CUDA_MEMORY_MANAGER=rmm. See:
-# https://numba.readthedocs.io/en/stable/cuda/external-memory.html#environment-variable
-_numba_memory_manager = RMMNumbaManager
-
-try:
-    import cupy
-except Exception:
-    cupy = None
-
-
-def rmm_cupy_allocator(nbytes):
-    """
-    A CuPy allocator that makes use of RMM.
-
-    Examples
-    --------
-    >>> import rmm
-    >>> import cupy
-    >>> cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
-    """
-    if cupy is None:
-        raise ModuleNotFoundError("No module named 'cupy'")
-
-    stream = Stream(obj=cupy.cuda.get_current_stream())
-    buf = librmm.device_buffer.DeviceBuffer(size=nbytes, stream=stream)
-    dev_id = -1 if buf.ptr else cupy.cuda.device.get_device_id()
-    mem = cupy.cuda.UnownedMemory(
-        ptr=buf.ptr, size=buf.size, owner=buf, device_id=dev_id
-    )
-    ptr = cupy.cuda.memory.MemoryPointer(mem, 0)
-
-    return ptr
-
-
-try:
-    from torch.cuda.memory import CUDAPluggableAllocator
-except ImportError:
-    rmm_torch_allocator = None
-else:
-    import rmm._lib.torch_allocator
-
-    _alloc_free_lib_path = rmm._lib.torch_allocator.__file__
-    rmm_torch_allocator = CUDAPluggableAllocator(
-        _alloc_free_lib_path,
-        alloc_fn_name="allocate",
-        free_fn_name="deallocate",
-    )
 
 
 def register_reinitialize_hook(func, *args, **kwargs):

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -24,6 +24,8 @@ from numba import cuda
 
 import rmm
 import rmm._cuda.stream
+from rmm.allocators.cupy import rmm_cupy_allocator
+from rmm.allocators.numba import RMMNumbaManager
 
 if sys.version_info < (3, 8):
     try:
@@ -33,7 +35,7 @@ if sys.version_info < (3, 8):
 else:
     import pickle
 
-cuda.set_memory_manager(rmm.RMMNumbaManager)
+cuda.set_memory_manager(RMMNumbaManager)
 
 _driver_version = rmm._cuda.gpu.driverGetVersion()
 _runtime_version = rmm._cuda.gpu.runtimeGetVersion()
@@ -303,17 +305,17 @@ def test_rmm_pool_numba_stream(stream):
 def test_rmm_cupy_allocator():
     cupy = pytest.importorskip("cupy")
 
-    m = rmm.rmm_cupy_allocator(42)
+    m = rmm_cupy_allocator(42)
     assert m.mem.size == 42
     assert m.mem.ptr != 0
     assert isinstance(m.mem._owner, rmm.DeviceBuffer)
 
-    m = rmm.rmm_cupy_allocator(0)
+    m = rmm_cupy_allocator(0)
     assert m.mem.size == 0
     assert m.mem.ptr == 0
     assert isinstance(m.mem._owner, rmm.DeviceBuffer)
 
-    cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+    cupy.cuda.set_allocator(rmm_cupy_allocator)
     a = cupy.arange(10)
     assert isinstance(a.data.mem._owner, rmm.DeviceBuffer)
 
@@ -323,7 +325,7 @@ def test_rmm_pool_cupy_allocator_with_stream(stream):
     cupy = pytest.importorskip("cupy")
 
     rmm.reinitialize(pool_allocator=True)
-    cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+    cupy.cuda.set_allocator(rmm_cupy_allocator)
 
     if stream == "null":
         stream = cupy.cuda.stream.Stream.null
@@ -331,12 +333,12 @@ def test_rmm_pool_cupy_allocator_with_stream(stream):
         stream = cupy.cuda.stream.Stream()
 
     with stream:
-        m = rmm.rmm_cupy_allocator(42)
+        m = rmm_cupy_allocator(42)
         assert m.mem.size == 42
         assert m.mem.ptr != 0
         assert isinstance(m.mem._owner, rmm.DeviceBuffer)
 
-        m = rmm.rmm_cupy_allocator(0)
+        m = rmm_cupy_allocator(0)
         assert m.mem.size == 0
         assert m.mem.ptr == 0
         assert isinstance(m.mem._owner, rmm.DeviceBuffer)
@@ -355,7 +357,7 @@ def test_rmm_pool_cupy_allocator_stream_lifetime():
     cupy = pytest.importorskip("cupy")
 
     rmm.reinitialize(pool_allocator=True)
-    cupy.cuda.set_allocator(rmm.rmm_cupy_allocator)
+    cupy.cuda.set_allocator(rmm_cupy_allocator)
 
     stream = cupy.cuda.stream.Stream()
 

--- a/python/rmm/tests/test_rmm_pytorch.py
+++ b/python/rmm/tests/test_rmm_pytorch.py
@@ -2,7 +2,7 @@ import gc
 
 import pytest
 
-import rmm
+from rmm.allocators.torch import rmm_torch_allocator
 
 torch = pytest.importorskip("torch")
 
@@ -13,7 +13,7 @@ def torch_allocator():
         from torch.cuda.memory import change_current_allocator
     except ImportError:
         pytest.skip("pytorch pluggable allocator not available")
-    change_current_allocator(rmm.rmm_torch_allocator)
+    change_current_allocator(rmm_torch_allocator)
 
 
 def test_rmm_torch_allocator(torch_allocator, stats_mr):


### PR DESCRIPTION
## Description

RMM provides callbacks to configure third-party libraries to use RMM
for memory allocation.

Previously, these were defined in the top-level package, but that
requires (potentially expensive) import of the package we're providing
a hook for, since typically we must import that package to define the
callback. This makes importing RMM expensive. To avoid this, move the
callbacks into (not imported by default) sub-modules in
`rmm.allocators`. So, if we want to configure the CuPy allocator, we
now import `rmm_cupy_allocator` from `rmm.allocators.cupy`, and don't
pay the price of importing pytorch.

This is a **breaking change** since these functions are in the public
API.

Before these changes, a sampling trace of `import rmm` with
pyinstrument shows:
    
    $ pyinstrument -i 0.01 importrmm.py

      _     ._   __/__   _ _  _  _ _/_   Recorded: 10:19:56  Samples:  67
     /_//_/// /_\ / //_// / //_'/ //     Duration: 0.839     CPU time: 0.837
    /   _/                      v4.4.0

    Program: importrmm.py

    0.839 <module>  importrmm.py:1
    └─ 0.839 <module>  rmm/__init__.py:1
       ├─ 0.315 <module>  rmm/allocators/torch.py:1
       │  └─ 0.315 <module>  torch/__init__.py:1
       │        [96 frames hidden]  torch, <built-in>, enum, inspect, tok...
       ├─ 0.297 <module>  rmm/mr.py:1
       │  └─ 0.297 <module>  rmm/_lib/__init__.py:1
       │     ├─ 0.216 <module>  numba/__init__.py:1
       │     │     [140 frames hidden]  numba, abc, <built-in>, importlib, em...
       │     ├─ 0.040 <module>  numba/cuda/__init__.py:1
       │     │     [34 frames hidden]  numba, asyncio, ssl, <built-in>, re, ...
       │     ├─ 0.030 __new__  enum.py:180
       │     │     [5 frames hidden]  enum, <built-in>
       │     └─ 0.011 [self]  None
       └─ 0.227 <module>  rmm/allocators/cupy.py:1
          └─ 0.227 <module>  cupy/__init__.py:1
                [123 frames hidden]  cupy, pytest, _pytest, attr, <built-i...

That is, almost a full second to import things, most of which is spent
importing pytorch and cupy. These modules are not needed in normal
usage of RMM, so we can defer the imports. Numba is a little bit
trickier, but we can also defer up-front imports, with a final result
that after these changes the same `import rmm` call takes just a tenth
of a second:

    $ pyinstrument -i 0.01 importrmm.py

      _     ._   __/__   _ _  _  _ _/_   Recorded: 10:37:40  Samples:  9
     /_//_/// /_\ / //_// / //_'/ //     Duration: 0.099     CPU time: 0.099
    /   _/                      v4.4.0

    Program: importrmm.py

    0.099 <module>  importrmm.py:1
    └─ 0.099 <module>  rmm/__init__.py:1
       └─ 0.099 <module>  rmm/mr.py:1
          └─ 0.099 <module>  rmm/_lib/__init__.py:1
             ├─ 0.059 <module>  numpy/__init__.py:1
             │     [31 frames hidden]  numpy, re, sre_compile, <built-in>, s...
             ├─ 0.020 __new__  enum.py:180
             │     [2 frames hidden]  enum
             ├─ 0.010 <module>  ctypes/__init__.py:1
             │     [3 frames hidden]  ctypes, <built-in>
             └─ 0.010 _EnumDict.__setitem__  enum.py:89
                   [3 frames hidden]  enum

Closes #1211.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
