### PR TITLE
Compile cdef public functions from torch_allocator with C ABI

### DIFF
--- a/python/rmm/_lib/CMakeLists.txt
+++ b/python/rmm/_lib/CMakeLists.txt
@@ -19,3 +19,5 @@ set(linked_libraries rmm::rmm)
 # Build all of the Cython targets
 rapids_cython_create_modules(SOURCE_FILES "${cython_sources}" LINKED_LIBRARIES "${linked_libraries}"
                                                                                CXX)
+# The cdef public functions in this file need to have a C ABI
+target_compile_definitions(torch_allocator PRIVATE CYTHON_EXTERN_C=extern\ "C")


### PR DESCRIPTION
## Description
Since Cython 3, we must explicitly request a C ABI with `-DCYTHON_EXTERN_C='extern "C"'` for `cdef public` functions.

- Closes #1349

Before:
```
$ nm -D .../rmm/python/rmm/_lib/torch_allocator.cpython-310-x86_64-linux-gnu.so | grep allocate
00000000000071c0 T _Z10deallocatePvlS_
0000000000007500 T _Z8allocateliPv
...
```

After:
```
$ nm -D .../rmm/python/rmm/_lib/torch_allocator.cpython-310-x86_64-linux-gnu.so | grep allocate
0000000000007500 T allocate
00000000000071c0 T deallocate
...
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
