### PR TITLE
Tests changes in `auditwheel_use_env_var` branch of `shared-action-workflows` repo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
       run_script: "ci/build_docs.sh"
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@auditwheel_use_env_var
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,7 +64,7 @@ jobs:
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@auditwheel_use_env_var
     with:
       build_type: pull-request
       package-dir: python


### PR DESCRIPTION
## Description

Tests changes in `auditwheel_use_env_var` branch of `shared-action-workflows` repo to ensure auditwheel changes work as expected.

This tests the changes in https://github.com/rapidsai/shared-action-workflows/pull/99 , which closes https://github.com/rapidsai/shared-action-workflows/issues/80

_Note: this PR is in `Draft` because it requires https://github.com/rapidsai/cibuildwheel-imgs/pull/20 to be merged and the relevant CI image updated before it can pass._

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
