### PR TITLE
Use cuda-version to constrain cudatoolkit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,7 @@ RMM can be installed with Conda ([miniconda](https://conda.io/miniconda.html), o
 [Anaconda distribution](https://www.anaconda.com/download)) from the `rapidsai` channel:
 
 ```bash
-# for CUDA 11.5
-conda install -c rapidsai -c conda-forge -c nvidia \
-    rmm cudatoolkit=11.5
-# for CUDA 11.2
-conda install -c rapidsai -c conda-forge -c nvidia \
-    rmm cudatoolkit=11.2
+conda install -c rapidsai -c conda-forge -c nvidia rmm cuda-version=11.8
 ```
 
 We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -6,7 +6,8 @@ channels:
 dependencies:
 - cmake>=3.26.4
 - cuda-python>=11.7.1,<12.0a0
-- cudatoolkit=11.8
+- cuda-version=11.8
+- cudatoolkit
 - cython>=0.29,<0.30
 - fmt>=9.1.0,<10
 - gcovr>=5.0

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -73,7 +73,7 @@ outputs:
         - cmake {{ cmake_version }}
       run:
         {% if cuda_major == "11" %}
-        - cudatoolkit {{ cuda_spec }}
+        - cudatoolkit
         {% endif %}
         - cuda-version {{ cuda_spec }}
         - fmt {{ fmt_version }}
@@ -132,13 +132,13 @@ outputs:
       host:
         - cuda-version ={{ cuda_version }}
         {% if cuda_major == "11" %}
-        - cudatoolkit ={{ cuda_version }}
+        - cudatoolkit
         {% else %}
         - cuda-cudart-dev
         {% endif %}
       run:
         {% if cuda_major == "11" %}
-        - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+        - cudatoolkit
         {% endif %}
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         - {{ pin_subpackage('librmm', exact=True) }}

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -52,7 +52,7 @@ requirements:
   host:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}
-    - cudatoolkit ={{ cuda_version }}
+    - cudatoolkit
     - cuda-python ==11.7.1
     {% else %}
     - cuda-cudart-dev
@@ -66,7 +66,7 @@ requirements:
     - tomli  # [py<311]
   run:
     {% if cuda_major == "11" %}
-    - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
+    - cudatoolkit
     {% endif %}
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     - numba >=0.57

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -114,23 +114,28 @@ dependencies:
           - matrix:
               cuda: "11.2"
             packages:
-              - cudatoolkit=11.2
+              - cuda-version=11.2
+              - cudatoolkit
           - matrix:
               cuda: "11.4"
             packages:
-              - cudatoolkit=11.4
+              - cuda-version=11.4
+              - cudatoolkit
           - matrix:
               cuda: "11.5"
             packages:
-              - cudatoolkit=11.5
+              - cuda-version=11.5
+              - cudatoolkit
           - matrix:
               cuda: "11.6"
             packages:
-              - cudatoolkit=11.6
+              - cuda-version=11.6
+              - cudatoolkit
           - matrix:
               cuda: "11.8"
             packages:
-              - cudatoolkit=11.8
+              - cuda-version=11.8
+              - cudatoolkit
           - matrix:
               cuda: "12.0"
             packages:


### PR DESCRIPTION
## Description
This PR changes CUDA 11 packaging to rely on `cuda-version` pinnings to constrain the installed version of `cudatoolkit`.

See also: https://github.com/rapidsai/cudf/pull/13615

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
