### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.