### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-tests:
     secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yml@branch-23.08
+    uses: rapidsai/shared-action-workflows/.github/workflows/wheels-test.yaml@branch-23.08
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.