### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -74,11 +74,18 @@ struct maybe_remove_property<PoolResource,
                              Upstream,
                              Property,
                              cuda::std::enable_if_t<!cuda::has_property<Upstream, Property>>> {
+#ifdef __GNUC__  // GCC warns about compatibility issues with pre ISO C++ code
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-template-friend"
+#endif  // __GNUC__
   /**
    * @brief Explicit removal of the friend function so we do not pretend to provide device
    * accessible memory
    */
   friend void get_property(const PoolResource&, Property) = delete;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
 };
 }  // namespace detail
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.