### PR TITLE
Update rapids-cmake functions to non-deprecated signatures

### DIFF
--- a/cmake/thirdparty/get_spdlog.cmake
+++ b/cmake/thirdparty/get_spdlog.cmake
@@ -26,7 +26,8 @@ function(find_and_configure_spdlog)
       GLOBAL_TARGETS spdlog spdlog_header_only
       NAMESPACE spdlog::)
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(BUILD spdlog [=[${CMAKE_CURRENT_LIST_DIR}]=] rmm-exports)
+    rapids_export_find_package_root(BUILD spdlog [=[${CMAKE_CURRENT_LIST_DIR}]=]
+                                    EXPORT_SET rmm-exports)
   endif()
 endfunction()
 


### PR DESCRIPTION
## Description
Update to use non deprecated signatures for `rapids_export` functions

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
