### PR TITLE
Document minimum CUDA version of 11.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,13 @@ RMM can be installed with Conda ([miniconda](https://conda.io/miniconda.html), o
 [Anaconda distribution](https://www.anaconda.com/download)) from the `rapidsai` channel:
 
 ```bash
-conda install -c rapidsai -c conda-forge -c nvidia rmm cuda-version=11.8
+conda install -c rapidsai -c conda-forge -c nvidia rmm cuda-version=12.0
 ```
 
 We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD
 of our latest development branch.
 
 Note: RMM is supported only on Linux, and only tested with Python versions 3.9 and 3.10.
-
 
 Note: The RMM package from Conda requires building with GCC 9 or later. Otherwise, your application may fail to build.
 
@@ -57,12 +56,12 @@ See the [Get RAPIDS version picker](https://rapids.ai/start.html) for more OS an
 Compiler requirements:
 
 * `gcc`     version 9.3+
-* `nvcc`    version 11.2+
+* `nvcc`    version 11.4+
 * `cmake`   version 3.26.4+
 
 CUDA/GPU requirements:
 
-* CUDA 11.2+
+* CUDA 11.4+
 * NVIDIA driver 450.51+
 * Pascal architecture or better
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Compiler requirements:
 CUDA/GPU requirements:
 
 * CUDA 11.4+
-* NVIDIA driver 450.51+
 * Pascal architecture or better
 
 You can obtain CUDA from [https://developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads)


### PR DESCRIPTION
## Description
With the addition of libcudacxx 2.1.0, minimum CUDA version required to build RMM is now 11.4. This PR updates the readme to reflect this.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
