### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,5 +14,4 @@ python/            @rapidsai/rmm-python-codeowners
 .github/           @rapidsai/ops-codeowners
 ci/                @rapidsai/ops-codeowners
 conda/             @rapidsai/ops-codeowners
-**/Dockerfile      @rapidsai/ops-codeowners
-**/.dockerignore   @rapidsai/ops-codeowners
+dependencies.yaml  @rapidsai/ops-codeowners


### PR DESCRIPTION
Bring `CODEOWNERS` for Ops in line with [other RAPIDS repos](https://github.com/rapidsai/cudf/blob/branch-24.02/.github/CODEOWNERS).

See also: https://github.com/rapidsai/cucim/pull/669