### PR TITLE
Silence false gcc warning

### DIFF
--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -74,11 +74,18 @@ struct maybe_remove_property<PoolResource,
                              Upstream,
                              Property,
                              cuda::std::enable_if_t<!cuda::has_property<Upstream, Property>>> {
+#ifdef __GNUC__  // GCC warns about compatibility issues with pre ISO C++ code
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-template-friend"
+#endif  // __GNUC__
   /**
    * @brief Explicit removal of the friend function so we do not pretend to provide device
    * accessible memory
    */
   friend void get_property(const PoolResource&, Property) = delete;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
 };
 }  // namespace detail
 


### PR DESCRIPTION
gcc has a warning about potential compatibility issues with pre ISO C++ code. There is no danger in us compiling in that mode so silence this warning
