### PR TITLE
Update dependencies.yaml to support CUDA 12.*.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
           - id: trailing-whitespace
           - id: end-of-file-fixer
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.5.1
+      rev: v1.8.0
       hooks:
           - id: rapids-dependency-file-generator
             args: ["--clean"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -109,7 +109,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         matrices:
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
               - &cuda_python12 cuda-python>=12.0,<13.0a0
           - matrix: # All CUDA 11 versions
@@ -208,7 +208,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         matrices:
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
               - *cuda_python12
           - matrix: # All CUDA 11 versions


### PR DESCRIPTION
## Description
This PR updates `dependencies.yaml` so that generic CUDA 12.* dependencies can be specified with a glob, like `cuda: "12.*"`. This feature requires `rapids-dependency-file-generator>=1.8.0`, so the pre-commit hook has been updated.

I have not yet added support for a specific CUDA version like 12.1 or 12.2. That can be done separately.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
