### PR TITLE
Update to clang 16.0.6.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       hooks:
           - id: cython-lint
     - repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: v16.0.1
+      rev: v16.0.6
       hooks:
             - id: clang-format
               types_or: [c, c++, cuda]

--- a/benchmarks/random_allocations/random_allocations.cpp
+++ b/benchmarks/random_allocations/random_allocations.cpp
@@ -68,7 +68,7 @@ void random_allocation_free(rmm::mr::device_memory_resource& mr,
 {
   std::default_random_engine generator;
 
-  max_usage *= size_mb;                      // convert to bytes
+  max_usage *= size_mb;  // convert to bytes
 
   constexpr int allocation_probability{73};  // percent
   constexpr int max_op_chance{99};

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -397,10 +397,10 @@ class device_buffer {
   [[nodiscard]] mr::device_memory_resource* memory_resource() const noexcept { return _mr; }
 
  private:
-  void* _data{nullptr};                  ///< Pointer to device memory allocation
-  std::size_t _size{};                   ///< Requested size of the device memory allocation
-  std::size_t _capacity{};               ///< The actual size of the device memory allocation
-  cuda_stream_view _stream{};            ///< Stream to use for device memory deallocation
+  void* _data{nullptr};        ///< Pointer to device memory allocation
+  std::size_t _size{};         ///< Requested size of the device memory allocation
+  std::size_t _capacity{};     ///< The actual size of the device memory allocation
+  cuda_stream_view _stream{};  ///< Stream to use for device memory deallocation
   mr::device_memory_resource* _mr{
     mr::get_current_device_resource()};  ///< The memory resource used to
                                          ///< allocate/deallocate device memory

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -88,7 +88,7 @@ using thrust_exec_policy_nosync_t =
   thrust_exec_policy_t;  ///< When used with Thrust < 1.16.0, thrust_exec_policy_nosync_t is an
                          ///< alias for thrust_exec_policy_t
 using exec_policy_nosync =
-  exec_policy;           ///< When used with Thrust < 1.16.0, exec_policy_nosync is an alias for exec_policy
+  exec_policy;  ///< When used with Thrust < 1.16.0, exec_policy_nosync is an alias for exec_policy
 #endif
 
 }  // namespace rmm

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -85,7 +85,7 @@ class device_memory_resource {
   virtual ~device_memory_resource()                     = default;
   device_memory_resource(device_memory_resource const&) = default;  ///< @default_copy_constructor
   device_memory_resource(device_memory_resource&&) noexcept =
-    default;                                                        ///< @default_move_constructor
+    default;  ///< @default_move_constructor
   device_memory_resource& operator=(device_memory_resource const&) =
     default;  ///< @default_copy_assignment{device_memory_resource}
   device_memory_resource& operator=(device_memory_resource&&) noexcept =

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -271,7 +271,7 @@ class fixed_size_memory_resource
   }
 
  private:
-  Upstream* upstream_mr_;                  // The resource from which to allocate new blocks
+  Upstream* upstream_mr_;  // The resource from which to allocate new blocks
 
   std::size_t const block_size_;           // size of blocks this MR allocates
   std::size_t const upstream_chunk_size_;  // size of chunks allocated from heap MR

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -317,8 +317,8 @@ class logging_resource_adaptor final : public device_memory_resource {
 
   std::shared_ptr<spdlog::logger> logger_;  ///< spdlog logger object
 
-  Upstream* upstream_;                      ///< The upstream resource used for satisfying
-                                            ///< allocation requests
+  Upstream* upstream_;  ///< The upstream resource used for satisfying
+                        ///< allocation requests
 };
 
 /**

--- a/tests/mr/device/arena_mr_tests.cpp
+++ b/tests/mr/device/arena_mr_tests.cpp
@@ -486,7 +486,7 @@ TEST_F(ArenaTest, SizeSmallerThanSuperblockSize)  // NOLINT
 
 TEST_F(ArenaTest, AllocateNinetyPercent)  // NOLINT
 {
-  EXPECT_NO_THROW([]() {                  // NOLINT(cppcoreguidelines-avoid-goto)
+  EXPECT_NO_THROW([]() {  // NOLINT(cppcoreguidelines-avoid-goto)
     auto const free = rmm::detail::available_device_memory().first;
     auto const ninety_percent =
       rmm::detail::align_up(static_cast<std::size_t>(static_cast<double>(free) * 0.9),
@@ -497,7 +497,7 @@ TEST_F(ArenaTest, AllocateNinetyPercent)  // NOLINT
 
 TEST_F(ArenaTest, SmallMediumLarge)  // NOLINT
 {
-  EXPECT_NO_THROW([]() {             // NOLINT(cppcoreguidelines-avoid-goto)
+  EXPECT_NO_THROW([]() {  // NOLINT(cppcoreguidelines-avoid-goto)
     arena_mr mr(rmm::mr::get_current_device_resource());
     auto* small     = mr.allocate(256);
     auto* medium    = mr.allocate(64_MiB);
@@ -511,7 +511,7 @@ TEST_F(ArenaTest, SmallMediumLarge)  // NOLINT
 
 TEST_F(ArenaTest, Defragment)  // NOLINT
 {
-  EXPECT_NO_THROW([]() {       // NOLINT(cppcoreguidelines-avoid-goto)
+  EXPECT_NO_THROW([]() {  // NOLINT(cppcoreguidelines-avoid-goto)
     auto const arena_size = superblock::minimum_size * 4;
     arena_mr mr(rmm::mr::get_current_device_resource(), arena_size);
     std::vector<std::thread> threads;

--- a/tests/mr/device/failure_callback_mr_tests.cpp
+++ b/tests/mr/device/failure_callback_mr_tests.cpp
@@ -40,7 +40,7 @@ bool failure_handler(std::size_t /*bytes*/, void* arg)
     retried = true;
     return true;  // First time we request an allocation retry
   }
-  return false;   // Second time we let the adaptor throw std::bad_alloc
+  return false;  // Second time we let the adaptor throw std::bad_alloc
 }
 
 TEST(FailureCallbackTest, RetryAllocationOnce)

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -102,7 +102,7 @@ TEST(PoolTest, ForceGrowth)
     EXPECT_NO_THROW(mr.allocate(1000));
     EXPECT_THROW(mr.allocate(4000), rmm::out_of_memory);  // too much
     EXPECT_NO_THROW(mr.allocate(500));
-    EXPECT_NO_THROW(mr.allocate(2000));                   // fits
+    EXPECT_NO_THROW(mr.allocate(2000));  // fits
   }
 }
 


### PR DESCRIPTION
## Description
This PR updates rmm to use clang 16.0.6. The previous version 16.0.1 has some minor formatting issues affecting several RAPIDS repos.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
