### PR TITLE
Fix more doxygen issues

### DIFF
--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -91,8 +91,6 @@ class simulated_memory_resource final : public device_memory_resource {
    *
    * @note This call is ignored.
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    */
   void do_deallocate(void* ptr, std::size_t, cuda_stream_view) override {}

--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -72,7 +72,7 @@ class simulated_memory_resource final : public device_memory_resource {
    *
    * @note Stream argument is ignored
    *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled
    *
    * @param bytes The size, in bytes, of the allocation
    * @return void* Pointer to the newly allocated memory

--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -859,8 +859,11 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
+# Need to specify the error.hpp file explicitly because it is excluded by the
+# EXCLUDE_PATTERNS below.
 INPUT                  = main_page.md \
-                         ../include
+                         ../include \
+                         ../include/rmm/detail/error.hpp
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/include/doxygen_groups.h
+++ b/include/doxygen_groups.h
@@ -38,6 +38,7 @@
  * @defgroup cuda_device_management CUDA Device Management
  * @defgroup cuda_streams CUDA Streams
  * @defgroup data_containers Data Containers
+ * @defgroup errors Errors
  * @defgroup logging Logging
  * @defgroup thrust_integrations Thrust Integrations
  */

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -26,13 +26,9 @@
 namespace rmm {
 
 /**
- * @addtogroup errors
- * @{
- * @file
- */
-
-/**
  * @brief Exception thrown when logical precondition is violated.
+ *
+ * @ingroup errors
  *
  * This exception should not be thrown directly and is instead thrown by the
  * RMM_EXPECTS macro.
@@ -45,6 +41,8 @@ struct logic_error : public std::logic_error {
 /**
  * @brief Exception thrown when a CUDA error is encountered.
  *
+ * @ingroup errors
+ *
  */
 struct cuda_error : public std::runtime_error {
   using std::runtime_error::runtime_error;
@@ -53,12 +51,28 @@ struct cuda_error : public std::runtime_error {
 /**
  * @brief Exception thrown when an RMM allocation fails
  *
+ * @ingroup errors
+ *
  */
 class bad_alloc : public std::bad_alloc {
  public:
+  /**
+   * @brief Constructs a bad_alloc with the error message.
+   *
+   * @param msg Message to be associated with the exception
+   */
   bad_alloc(const char* msg) : _what{std::string{std::bad_alloc::what()} + ": " + msg} {}
+
+  /**
+   * @brief Constructs a bad_alloc with the error message.
+   *
+   * @param msg Message to be associated with the exception
+   */
   bad_alloc(std::string const& msg) : bad_alloc{msg.c_str()} {}
 
+  /**
+   * @briefreturn{The explanatory string}
+   */
   [[nodiscard]] const char* what() const noexcept override { return _what.c_str(); }
 
  private:
@@ -68,23 +82,36 @@ class bad_alloc : public std::bad_alloc {
 /**
  * @brief Exception thrown when RMM runs out of memory
  *
+ * @ingroup errors
+ *
  * This error should only be thrown when we know for sure a resource is out of memory.
  */
 class out_of_memory : public bad_alloc {
  public:
+  /**
+   * @brief Constructs an out_of_memory with the error message.
+   *
+   * @param msg Message to be associated with the exception
+   */
   out_of_memory(const char* msg) : bad_alloc{std::string{"out_of_memory: "} + msg} {}
+
+  /**
+   * @brief Constructs an out_of_memory with the error message.
+   *
+   * @param msg Message to be associated with the exception
+   */
   out_of_memory(std::string const& msg) : out_of_memory{msg.c_str()} {}
 };
 
 /**
  * @brief Exception thrown when attempting to access outside of a defined range
  *
+ * @ingroup errors
+ *
  */
 class out_of_range : public std::out_of_range {
   using std::out_of_range::out_of_range;
 };
-
-/** @} */  // end of group
 
 }  // namespace rmm
 
@@ -106,12 +133,13 @@ class out_of_range : public std::out_of_range {
  * // throws std::runtime_error
  * RMM_EXPECTS(p != nullptr, "Unexpected nullptr", std::runtime_error);
  * ```
- * @param[in] _condition Expression that evaluates to true or false
- * @param[in] _what  String literal description of why the exception was
- *     thrown, i.e. why `_condition` was expected to be true.
- * @param[in] _expection_type The exception type to throw; must inherit
- *     std::exception. If not specified (i.e. if only two macro
- *     arguments are provided), defaults to rmm::logic_error
+ * @param ... This macro accepts either two or three arguments:
+ *   - The first argument must be an expression that evaluates to true or
+ *     false, and is the condition being checked.
+ *   - The second argument is a string literal used to construct the `what` of
+ *     the exception.
+ *   - When given, the third argument is the exception to be thrown. When not
+ *     specified, defaults to `rmm::logic_error`.
  * @throw `_exception_type` if the condition evaluates to 0 (false).
  */
 #define RMM_EXPECTS(...)                                           \

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -24,6 +24,13 @@
 #include <string>
 
 namespace rmm {
+
+/**
+ * @addtogroup errors
+ * @{
+ * @file
+ */
+
 /**
  * @brief Exception thrown when logical precondition is violated.
  *
@@ -76,6 +83,8 @@ class out_of_memory : public bad_alloc {
 class out_of_range : public std::out_of_range {
   using std::out_of_range::out_of_range;
 };
+
+/** @} */  // end of group
 
 }  // namespace rmm
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -95,7 +95,7 @@ class out_of_range : public std::out_of_range {
  * @brief Macro for checking (pre-)conditions that throws an exception when
  * a condition is violated.
  *
- * Defaults to throwing `rmm::logic_error`, but a custom exception may also be
+ * Defaults to throwing rmm::logic_error, but a custom exception may also be
  * specified.
  *
  * Example usage:
@@ -110,8 +110,8 @@ class out_of_range : public std::out_of_range {
  * @param[in] _what  String literal description of why the exception was
  *     thrown, i.e. why `_condition` was expected to be true.
  * @param[in] _expection_type The exception type to throw; must inherit
- *     `std::exception`. If not specified (i.e. if only two macro
- *     arguments are provided), defaults to `rmm::logic_error`
+ *     std::exception. If not specified (i.e. if only two macro
+ *     arguments are provided), defaults to rmm::logic_error
  * @throw `_exception_type` if the condition evaluates to 0 (false).
  */
 #define RMM_EXPECTS(...)                                           \
@@ -131,7 +131,7 @@ class out_of_range : public std::out_of_range {
  *
  * Example usage:
  * ```c++
- * // Throws `rmm::logic_error`
+ * // Throws rmm::logic_error
  * RMM_FAIL("Unsupported code path");
  *
  * // Throws `std::runtime_error`
@@ -154,16 +154,16 @@ class out_of_range : public std::out_of_range {
  * `cudaSuccess`, invokes cudaGetLastError() to clear the error and throws an
  * exception detailing the CUDA error that occurred
  *
- * Defaults to throwing `rmm::cuda_error`, but a custom exception may also be
+ * Defaults to throwing rmm::cuda_error, but a custom exception may also be
  * specified.
  *
  * Example:
  * ```c++
  *
- * // Throws `rmm::cuda_error` if `cudaMalloc` fails
+ * // Throws rmm::cuda_error if `cudaMalloc` fails
  * RMM_CUDA_TRY(cudaMalloc(&p, 100));
  *
- * // Throws `std::runtime_error` if `cudaMalloc` fails
+ * // Throws std::runtime_error if `cudaMalloc` fails
  * RMM_CUDA_TRY(cudaMalloc(&p, 100), std::runtime_error);
  * ```
  *
@@ -192,8 +192,8 @@ class out_of_range : public std::out_of_range {
  * `cudaSuccess`, invokes cudaGetLastError() to clear the error and throws an
  * exception detailing the CUDA error that occurred
  *
- * Defaults to throwing `rmm::bad_alloc`, but when `cudaErrorMemoryAllocation` is returned,
- * `rmm::out_of_memory` is thrown instead.
+ * Defaults to throwing rmm::bad_alloc, but when `cudaErrorMemoryAllocation` is returned,
+ * rmm::out_of_memory is thrown instead.
  */
 #define RMM_CUDA_TRY_ALLOC(_call)                                                                  \
   do {                                                                                             \

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -177,8 +177,6 @@ class device_buffer {
    * valid, empty `device_buffer`, i.e., `data()` returns `nullptr`, and
    * `size()` and `capacity()` are zero.
    *
-   * @throws Nothing
-   *
    * @param other The `device_buffer` whose contents will be moved into the
    * newly constructed one.
    */

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -87,7 +87,7 @@ class device_scalar {
    * stream, or on another stream only if a dependency is enforced (e.g. using
    * `cudaStreamWaitEvent()`).
    *
-   * @throws `rmm::bad_alloc` if allocating the device memory fails.
+   * @throws rmm::bad_alloc if allocating the device memory fails.
    *
    * @param stream Stream on which to perform asynchronous allocation.
    * @param mr Optional, resource with which to allocate.
@@ -108,8 +108,8 @@ class device_scalar {
    * stream, or on another stream only if a dependency is enforced (e.g. using
    * `cudaStreamWaitEvent()`).
    *
-   * @throws `rmm::bad_alloc` if allocating the device memory for `initial_value` fails.
-   * @throws `rmm::cuda_error` if copying `initial_value` to device memory fails.
+   * @throws rmm::bad_alloc if allocating the device memory for `initial_value` fails.
+   * @throws rmm::cuda_error if copying `initial_value` to device memory fails.
    *
    * @param initial_value The initial value of the object in device memory.
    * @param stream Optional, stream on which to perform allocation and copy.
@@ -153,8 +153,8 @@ class device_scalar {
    * (e.g. using `cudaStreamWaitEvent()` or `cudaStreamSynchronize()`) before calling this function,
    * otherwise there may be a race condition.
    *
-   * @throws `rmm::cuda_error` If the copy fails.
-   * @throws `rmm::cuda_error` If synchronizing `stream` fails.
+   * @throws rmm::cuda_error If the copy fails.
+   * @throws rmm::cuda_error If synchronizing `stream` fails.
    *
    * @return T The value of the scalar.
    * @param stream CUDA stream on which to perform the copy and synchronize.
@@ -196,7 +196,7 @@ class device_scalar {
    * v = 13;
    * \endcode
    *
-   * @throws `rmm::cuda_error` if copying `host_value` to device memory fails.
+   * @throws rmm::cuda_error if copying @p value to device memory fails.
    *
    * @param value The host value which will be copied to device
    * @param stream CUDA stream on which to perform the copy

--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -97,14 +97,8 @@ struct bytes {
 }  // namespace detail
 
 /**
- * @addtogroup logging
- * @{
- * @file
- */
-
-/**
  * @brief Returns the global RMM logger
- *
+ * @addtogroup logging
  * This is a spdlog logger. The easiest way to log messages is to use the `RMM_LOG_*` macros.
  *
  * @return spdlog::logger& The logger.
@@ -136,5 +130,4 @@ inline spdlog::logger& logger()
 template <>
 struct fmt::formatter<rmm::detail::bytes> : fmt::ostream_formatter {};
 
-/** @} */  // end of group
 //! @endcond

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -56,8 +56,8 @@ class aligned_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Construct an aligned resource adaptor using `upstream` to satisfy allocation requests.
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
-   * @throws `rmm::logic_error` if `allocation_alignment` is not a power of 2
+   * @throws rmm::logic_error if `upstream == nullptr`
+   * @throws rmm::logic_error if `allocation_alignment` is not a power of 2
    *
    * @param upstream The resource used for allocating/deallocating device memory.
    * @param alignment The size used for allocation alignment.
@@ -114,7 +114,7 @@ class aligned_resource_adaptor final : public device_memory_resource {
    * @brief Allocates memory of size at least `bytes` using the upstream resource with the specified
    * alignment.
    *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled
    * by the upstream resource.
    *
    * @param bytes The size, in bytes, of the allocation
@@ -184,7 +184,7 @@ class aligned_resource_adaptor final : public device_memory_resource {
    *
    * The free size may not be fully allocatable because of alignment requirements.
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @param stream Stream on which to get the mem info.
    * @return std::pair containing free_size and total_size of memory

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -143,8 +143,6 @@ class aligned_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Free allocation of size `bytes` pointed to to by `p` and log the deallocation.
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
@@ -168,8 +166,6 @@ class aligned_resource_adaptor final : public device_memory_resource {
 
   /**
    * @brief Compare this resource to another.
-   *
-   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -220,8 +220,6 @@ class cuda_async_memory_resource final : public device_memory_resource {
   /**
    * @brief Compare this resource to another.
    *
-   * @throws Nothing.
-   *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -237,7 +237,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
   /**
    * @brief Get free and available memory for memory resource
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @return std::pair contaiing free_size and total_size of memory
    */

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -174,7 +174,7 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
   /**
    * @brief Get free and available memory for memory resource
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @return std::pair contaiing free_size and total_size of memory
    */

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -162,8 +162,6 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
   /**
    * @brief Compare this resource to another.
    *
-   * @throws Nothing.
-   *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -100,8 +100,6 @@ class cuda_memory_resource final : public device_memory_resource {
    * Two cuda_memory_resources always compare equal, because they can each
    * deallocate memory allocated by the other.
    *
-   * @throws Nothing.
-   *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -112,7 +112,7 @@ class cuda_memory_resource final : public device_memory_resource {
   /**
    * @brief Get free and available memory for memory resource
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @return std::pair contaiing free_size and total_size of memory
    */

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -127,8 +127,6 @@ class device_memory_resource {
    * If supported, this operation may optionally be executed on a stream.
    * Otherwise, the stream is ignored and the null stream is used.
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
    * value of `bytes` that was passed to the `allocate` call that returned `p`.

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -104,8 +104,8 @@ class device_memory_resource {
    * If supported, this operation may optionally be executed on a stream.
    * Otherwise, the stream is ignored and the null stream is used.
    *
-   * @throws `rmm::bad_alloc` When the requested `bytes` cannot be allocated on
-   * the specified `stream`.
+   * @throws rmm::bad_alloc When the requested `bytes` cannot be allocated on
+   * the specified @p stream.
    *
    * @param bytes The size of the allocation
    * @param stream Stream on which to perform allocation

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -175,8 +175,6 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Free allocation of size `bytes` pointed to by `ptr`
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
@@ -188,8 +186,6 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
 
   /**
    * @brief Compare the upstream resource to another.
-   *
-   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -96,7 +96,7 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
    * @brief Construct a new `failure_callback_resource_adaptor` using `upstream` to satisfy
    * allocation requests.
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
+   * @throws rmm::logic_error if `upstream == nullptr`
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param callback Callback function @see failure_callback_t
@@ -202,7 +202,7 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Get free and available memory from upstream resource.
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -46,7 +46,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    * @brief Construct a new limiting resource adaptor using `upstream` to satisfy
    * allocation requests and limiting the total allocation amount possible.
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
+   * @throws rmm::logic_error if `upstream == nullptr`
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param allocation_limit Maximum memory allowed for this allocator
@@ -125,7 +125,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
    *
    * The returned pointer has at least 256B alignment.
    *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled
    * by the upstream resource.
    *
    * @param bytes The size, in bytes, of the allocation
@@ -181,7 +181,7 @@ class limiting_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Get free and available memory from upstream resource.
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -152,8 +152,6 @@ class limiting_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Free allocation of size `bytes` pointed to by `ptr`
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
@@ -167,8 +165,6 @@ class limiting_resource_adaptor final : public device_memory_resource {
 
   /**
    * @brief Compare the upstream resource to another.
-   *
-   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -62,8 +62,8 @@ class logging_resource_adaptor final : public device_memory_resource {
    * Creating multiple `logging_resource_adaptor`s with the same `filename` will
    * result in undefined behavior.
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
-   * @throws `spdlog::spdlog_ex` if opening `filename` failed
+   * @throws rmm::logic_error if `upstream == nullptr`
+   * @throws spdlog::spdlog_ex if opening `filename` failed
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param filename Name of file to write log info. If not specified, retrieves
@@ -88,7 +88,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * The logfile will be written using CSV formatting.
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
+   * @throws rmm::logic_error if `upstream == nullptr`
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param stream The ostream to write log info.
@@ -110,7 +110,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * The logfile will be written using CSV formatting.
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
+   * @throws rmm::logic_error if `upstream == nullptr`
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param sinks A list of logging sinks to which log output will be written.
@@ -183,7 +183,7 @@ class logging_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Return the value of the environment variable RMM_LOG_FILE.
    *
-   * @throws `rmm::logic_error` if `RMM_LOG_FILE` is not set.
+   * @throws rmm::logic_error if `RMM_LOG_FILE` is not set.
    *
    * @return The value of RMM_LOG_FILE as `std::string`.
    */
@@ -241,7 +241,7 @@ class logging_resource_adaptor final : public device_memory_resource {
    *
    * The returned pointer has at least 256B alignment.
    *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled
    * by the upstream resource.
    *
    * @param bytes The size, in bytes, of the allocation
@@ -298,7 +298,7 @@ class logging_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Get free and available memory from upstream resource.
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -270,8 +270,6 @@ class logging_resource_adaptor final : public device_memory_resource {
    * thread_id,*TIMESTAMP*,"free",*bytes*,*stream*
    * ```
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
@@ -284,8 +282,6 @@ class logging_resource_adaptor final : public device_memory_resource {
 
   /**
    * @brief Compare the upstream resource to another.
-   *
-   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -116,7 +116,7 @@ class managed_memory_resource final : public device_memory_resource {
   /**
    * @brief Get free and available memory for memory resource
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info
+   * @throws rmm::cuda_error if unable to retrieve memory info
    *
    * @param stream to execute on
    * @return std::pair contaiing free_size and total_size of memory

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -104,8 +104,6 @@ class managed_memory_resource final : public device_memory_resource {
    * Two `managed_memory_resources` always compare equal, because they can each
    * deallocate memory allocated by the other.
    *
-   * @throws Nothing.
-   *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -194,8 +194,6 @@ class owning_wrapper : public device_memory_resource {
    *
    * `ptr` must have been returned from a prior call to `do_allocate(bytes)`.
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to the allocation to free.
    * @param bytes Size of the allocation
    * @param stream Stream on which to deallocate the memory
@@ -209,8 +207,6 @@ class owning_wrapper : public device_memory_resource {
    * @brief Compare if this resource is equal to another.
    *
    * Two resources are equal if memory allocated by one resource can be freed by the other.
-   *
-   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equal

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -177,7 +177,7 @@ class owning_wrapper : public device_memory_resource {
   /**
    * @brief Allocates memory using the wrapped resource.
    *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled by the wrapped
+   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled by the wrapped
    * resource.
    *
    * @param bytes The size, in bytes, of the allocation
@@ -223,7 +223,7 @@ class owning_wrapper : public device_memory_resource {
   /**
    * @brief Get free and available memory from upstream resource.
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -190,8 +190,6 @@ class statistics_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Free allocation of size `bytes` pointed to by `ptr`
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
@@ -211,8 +209,6 @@ class statistics_resource_adaptor final : public device_memory_resource {
 
   /**
    * @brief Compare the upstream resource to another.
-   *
-   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -88,7 +88,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
    * @brief Construct a new statistics resource adaptor using `upstream` to satisfy
    * allocation requests.
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
+   * @throws rmm::logic_error if `upstream == nullptr`
    *
    * @param upstream The resource used for allocating/deallocating device memory
    */
@@ -164,7 +164,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
    *
    * The returned pointer has at least 256B alignment.
    *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled
    * by the upstream resource.
    *
    * @param bytes The size, in bytes, of the allocation
@@ -225,7 +225,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Get free and available memory from upstream resource.
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -48,7 +48,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    *
    * All allocations and frees are protected by a mutex lock
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
+   * @throws rmm::logic_error if `upstream == nullptr`
    *
    * @param upstream The resource used for allocating/deallocating device memory.
    */
@@ -91,7 +91,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    * @brief Allocates memory of size at least `bytes` using the upstream
    * resource with thread safety.
    *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled
    * by the upstream resource.
    *
    * @param bytes The size, in bytes, of the allocation
@@ -137,7 +137,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Get free and available memory from upstream resource.
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -107,8 +107,6 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Free allocation of size `bytes` pointed to to by `ptr`.s
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
@@ -121,8 +119,6 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
 
   /**
    * @brief Compare the upstream resource to another.
-   *
-   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -85,7 +85,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @brief Construct a new tracking resource adaptor using `upstream` to satisfy
    * allocation requests.
    *
-   * @throws `rmm::logic_error` if `upstream == nullptr`
+   * @throws rmm::logic_error if `upstream == nullptr`
    *
    * @param upstream The resource used for allocating/deallocating device memory
    * @param capture_stacks If true, capture stacks for allocation calls
@@ -198,7 +198,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    *
    * The returned pointer has at least 256B alignment.
    *
-   * @throws `rmm::bad_alloc` if the requested allocation could not be fulfilled
+   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled
    * by the upstream resource.
    *
    * @param bytes The size, in bytes, of the allocation
@@ -280,7 +280,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Get free and available memory from upstream resource.
    *
-   * @throws `rmm::cuda_error` if unable to retrieve memory info.
+   * @throws rmm::cuda_error if unable to retrieve memory info.
    *
    * @param stream Stream on which to get the mem info.
    * @return std::pair contaiing free_size and total_size of memory

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -222,8 +222,6 @@ class tracking_resource_adaptor final : public device_memory_resource {
   /**
    * @brief Free allocation of size `bytes` pointed to by `ptr`
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation
    * @param stream Stream on which to perform the deallocation
@@ -266,8 +264,6 @@ class tracking_resource_adaptor final : public device_memory_resource {
 
   /**
    * @brief Compare the upstream resource to another.
-   *
-   * @throws Nothing.
    *
    * @param other The other resource to compare to
    * @return true If the two resources are equivalent

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -84,8 +84,6 @@ class host_memory_resource {
    * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
    * yet have been deallocated, otherwise behavior is undefined.
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
    *              that was passed to the `allocate` call that returned `ptr`.
@@ -136,8 +134,6 @@ class host_memory_resource {
    * `ptr` must have been returned by a prior call to `allocate(bytes,alignment)` on a
    * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
    * yet have been deallocated, otherwise behavior is undefined.
-   *
-   * @throws Nothing.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -76,8 +76,6 @@ class new_delete_resource final : public host_memory_resource {
    * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
    * yet have been deallocated, otherwise behavior is undefined.
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
    *              that was passed to the `allocate` call that returned `ptr`.

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -84,8 +84,6 @@ class pinned_memory_resource final : public host_memory_resource {
    * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
    * yet have been deallocated, otherwise behavior is undefined.
    *
-   * @throws Nothing.
-   *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
    *               that was passed to the `allocate` call that returned `ptr`.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR:
- Adds the errors group to the doxygen so that errors are also contained in a group
- Removes invalid `@throws` sections that throw nothing
- Remove unnecessary backticks around exception types in contexts where they are already assumed to be types and therefore will link/use the appropriate font automatically

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
