### PR TITLE
Ensure logger tests don't generate temp directories in build dir

### DIFF
--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -65,11 +65,11 @@ class raii_temp_directory {
  public:
   raii_temp_directory()
   {
-    directory_path_             = std::filesystem::temp_directory_path();
-    std::string unique_dir_name = "rmm_XXXXXX";
-    auto const ptr              = mkdtemp(const_cast<char*>(unique_dir_name.data()));
+    std::string random_path{std::filesystem::temp_directory_path().string()};
+    random_path += "/rmm_XXXXXX";
+    auto const ptr = mkdtemp(const_cast<char*>(random_path.data()));
     EXPECT_TRUE((ptr != nullptr));
-    directory_path_ /= unique_dir_name;
+    directory_path_ = std::filesystem::path{random_path};
   }
   ~raii_temp_directory() { std::filesystem::remove_all(directory_path_); }
 


### PR DESCRIPTION
## Description
Corrects a bug introduced in #1277 which caused the logger tests to construct temporary directories in the build directory ( that never go deleted ).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
