### PR TITLE
Deprecate rmm::mr::device_memory_resource::supports_streams()

### DIFF
--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -297,9 +297,16 @@ class device_memory_resource {
    * @brief Query whether the resource supports use of non-null CUDA streams for
    * allocation/deallocation.
    *
+   * @deprecated Functionality removed in favor of cuda::mr::async_memory_resource.
+   *
    * @returns bool true if the resource supports non-null CUDA streams.
    */
-  [[nodiscard]] virtual bool supports_streams() const noexcept { return false; }
+  [[deprecated("Functionality removed in favor of cuda::mr::async_memory_resource.")]]  //
+  [[nodiscard]] virtual bool
+  supports_streams() const noexcept
+  {
+    return false;
+  }
 
   /**
    * @brief Query whether the resource supports the get_mem_info API.

--- a/tests/mock_resource.hpp
+++ b/tests/mock_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ namespace rmm::test {
 
 class mock_resource : public rmm::mr::device_memory_resource {
  public:
-  MOCK_METHOD(bool, supports_streams, (), (const, override, noexcept));
   MOCK_METHOD(void*, do_allocate, (std::size_t, cuda_stream_view), (override));
   MOCK_METHOD(void, do_deallocate, (void*, std::size_t, cuda_stream_view), (override));
   using size_pair = std::pair<std::size_t, std::size_t>;


### PR DESCRIPTION
## Description

Deprecates now unused `device_memory_resource::supports_streams()`. Will be removed in next release (24.06).

Merge after:
* https://github.com/rapidsai/raft/pull/2121
* https://github.com/rapidsai/cudf/pull/14857

Closes #1433 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
