### PR TITLE
Use cuda-version to pin cudatoolkit.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -6,7 +6,8 @@ channels:
 dependencies:
 - cmake>=3.23.1,!=3.25.0
 - cuda-python>=11.7.1,<12.0
-- cudatoolkit=11.8
+- cuda-version=11.8
+- cudatoolkit
 - cython>=0.29,<0.30
 - fmt>=9.1.0,<10
 - gcovr>=5.0

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -21,7 +21,8 @@ requirements:
     - {{ compiler('cuda') }} {{ cuda_version }}
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
-    - cudatoolkit ={{ cuda_version }}
+    - cuda-version ={{ cuda_version }}
+    - cudatoolkit
     # We require spdlog and fmt (which was devendored from spdlog
     # conda-forge packages in 1.11.0) so that the spdlog headers are not
     # pulled by CPM and installed as a part of the rmm packages. However,
@@ -65,7 +66,8 @@ outputs:
       build:
         - cmake {{ cmake_version }}
       run:
-        - cudatoolkit {{ cuda_spec }}
+        - cuda-version {{ cuda_spec }}
+        - cudatoolkit
         - fmt {{ fmt_version }}
         - spdlog {{ spdlog_version }}
     test:
@@ -118,7 +120,8 @@ outputs:
       build:
         - cmake {{ cmake_version }}
       run:
-        - cudatoolkit {{ cuda_spec }}
+        - cuda-version {{ cuda_spec }}
+        - cudatoolkit
         - {{ pin_subpackage('librmm', exact=True) }}
         - gtest {{ gtest_version }}
         - gmock {{ gtest_version }}

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -44,7 +44,8 @@ requirements:
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cuda-python >=11.7.1,<12.0
-    - cudatoolkit ={{ cuda_version }}
+    - cuda-version ={{ cuda_version }}
+    - cudatoolkit
     - cython >=0.29,<0.30
     - librmm ={{ version }}
     - python

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -88,23 +88,28 @@ dependencies:
           - matrix:
               cuda: "11.2"
             packages:
-              - cudatoolkit=11.2
+              - cuda-version=11.2
+              - cudatoolkit
           - matrix:
               cuda: "11.4"
             packages:
-              - cudatoolkit=11.4
+              - cuda-version=11.4
+              - cudatoolkit
           - matrix:
               cuda: "11.5"
             packages:
-              - cudatoolkit=11.5
+              - cuda-version=11.5
+              - cudatoolkit
           - matrix:
               cuda: "11.6"
             packages:
-              - cudatoolkit=11.6
+              - cuda-version=11.6
+              - cudatoolkit
           - matrix:
               cuda: "11.8"
             packages:
-              - cudatoolkit=11.8
+              - cuda-version=11.8
+              - cudatoolkit
   develop:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
This PR uses the `cuda-version` package to pin `cudatoolkit`. The `cuda-version` package was created to help with packaging CUDA 12 for conda-forge, and has been backported to support earlier CUDA versions. This pinning helps smooth the transition to supporting CUDA 12 in RAPIDS conda packages.
