### PR TITLE
Stop setting package version attribute in wheels

### DIFF
--- a/ci/release/apply_wheel_modifications.sh
+++ b/ci/release/apply_wheel_modifications.sh
@@ -6,7 +6,6 @@
 VERSION=${1}
 CUDA_SUFFIX=${2}
 
-sed -i "s/__version__ = .*/__version__ = \"${VERSION}\"/g" python/rmm/__init__.py
 sed -i "s/^version = .*/version = \"${VERSION}\"/g" python/pyproject.toml
 
 sed -i "s/^name = \"rmm\"/name = \"rmm${CUDA_SUFFIX}\"/g" python/pyproject.toml


### PR DESCRIPTION
This PR removes modification of the `__init__.py::version` attribute that occurs during the wheel build process. See https://github.com/rapidsai/ops/issues/2592 for more information.
