### PR TITLE
Change `rmm::exec_policy` to take `async_resource_ref`

### DIFF
--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -29,8 +29,6 @@
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
 
-#include <cuda/memory_resource>
-
 namespace rmm {
 /**
  * @addtogroup thrust_integrations
@@ -42,7 +40,7 @@ namespace rmm {
  * @brief Synchronous execution policy for allocations using thrust
  */
 using thrust_exec_policy_t =
-  thrust::detail::execute_with_allocator<rmm::mr::thrust_allocator<char>,
+  thrust::detail::execute_with_allocator<mr::thrust_allocator<char>,
                                          thrust::cuda_cub::execute_on_stream_base>;
 
 /**
@@ -57,10 +55,10 @@ class exec_policy : public thrust_exec_policy_t {
    * @param stream The stream on which to allocate temporary memory
    * @param mr The resource to use for allocating temporary memory
    */
-  explicit exec_policy(cuda_stream_view stream           = cuda_stream_default,
-                       rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
+  explicit exec_policy(cuda_stream_view stream      = cuda_stream_default,
+                       device_async_resource_ref mr = mr::get_current_device_resource())
     : thrust_exec_policy_t(
-        thrust::cuda::par(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
+        thrust::cuda::par(mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
   {
   }
 };
@@ -71,7 +69,7 @@ class exec_policy : public thrust_exec_policy_t {
  * @brief Asynchronous execution policy for allocations using thrust
  */
 using thrust_exec_policy_nosync_t =
-  thrust::detail::execute_with_allocator<rmm::mr::thrust_allocator<char>,
+  thrust::detail::execute_with_allocator<mr::thrust_allocator<char>,
                                          thrust::cuda_cub::execute_on_stream_nosync_base>;
 /**
  * @brief Helper class usable as a Thrust CUDA execution policy
@@ -81,11 +79,10 @@ using thrust_exec_policy_nosync_t =
  */
 class exec_policy_nosync : public thrust_exec_policy_nosync_t {
  public:
-  explicit exec_policy_nosync(
-    cuda_stream_view stream           = cuda_stream_default,
-    rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
+  explicit exec_policy_nosync(cuda_stream_view stream      = cuda_stream_default,
+                              device_async_resource_ref mr = mr::get_current_device_resource())
     : thrust_exec_policy_nosync_t(
-        thrust::cuda::par_nosync(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
+        thrust::cuda::par_nosync(mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
   {
   }
 };

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
 
+#include <cuda/memory_resource>
+
 namespace rmm {
 /**
  * @addtogroup thrust_integrations
@@ -47,6 +49,8 @@ using thrust_exec_policy_t =
  * that uses RMM for temporary memory allocation on the specified stream.
  */
 class exec_policy : public thrust_exec_policy_t {
+  using async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::device_accessible>;
+
  public:
   /**
    * @brief Construct a new execution policy object
@@ -54,8 +58,8 @@ class exec_policy : public thrust_exec_policy_t {
    * @param stream The stream on which to allocate temporary memory
    * @param mr The resource to use for allocating temporary memory
    */
-  explicit exec_policy(cuda_stream_view stream             = cuda_stream_default,
-                       rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
+  explicit exec_policy(cuda_stream_view stream = cuda_stream_default,
+                       async_resource_ref mr   = rmm::mr::get_current_device_resource())
     : thrust_exec_policy_t(
         thrust::cuda::par(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
   {
@@ -77,10 +81,11 @@ using thrust_exec_policy_nosync_t =
  * are not required for correctness.
  */
 class exec_policy_nosync : public thrust_exec_policy_nosync_t {
+  using async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::device_accessible>;
+
  public:
-  explicit exec_policy_nosync(
-    cuda_stream_view stream             = cuda_stream_default,
-    rmm::mr::device_memory_resource* mr = mr::get_current_device_resource())
+  explicit exec_policy_nosync(cuda_stream_view stream = cuda_stream_default,
+                              async_resource_ref mr   = rmm::mr::get_current_device_resource())
     : thrust_exec_policy_nosync_t(
         thrust::cuda::par_nosync(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
   {

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -23,6 +23,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <rmm/detail/thrust_namespace.h>
 #include <thrust/system/cuda/execution_policy.h>
@@ -49,8 +50,6 @@ using thrust_exec_policy_t =
  * that uses RMM for temporary memory allocation on the specified stream.
  */
 class exec_policy : public thrust_exec_policy_t {
-  using async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::device_accessible>;
-
  public:
   /**
    * @brief Construct a new execution policy object
@@ -58,8 +57,8 @@ class exec_policy : public thrust_exec_policy_t {
    * @param stream The stream on which to allocate temporary memory
    * @param mr The resource to use for allocating temporary memory
    */
-  explicit exec_policy(cuda_stream_view stream = cuda_stream_default,
-                       async_resource_ref mr   = rmm::mr::get_current_device_resource())
+  explicit exec_policy(cuda_stream_view stream           = cuda_stream_default,
+                       rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
     : thrust_exec_policy_t(
         thrust::cuda::par(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
   {
@@ -81,11 +80,10 @@ using thrust_exec_policy_nosync_t =
  * are not required for correctness.
  */
 class exec_policy_nosync : public thrust_exec_policy_nosync_t {
-  using async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::device_accessible>;
-
  public:
-  explicit exec_policy_nosync(cuda_stream_view stream = cuda_stream_default,
-                              async_resource_ref mr   = rmm::mr::get_current_device_resource())
+  explicit exec_policy_nosync(
+    cuda_stream_view stream           = cuda_stream_default,
+    rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
     : thrust_exec_policy_nosync_t(
         thrust::cuda::par_nosync(rmm::mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
   {


### PR DESCRIPTION
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

This rewrites `rmm::exec_policy` to take a `cuda::std::async_resource_ref` instead of a plain `rmm::device_memory_resource*`. This is completely opaque to the user as the underlying `rmm::thrust_allocator` already takes a `cuda::mr::async_resource_ref`

Closes #1448
