### PR TITLE
Remove uses-setup-env-vars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,6 @@ jobs:
       package-name: rmm
       package-dir: python
       skbuild-configure-options: "-DRMM_BUILD_WHEELS=ON"
-      uses-setup-env-vars: false
   wheel-publish:
     needs: wheel-build
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,7 +70,6 @@ jobs:
       package-dir: python
       package-name: rmm
       skbuild-configure-options: "-DRMM_BUILD_WHEELS=ON"
-      uses-setup-env-vars: false
   wheel-tests:
     needs: wheel-build
     secrets: inherit


### PR DESCRIPTION
This setting now matches the default behavior of the shared-action-workflows repo
