### PR TITLE
Update recipes to GTest version >=1.13.0

### DIFF
--- a/conda/recipes/librmm/conda_build_config.yaml
+++ b/conda/recipes/librmm/conda_build_config.yaml
@@ -14,7 +14,7 @@ fmt_version:
   - ">=9.1.0,<10"
 
 gtest_version:
-  - "=1.10.0"
+  - ">=1.13.0"
 
 spdlog_version:
   - ">=1.11.0,<1.12"

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -29,6 +29,8 @@ requirements:
     # added as a run requirement via the packages' run_exports.
     - fmt {{ fmt_version }}
     - spdlog {{ spdlog_version }}
+    - gtest {{ gtest_version }}
+    - gmock {{ gtest_version }}
 
 build:
   script_env:


### PR DESCRIPTION
This PR updates GTest pinnings to >=1.13.0. This aligns with recent changes in rapids-cmake: https://github.com/rapidsai/rapids-cmake/pull/401.
