### PR TITLE
Switch to new CI wheel building pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yml@local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yml@feat/local-test
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yaml@feat/local-test
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
       run_script: "ci/build_docs.sh"
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@branch-23.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -78,7 +78,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yaml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yaml@branch-23.08
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,11 +74,11 @@ jobs:
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
-      build_script: ci/build_wheel.sh
+      script: ci/build_wheel.sh
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-publish.yml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yml@local-test
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
       run_script: "ci/build_docs.sh"
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yml@feat/local-test
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
       run_script: "ci/build_docs.sh"
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@feat/local-test
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -79,7 +79,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yml@local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yml@feat/local-test
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -73,7 +73,7 @@ jobs:
   wheel-tests:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@local-test
     with:
       build_type: pull-request
       package-name: rmm

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -67,10 +67,22 @@ jobs:
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@branch-23.08
     with:
       build_type: pull-request
-      build_script: ci/build_wheel.sh
+      script: ci/build_wheel.sh
   wheel-tests:
     needs: wheel-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@feat/local-test
     with:
       build_type: pull-request
+      script: ci/test_wheel.sh
+  #       WARNING: REMOVE THIS WHEN SWITCHING BACK TO THE MAIN BRANCH AND MERGING THIS PR.
+  wheel-publish:
+    needs: wheel-build
+    secrets: inherit
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yml@local-test
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: rmm

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,7 +64,7 @@ jobs:
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@feat/local-test
     with:
       build_type: pull-request
       script: ci/build_wheel.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,7 +83,7 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yaml@feat/local-test
     with:
-      build_type: pull-request
+      build_type: ${{ inputs.build_type || 'pull-request' }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -73,9 +73,6 @@ jobs:
   wheel-tests:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@feat/local-test
     with:
       build_type: pull-request
-      package-name: rmm
-      test-unittest: "python -m pytest ./python/rmm/tests"
-      test-smoketest: "python ./ci/wheel_smoke_test.py"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,6 +20,8 @@ jobs:
       - docs-build
       - wheel-build
       - wheel-tests
+  #       WARNING: REMOVE THIS WHEN SWITCHING BACK TO THE MAIN BRANCH AND MERGING THIS PR.
+      - wheel-publish
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.08
   checks:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -79,7 +79,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yaml@feat/local-test
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -73,6 +73,6 @@ jobs:
   wheel-tests:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@feat/local-test
     with:
       build_type: pull-request

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,14 +64,14 @@ jobs:
   wheel-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@branch-23.08
     with:
       build_type: pull-request
       script: ci/build_wheel.sh
   wheel-tests:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@branch-23.08
     with:
       build_type: pull-request
       script: ci/test_wheel.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,8 +20,6 @@ jobs:
       - docs-build
       - wheel-build
       - wheel-tests
-  #       WARNING: REMOVE THIS WHEN SWITCHING BACK TO THE MAIN BRANCH AND MERGING THIS PR.
-      - wheel-publish
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/pr-builder.yaml@branch-23.08
   checks:
@@ -77,14 +75,3 @@ jobs:
     with:
       build_type: pull-request
       script: ci/test_wheel.sh
-  #       WARNING: REMOVE THIS WHEN SWITCHING BACK TO THE MAIN BRANCH AND MERGING THIS PR.
-  wheel-publish:
-    needs: wheel-build
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yaml@feat/local-test
-    with:
-      build_type: ${{ inputs.build_type || 'pull-request' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
-      package-name: rmm

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,7 +83,7 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-publish.yaml@feat/local-test
     with:
-      build_type: ${{ inputs.build_type || 'branch' }}
+      build_type: pull-request
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@feat/local-test
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,11 +32,10 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-test.yml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@local-test
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-      package-name: rmm
-      test-unittest: "python -m pytest ./python/rmm/tests"
+      script: ci/test_wheel.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@feat/local-test
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@branch-23.08
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -12,7 +12,7 @@ version_override="$(rapids-pip-wheel-version ${RAPIDS_DATE_STRING})"
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
-bash ci/release/apply_wheel_modifications.sh ${version_override} "-${RAPIDS_PY_CUDA_SUFFIX}"
+ci/release/apply_wheel_modifications.sh ${version_override} "-${RAPIDS_PY_CUDA_SUFFIX}"
 echo "The package name and/or version was modified in the package source. The git diff is:"
 git diff
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -18,7 +18,6 @@ git diff
 
 cd python
 
-# Hardcode the output dir
 SKBUILD_CONFIGURE_OPTIONS="-DRMM_BUILD_WHEELS=ON" python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
 mkdir -p final_dist

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -11,7 +11,7 @@ RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-
 PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
 
 # echo to expand wildcard before adding `[extra]` requires for pip
-python -m pip install -v $(echo ./dist/${RAPIDS_PY_WHEEL_NAME}*.whl)[test]
+python -m pip install -v $(echo ./dist/rmm*.whl)[test]
 
 # Run smoke tests for aarch64 pull requests
 if [ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]; then

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -9,7 +9,9 @@ RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-
 
 # TODO: Remove when this is set in the container
 PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
-python -m pip install -v './dist/rmm*.whl[test]'
+
+# echo to expand wildcard before adding `[extra]` requires for pip
+python -m pip install -v $(echo ./dist/${RAPIDS_PY_WHEEL_NAME}*.whl)[test]
 
 # Run smoke tests for aarch64 pull requests
 if [ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]; then

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+set -eoxu pipefail
+
+mkdir -p ./dist
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
+
+PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
+python -m pip install -v ./dist/rmm*.whl[test]
+python -m pip check
+
+if [ "${arch}" == "x86_64" ]; then
+    python -m pytest ./python/rmm/tests
+elif [ "${arch}" == "aarch64" ]; then
+    python ./ci/wheel_smoke_test.py
+fi

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,9 +7,9 @@ mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 
+# TODO: Remove when this is set in the container
 PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
 python -m pip install -v ./dist/rmm*.whl[test]
-python -m pip check
 
 if [ "${arch}" == "x86_64" ]; then
     python -m pytest ./python/rmm/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -11,8 +11,9 @@ RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-
 PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
 python -m pip install -v ./dist/rmm*.whl[test]
 
-if [ "${arch}" == "x86_64" ]; then
-    python -m pytest ./python/rmm/tests
-elif [ "${arch}" == "aarch64" ]; then
+# Run smoke tests for aarch64 pull requests
+if [ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]; then
     python ./ci/wheel_smoke_test.py
+else
+    python -m pytest ./python/rmm/tests
 fi

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -8,7 +8,7 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 
 # echo to expand wildcard before adding `[extra]` requires for pip
-python -m pip install -v $(echo ./dist/rmm*.whl)[test]
+python -m pip install $(echo ./dist/rmm*.whl)[test]
 
 # Run smoke tests for aarch64 pull requests
 arch=$(uname -m)

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -3,7 +3,6 @@
 
 set -eou pipefail
 
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2023, NVIDIA CORPORATION.
 
-set -eoxu pipefail
+set -eou pipefail
 
 mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
@@ -11,8 +11,7 @@ RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-
 python -m pip install $(echo ./dist/rmm*.whl)[test]
 
 # Run smoke tests for aarch64 pull requests
-arch=$(uname -m)
-if [ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]; then
+if [ "$(arch)" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]; then
     python ./ci/wheel_smoke_test.py
 else
     python -m pytest ./python/rmm/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -14,6 +14,7 @@ PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
 python -m pip install -v $(echo ./dist/rmm*.whl)[test]
 
 # Run smoke tests for aarch64 pull requests
+arch=$(uname -m)
 if [ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]; then
     python ./ci/wheel_smoke_test.py
 else

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,9 +7,6 @@ mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 ./dist
 
-# TODO: Remove when this is set in the container
-PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
-
 # echo to expand wildcard before adding `[extra]` requires for pip
 python -m pip install -v $(echo ./dist/rmm*.whl)[test]
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -9,7 +9,7 @@ RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-
 
 # TODO: Remove when this is set in the container
 PIP_EXTRA_INDEX_URL="https://pypi.k8s.rapids.ai/simple"
-python -m pip install -v ./dist/rmm*.whl[test]
+python -m pip install -v './dist/rmm*.whl[test]'
 
 # Run smoke tests for aarch64 pull requests
 if [ "${arch}" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]; then


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Moves the wheel build and test logic out of the workflow into the repo. This matches conda tests more closely and allows each repo to manage its own wheels more easily.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
