### PR TITLE
Make device_memory_resource::do_get_mem_info() and supports_get_mem_info() nonvirtual. Remove derived implementations and calls in RMM

### DIFF
--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,13 +59,6 @@ class simulated_memory_resource final : public device_memory_resource {
    */
   [[nodiscard]] bool supports_streams() const noexcept override { return false; }
 
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return false
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
-
  private:
   /**
    * @brief Allocates memory of size at least `bytes`.
@@ -94,18 +87,6 @@ class simulated_memory_resource final : public device_memory_resource {
    * @param ptr Pointer to be deallocated
    */
   void do_deallocate(void* ptr, std::size_t, cuda_stream_view) override {}
-
-  /**
-   * @brief Get free and available memory for memory resource.
-   *
-   * @param stream to execute on.
-   * @return std::pair containing free_size and total_size of memory.
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const override
-  {
-    return std::make_pair(0, 0);
-  }
 
   char* begin_{};
   char* end_{};

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -97,16 +97,6 @@ class aligned_resource_adaptor final : public device_memory_resource {
   }
 
   /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool true if the upstream resource supports get_mem_info, false otherwise.
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
-
-  /**
    * @brief The default alignment used by the adaptor.
    */
   static constexpr std::size_t default_alignment_threshold = 0;
@@ -181,22 +171,6 @@ class aligned_resource_adaptor final : public device_memory_resource {
     auto cast = dynamic_cast<aligned_resource_adaptor<Upstream> const*>(&other);
     return cast != nullptr && upstream_->is_equal(*cast->get_upstream()) &&
            alignment_ == cast->alignment_ && alignment_threshold_ == cast->alignment_threshold_;
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * The free size may not be fully allocatable because of alignment requirements.
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair containing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const override
-  {
-    return upstream_->get_mem_info(stream);
   }
 
   /**

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -118,13 +118,6 @@ class arena_memory_resource final : public device_memory_resource {
    */
   bool supports_streams() const noexcept override { return true; }
 
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool false.
-   */
-  bool supports_get_mem_info() const noexcept override { return false; }
-
  private:
   using global_arena = rmm::mr::detail::arena::global_arena<Upstream>;
   using arena        = rmm::mr::detail::arena::arena<Upstream>;
@@ -310,18 +303,6 @@ class arena_memory_resource final : public device_memory_resource {
       stream_arenas_.emplace(stream.value(), global_arena_);
       return stream_arenas_.at(stream.value());
     }
-  }
-
-  /**
-   * @brief Get free and available memory for memory resource.
-   *
-   * @param stream to execute on.
-   * @return std::pair containing free_size and total_size of memory.
-   */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(
-    [[maybe_unused]] cuda_stream_view stream) const override
-  {
-    return std::make_pair(0, 0);
   }
 
   /**

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -107,13 +107,6 @@ class binning_memory_resource final : public device_memory_resource {
   [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
   /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return false
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
-
-  /**
    * @brief Get the upstream memory_resource object.
    *
    * @return UpstreamResource* the upstream memory resource.
@@ -195,20 +188,6 @@ class binning_memory_resource final : public device_memory_resource {
   {
     auto res = get_resource(bytes);
     if (res != nullptr) { res->deallocate(ptr, bytes, stream); }
-  }
-
-  /**
-   * @brief Get free and available memory for memory resource
-   *
-   * @throws std::runtime_error if we could not get free / total memory
-   *
-   * @param stream the stream being executed on
-   * @return std::pair with available and free memory for resource
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    [[maybe_unused]] cuda_stream_view stream) const override
-  {
-    return std::make_pair(0, 0);
   }
 
   Upstream* upstream_mr_;  // The upstream memory_resource from which to allocate blocks.

--- a/include/rmm/mr/device/callback_memory_resource.hpp
+++ b/include/rmm/mr/device/callback_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,13 +138,7 @@ class callback_memory_resource final : public device_memory_resource {
     deallocate_callback_(ptr, bytes, stream, deallocate_callback_arg_);
   }
 
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view) const override
-  {
-    throw std::runtime_error("cannot get free / total memory");
-  }
-
   [[nodiscard]] bool supports_streams() const noexcept override { return false; }
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 
   allocate_callback_t allocate_callback_;
   deallocate_callback_t deallocate_callback_;

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -164,13 +164,6 @@ class cuda_async_memory_resource final : public device_memory_resource {
    */
   [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return false
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
-
  private:
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   cuda_async_view_memory_resource pool_{};
@@ -231,19 +224,6 @@ class cuda_async_memory_resource final : public device_memory_resource {
 #else
     return async_mr != nullptr;
 #endif
-  }
-
-  /**
-   * @brief Get free and available memory for memory resource
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    rmm::cuda_stream_view) const override
-  {
-    return std::make_pair(0, 0);
   }
 };
 

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -99,13 +99,6 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
    */
   [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return true
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
-
  private:
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   cudaMemPool_t cuda_pool_handle_{};
@@ -168,19 +161,6 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
   [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
     return dynamic_cast<cuda_async_view_memory_resource const*>(&other) != nullptr;
-  }
-
-  /**
-   * @brief Get free and available memory for memory resource
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    rmm::cuda_stream_view) const override
-  {
-    return std::make_pair(0, 0);
   }
 };
 

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,13 +51,6 @@ class cuda_memory_resource final : public device_memory_resource {
    */
   [[nodiscard]] bool supports_streams() const noexcept override { return false; }
 
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return true
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return true; }
-
  private:
   /**
    * @brief Allocates memory of size at least \p bytes.
@@ -107,21 +100,6 @@ class cuda_memory_resource final : public device_memory_resource {
   [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
     return dynamic_cast<cuda_memory_resource const*>(&other) != nullptr;
-  }
-
-  /**
-   * @brief Get free and available memory for memory resource
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view) const override
-  {
-    std::size_t free_size{};
-    std::size_t total_size{};
-    RMM_CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));
-    return std::make_pair(free_size, total_size);
   }
 };
 /** @} */  // end of group

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -306,7 +306,6 @@ class device_memory_resource {
    *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
-  //[[deprecated("Use rmm::available_device_memory())")]]  //
   [[nodiscard]] virtual bool supports_get_mem_info() const noexcept { return false; };
 
   /**
@@ -317,7 +316,6 @@ class device_memory_resource {
    * @returns a pair containing the free memory in bytes in .first and total amount of memory in
    * .second
    */
-  //[[deprecated("Use rmm::available_device_memory())")]]  //
   [[nodiscard]] std::pair<std::size_t, std::size_t> get_mem_info(cuda_stream_view stream) const
   {
     return do_get_mem_info(stream);

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -306,7 +306,8 @@ class device_memory_resource {
    *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
-  [[nodiscard]] virtual bool supports_get_mem_info() const noexcept = 0;
+  //[[deprecated("Use rmm::available_device_memory())")]]  //
+  [[nodiscard]] virtual bool supports_get_mem_info() const noexcept { return false; };
 
   /**
    * @brief Queries the amount of free and total memory for the resource.
@@ -316,6 +317,7 @@ class device_memory_resource {
    * @returns a pair containing the free memory in bytes in .first and total amount of memory in
    * .second
    */
+  //[[deprecated("Use rmm::available_device_memory())")]]  //
   [[nodiscard]] std::pair<std::size_t, std::size_t> get_mem_info(cuda_stream_view stream) const
   {
     return do_get_mem_info(stream);
@@ -384,7 +386,10 @@ class device_memory_resource {
    * @return std::pair with available and free memory for resource
    */
   [[nodiscard]] virtual std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const = 0;
+    cuda_stream_view stream) const
+  {
+    return {0, 0};
+  }
 };
 static_assert(cuda::mr::async_resource_with<device_memory_resource, cuda::mr::device_accessible>);
 /** @} */  // end of group

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,16 +135,6 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
     return upstream_->supports_streams();
   }
 
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool true if the upstream resource supports get_mem_info, false otherwise.
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
-
  private:
   /**
    * @brief Allocates memory of size at least `bytes` using the upstream
@@ -197,20 +187,6 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
     auto cast = dynamic_cast<failure_callback_resource_adaptor<Upstream> const*>(&other);
     return cast != nullptr ? upstream_->is_equal(*cast->get_upstream())
                            : upstream_->is_equal(other);
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const override
-  {
-    return upstream_->get_mem_info(stream);
   }
 
   Upstream* upstream_;  // the upstream resource used for satisfying allocation requests

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -105,13 +105,6 @@ class fixed_size_memory_resource
   [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
   /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return false
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
-
-  /**
    * @brief Get the upstream memory_resource object.
    *
    * @return UpstreamResource* the upstream memory resource.
@@ -212,20 +205,6 @@ class fixed_size_memory_resource
   }
 
   /**
-   * @brief Get free and available memory for memory resource
-   *
-   * @throws std::runtime_error if we could not get free / total memory
-   *
-   * @param stream the stream being executed on
-   * @return std::pair with available and free memory for resource
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    [[maybe_unused]] cuda_stream_view stream) const override
-  {
-    return std::make_pair(0, 0);
-  }
-
-  /**
    * @brief free all memory allocated using the upstream resource.
    *
    */
@@ -244,7 +223,7 @@ class fixed_size_memory_resource
   {
     lock_guard lock(this->get_mutex());
 
-    auto const [free, total] = get_upstream()->get_mem_info(rmm::cuda_stream_default);
+    auto const [free, total] = rmm::available_device_memory();
     std::cout << "GPU free memory: " << free << " total: " << total << "\n";
 
     std::cout << "upstream_blocks: " << upstream_blocks_.size() << "\n";

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -89,16 +89,6 @@ class limiting_resource_adaptor final : public device_memory_resource {
   }
 
   /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool true if the upstream resource supports get_mem_info, false otherwise.
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
-
-  /**
    * @brief Query the number of bytes that have been allocated. Note that
    * this can not be used to know how large of an allocation is possible due
    * to both possible fragmentation and also internal page sizes and alignment
@@ -176,20 +166,6 @@ class limiting_resource_adaptor final : public device_memory_resource {
     auto const* cast = dynamic_cast<limiting_resource_adaptor<Upstream> const*>(&other);
     if (cast != nullptr) { return upstream_->is_equal(*cast->get_upstream()); }
     return upstream_->is_equal(other);
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    [[maybe_unused]] cuda_stream_view stream) const override
-  {
-    return {allocation_limit_ - allocated_bytes_, allocation_limit_};
   }
 
   // maximum bytes this allocator is allowed to allocate.

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,16 +155,6 @@ class logging_resource_adaptor final : public device_memory_resource {
   }
 
   /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool true if the upstream resource supports get_mem_info, false otherwise.
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
-
-  /**
    * @brief Flush logger contents.
    */
   void flush() { logger_->flush(); }
@@ -293,20 +283,6 @@ class logging_resource_adaptor final : public device_memory_resource {
     auto const* cast = dynamic_cast<logging_resource_adaptor<Upstream> const*>(&other);
     if (cast != nullptr) { return upstream_->is_equal(*cast->get_upstream()); }
     return upstream_->is_equal(other);
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const override
-  {
-    return upstream_->get_mem_info(stream);
   }
 
   // make_logging_adaptor needs access to private get_default_filename

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,13 +50,6 @@ class managed_memory_resource final : public device_memory_resource {
    * @returns false
    */
   [[nodiscard]] bool supports_streams() const noexcept override { return false; }
-
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return true
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return true; }
 
  private:
   /**
@@ -111,23 +104,6 @@ class managed_memory_resource final : public device_memory_resource {
   [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
     return dynamic_cast<managed_memory_resource const*>(&other) != nullptr;
-  }
-
-  /**
-   * @brief Get free and available memory for memory resource
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info
-   *
-   * @param stream to execute on
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    [[maybe_unused]] cuda_stream_view stream) const override
-  {
-    std::size_t free_size{};
-    std::size_t total_size{};
-    RMM_CUDA_TRY(cudaMemGetInfo(&free_size, &total_size));
-    return std::make_pair(free_size, total_size);
   }
 };
 

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,14 +165,6 @@ class owning_wrapper : public device_memory_resource {
     return wrapped().supports_streams();
   }
 
-  /**
-   * @briefreturn{true if the wrapped resource supports get_mem_info, false otherwise}
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override
-  {
-    return wrapped().supports_get_mem_info();
-  }
-
  private:
   /**
    * @brief Allocates memory using the wrapped resource.
@@ -218,20 +210,6 @@ class owning_wrapper : public device_memory_resource {
     auto casted = dynamic_cast<owning_wrapper<Resource, Upstreams...> const*>(&other);
     if (nullptr != casted) { return wrapped().is_equal(casted->wrapped()); }
     return wrapped().is_equal(other);
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const override
-  {
-    return wrapped().get_mem_info(stream);
   }
 
   upstream_tuple upstreams_;           ///< The owned upstream resources

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -237,13 +237,6 @@ class pool_memory_resource final
   [[nodiscard]] bool supports_streams() const noexcept override { return true; }
 
   /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool false
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
-
-  /**
    * @brief Get the upstream memory_resource object.
    *
    * @return const reference to the upstream memory resource.
@@ -487,7 +480,7 @@ class pool_memory_resource final
   {
     lock_guard lock(this->get_mutex());
 
-    auto const [free, total] = upstream_mr_->get_mem_info(rmm::cuda_stream_default);
+    auto const [free, total] = rmm::available_device_memory();
     std::cout << "GPU free memory: " << free << " total: " << total << "\n";
 
     std::cout << "upstream_blocks: " << upstream_blocks_.size() << "\n";
@@ -526,21 +519,6 @@ class pool_memory_resource final
       largest = std::max(largest, block.size());
     });
     return {largest, total};
-  }
-
-  /**
-   * @brief Get free and available memory for memory resource
-   *
-   * @throws nothing
-   *
-   * @param stream to execute on
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const override
-  {
-    // TODO implement this
-    return {0, 0};
   }
 
  private:

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,16 +120,6 @@ class statistics_resource_adaptor final : public device_memory_resource {
   bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
 
   /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool true if the upstream resource supports get_mem_info, false otherwise.
-   */
-  bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
-
-  /**
    * @brief Returns a `counter` struct for this adaptor containing the current,
    * peak, and total number of allocated bytes for this
    * adaptor since it was created.
@@ -220,19 +210,6 @@ class statistics_resource_adaptor final : public device_memory_resource {
     auto cast = dynamic_cast<statistics_resource_adaptor<Upstream> const*>(&other);
     return cast != nullptr ? upstream_->is_equal(*cast->get_upstream())
                            : upstream_->is_equal(other);
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
-  {
-    return upstream_->get_mem_info(stream);
   }
 
   counter bytes_;                        // peak, current and total allocated bytes

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,16 +76,6 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    */
   bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
 
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool true if the upstream resource supports get_mem_info, false otherwise.
-   */
-  bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
-
  private:
   /**
    * @brief Allocates memory of size at least `bytes` using the upstream
@@ -132,20 +122,6 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
       return upstream_->is_equal(*thread_safe_other->get_upstream());
     }
     return upstream_->is_equal(other);
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
-  {
-    lock_t lock(mtx);
-    return upstream_->get_mem_info(stream);
   }
 
   std::mutex mutable mtx;  // mutex for thread safe access to upstream

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,16 +117,6 @@ class tracking_resource_adaptor final : public device_memory_resource {
    * @return false The upstream resource does not support streams.
    */
   bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
-
-  /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool true if the upstream resource supports get_mem_info, false otherwise.
-   */
-  bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
 
   /**
    * @brief Get the outstanding allocations map
@@ -275,19 +265,6 @@ class tracking_resource_adaptor final : public device_memory_resource {
     auto cast = dynamic_cast<tracking_resource_adaptor<Upstream> const*>(&other);
     return cast != nullptr ? upstream_->is_equal(*cast->get_upstream())
                            : upstream_->is_equal(other);
-  }
-
-  /**
-   * @brief Get free and available memory from upstream resource.
-   *
-   * @throws rmm::cuda_error if unable to retrieve memory info.
-   *
-   * @param stream Stream on which to get the mem info.
-   * @return std::pair contaiing free_size and total_size of memory
-   */
-  std::pair<std::size_t, std::size_t> do_get_mem_info(cuda_stream_view stream) const override
-  {
-    return upstream_->get_mem_info(stream);
   }
 
   bool capture_stacks_;                           // whether or not to capture call stacks

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -57,26 +57,6 @@ class pinned_memory_resource final : public host_memory_resource {
   [[nodiscard]] bool supports_streams() const noexcept { return false; }
 
   /**
-   * @brief Query whether the resource supports the get_mem_info API.
-   *
-   * @return bool false.
-   */
-  [[nodiscard]] bool supports_get_mem_info() const noexcept { return false; }
-
-  /**
-   * @brief Queries the amount of free and total memory for the resource.
-   *
-   * @param stream the stream whose memory manager we want to retrieve
-   *
-   * @returns a pair containing the free memory in bytes in .first and total amount of memory in
-   * .second
-   */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> get_mem_info(cuda_stream_view stream) const
-  {
-    return std::make_pair(0, 0);
-  }
-
-  /**
    * @brief Pretend to support the allocate_async interface, falling back to stream 0
    *
    * @throws rmm::bad_alloc When the requested `bytes` cannot be allocated on

--- a/tests/device_check_resource_adaptor.hpp
+++ b/tests/device_check_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,6 @@ class device_check_resource_adaptor final : public rmm::mr::device_memory_resour
     return upstream_->supports_streams();
   }
 
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override
-  {
-    return upstream_->supports_get_mem_info();
-  }
-
   [[nodiscard]] device_memory_resource* get_upstream() const noexcept { return upstream_; }
 
  private:
@@ -64,12 +59,6 @@ class device_check_resource_adaptor final : public rmm::mr::device_memory_resour
     auto const* cast = dynamic_cast<device_check_resource_adaptor const*>(&other);
     if (cast != nullptr) { return upstream_->is_equal(*cast->get_upstream()); }
     return upstream_->is_equal(other);
-  }
-
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    rmm::cuda_stream_view stream) const override
-  {
-    return upstream_->get_mem_info(stream);
   }
 
   rmm::cuda_device_id device_id;

--- a/tests/mock_resource.hpp
+++ b/tests/mock_resource.hpp
@@ -24,11 +24,9 @@ namespace rmm::test {
 class mock_resource : public rmm::mr::device_memory_resource {
  public:
   MOCK_METHOD(bool, supports_streams, (), (const, override, noexcept));
-  MOCK_METHOD(bool, supports_get_mem_info, (), (const, override, noexcept));
   MOCK_METHOD(void*, do_allocate, (std::size_t, cuda_stream_view), (override));
   MOCK_METHOD(void, do_deallocate, (void*, std::size_t, cuda_stream_view), (override));
   using size_pair = std::pair<std::size_t, std::size_t>;
-  MOCK_METHOD(size_pair, do_get_mem_info, (cuda_stream_view), (const, override));
 };
 
 }  // namespace rmm::test

--- a/tests/mr/device/adaptor_tests.cpp
+++ b/tests/mr/device/adaptor_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,20 +145,6 @@ TYPED_TEST(AdaptorTest, GetUpstream)
 TYPED_TEST(AdaptorTest, SupportsStreams)
 {
   EXPECT_EQ(this->mr->supports_streams(), this->cuda.supports_streams());
-}
-
-TYPED_TEST(AdaptorTest, MemInfo)
-{
-  EXPECT_EQ(this->mr->supports_get_mem_info(), this->cuda.supports_get_mem_info());
-
-  auto [free, total] = this->mr->get_mem_info(rmm::cuda_stream_default);
-
-  if (this->mr->supports_get_mem_info()) {
-    EXPECT_NE(total, 0);
-  } else {
-    EXPECT_EQ(free, 0);
-    EXPECT_EQ(total, 0);
-  }
 }
 
 TYPED_TEST(AdaptorTest, AllocFree)

--- a/tests/mr/device/aligned_mr_tests.cpp
+++ b/tests/mr/device/aligned_mr_tests.cpp
@@ -72,12 +72,6 @@ TEST(AlignedTest, SupportsGetMemInfo)
 {
   mock_resource mock;
   aligned_mock mr{&mock};
-
-  EXPECT_CALL(mock, supports_get_mem_info()).WillOnce(Return(true));
-  EXPECT_TRUE(mr.supports_get_mem_info());
-
-  EXPECT_CALL(mock, supports_get_mem_info()).WillOnce(Return(false));
-  EXPECT_FALSE(mr.supports_get_mem_info());
 }
 
 TEST(AlignedTest, DefaultAllocationAlignmentPassthrough)

--- a/tests/mr/device/arena_mr_tests.cpp
+++ b/tests/mr/device/arena_mr_tests.cpp
@@ -596,10 +596,6 @@ TEST_F(ArenaTest, FeatureSupport)  // NOLINT
 {
   arena_mr mr{rmm::mr::get_current_device_resource(), 1_MiB};
   EXPECT_TRUE(mr.supports_streams());
-  EXPECT_FALSE(mr.supports_get_mem_info());
-  auto [free, total] = mr.get_mem_info(rmm::cuda_stream_default);
-  EXPECT_EQ(free, 0);
-  EXPECT_EQ(total, 0);
 }
 
 }  // namespace

--- a/tests/mr/device/failure_callback_mr_tests.cpp
+++ b/tests/mr/device/failure_callback_mr_tests.cpp
@@ -61,14 +61,8 @@ class always_throw_memory_resource final : public mr::device_memory_resource {
     throw ExceptionType{"foo"};
   }
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override{};
-  [[nodiscard]] std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const override
-  {
-    return {0, 0};
-  }
 
   [[nodiscard]] bool supports_streams() const noexcept override { return false; }
-  [[nodiscard]] bool supports_get_mem_info() const noexcept override { return false; }
 };
 
 TEST(FailureCallbackTest, DifferentExceptionTypes)

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -95,31 +95,6 @@ TEST_P(mr_test, SupportsStreams)
   }
 }
 
-TEST_P(mr_test, GetMemInfo)
-{
-  if (this->mr->supports_get_mem_info()) {
-    const auto allocation_size{16 * 256};
-    {
-      auto const [free, total] = this->mr->get_mem_info(rmm::cuda_stream_view{});
-      EXPECT_TRUE(free >= allocation_size);
-    }
-
-    void* ptr{nullptr};
-    ptr = this->mr->allocate(allocation_size);
-
-    {
-      auto const [free, total] = this->mr->get_mem_info(rmm::cuda_stream_view{});
-      EXPECT_TRUE(free >= allocation_size);
-    }
-
-    this->mr->deallocate(ptr, allocation_size);
-  } else {
-    auto const [free, total] = this->mr->get_mem_info(rmm::cuda_stream_view{});
-    EXPECT_EQ(free, 0);
-    EXPECT_EQ(total, 0);
-  }
-}
-
 // Simple reproducer for https://github.com/rapidsai/rmm/issues/861
 TEST_P(mr_test, AllocationsAreDifferentDefaultStream)
 {

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -213,7 +213,6 @@ class fake_async_resource {
 
   // To model stream_resource
   [[nodiscard]] bool supports_streams() const noexcept { return false; }
-  [[nodiscard]] bool supports_get_mem_info() const noexcept { return false; }
 
  private:
   void* do_allocate(std::size_t bytes, cuda_stream_view) { return nullptr; }


### PR DESCRIPTION
## Description

Closes #1426

As part of #1388, this PR contributes to deprecating and removing all `get_mem_info` functionality from memory resources.  This first PR makes these methods optional without deprecating them. 

 - Makes `rmm::mr::device_memory_resource::supports_get_mem_info()` nonvirtual (and always return false) 
 - Makes `rmm::mr::device_memory_resource::do_get_mem_info()` nonvirtual (and always return `{0, 0}`).
 - Removes all derived implementations of the above.
 - Removes all calls to the above.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
