### PR TITLE
Define python dependency range as a matrix fallback.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -11,6 +11,7 @@ files:
       - cudatoolkit
       - develop
       - docs
+      - py_version
       - run
       - test_python
   test_python:
@@ -72,7 +73,6 @@ dependencies:
           - fmt>=10.1.1,<11
           - scikit-build-core>=0.7.0
           - spdlog>=1.12.0,<1.13
-          - python>=3.9,<3.11
       - output_types: [requirements, pyproject]
         packages:
           - scikit-build-core[pyproject]>=0.7.0
@@ -195,6 +195,9 @@ dependencies:
               py: "3.10"
             packages:
               - python=3.10
+          - matrix:
+            packages:
+              - python>=3.9,<3.11
   run:
     common:
       - output_types: [conda, requirements, pyproject]


### PR DESCRIPTION
## Description
This PR moves the definition of `python>=3.9,<3.11` into the `py_version` dependency list, under the empty (fallback) matrix. This change aligns RMM's `dependencies.yaml` with other RAPIDS repositories.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
