### PR TITLE
run docs builds nightly too

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,12 +53,12 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
   docs-build:
-    if: github.ref_type == 'branch' && github.event_name == 'push'
+    if: github.ref_type == 'branch'
     needs: python-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@py-39
     with:
-      build_type: branch
+      build_type: ${{ inputs.build_type || 'branch' }}
       node_type: "gpu-v100-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci:latest"

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -39,7 +39,7 @@ sphinx-build -b dirhtml . _html
 sphinx-build -b text . _text
 popd
 
-if [[ "${RAPIDS_BUILD_TYPE}" == "branch" ]]; then
+if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
   rapids-logger "Upload Docs to S3"
   aws s3 sync --no-progress --delete doxygen/html "s3://rapidsai-docs/librmm/${VERSION_NUMBER}/html"
   aws s3 sync --no-progress --delete python/docs/_html "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/html"


### PR DESCRIPTION
This PR configures `rmm` docs builds to also run nightly (not just on PR merges only)

