### PR TITLE
Add missing CUDA 12 dependencies and fix dlopen library names

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -11,7 +11,9 @@ rapids-dependency-file-generator \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n test
+set +u
 conda activate test
+set -u
 
 rapids-print-env
 

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -8,6 +8,7 @@ dependencies:
 - clang-tools==16.0.6
 - clang==16.0.6
 - cmake>=3.26.4
+- cuda-nvcc
 - cuda-python>=11.7.1,<12.0a0
 - cuda-version=11.8
 - cudatoolkit

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -10,7 +10,6 @@ package:
   name: rmm
   version: {{ version }}
 
-
 source:
   git_url: ../../..
 

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -10,6 +10,7 @@ package:
   name: rmm
   version: {{ version }}
 
+
 source:
   git_url: ../../..
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -223,3 +223,7 @@ dependencies:
         packages:
           - pytest
           - pytest-cov
+      - output_types: conda
+        packages:
+          # Needed for numba in tests
+          - cuda-nvcc

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -39,7 +39,7 @@ struct dynamic_load_runtime {
     auto open_cudart  = []() {
       ::dlerror();
       const int major               = CUDART_VERSION / 1000;
-      const std::string libname_ver = "libcudart.so." + std::to_string(major) + ".0";
+      const std::string libname_ver = "libcudart.so." + std::to_string(major);
       const std::string libname     = "libcudart.so";
 
       auto ptr = ::dlopen(libname_ver.c_str(), RTLD_LAZY);


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The dropping of system CTK libraries from our CUDA 12 CI images revealed that we were missing the cuda-nvcc package required to provide nvvm for numba in the Python tests. They also revealed that the list of libraries we searched to dlopen is incomplete; for CUDA 11, the SONAME of the library incorrectly includes an extra `.0` version segment, and rmm was designed to search for that, but CUDA 12 correctly has just `libcudart.so.12` and that needs to be added to the search path. We were previously getting by on finding `libcudart.so`, but the linker name is only present in conda environments if `cuda-cudart-dev` is installed, and that package should not be a runtime requirement for rmm.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
