### PR TITLE
Test arbitrary artifact uploads

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,73 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-builder:
-    needs:
-      - checks
-      - conda-cpp-build
-      - conda-cpp-tests
-      - conda-python-build
-      - conda-python-tests
-      - docs-build
-      - wheel-build
-      - wheel-tests
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.04
-  checks:
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/checks.yaml@branch-23.04
-    with:
-      enable_check_generated_files: false
   conda-cpp-build:
-    needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@branch-23.04
+    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@artifacts-dir
     with:
       build_type: pull-request
-  conda-cpp-tests:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@branch-23.04
-    with:
-      build_type: pull-request
-  conda-python-build:
-    needs: conda-cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-build.yaml@branch-23.04
-    with:
-      build_type: pull-request
-  conda-python-tests:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@branch-23.04
-    with:
-      build_type: pull-request
-  docs-build:
-    needs: conda-python-build
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@branch-23.04
-    with:
-      build_type: pull-request
-      node_type: "gpu-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci:latest"
-      run_script: "ci/build_docs.sh"
-  wheel-build:
-    needs: checks
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@branch-23.04
-    with:
-      build_type: pull-request
-      package-dir: python
-      package-name: rmm
-      skbuild-configure-options: "-DRMM_BUILD_WHEELS=ON"
-      uses-setup-env-vars: false
-  wheel-tests:
-    needs: wheel-build
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@branch-23.04
-    with:
-      build_type: pull-request
-      package-name: rmm
-      test-unittest: "python -m pytest -v ./python/rmm/tests"
-      test-smoketest: "python ./ci/wheel_smoke_test.py"

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -15,3 +15,5 @@ wget \
 
 echo "file contents" > "${RAPIDS_ARTIFACTS_DIR}"/somefile.txt
 echo "more file contents" > "${RAPIDS_ARTIFACTS_DIR}"/another_file.txt
+
+exit 1

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -8,4 +8,10 @@ env | sort
 RAPIDS_ARTIFACTS_DIR=${RAPIDS_ARTIFACTS_DIR:-"${PWD}/artifacts"}
 mkdir -p "${RAPIDS_ARTIFACTS_DIR}"
 
+# Test latest script changes
+wget \
+  https://raw.githubusercontent.com/ajschmidt8/gha-tools/upload-artifacts-dir/tools/rapids-upload-artifacts-dir \
+  -O /usr/local/bin/rapids-upload-artifacts-dir
+
 echo "file contents" > "${RAPIDS_ARTIFACTS_DIR}"/somefile.txt
+echo "more file contents" > "${RAPIDS_ARTIFACTS_DIR}"/another_file.txt

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
-rapids-print-env
+env | sort
+
+RAPIDS_ARTIFACTS_DIR=${RAPIDS_ARTIFACTS_DIR:-"${PWD}/artifacts"}
+mkdir -p "${RAPIDS_ARTIFACTS_DIR}"
 
 echo "file contents" > "${RAPIDS_ARTIFACTS_DIR}"/somefile.txt

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -3,14 +3,6 @@
 
 set -euo pipefail
 
-source rapids-env-update
-
-export CMAKE_GENERATOR=Ninja
-
 rapids-print-env
 
-rapids-logger "Begin cpp build"
-
-rapids-mamba-retry mambabuild conda/recipes/librmm
-
-rapids-upload-conda-to-s3 cpp
+echo "file contents" > "${RAPIDS_ARTIFACTS_DIR}"/somefile.txt

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -8,12 +8,5 @@ env | sort
 RAPIDS_ARTIFACTS_DIR=${RAPIDS_ARTIFACTS_DIR:-"${PWD}/artifacts"}
 mkdir -p "${RAPIDS_ARTIFACTS_DIR}"
 
-# Test latest script changes
-wget \
-  https://raw.githubusercontent.com/ajschmidt8/gha-tools/upload-artifacts-dir/tools/rapids-upload-artifacts-dir \
-  -O /usr/local/bin/rapids-upload-artifacts-dir
-
 echo "file contents" > "${RAPIDS_ARTIFACTS_DIR}"/somefile.txt
 echo "more file contents" > "${RAPIDS_ARTIFACTS_DIR}"/another_file.txt
-
-exit 1


### PR DESCRIPTION
Do not merge.

This PR just tests a `shared-actions-workflow` [branch](https://github.com/rapidsai/shared-action-workflows/pull/51) which add supports for uploading arbitrary artifacts.