### PR TITLE
Switch to static libcudart builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set_property(CACHE RMM_LOGGING_LEVEL PROPERTY STRINGS "TRACE" "DEBUG" "INFO" "WA
 message(STATUS "RMM: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'")
 
 # cudart can be statically linked or dynamically linked the python ecosystem wants dynamic linking
-option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
+option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" ON)
 
 # ##################################################################################################
 # * compiler options -------------------------------------------------------------------------------


### PR DESCRIPTION
This PR changes the default for C++ builds to statically link to libcudart.
