### PR TITLE
Deliberately leak PTDS thread_local events in stream ordered mr

### DIFF
--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -274,11 +274,14 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
       // main: it is undefined behaviour to call into the CUDA
       // runtime below main.
       thread_local std::vector<cudaEvent_t> events_tls(rmm::get_num_cuda_devices());
-      auto event = [device_id = this->device_id_]() {
-        if (events_tls[device_id.value()]) { return events_tls[device_id.value()]; }
-        RMM_ASSERT_CUDA_SUCCESS(
-          cudaEventCreateWithFlags(&events_tls[device_id.value()], cudaEventDisableTiming));
-        return events_tls[device_id.value()];
+    auto event = [device_id = this->device_id_]() {
+      auto& e = events_tls[device_id.value()];
+      if (!e) {
+          // These events are deliberately not destructed and therefore live until
+          // program exit.
+          RMM_ASSERT_CUDA_SUCCESS(cudaEventCreateWithFlags(&e, cudaEventDisableTiming));
+      }
+      return e;
       }();
       return stream_event_pair{stream.value(), event};
     }

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -274,14 +274,14 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
       // main: it is undefined behaviour to call into the CUDA
       // runtime below main.
       thread_local std::vector<cudaEvent_t> events_tls(rmm::get_num_cuda_devices());
-    auto event = [device_id = this->device_id_]() {
-      auto& e = events_tls[device_id.value()];
-      if (!e) {
+      auto event = [device_id = this->device_id_]() {
+        auto& e = events_tls[device_id.value()];
+        if (!e) {
           // These events are deliberately not destructed and therefore live until
           // program exit.
           RMM_ASSERT_CUDA_SUCCESS(cudaEventCreateWithFlags(&e, cudaEventDisableTiming));
-      }
-      return e;
+        }
+        return e;
       }();
       return stream_event_pair{stream.value(), event};
     }


### PR DESCRIPTION
## Description
An object with `thread_local` modifier has thread storage duration, its destructor (if it exists) will after the thread exits, which, on the main thread, is below `main` (https://eel.is/c++draft/basic.start.term). The CUDA runtime sets up (when the first call into the runtime is made) a teardown of the driver that runs `atexit`. Although [basic.start.term#5](https://eel.is/c++draft/basic.start.term#5) provides guarantees on the order in which these destructors are called (thread storage duration objects are destructed _before_ any `atexit` handlers run), it appears that gnu libstdc++ does not always implement this correctly (if not compiled with `_GLIBCXX_HAVE___CXA_THREAD_ATEXIT`).

Moreover (possibly consequently) it is considered undefined behaviour to call into the CUDA runtime below `main`. Hence, we cannot call `cudaEventDestroy` to deallocate our `thread_local` events. Since there are a finite number of these event (`ndevices * nparticipating_threads`), rather than attempting to destroy them we choose to leak them, thus avoiding any sequencing problems.

- Closes #1371

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
