### PR TITLE
Make device_memory_resource::supports_streams() not pure virtual. Remove derived implementations and calls in RMM

### DIFF
--- a/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/benchmarks/utilities/simulated_memory_resource.hpp
@@ -51,14 +51,6 @@ class simulated_memory_resource final : public device_memory_resource {
   simulated_memory_resource(simulated_memory_resource&&)                 = delete;
   simulated_memory_resource& operator=(simulated_memory_resource&&)      = delete;
 
-  /**
-   * @brief Query whether the resource supports use of non-null CUDA streams for
-   * allocation/deallocation.
-   *
-   * @returns bool false
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override { return false; }
-
  private:
   /**
    * @brief Allocates memory of size at least `bytes`.

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -89,14 +89,6 @@ class aligned_resource_adaptor final : public device_memory_resource {
   Upstream* get_upstream() const noexcept { return upstream_; }
 
   /**
-   * @copydoc rmm::mr::device_memory_resource::supports_streams()
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override
-  {
-    return upstream_->supports_streams();
-  }
-
-  /**
    * @brief The default alignment used by the adaptor.
    */
   static constexpr std::size_t default_alignment_threshold = 0;

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -110,14 +110,6 @@ class arena_memory_resource final : public device_memory_resource {
   arena_memory_resource(arena_memory_resource&&) noexcept            = delete;
   arena_memory_resource& operator=(arena_memory_resource&&) noexcept = delete;
 
-  /**
-   * @brief Queries whether the resource supports use of non-null CUDA streams for
-   * allocation/deallocation.
-   *
-   * @returns bool true.
-   */
-  bool supports_streams() const noexcept override { return true; }
-
  private:
   using global_arena = rmm::mr::detail::arena::global_arena<Upstream>;
   using arena        = rmm::mr::detail::arena::arena<Upstream>;

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -99,14 +99,6 @@ class binning_memory_resource final : public device_memory_resource {
   binning_memory_resource& operator=(binning_memory_resource&&)      = delete;
 
   /**
-   * @brief Query whether the resource supports use of non-null streams for
-   * allocation/deallocation.
-   *
-   * @returns true
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
-
-  /**
    * @brief Get the upstream memory_resource object.
    *
    * @return UpstreamResource* the upstream memory resource.

--- a/include/rmm/mr/device/callback_memory_resource.hpp
+++ b/include/rmm/mr/device/callback_memory_resource.hpp
@@ -138,8 +138,6 @@ class callback_memory_resource final : public device_memory_resource {
     deallocate_callback_(ptr, bytes, stream, deallocate_callback_arg_);
   }
 
-  [[nodiscard]] bool supports_streams() const noexcept override { return false; }
-
   allocate_callback_t allocate_callback_;
   deallocate_callback_t deallocate_callback_;
   void* allocate_callback_arg_;

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -156,14 +156,6 @@ class cuda_async_memory_resource final : public device_memory_resource {
   cuda_async_memory_resource& operator=(cuda_async_memory_resource const&) = delete;
   cuda_async_memory_resource& operator=(cuda_async_memory_resource&&)      = delete;
 
-  /**
-   * @brief Query whether the resource supports use of non-null CUDA streams for
-   * allocation/deallocation. `cuda_memory_resource` does not support streams.
-   *
-   * @returns bool true
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
-
  private:
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   cuda_async_view_memory_resource pool_{};

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -91,14 +91,6 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
   cuda_async_view_memory_resource& operator=(cuda_async_view_memory_resource&&) =
     default;  ///< @default_move_assignment{cuda_async_view_memory_resource}
 
-  /**
-   * @brief Query whether the resource supports use of non-null CUDA streams for
-   * allocation/deallocation. `cuda_memory_resource` does not support streams.
-   *
-   * @returns bool true
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
-
  private:
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
   cudaMemPool_t cuda_pool_handle_{};

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -43,14 +43,6 @@ class cuda_memory_resource final : public device_memory_resource {
   cuda_memory_resource& operator=(cuda_memory_resource&&) =
     default;  ///< @default_move_assignment{cuda_memory_resource}
 
-  /**
-   * @brief Query whether the resource supports use of non-null CUDA streams for
-   * allocation/deallocation. `cuda_memory_resource` does not support streams.
-   *
-   * @returns bool false
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override { return false; }
-
  private:
   /**
    * @brief Allocates memory of size at least \p bytes.

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -299,7 +299,7 @@ class device_memory_resource {
    *
    * @returns bool true if the resource supports non-null CUDA streams.
    */
-  [[nodiscard]] virtual bool supports_streams() const noexcept = 0;
+  [[nodiscard]] virtual bool supports_streams() const noexcept { return false; }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -124,17 +124,6 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
    */
   Upstream* get_upstream() const noexcept { return upstream_; }
 
-  /**
-   * @brief Checks whether the upstream resource supports streams.
-   *
-   * @return true The upstream resource supports streams
-   * @return false The upstream resource does not support streams.
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override
-  {
-    return upstream_->supports_streams();
-  }
-
  private:
   /**
    * @brief Allocates memory of size at least `bytes` using the upstream

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -97,14 +97,6 @@ class fixed_size_memory_resource
   fixed_size_memory_resource& operator=(fixed_size_memory_resource&&)      = delete;
 
   /**
-   * @brief Query whether the resource supports use of non-null streams for
-   * allocation/deallocation.
-   *
-   * @returns true
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
-
-  /**
    * @brief Get the upstream memory_resource object.
    *
    * @return UpstreamResource* the upstream memory resource.

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -78,17 +78,6 @@ class limiting_resource_adaptor final : public device_memory_resource {
   [[nodiscard]] Upstream* get_upstream() const noexcept { return upstream_; }
 
   /**
-   * @brief Checks whether the upstream resource supports streams.
-   *
-   * @return true The upstream resource supports streams
-   * @return false The upstream resource does not support streams.
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override
-  {
-    return upstream_->supports_streams();
-  }
-
-  /**
    * @brief Query the number of bytes that have been allocated. Note that
    * this can not be used to know how large of an allocation is possible due
    * to both possible fragmentation and also internal page sizes and alignment

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -144,17 +144,6 @@ class logging_resource_adaptor final : public device_memory_resource {
   [[nodiscard]] Upstream* get_upstream() const noexcept { return upstream_; }
 
   /**
-   * @brief Checks whether the upstream resource supports streams.
-   *
-   * @return true The upstream resource supports streams
-   * @return false The upstream resource does not support streams.
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override
-  {
-    return upstream_->supports_streams();
-  }
-
-  /**
    * @brief Flush logger contents.
    */
   void flush() { logger_->flush(); }

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -43,14 +43,6 @@ class managed_memory_resource final : public device_memory_resource {
   managed_memory_resource& operator=(managed_memory_resource&&) =
     default;  ///< @default_move_assignment{managed_memory_resource}
 
-  /**
-   * @brief Query whether the resource supports use of non-null streams for
-   * allocation/deallocation.
-   *
-   * @returns false
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override { return false; }
-
  private:
   /**
    * @brief Allocates memory of size at least \p bytes.

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -157,14 +157,6 @@ class owning_wrapper : public device_memory_resource {
    */
   [[nodiscard]] Resource& wrapped() noexcept { return *wrapped_; }
 
-  /**
-   * @copydoc rmm::mr::device_memory_resource::supports_streams()
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override
-  {
-    return wrapped().supports_streams();
-  }
-
  private:
   /**
    * @brief Allocates memory using the wrapped resource.

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -229,14 +229,6 @@ class pool_memory_resource final
   pool_memory_resource& operator=(pool_memory_resource&&)      = delete;
 
   /**
-   * @brief Queries whether the resource supports use of non-null CUDA streams for
-   * allocation/deallocation.
-   *
-   * @returns bool true.
-   */
-  [[nodiscard]] bool supports_streams() const noexcept override { return true; }
-
-  /**
    * @brief Get the upstream memory_resource object.
    *
    * @return const reference to the upstream memory resource.

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -112,14 +112,6 @@ class statistics_resource_adaptor final : public device_memory_resource {
   Upstream* get_upstream() const noexcept { return upstream_; }
 
   /**
-   * @brief Checks whether the upstream resource supports streams.
-   *
-   * @return true The upstream resource supports streams
-   * @return false The upstream resource does not support streams.
-   */
-  bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
-
-  /**
    * @brief Returns a `counter` struct for this adaptor containing the current,
    * peak, and total number of allocated bytes for this
    * adaptor since it was created.

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -71,11 +71,6 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
    */
   Upstream* get_upstream() const noexcept { return upstream_; }
 
-  /**
-   * @copydoc rmm::mr::device_memory_resource::supports_streams()
-   */
-  bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
-
  private:
   /**
    * @brief Allocates memory of size at least `bytes` using the upstream

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -111,14 +111,6 @@ class tracking_resource_adaptor final : public device_memory_resource {
   Upstream* get_upstream() const noexcept { return upstream_; }
 
   /**
-   * @brief Checks whether the upstream resource supports streams.
-   *
-   * @return true The upstream resource supports streams
-   * @return false The upstream resource does not support streams.
-   */
-  bool supports_streams() const noexcept override { return upstream_->supports_streams(); }
-
-  /**
    * @brief Get the outstanding allocations map
    *
    * @return std::map<void*, allocation_info> const& of a map of allocations. The key

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -49,14 +49,6 @@ class pinned_memory_resource final : public host_memory_resource {
     default;  ///< @default_move_assignment{pinned_memory_resource}
 
   /**
-   * @brief Query whether the pinned_memory_resource supports use of non-null CUDA streams for
-   * allocation/deallocation.
-   *
-   * @returns bool false.
-   */
-  [[nodiscard]] bool supports_streams() const noexcept { return false; }
-
-  /**
    * @brief Pretend to support the allocate_async interface, falling back to stream 0
    *
    * @throws rmm::bad_alloc When the requested `bytes` cannot be allocated on

--- a/tests/device_check_resource_adaptor.hpp
+++ b/tests/device_check_resource_adaptor.hpp
@@ -27,11 +27,6 @@ class device_check_resource_adaptor final : public rmm::mr::device_memory_resour
   {
   }
 
-  [[nodiscard]] bool supports_streams() const noexcept override
-  {
-    return upstream_->supports_streams();
-  }
-
   [[nodiscard]] device_memory_resource* get_upstream() const noexcept { return upstream_; }
 
  private:

--- a/tests/mr/device/adaptor_tests.cpp
+++ b/tests/mr/device/adaptor_tests.cpp
@@ -142,11 +142,6 @@ TYPED_TEST(AdaptorTest, GetUpstream)
   }
 }
 
-TYPED_TEST(AdaptorTest, SupportsStreams)
-{
-  EXPECT_EQ(this->mr->supports_streams(), this->cuda.supports_streams());
-}
-
 TYPED_TEST(AdaptorTest, AllocFree)
 {
   void* ptr{nullptr};

--- a/tests/mr/device/aligned_mr_tests.cpp
+++ b/tests/mr/device/aligned_mr_tests.cpp
@@ -56,18 +56,6 @@ TEST(AlignedTest, ThrowOnInvalidAllocationAlignment)
   EXPECT_THROW(construct_alignment(&mock, 768), rmm::logic_error);
 }
 
-TEST(AlignedTest, SupportsStreams)
-{
-  mock_resource mock;
-  aligned_mock mr{&mock};
-
-  EXPECT_CALL(mock, supports_streams()).WillOnce(Return(true));
-  EXPECT_TRUE(mr.supports_streams());
-
-  EXPECT_CALL(mock, supports_streams()).WillOnce(Return(false));
-  EXPECT_FALSE(mr.supports_streams());
-}
-
 TEST(AlignedTest, SupportsGetMemInfo)
 {
   mock_resource mock;

--- a/tests/mr/device/arena_mr_tests.cpp
+++ b/tests/mr/device/arena_mr_tests.cpp
@@ -592,11 +592,5 @@ TEST_F(ArenaTest, DumpLogOnFailure)  // NOLINT
   EXPECT_GE(file_status.st_size, 0);
 }
 
-TEST_F(ArenaTest, FeatureSupport)  // NOLINT
-{
-  arena_mr mr{rmm::mr::get_current_device_resource(), 1_MiB};
-  EXPECT_TRUE(mr.supports_streams());
-}
-
 }  // namespace
 }  // namespace rmm::test

--- a/tests/mr/device/failure_callback_mr_tests.cpp
+++ b/tests/mr/device/failure_callback_mr_tests.cpp
@@ -61,8 +61,6 @@ class always_throw_memory_resource final : public mr::device_memory_resource {
     throw ExceptionType{"foo"};
   }
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) override{};
-
-  [[nodiscard]] bool supports_streams() const noexcept override { return false; }
 };
 
 TEST(FailureCallbackTest, DifferentExceptionTypes)

--- a/tests/mr/device/mr_tests.cpp
+++ b/tests/mr/device/mr_tests.cpp
@@ -87,16 +87,6 @@ TEST_P(mr_test, SetCurrentDeviceResource)
 
 TEST_P(mr_test, SelfEquality) { EXPECT_TRUE(this->mr->is_equal(*this->mr)); }
 
-TEST_P(mr_test, SupportsStreams)
-{
-  if (this->mr->is_equal(rmm::mr::cuda_memory_resource{}) ||
-      this->mr->is_equal(rmm::mr::managed_memory_resource{})) {
-    EXPECT_FALSE(this->mr->supports_streams());
-  } else {
-    EXPECT_TRUE(this->mr->supports_streams());
-  }
-}
-
 // Simple reproducer for https://github.com/rapidsai/rmm/issues/861
 TEST_P(mr_test, AllocationsAreDifferentDefaultStream)
 {

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -211,9 +211,6 @@ class fake_async_resource {
   bool operator==(const fake_async_resource& other) const { return true; }
   bool operator!=(const fake_async_resource& other) const { return false; }
 
-  // To model stream_resource
-  [[nodiscard]] bool supports_streams() const noexcept { return false; }
-
  private:
   void* do_allocate(std::size_t bytes, cuda_stream_view) { return nullptr; }
   void do_deallocate(void* ptr, std::size_t, cuda_stream_view) {}


### PR DESCRIPTION
Closes #1432. Part of #1389 

- Make supports_streams() nonpure
- Remove supports_streams() from all MRs and tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
