### PR TITLE
Fix else-after-thrown clang tidy error

### DIFF
--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -230,11 +230,8 @@ class out_of_range : public std::out_of_range {
       cudaGetLastError();                                                                          \
       auto const msg = std::string{"CUDA error at: "} + __FILE__ + ":" + RMM_STRINGIFY(__LINE__) + \
                        ": " + cudaGetErrorName(error) + " " + cudaGetErrorString(error);           \
-      if (cudaErrorMemoryAllocation == error) {                                                    \
-        throw rmm::out_of_memory{msg};                                                             \
-      } else {                                                                                     \
-        throw rmm::bad_alloc{msg};                                                                 \
-      }                                                                                            \
+      if (cudaErrorMemoryAllocation == error) { throw rmm::out_of_memory{msg}; }                   \
+      throw rmm::bad_alloc{msg};                                                                   \
     }                                                                                              \
   } while (0)
 


### PR DESCRIPTION
## Description
Updates code for `RMM_CUDA_TRY_ALLOC` macro in `detail/error.hpp` to eliminate a clang-tidy error.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
