### PR TITLE
Enable sccache hits from local builds

### DIFF
--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -46,6 +46,7 @@ build:
     - SCCACHE_S3_KEY_PREFIX=librmm-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=librmm-linux64 # [linux64]
     - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
 
 outputs:
   - name: librmm

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -30,6 +30,7 @@ build:
     - SCCACHE_S3_KEY_PREFIX=rmm-aarch64 # [aarch64]
     - SCCACHE_S3_KEY_PREFIX=rmm-linux64 # [linux64]
     - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
   ignore_run_exports_from:
     - {{ compiler('cuda') }}
 


### PR DESCRIPTION
This change passes through the value of `SCCACHE_S3_NO_CREDENTIALS` to our `conda` builds, enabling devs to utilize the `sccache` cache that's populated by CI when they are reproducing build issues locally as per [these](https://docs.rapids.ai/resources/reproducing-ci/) instructions.