### PR TITLE
Deprecate rmm::mr::device_memory_resource::get_mem_info() and supports_get_mem_info().

### DIFF
--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -304,6 +304,8 @@ class device_memory_resource {
   /**
    * @brief Query whether the resource supports the get_mem_info API.
    *
+   * @deprecated Use rmm::available_device_memory instead.
+   *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
   [[deprecated("Use rmm::available_device_memory instead.")]]  //
@@ -315,6 +317,8 @@ class device_memory_resource {
 
   /**
    * @brief Queries the amount of free and total memory for the resource.
+   *
+   * @deprecated Use rmm::available_device_memory instead.
    *
    * @param stream the stream whose memory manager we want to retrieve
    *

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -306,7 +306,12 @@ class device_memory_resource {
    *
    * @return bool true if the resource supports get_mem_info, false otherwise.
    */
-  [[nodiscard]] virtual bool supports_get_mem_info() const noexcept { return false; };
+  [[deprecated("Use rmm::available_device_memory instead.")]]  //
+  [[nodiscard]] virtual bool
+  supports_get_mem_info() const noexcept
+  {
+    return false;
+  };
 
   /**
    * @brief Queries the amount of free and total memory for the resource.
@@ -316,9 +321,11 @@ class device_memory_resource {
    * @returns a pair containing the free memory in bytes in .first and total amount of memory in
    * .second
    */
-  [[nodiscard]] std::pair<std::size_t, std::size_t> get_mem_info(cuda_stream_view stream) const
+  [[deprecated("Use rmm::available_device_memory instead.")]]  //
+  [[nodiscard]] std::pair<std::size_t, std::size_t>
+  get_mem_info(cuda_stream_view stream) const
   {
-    return do_get_mem_info(stream);
+    return {0, 0};
   }
 
   /**
@@ -373,20 +380,6 @@ class device_memory_resource {
   [[nodiscard]] virtual bool do_is_equal(device_memory_resource const& other) const noexcept
   {
     return this == &other;
-  }
-
-  /**
-   * @brief Get free and available memory for memory resource
-   *
-   * @throws std::runtime_error if we could not get free / total memory
-   *
-   * @param stream the stream being executed on
-   * @return std::pair with available and free memory for resource
-   */
-  [[nodiscard]] virtual std::pair<std::size_t, std::size_t> do_get_mem_info(
-    cuda_stream_view stream) const
-  {
-    return {0, 0};
   }
 };
 static_assert(cuda::mr::async_resource_with<device_memory_resource, cuda::mr::device_accessible>);

--- a/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -178,26 +178,6 @@ class pinned_host_memory_resource {
   bool operator!=(const pinned_host_memory_resource&) const { return false; }
 
   /**
-   * @brief Query whether the resource supports reporting free and available memory.
-   *
-   * @return false
-   */
-  static bool supports_get_mem_info() { return false; }
-
-  /**
-   * @brief Query the total amount of memory and free memory available for allocation by this
-   * resource.
-   *
-   * @throws nothing
-   *
-   * @return std::pair containing 0 for both total and free memory.
-   */
-  [[nodiscard]] static std::pair<std::size_t, std::size_t> get_mem_info(cuda::stream_ref) noexcept
-  {
-    return {0, 0};
-  }
-
-  /**
    * @brief Enables the `cuda::mr::device_accessible` property
    *
    * This property declares that a `pinned_host_memory_resource` provides device accessible memory


### PR DESCRIPTION
## Description
Closes #1427 . Part of #1388.

#1430 made these functions non-virtual and removed them from all MRs and tests. This PR completes the next step of deprecating them.  

Merge after 
 - https://github.com/rapidsai/raft/pull/2108
 - https://github.com/rapidsai/cudf/pull/14832

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
