### PR TITLE
Move RMM_LOGGING_ASSERT into separate header

### DIFF
--- a/include/rmm/cuda_stream.hpp
+++ b/include/rmm/cuda_stream.hpp
@@ -16,8 +16,10 @@
 
 #pragma once
 
+#include <functional>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/logging_assert.hpp>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <rmm/logger.hpp>
-
 #include <cuda_runtime_api.h>
 
 #include <cassert>
@@ -244,25 +242,4 @@ class out_of_range : public std::out_of_range {
     /* NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay) */   \
     assert(status__ == cudaSuccess);                                            \
   } while (0)
-#endif
-
-/**
- * @brief Assertion that logs a CRITICAL log message on failure.
- */
-#ifdef NDEBUG
-#define RMM_LOGGING_ASSERT(_expr) (void)0
-#elif SPDLOG_ACTIVE_LEVEL < SPDLOG_LEVEL_OFF
-#define RMM_LOGGING_ASSERT(_expr)                                                                 \
-  do {                                                                                            \
-    bool const success = (_expr);                                                                 \
-    if (!success) {                                                                               \
-      RMM_LOG_CRITICAL(                                                                           \
-        "[" __FILE__ ":" RMM_STRINGIFY(__LINE__) "] Assertion " RMM_STRINGIFY(_expr) " failed."); \
-      rmm::logger().flush();                                                                      \
-      /* NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay) */                   \
-      assert(success);                                                                            \
-    }                                                                                             \
-  } while (0)
-#else
-#define RMM_LOGGING_ASSERT(_expr) assert((_expr));
 #endif

--- a/include/rmm/detail/logging_assert.hpp
+++ b/include/rmm/detail/logging_assert.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Only include <rmm/logger.hpp> if needed in RMM_LOGGING_ASSERT below. The
+// logger can be extremely expensive to compile, so we want to avoid including
+// it.
+#if !defined(NDEBUG)
+#include <cassert>
+#include <rmm/detail/error.hpp>
+#include <rmm/logger.hpp>
+#endif
+
+/**
+ * @brief Assertion that logs a CRITICAL log message on failure.
+ */
+#ifdef NDEBUG
+#define RMM_LOGGING_ASSERT(_expr) (void)0
+#elif SPDLOG_ACTIVE_LEVEL < SPDLOG_LEVEL_OFF
+#define RMM_LOGGING_ASSERT(_expr)                                                                 \
+  do {                                                                                            \
+    bool const success = (_expr);                                                                 \
+    if (!success) {                                                                               \
+      RMM_LOG_CRITICAL(                                                                           \
+        "[" __FILE__ ":" RMM_STRINGIFY(__LINE__) "] Assertion " RMM_STRINGIFY(_expr) " failed."); \
+      rmm::logger().flush();                                                                      \
+      /* NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay) */                   \
+      assert(success);                                                                            \
+    }                                                                                             \
+  } while (0)
+#else
+#define RMM_LOGGING_ASSERT(_expr) assert((_expr));
+#endif

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/device/detail/arena.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -20,6 +20,7 @@
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/cuda_util.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 
 #include <cuda_runtime_api.h>

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -18,6 +18,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/logging_assert.hpp>
 #include <rmm/mr/device/detail/fixed_size_free_list.hpp>
 #include <rmm/mr/device/detail/stream_ordered_memory_resource.hpp>
 

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -19,6 +19,7 @@
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/cuda_util.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/device/detail/coalescing_free_list.hpp>
 #include <rmm/mr/device/detail/stream_ordered_memory_resource.hpp>

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -17,6 +17,7 @@
 
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/stack_trace.hpp>
+#include <rmm/logger.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <fmt/core.h>

--- a/tests/mr/device/tracking_mr_tests.cpp
+++ b/tests/mr/device/tracking_mr_tests.cpp
@@ -19,6 +19,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/logger.hpp>
 #include <rmm/mr/device/tracking_resource_adaptor.hpp>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
The inclusion of `rmm/logger.hpp` can increase compile times significantly. Before this PR, `rmm/logger.hpp` was included in `rmm/error.hpp` which by necessity was included almost everywhere. This PR moves `RMM_LOGGING_ASSERT` into its own header, thereby drastically cutting down on the headers which transitively include `rmm/logger.hpp`. 

This PR will make it possible to [reduce compile times](https://github.com/rapidsai/raft/issues/1300#issuecomment-1460047077) of RAFT by ~10 seconds per translation unit. 

## Description
Related to issue #1222 and also PR #1232. Compared to #1232, this PR might make it able to also have fast builds without precompiling spdlog. 

I include a table below showing which headers transitively include `rmm/logger.hpp` before and after PR (in debug and release builds). These are the rmm headers used by RAFT.

| Header                                              | Before         | After          |
|-----------------------------------------------------|----------------|----------------|
| rmm/cuda_device.hpp                                 | debug  release |                |
| rmm/cuda_stream.hpp                                 | debug  release | debug          |
| rmm/cuda_stream_pool.hpp                            | debug  release | debug          |
| rmm/cuda_stream_view.hpp                            | debug  release |                |
| rmm/device_buffer.hpp                               | debug  release |                |
| rmm/device_scalar.hpp                               | debug  release |                |
| rmm/device_uvector.hpp                              | debug  release |                |
| rmm/device_vector.hpp                               | debug  release |                |
| rmm/exec_policy.hpp                                 | debug  release |                |
| rmm/logger.hpp                                      | debug  release | debug  release |
| rmm/mr/device/aligned_resource_adaptor.hpp          | debug  release |                |
| rmm/mr/device/arena_memory_resource.hpp             | debug  release | debug  release |
| rmm/mr/device/binning_memory_resource.hpp           | debug  release | debug  release |
| rmm/mr/device/callback_memory_resource.hpp          | debug  release |                |
| rmm/mr/device/cuda_async_memory_resource.hpp        | debug  release |                |
| rmm/mr/device/cuda_async_view_memory_resource.hpp   | debug  release |                |
| rmm/mr/device/cuda_memory_resource.hpp              | debug  release |                |
| rmm/mr/device/device_memory_resource.hpp            | debug  release |                |
| rmm/mr/device/failure_callback_resource_adaptor.hpp | debug  release |                |
| rmm/mr/device/fixed_size_memory_resource.hpp        | debug  release | debug  release |
| rmm/mr/device/limiting_resource_adaptor.hpp         | debug  release |                |
| rmm/mr/device/logging_resource_adaptor.hpp          | debug  release | debug  release |
| rmm/mr/device/managed_memory_resource.hpp           | debug  release |                |
| rmm/mr/device/owning_wrapper.hpp                    | debug  release |                |
| rmm/mr/device/per_device_resource.hpp               | debug  release |                |
| rmm/mr/device/polymorphic_allocator.hpp             | debug  release |                |
| rmm/mr/device/pool_memory_resource.hpp              | debug  release | debug  release |
| rmm/mr/device/statistics_resource_adaptor.hpp       | debug  release |                |
| rmm/mr/device/thread_safe_resource_adaptor.hpp      | debug  release |                |
| rmm/mr/device/thrust_allocator_adaptor.hpp          | debug  release |                |
| rmm/mr/device/tracking_resource_adaptor.hpp         | debug  release | debug  release |
| rmm/mr/host/host_memory_resource.hpp                |                |                |
| rmm/mr/host/new_delete_resource.hpp                 |                |                |
| rmm/mr/host/pinned_memory_resource.hpp              | debug  release |                |

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
