### PR TITLE
remove references to setup.py in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ are required.
 To set up a development environment, follow the steps in the [README](https://github.com/rapidsai/rmm/blob/main/README.md) for cloning the repository and creating the conda environment.
 Once the environment is created, you can build and install RMM using
 ```bash
-$ python setup.py develop
+$ python -m pip install ./python
 ```
 This command will build the RMM Python library inside the clone and automatically make it importable when running Python anywhere on your machine.
 Remember, if you are unsure about anything, don't hesitate to comment on issues

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ $ make test
 
 - Build, install, and test the `rmm` python package, in the `python` folder:
 ```bash
-$ python setup.py build_ext --inplace
-$ python setup.py install
+$ python -m pip install -e ./python
 $ pytest -v
 ```
 


### PR DESCRIPTION
## Description

Removes remaining references to `setup.py` in documentation.

This project no longer has a `setup.py` as of its switch to `pyproject.toml` + `scikit-build-core` (see #1287, #1300).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

### How I tested this

Built the library in editable mode and ran its tests on a machine w/ 8 V100s.

<details><summary>nvidia-smi output (click me)</summary>

```text
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.105.17   Driver Version: 525.105.17   CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
```
</details>

```shell
mamba env create \
    --name rmm-dev \
    -f ./conda/environments/all_cuda-120_arch-x86_64.yaml

source activate rmm-dev

python -m pip install -e ./python

pytest -v
```

Saw all the tests pass:

```text
... ==== 773 passed, 5 skipped in 48.82s ...
```

To test that editable was working, added the following:

```shell
echo "print('beep boop')" >> ./python/rmm/__init__.py
python -c "import rmm"
# beep boop
```

Confirmed that this caught all references to `setup.py` like this:

```shell
git grep -E 'setup\.py'
```

