### PR TITLE
Add codespell as a linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,15 @@ repos:
                 (?x)^(
                   ^benchmarks/utilities/cxxopts.hpp
                 )
+    - repo: https://github.com/codespell-project/codespell
+      rev: v2.2.4
+      hooks:
+            - id: codespell
+              exclude: |
+                (?x)^(
+                  pyproject.toml|
+                  benchmarks/utilities/cxxopts.hpp
+                )
     - repo: local
       hooks:
             - id: cmake-format

--- a/benchmarks/synchronization/synchronization.hpp
+++ b/benchmarks/synchronization/synchronization.hpp
@@ -50,7 +50,7 @@
     }
 
     // Register the function as a benchmark. You will need to set the `UseManualTime()`
-    // flag in order to use the timer embeded in this class.
+    // flag in order to use the timer embedded in this class.
     BENCHMARK(sample_cuda_benchmark)->UseManualTime();
 
 

--- a/include/rmm/detail/stack_trace.hpp
+++ b/include/rmm/detail/stack_trace.hpp
@@ -39,7 +39,7 @@
 namespace rmm::detail {
 
 /**
- * @brief stack_trace is a class that will capture a stack on instatiation for output later.
+ * @brief stack_trace is a class that will capture a stack on instantiation for output later.
  * It can then be used in an output stream to display stack information.
  *
  * rmm::detail::stack_trace saved_stack;

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -58,7 +58,7 @@ struct crtp {
  * This base class uses CRTP (https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
  * to provide static polymorphism to enable defining suballocator resources that maintain separate
  * pools per stream. All of the stream-ordering logic is contained in this class, but the logic
- * to determine how memory pools are managed and the type of allocation is implented in a derived
+ * to determine how memory pools are managed and the type of allocation is implemented in a derived
  * class and in a free list class.
  *
  * For example, a coalescing pool memory resource uses a coalescing_free_list and maintains data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.codespell]
+# note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
+# this is only to allow you to run codespell interactively
+skip = "./pyproject.toml,./.git,./.github,./cpp/build,.*egg-info.*,./.mypy_cache,./benchmarks/utilities/cxxopts.hpp"
+# ignore short words, and typename parameters like OffsetT
+ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
+ignore-words-list = "inout"
+builtin = "clear"
+quiet-level = 3

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -438,7 +438,7 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
   buff.shrink_to_fit(rmm::cuda_stream_default);
   EXPECT_NE(nullptr, buff.data());
-  // A reallocation should have occured
+  // A reallocation should have occurred
   EXPECT_NE(old_data, buff.data());
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(buff.capacity(), buff.size());

--- a/tests/device_scalar_tests.cpp
+++ b/tests/device_scalar_tests.cpp
@@ -71,7 +71,7 @@ using Types = ::testing::Types<bool, int8_t, int16_t, int32_t, int64_t, float, d
 
 TYPED_TEST_CASE(DeviceScalarTest, Types);
 
-TYPED_TEST(DeviceScalarTest, Unitialized)
+TYPED_TEST(DeviceScalarTest, Uninitialized)
 {
   rmm::device_scalar<TypeParam> scalar{this->stream, this->mr};
   EXPECT_NE(nullptr, scalar.data());


### PR DESCRIPTION
## Description
Following the example of https://github.com/rapidsai/cudf/pull/12097, this PR adds [codespell](https://github.com/codespell-project/codespell) as a linter for rmm.

Note: I have not included a section in the CONTRIBUTING.md about how to use this (as was done in cudf's PR) because I plan to overhaul the contributing guides for all RAPIDS repos in the near term, and have a single source in docs.rapids.ai with common information about linters used in RAPIDS.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
