### PR TITLE
Refactor CUDA versions in dependencies.yaml.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,7 +8,8 @@ files:
     includes:
       - build
       - checks
-      - cudatoolkit
+      - cuda_version
+      - cuda
       - develop
       - docs
       - py_version
@@ -17,13 +18,13 @@ files:
   test_python:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - py_version
       - test_python
   test_cpp:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - test_cpp
   checks:
     output: none
@@ -33,7 +34,7 @@ files:
   docs:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - docs
       - py_version
   py_build:
@@ -102,9 +103,8 @@ dependencies:
             packages:
               - nvcc_linux-aarch64=11.8
           - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
-              - cuda-version=12.0
               - cuda-nvcc
       - output_types: [conda, requirements, pyproject]
         matrices:
@@ -126,7 +126,7 @@ dependencies:
       - output_types: conda
         packages:
           - &doxygen doxygen=1.9.1
-  cudatoolkit:
+  cuda_version:
     specific:
       - output_types: conda
         matrices:
@@ -134,31 +134,37 @@ dependencies:
               cuda: "11.2"
             packages:
               - cuda-version=11.2
-              - cudatoolkit
           - matrix:
               cuda: "11.4"
             packages:
               - cuda-version=11.4
-              - cudatoolkit
           - matrix:
               cuda: "11.5"
             packages:
               - cuda-version=11.5
-              - cudatoolkit
           - matrix:
               cuda: "11.6"
             packages:
               - cuda-version=11.6
-              - cudatoolkit
           - matrix:
               cuda: "11.8"
             packages:
               - cuda-version=11.8
-              - cudatoolkit
           - matrix:
               cuda: "12.0"
             packages:
               - cuda-version=12.0
+  cuda:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.*"
+            packages:
+              - cudatoolkit
+          - matrix:
+              cuda: "12.*"
+            packages:
   develop:
     common:
       - output_types: [conda, requirements]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,8 +8,8 @@ files:
     includes:
       - build
       - checks
-      - cuda_version
       - cuda
+      - cuda_version
       - develop
       - docs
       - py_version


### PR DESCRIPTION
## Description
This is a follow-up PR to #1414. I thought some more about how to separate `cuda-version` pinnings (which control the CUDA version we use to build and test in conda) from actual CUDA Toolkit package dependencies (which we can handle according to only the major version 11/12). I discussed this PR on a call with @jameslamb in the context of upgrading to CUDA 12.2 (https://github.com/rapidsai/build-planning/issues/6). This set of changes is mostly important for conda builds/tests, since `cuda-version` only controls conda. The pip wheel build/test process is unchanged, since its CUDA versions are controlled by the `shared-workflows` CI images.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
