### PR TITLE
Make internally stored default argument values public

### DIFF
--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -106,9 +106,13 @@ class aligned_resource_adaptor final : public device_memory_resource {
     return upstream_->supports_get_mem_info();
   }
 
- private:
+  /**
+   * @brief The default alignment used by the adaptor.
+   */
   static constexpr std::size_t default_alignment_threshold = 0;
-  using lock_guard                                         = std::lock_guard<std::mutex>;
+
+ private:
+  using lock_guard = std::lock_guard<std::mutex>;
 
   /**
    * @brief Allocates memory of size at least `bytes` using the upstream resource with the specified

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -179,7 +179,6 @@ class logging_resource_adaptor final : public device_memory_resource {
     return std::string{"Thread,Time,Action,Pointer,Size,Stream"};
   }
 
- private:
   /**
    * @brief Return the value of the environment variable RMM_LOG_FILE.
    *
@@ -195,6 +194,7 @@ class logging_resource_adaptor final : public device_memory_resource {
     return std::string{filename};
   }
 
+ private:
   static auto make_logger(std::ostream& stream)
   {
     return std::make_shared<spdlog::logger>(

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -222,8 +222,6 @@ def on_missing_reference(app, env, node, contnode):
         # Internal objects
         "detail",
         "RMM_EXEC_CHECK_DISABLE",
-        "default_alignment_threshold",
-        "get_default_filename",
         # Template types
         "Base",
     ]


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
There are a couple of default parameters that are being set, one to a local constexpr and another by a method, both of which were previously private. That made the defaults unintentionally opaque. This change makes both of them publicly visible values.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
