### PR TITLE
Pin to scikit-build<0.17.2.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - pytest
 - pytest-cov
 - python>=3.9,<3.11
-- scikit-build>=0.13.1
+- scikit-build>=0.13.1,<0.17.2
 - spdlog>=1.11.0,<1.12
 - tomli
 name: all_cuda-118_arch-x86_64

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - cython >=0.29,<0.30
     - librmm ={{ version }}
     - python
-    - scikit-build >=0.13.1
+    - scikit-build >=0.13.1,<0.17.2
     - setuptools >=61.0.0
     - tomli  # [py<311]
   run:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -65,7 +65,7 @@ dependencies:
           - &cuda_python cuda-python>=11.7.1,<12.0
           - cython>=0.29,<0.30
           - ninja
-          - scikit-build>=0.13.1
+          - scikit-build>=0.13.1,<0.17.2
           - tomli
       - output_types: conda
         packages:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,7 @@ requires = [
     "cuda-python>=11.7.1,<12.0",
     "cython>=0.29,<0.30",
     "ninja",
-    "scikit-build>=0.13.1",
+    "scikit-build>=0.13.1,<0.17.2",
     "setuptools>=61.0.0",
     "tomli",
     "wheel",


### PR DESCRIPTION
## Description
Wheel builds are failing because of a recent update to scikit-build. See related PR: https://github.com/rapidsai/cudf/pull/13188

Blocks #1259.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
