### PR TITLE
use rapids-upload-docs script

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -19,29 +19,29 @@ rapids-print-env
 rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
-VERSION_NUMBER="23.08"
 
 rapids-mamba-retry install \
   --channel "${CPP_CHANNEL}" \
   --channel "${PYTHON_CHANNEL}" \
   rmm librmm
 
-# Build CPP docs
-rapids-logger "Build Doxygen docs"
+export RAPIDS_VERSION_NUMBER="23.08"
+export RAPIDS_DOCS_DIR="$(mktemp -d)"
+
+rapids-logger "Build CPP docs"
 pushd doxygen
 doxygen Doxyfile
+mkdir -p "${RAPIDS_DOCS_DIR}/librmm/html"
+mv html/* "${RAPIDS_DOCS_DIR}/librmm/html"
 popd
 
-# Build Python docs
 rapids-logger "Build Python docs"
 pushd python/docs
 sphinx-build -b dirhtml . _html
 sphinx-build -b text . _text
+mkdir -p "${RAPIDS_DOCS_DIR}/rmm/"{html,txt}
+mv _html/* "${RAPIDS_DOCS_DIR}/rmm/html"
+mv _text/* "${RAPIDS_DOCS_DIR}/rmm/txt"
 popd
 
-if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
-  rapids-logger "Upload Docs to S3"
-  aws s3 sync --no-progress --delete doxygen/html "s3://rapidsai-docs/librmm/${VERSION_NUMBER}/html"
-  aws s3 sync --no-progress --delete python/docs/_html "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/html"
-  aws s3 sync --no-progress --delete python/docs/_text "s3://rapidsai-docs/rmm/${VERSION_NUMBER}/txt"
-fi
+rapids-upload-docs

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -53,4 +53,4 @@ sed_runner 's/'"release =.*"'/'"release = \"${NEXT_FULL_TAG}\""'/g' python/docs/
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done
-sed_runner "s/VERSION_NUMBER=\".*/VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh
+sed_runner "s/RAPIDS_VERSION_NUMBER=\".*/RAPIDS_VERSION_NUMBER=\"${NEXT_SHORT_TAG}\"/g" ci/build_docs.sh


### PR DESCRIPTION
This PR updates the `build_docs.sh` script to use the new consolidatory `rapids-upload-script` [shared script](https://github.com/rapidsai/gha-tools/pull/56). 

The shared script enables docs uploads to applicable S3 buckets for branch. nightly and PR builds.