### PR TITLE
Use latest cuda-python within CUDA major version.

### DIFF
--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -53,10 +53,10 @@ requirements:
     - cuda-version ={{ cuda_version }}
     {% if cuda_major == "11" %}
     - cudatoolkit
-    - cuda-python ==11.7.1
+    - cuda-python >=11.7.1,<12.0a0
     {% else %}
     - cuda-cudart-dev
-    - cuda-python ==12.0.0
+    - cuda-python >=12.0,<13.0a0
     {% endif %}
     - cython >=3.0.0
     - librmm ={{ version }}


### PR DESCRIPTION
## Description
This PR updates cuda-python. The CUDA 11 build was locked to an outdated version (11.7.1). This matches the specifications in dependencies.yaml and also cudf recipes.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
