### PR TITLE
Ensure Logger tests aren't run in parallel

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,7 +77,7 @@ endfunction()
 # stream
 function(ConfigureTest TEST_NAME)
 
-  set(options NOT_PARALLEL_SAFE)
+  set(options)
   set(one_value GPUS PERCENT)
   set(multi_value)
   cmake_parse_arguments(_RMM_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
@@ -90,11 +90,6 @@ function(ConfigureTest TEST_NAME)
   endif()
   if(NOT DEFINED _RMM_TEST_PERCENT)
     set(_RMM_TEST_PERCENT 100)
-  endif()
-
-  set(_RAPIDS_GPU_ALLOCATION)
-  if(NOT _RMM_TEST_NOT_PARALLEL_SAFE)
-  set(_RAPIDS_GPU_ALLOCATION "GPUS" ${_RMM_TEST_GPUS} "PERCENT" ${_RMM_TEST_PERCENT})
   endif()
 
   # Test with legacy default stream.
@@ -114,7 +109,8 @@ function(ConfigureTest TEST_NAME)
     rapids_test_add(
       NAME ${name}
       COMMAND ${TEST_NAME}
-      ${_RAPIDS_GPU_ALLOCATION}
+      GPUS ${_RMM_TEST_GPUS}
+      PERCENT ${_RMM_TEST_PERCENT}
       INSTALL_COMPONENT_SET testing)
   endforeach()
 
@@ -172,7 +168,7 @@ ConfigureTest(DEVICE_BUFFER_TEST device_buffer_tests.cu)
 ConfigureTest(DEVICE_SCALAR_TEST device_scalar_tests.cpp)
 
 # logger tests
-ConfigureTest(LOGGER_TEST logger_tests.cpp NOT_PARALLEL_SAFE)
+ConfigureTest(LOGGER_TEST logger_tests.cpp)
 
 # uvector tests
 ConfigureTest(DEVICE_UVECTOR_TEST device_uvector_tests.cpp GPUS 1 PERCENT 60)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,7 +77,7 @@ endfunction()
 # stream
 function(ConfigureTest TEST_NAME)
 
-  set(options)
+  set(options NOT_PARALLEL_SAFE)
   set(one_value GPUS PERCENT)
   set(multi_value)
   cmake_parse_arguments(_RMM_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
@@ -90,6 +90,11 @@ function(ConfigureTest TEST_NAME)
   endif()
   if(NOT DEFINED _RMM_TEST_PERCENT)
     set(_RMM_TEST_PERCENT 100)
+  endif()
+
+  set(_RAPIDS_GPU_ALLOCATION)
+  if(NOT _RMM_TEST_NOT_PARALLEL_SAFE)
+  set(_RAPIDS_GPU_ALLOCATION "GPUS" ${_RMM_TEST_GPUS} "PERCENT" ${_RMM_TEST_PERCENT})
   endif()
 
   # Test with legacy default stream.
@@ -109,8 +114,7 @@ function(ConfigureTest TEST_NAME)
     rapids_test_add(
       NAME ${name}
       COMMAND ${TEST_NAME}
-      GPUS ${_RMM_TEST_GPUS}
-      PERCENT ${_RMM_TEST_PERCENT}
+      ${_RAPIDS_GPU_ALLOCATION}
       INSTALL_COMPONENT_SET testing)
   endforeach()
 
@@ -168,7 +172,7 @@ ConfigureTest(DEVICE_BUFFER_TEST device_buffer_tests.cu)
 ConfigureTest(DEVICE_SCALAR_TEST device_scalar_tests.cpp)
 
 # logger tests
-ConfigureTest(LOGGER_TEST logger_tests.cpp)
+ConfigureTest(LOGGER_TEST logger_tests.cpp NOT_PARALLEL_SAFE)
 
 # uvector tests
 ConfigureTest(DEVICE_UVECTOR_TEST device_uvector_tests.cpp GPUS 1 PERCENT 60)

--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -50,10 +50,10 @@ class raii_restore_env {
     }
   }
 
-  raii_restore_env(raii_restore_env const&)            = default;
+  raii_restore_env(raii_restore_env const&) = default;
   raii_restore_env& operator=(raii_restore_env const&) = default;
   raii_restore_env(raii_restore_env&&)                 = default;
-  raii_restore_env& operator=(raii_restore_env&&)      = default;
+  raii_restore_env& operator=(raii_restore_env&&) = default;
 
  private:
   std::string name_{};
@@ -62,19 +62,16 @@ class raii_restore_env {
 };
 
 class raii_temp_directory {
-public:
+ public:
   raii_temp_directory()
   {
-    directory_path_ = std::filesystem::temp_directory_path();
+    directory_path_             = std::filesystem::temp_directory_path();
     std::string unique_dir_name = "rmm_XXXXXX";
-    auto const ptr = mkdtemp(const_cast<char*>(unique_dir_name.data()));
-    EXPECT_TRUE( (ptr!=nullptr) );
+    auto const ptr              = mkdtemp(const_cast<char*>(unique_dir_name.data()));
+    EXPECT_TRUE((ptr != nullptr));
     directory_path_ /= unique_dir_name;
   }
-  ~raii_temp_directory()
-  {
-     std::filesystem::remove_all(directory_path_);
-  }
+  ~raii_temp_directory() { std::filesystem::remove_all(directory_path_); }
 
   raii_temp_directory& operator=(raii_temp_directory const&) = delete;
   raii_temp_directory(raii_temp_directory const&)            = delete;
@@ -83,7 +80,8 @@ public:
   {
     return directory_path_ / filename;
   }
-private:
+
+ private:
   std::filesystem::path directory_path_{};
 };
 

--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -50,10 +50,10 @@ class raii_restore_env {
     }
   }
 
-  raii_restore_env(raii_restore_env const&) = default;
+  raii_restore_env(raii_restore_env const&)            = default;
   raii_restore_env& operator=(raii_restore_env const&) = default;
   raii_restore_env(raii_restore_env&&)                 = default;
-  raii_restore_env& operator=(raii_restore_env&&) = default;
+  raii_restore_env& operator=(raii_restore_env&&)      = default;
 
  private:
   std::string name_{};


### PR DESCRIPTION
## Description
The logger tests all read and write to the same temporary files so we extend the tests to generate temporary directories to write the files. This will ensure that concurrent execution of the logger test variants is supported.

Due to the current limitations of rapids-cmake in 23.06 we can't use the `SERIAL` or `RESOURCE_LOCK` functions of CTest
to instead limit execution to be serial.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
