### PR TITLE
Remove RMM_BUILD_WHEELS and standardize Python builds

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -31,7 +31,7 @@ fi
 
 cd "${package_dir}"
 
-SKBUILD_CONFIGURE_OPTIONS="-DRMM_BUILD_WHEELS=ON" python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
+python -m pip wheel . -w dist -vvv --no-deps --disable-pip-version-check
 
 mkdir -p final_dist
 python -m auditwheel repair -w final_dist dist/*

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -29,7 +29,6 @@ project(
 
 option(FIND_RMM_CPP "Search for existing RMM C++ installations before defaulting to local files"
        OFF)
-option(RMM_BUILD_WHEELS "Whether this build is generating a Python wheel." OFF)
 
 # If the user requested it we attempt to find RMM.
 if(FIND_RMM_CPP)
@@ -41,16 +40,9 @@ endif()
 if(NOT rmm_FOUND)
   set(BUILD_TESTS OFF)
   set(BUILD_BENCHMARKS OFF)
+  set(CUDA_STATIC_RUNTIME ON)
 
-  set(_exclude_from_all "")
-  if(RMM_BUILD_WHEELS)
-    # Statically link dependencies if building wheels
-    set(CUDA_STATIC_RUNTIME ON)
-    # Don't install the rmm C++ targets into wheels
-    set(_exclude_from_all EXCLUDE_FROM_ALL)
-  endif()
-
-  add_subdirectory(../ rmm-cpp ${_exclude_from_all})
+  add_subdirectory(../ rmm-cpp EXCLUDE_FROM_ALL)
 endif()
 
 include(rapids-cython)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Some minor simplification in advance of the scikit-build-core migration to better align wheel and non-wheel Python builds.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
