### PR TITLE
Remove now-deprecated top-level allocator functions

### DIFF
--- a/python/rmm/__init__.py
+++ b/python/rmm/__init__.py
@@ -37,31 +37,3 @@ __all__ = [
 ]
 
 __version__ = "23.08.00"
-
-
-_deprecated_names = {
-    "rmm_cupy_allocator": "cupy",
-    "rmm_torch_allocator": "torch",
-    "RMMNumbaManager": "numba",
-    "_numba_memory_manager": "numba",
-}
-
-
-def __getattr__(name):
-    if name in _deprecated_names:
-        import importlib
-        import warnings
-
-        package = _deprecated_names[name]
-        warnings.warn(
-            f"Use of 'rmm.{name}' is deprecated and will be removed. "
-            f"'{name}' now lives in the 'rmm.allocators.{package}' sub-module, "
-            "please update your imports.",
-            FutureWarning,
-        )
-        module = importlib.import_module(
-            f".allocators.{package}", package=__name__
-        )
-        return getattr(module, name)
-    else:
-        raise AttributeError(f"Module '{__name__}' has no attribute '{name}'")


### PR DESCRIPTION
## Description

We deprecated these functions in 23.04, so there will have been two
releases with deprecation warnings.

Closes #1225.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
