### PR TITLE
Remove HTML builds of librmm

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -31,8 +31,6 @@ export RAPIDS_DOCS_DIR="$(mktemp -d)"
 rapids-logger "Build CPP docs"
 pushd doxygen
 doxygen Doxyfile
-mkdir -p "${RAPIDS_DOCS_DIR}/librmm/html"
-mv html/* "${RAPIDS_DOCS_DIR}/librmm/html"
 popd
 
 rapids-logger "Build Python docs"

--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -1135,7 +1135,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = YES
+GENERATE_HTML          = NO
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
We no longer require separate librmm doc builds since they are incorporated into the Sphinx build now.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
