### PR TITLE
Use rapids_init_cuda_runtime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,15 @@ project(
 # Write the version header
 rapids_cmake_write_version_file(include/rmm/version_config.hpp)
 
+# ##################################################################################################
+# * build type -------------------------------------------------------------------------------------
+
 # Set a default build type if none was specified
 rapids_cmake_build_type(Release)
 
-# build options
+# ##################################################################################################
+# * build options ----------------------------------------------------------------------------------
+
 option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 set(RMM_LOGGING_LEVEL
@@ -52,17 +57,31 @@ message(STATUS "RMM: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'")
 # cudart can be statically linked or dynamically linked the python ecosystem wants dynamic linking
 option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
 
+# ##################################################################################################
+# * compiler options -------------------------------------------------------------------------------
+
+# CUDA runtime
+rapids_cuda_init_runtime(USE_STATIC ${CUDA_STATIC_RUNTIME})
+
 # find packages we depend on
 rapids_find_package(
   CUDAToolkit REQUIRED
   BUILD_EXPORT_SET rmm-exports
   INSTALL_EXPORT_SET rmm-exports)
+
+# ##################################################################################################
+# * dependencies -----------------------------------------------------------------------------------
+
+# add third party dependencies using CPM
 rapids_cpm_init()
+
 include(cmake/thirdparty/get_fmt.cmake)
 include(cmake/thirdparty/get_spdlog.cmake)
 include(cmake/thirdparty/get_thrust.cmake)
 
-# library targets
+# ##################################################################################################
+# * library targets --------------------------------------------------------------------------------
+
 add_library(rmm INTERFACE)
 add_library(rmm::rmm ALIAS rmm)
 
@@ -71,10 +90,7 @@ target_include_directories(rmm INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOUR
 
 if(CUDA_STATIC_RUNTIME)
   message(STATUS "RMM: Enabling static linking of cudart")
-  target_link_libraries(rmm INTERFACE CUDA::cudart_static)
   target_compile_definitions(rmm INTERFACE RMM_STATIC_CUDART)
-else()
-  target_link_libraries(rmm INTERFACE CUDA::cudart)
 endif()
 
 target_link_libraries(rmm INTERFACE rmm::Thrust)
@@ -82,6 +98,9 @@ target_link_libraries(rmm INTERFACE fmt::fmt-header-only)
 target_link_libraries(rmm INTERFACE spdlog::spdlog_header_only)
 target_link_libraries(rmm INTERFACE dl)
 target_compile_features(rmm INTERFACE cxx_std_17 $<BUILD_INTERFACE:cuda_std_17>)
+
+# ##################################################################################################
+# * tests and benchmarks ---------------------------------------------------------------------------
 
 if((BUILD_TESTS OR BUILD_BENCHMARKS) AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   include(rapids-cuda)
@@ -94,7 +113,9 @@ if((BUILD_TESTS OR BUILD_BENCHMARKS) AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAM
   message(STATUS "RMM: Building benchmarks with GPU Architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 endif()
 
-# optionally build tests
+# ##################################################################################################
+# * add tests --------------------------------------------------------------------------------------
+
 if(BUILD_TESTS AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   include(cmake/thirdparty/get_gtest.cmake)
   include(CTest) # calls enable_testing()
@@ -102,19 +123,19 @@ if(BUILD_TESTS AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   add_subdirectory(tests)
 endif()
 
-# optionally build benchmarks
+# ##################################################################################################
+# * add benchmarks ---------------------------------------------------------------------------------
+
 if(BUILD_BENCHMARKS AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   include(${rapids-cmake-dir}/cpm/gbench.cmake)
   rapids_cpm_gbench()
   add_subdirectory(benchmarks)
 endif()
 
-include(CPack)
+# ##################################################################################################
+# * install targets --------------------------------------------------------------------------------
 
-# optionally assemble Thrust pretty-printers
-if(Thrust_SOURCE_DIR)
-  configure_file(scripts/load-pretty-printers.in load-pretty-printers @ONLY)
-endif()
+include(CPack)
 
 # install export targets
 install(TARGETS rmm EXPORT rmm-exports)
@@ -147,7 +168,9 @@ rapids_export(
   DOCUMENTATION doc_string
   FINAL_CODE_BLOCK code_string)
 
-# build export targets
+# ##################################################################################################
+# * build export -----------------------------------------------------------------------------------
+
 rapids_export(
   BUILD rmm
   EXPORT_SET rmm-exports
@@ -156,7 +179,8 @@ rapids_export(
   DOCUMENTATION doc_string
   FINAL_CODE_BLOCK code_string)
 
-# make documentation
+# ##################################################################################################
+# * make documentation -----------------------------------------------------------------------------
 
 add_custom_command(
   OUTPUT RMM_DOXYGEN
@@ -169,3 +193,11 @@ add_custom_target(
   rmm_doc
   DEPENDS RMM_DOXYGEN
   COMMENT "Target for the custom command to build the RMM doxygen docs")
+
+# ##################################################################################################
+# * make gdb helper scripts ------------------------------------------------------------------------
+
+# optionally assemble Thrust pretty-printers
+if(Thrust_SOURCE_DIR)
+  configure_file(scripts/load-pretty-printers.in load-pretty-printers @ONLY)
+endif()


### PR DESCRIPTION
## Description
This PR updates rmm to use `rapids_init_cuda_runtime`. I also added section headers to the CMakeLists.txt to mirror other RAPIDS packages, which makes it easier to follow the logic and compare across packages.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
