### PR TITLE
Remove pickle compatibility layer in tests for Python < 3.8.

### DIFF
--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -268,17 +268,16 @@ def test_rmm_device_buffer_pickle_roundtrip(hb):
     hb2 = db2.tobytes()
     assert hb == hb2
     # out-of-band
-    if pickle.HIGHEST_PROTOCOL >= 5:
-        db = rmm.DeviceBuffer.to_device(hb)
-        buffers = []
-        pb2 = pickle.dumps(db, protocol=5, buffer_callback=buffers.append)
-        del db
-        assert len(buffers) == 1
-        assert isinstance(buffers[0], pickle.PickleBuffer)
-        assert bytes(buffers[0]) == hb
-        db3 = pickle.loads(pb2, buffers=buffers)
-        hb3 = db3.tobytes()
-        assert hb3 == hb
+    db = rmm.DeviceBuffer.to_device(hb)
+    buffers = []
+    pb2 = pickle.dumps(db, protocol=5, buffer_callback=buffers.append)
+    del db
+    assert len(buffers) == 1
+    assert isinstance(buffers[0], pickle.PickleBuffer)
+    assert bytes(buffers[0]) == hb
+    db3 = pickle.loads(pb2, buffers=buffers)
+    hb3 = db3.tobytes()
+    assert hb3 == hb
 
 
 @pytest.mark.parametrize("stream", [cuda.default_stream(), cuda.stream()])

--- a/python/rmm/tests/test_rmm.py
+++ b/python/rmm/tests/test_rmm.py
@@ -15,7 +15,7 @@
 import copy
 import gc
 import os
-import sys
+import pickle
 from itertools import product
 
 import numpy as np
@@ -24,14 +24,6 @@ from numba import cuda
 
 import rmm
 import rmm._cuda.stream
-
-if sys.version_info < (3, 8):
-    try:
-        import pickle5 as pickle
-    except ImportError:
-        import pickle
-else:
-    import pickle
 
 cuda.set_memory_manager(rmm.RMMNumbaManager)
 


### PR DESCRIPTION
## Description
This is a small cleanup PR to remove a pickle compatibility layer for Python < 3.8.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
