### PR TITLE
Use `conda mambabuild` not `mamba mambabuild`

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -12,6 +12,6 @@ rapids-print-env
 rapids-logger "Begin cpp build"
 
 # This calls mambabuild when boa is installed (as is the case in the CI images)
-rapids-conda-retry build conda/recipes/librmm
+rapids-conda-retry mambabuild conda/recipes/librmm
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -11,6 +11,7 @@ rapids-print-env
 
 rapids-logger "Begin cpp build"
 
-rapids-mamba-retry mambabuild conda/recipes/librmm
+# This calls mambabuild when boa is installed (as is the case in the CI images)
+rapids-conda-retry build conda/recipes/librmm
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -14,6 +14,6 @@ rapids-logger "Begin py build"
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
 # This calls mambabuild when boa is installed (as is the case in the CI images)
-rapids-conda-retry build -c "${CPP_CHANNEL}" conda/recipes/rmm
+rapids-conda-retry mambabuild -c "${CPP_CHANNEL}" conda/recipes/rmm
 
 rapids-upload-conda-to-s3 python

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -13,6 +13,7 @@ rapids-logger "Begin py build"
 
 CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
 
-rapids-mamba-retry mambabuild -c "${CPP_CHANNEL}" conda/recipes/rmm
+# This calls mambabuild when boa is installed (as is the case in the CI images)
+rapids-conda-retry build -c "${CPP_CHANNEL}" conda/recipes/rmm
 
 rapids-upload-conda-to-s3 python


### PR DESCRIPTION
## Description
With the release of conda 23.7.3, mamba's mambabuild stopped working. With boa installed, `conda mambabuild` uses the mamba solver, so just use that instead.

See also rapidsai/cudf#14068.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
