### PR TITLE
Remove MANIFEST.in use auto-generated one for sdists and package_data for wheels

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,7 +1,0 @@
-# Cython files
-recursive-include rmm *.pxd
-recursive-include rmm *.pyx
-
-# Build files. Don't use a recursive include on '.' in case the repo is dirty
-include . CMakeLists.txt
-recursive-include rmm CMakeLists.txt

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,8 +3,11 @@
 from setuptools import find_packages
 from skbuild import setup
 
+packages = find_packages(include=["rmm*"])
 setup(
-    packages=find_packages(include=["rmm*"]),
-    package_data={"": ["*.pxd", "*.pyx", "CMakeLists.txt"]},
+    packages=packages,
+    package_data={
+        key: ["*.pxd", "*.pyx", "CMakeLists.txt"] for key in packages
+    },
     zip_safe=False,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,5 +5,6 @@ from skbuild import setup
 
 setup(
     packages=find_packages(include=["rmm*"]),
+    package_data={"": ["*.pxd", "*.pyx", "CMakeLists.txt"]},
     zip_safe=False,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,8 +6,6 @@ from skbuild import setup
 packages = find_packages(include=["rmm*"])
 setup(
     packages=packages,
-    package_data={
-        key: ["*.pxd", "*.pyx", "CMakeLists.txt"] for key in packages
-    },
+    package_data={key: ["*.pxd"] for key in packages},
     zip_safe=False,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,10 +1,9 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION.
 
 from setuptools import find_packages
 from skbuild import setup
 
 setup(
-    packages=find_packages(include=["rmm", "rmm.*"]),
-    include_package_data=True,
+    packages=find_packages(include=["rmm*"]),
     zip_safe=False,
 )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Using MANIFEST.in currently runs into a pretty nasty scikit-build bug (https://github.com/scikit-build/scikit-build/issues/886) that results in any file included by the manifest being copied from the install tree back into the source tree whenever an in place build occurs after an install, overwriting any local changes. We need an alternative approach to ensure that all necessary files are included in built packages. There are two types:
- sdists: scikit-build automatically generates a manifest during sdist generation if we don't provide one, and that manifest is reliably complete. It contains all files needed for a source build up to the rmm C++ code (which has always been true and is something we can come back to improving later if desired).
- wheels: The autogenerated manifest is not used during wheel generation because the manifest generation hook is not invoked during wheel builds, so to include data in the wheels we must provide the `package_data` argument to `setup`. In this case we do not need to include CMake or pyx files because the result does not need to be possible to build from, it just needs pxd files for other packages to cimport if desired.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
