### PR TITLE
Add a missing '#include <array>' in logger.hpp

### DIFF
--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -21,6 +21,7 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
 
+#include <array>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
For `std::array units{...}`.

Cropped up in https://github.com/conan-io/conan-center-index/pull/17671.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
