### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/python/rmm/_lib/CMakeLists.txt
+++ b/python/rmm/_lib/CMakeLists.txt
@@ -19,3 +19,5 @@ set(linked_libraries rmm::rmm)
 # Build all of the Cython targets
 rapids_cython_create_modules(SOURCE_FILES "${cython_sources}" LINKED_LIBRARIES "${linked_libraries}"
                                                                                CXX)
+# The cdef public functions in this file need to have a C ABI
+target_compile_definitions(torch_allocator PRIVATE CYTHON_EXTERN_C=extern\ "C")


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.