### PR TITLE
Update GPU support docs to drop Pascal

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ Compiler requirements:
 
 CUDA/GPU requirements:
 
-* CUDA 11.4+
-* Pascal architecture or better
+* CUDA 11.4+. You can obtain CUDA from
+  [https://developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads)
 
-You can obtain CUDA from [https://developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads)
+GPU Support:
+* RMM is tested and supported only on Volta architecture and newer (Compute Capability 7.0+). It
+  may work on earlier architectures.
 
 Python requirements:
 * `scikit-build-core`


### PR DESCRIPTION
## Description
We are dropping Pascal support in 24.02 (see https://github.com/rapidsai/rapids-cmake/pull/482) 

This PR changes the way we document GPU support in RMM to explain what is tested and supported rather than what is required (since it may work on earlier hardware than we test/support).

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
