### PR TITLE
Make doxygen only a conda dependency.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -111,6 +111,8 @@ dependencies:
           # pre-commit requires identify minimum version 1.0, but clang-format requires textproto support and that was
           # added in 2.5.20, so we need to call out the minimum version needed for our plugins
           - identify>=2.5.20
+      - output_types: conda
+        packages:
           - &doxygen doxygen=1.9.1
   cudatoolkit:
     specific:


### PR DESCRIPTION
## Description
This PR fixes a devcontainers issue seen by @miscco. The `doxygen` dependency can only be installed with conda, so we can't specify it in `requirements.txt`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
