### PR TITLE
Adopt the `rmm::device_async_resource_ref` alias

### DIFF
--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -109,7 +109,7 @@ class device_buffer {
    */
   explicit device_buffer(std::size_t size,
                          cuda_stream_view stream,
-                         rmm::device_async_resource_ref mr = mr::get_current_device_resource())
+                         device_async_resource_ref mr = mr::get_current_device_resource())
     : _stream{stream}, _mr{mr}
   {
     cuda_set_device_raii dev{_device};
@@ -138,7 +138,7 @@ class device_buffer {
   device_buffer(void const* source_data,
                 std::size_t size,
                 cuda_stream_view stream,
-                rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
+                device_async_resource_ref mr = mr::get_current_device_resource())
     : _stream{stream}, _mr{mr}
   {
     cuda_set_device_raii dev{_device};
@@ -169,7 +169,7 @@ class device_buffer {
    */
   device_buffer(device_buffer const& other,
                 cuda_stream_view stream,
-                rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
+                device_async_resource_ref mr = mr::get_current_device_resource())
     : device_buffer{other.data(), other.size(), stream, mr}
   {
   }

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -18,7 +18,6 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -41,7 +40,7 @@ namespace rmm {
  * @brief RAII construct for device memory allocation
  *
  * This class allocates untyped and *uninitialized* device memory using a
- * `device_memory_resource`. If not explicitly specified, the memory resource
+ * `device_async_resource_ref`. If not explicitly specified, the memory resource
  * returned from `get_current_device_resource()` is used.
  *
  * @note Unlike `std::vector` or `thrust::device_vector`, the device memory

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -20,6 +20,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <cuda_runtime_api.h>
 
@@ -82,8 +83,6 @@ namespace rmm {
  *```
  */
 class device_buffer {
-  using async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::device_accessible>;
-
  public:
   // The copy constructor and copy assignment operator without a stream are deleted because they
   // provide no way to specify an explicit stream
@@ -111,7 +110,7 @@ class device_buffer {
    */
   explicit device_buffer(std::size_t size,
                          cuda_stream_view stream,
-                         async_resource_ref mr = mr::get_current_device_resource())
+                         rmm::device_async_resource_ref mr = mr::get_current_device_resource())
     : _stream{stream}, _mr{mr}
   {
     cuda_set_device_raii dev{_device};
@@ -140,7 +139,7 @@ class device_buffer {
   device_buffer(void const* source_data,
                 std::size_t size,
                 cuda_stream_view stream,
-                async_resource_ref mr = rmm::mr::get_current_device_resource())
+                rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
     : _stream{stream}, _mr{mr}
   {
     cuda_set_device_raii dev{_device};
@@ -171,7 +170,7 @@ class device_buffer {
    */
   device_buffer(device_buffer const& other,
                 cuda_stream_view stream,
-                async_resource_ref mr = rmm::mr::get_current_device_resource())
+                rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
     : device_buffer{other.data(), other.size(), stream, mr}
   {
   }
@@ -410,9 +409,9 @@ class device_buffer {
   void set_stream(cuda_stream_view stream) noexcept { _stream = stream; }
 
   /**
-   * @briefreturn{The async_resource_ref used to allocate and deallocate}
+   * @briefreturn{The resource used to allocate and deallocate}
    */
-  [[nodiscard]] async_resource_ref memory_resource() const noexcept { return _mr; }
+  [[nodiscard]] rmm::device_async_resource_ref memory_resource() const noexcept { return _mr; }
 
  private:
   void* _data{nullptr};        ///< Pointer to device memory allocation
@@ -420,7 +419,7 @@ class device_buffer {
   std::size_t _capacity{};     ///< The actual size of the device memory allocation
   cuda_stream_view _stream{};  ///< Stream to use for device memory deallocation
 
-  async_resource_ref _mr{
+  rmm::device_async_resource_ref _mr{
     rmm::mr::get_current_device_resource()};  ///< The memory resource used to
                                               ///< allocate/deallocate device memory
   cuda_device_id _device{get_current_cuda_device()};

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -123,10 +123,9 @@ class device_uvector {
    * @param stream The stream on which to perform the allocation
    * @param mr The resource used to allocate the device storage
    */
-  explicit device_uvector(
-    std::size_t size,
-    cuda_stream_view stream,
-    rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
+  explicit device_uvector(std::size_t size,
+                          cuda_stream_view stream,
+                          device_async_resource_ref mr = mr::get_current_device_resource())
     : _storage{elements_to_bytes(size), stream, mr}
   {
   }
@@ -140,10 +139,9 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @param mr The resource used to allocate device memory for the new vector
    */
-  explicit device_uvector(
-    device_uvector const& other,
-    cuda_stream_view stream,
-    rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
+  explicit device_uvector(device_uvector const& other,
+                          cuda_stream_view stream,
+                          device_async_resource_ref mr = mr::get_current_device_resource())
     : _storage{other._storage, stream, mr}
   {
   }

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -22,6 +22,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <cstddef>
 #include <vector>
@@ -74,7 +75,6 @@ namespace rmm {
  */
 template <typename T>
 class device_uvector {
-  using async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::device_accessible>;
   static_assert(std::is_trivially_copyable<T>::value,
                 "device_uvector only supports types that are trivially copyable.");
 
@@ -124,9 +124,10 @@ class device_uvector {
    * @param stream The stream on which to perform the allocation
    * @param mr The resource used to allocate the device storage
    */
-  explicit device_uvector(std::size_t size,
-                          cuda_stream_view stream,
-                          async_resource_ref mr = rmm::mr::get_current_device_resource())
+  explicit device_uvector(
+    std::size_t size,
+    cuda_stream_view stream,
+    rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
     : _storage{elements_to_bytes(size), stream, mr}
   {
   }
@@ -140,9 +141,10 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @param mr The resource used to allocate device memory for the new vector
    */
-  explicit device_uvector(device_uvector const& other,
-                          cuda_stream_view stream,
-                          async_resource_ref mr = rmm::mr::get_current_device_resource())
+  explicit device_uvector(
+    device_uvector const& other,
+    cuda_stream_view stream,
+    rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
     : _storage{other._storage, stream, mr}
   {
   }
@@ -525,9 +527,10 @@ class device_uvector {
   [[nodiscard]] bool is_empty() const noexcept { return size() == 0; }
 
   /**
-   * @briefreturn{The async_resource_ref used to allocate and deallocate the device storage}
+   * @briefreturn{The resource used to allocate and deallocate the device
+   * storage}
    */
-  [[nodiscard]] async_resource_ref memory_resource() const noexcept
+  [[nodiscard]] rmm::device_async_resource_ref memory_resource() const noexcept
   {
     return _storage.memory_resource();
   }

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -20,7 +20,6 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/exec_check_disable.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -35,9 +34,9 @@ namespace rmm::mr {
  */
 /**
  * @brief An `allocator` compatible with Thrust containers and algorithms using
- * a `device_memory_resource` for memory (de)allocation.
+ * a `device_async_resource_ref` for memory (de)allocation.
  *
- * Unlike a `device_memory_resource`, `thrust_allocator` is typed and bound to
+ * Unlike a `device_async_resource_ref`, `thrust_allocator` is typed and bound to
  * allocate objects of a specific type `T`, but can be freely rebound to other
  * types.
  *

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -18,6 +18,7 @@
 
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <rmm/detail/thrust_namespace.h>
 #include <thrust/device_malloc_allocator.h>
@@ -44,8 +45,6 @@ namespace rmm::mr {
  */
 template <typename T>
 class thrust_allocator : public thrust::device_malloc_allocator<T> {
-  using async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::device_accessible>;
-
  public:
   using Base      = thrust::device_malloc_allocator<T>;  ///< The base type of this allocator
   using pointer   = typename Base::pointer;              ///< The pointer type
@@ -83,7 +82,10 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @param mr The resource to be used for device memory allocation
    * @param stream The stream to be used for device memory (de)allocation
    */
-  thrust_allocator(cuda_stream_view stream, async_resource_ref mr) : _stream{stream}, _mr(mr) {}
+  thrust_allocator(cuda_stream_view stream, rmm::device_async_resource_ref mr)
+    : _stream{stream}, _mr(mr)
+  {
+  }
 
   /**
    * @brief Copy constructor. Copies the resource pointer and stream.
@@ -121,9 +123,9 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   }
 
   /**
-   * @briefreturn{The async_resource_ref used to allocate and deallocate}
+   * @briefreturn{The resource used to allocate and deallocate}
    */
-  [[nodiscard]] async_resource_ref memory_resource() const noexcept { return _mr; }
+  [[nodiscard]] rmm::device_async_resource_ref memory_resource() const noexcept { return _mr; }
 
   /**
    * @briefreturn{The stream used by this allocator}
@@ -139,7 +141,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
 
  private:
   cuda_stream_view _stream{};
-  async_resource_ref _mr{rmm::mr::get_current_device_resource()};
+  rmm::device_async_resource_ref _mr{rmm::mr::get_current_device_resource()};
 };
 /** @} */  // end of group
 }  // namespace rmm::mr

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -59,7 +59,6 @@ struct DeviceBufferTest : public ::testing::Test {
 };
 
 using resources = ::testing::Types<rmm::mr::cuda_memory_resource, rmm::mr::managed_memory_resource>;
-using async_resource_ref = rmm::device_async_resource_ref;
 
 TYPED_TEST_CASE(DeviceBufferTest, resources);
 
@@ -76,7 +75,8 @@ TYPED_TEST(DeviceBufferTest, DefaultMemoryResource)
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.ssize());
   EXPECT_EQ(this->size, buff.capacity());
-  EXPECT_EQ(async_resource_ref{rmm::mr::get_current_device_resource()}, buff.memory_resource());
+  EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()},
+            buff.memory_resource());
   EXPECT_EQ(rmm::cuda_stream_view{}, buff.stream());
 }
 
@@ -87,7 +87,8 @@ TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
-  EXPECT_EQ(async_resource_ref{rmm::mr::get_current_device_resource()}, buff.memory_resource());
+  EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()},
+            buff.memory_resource());
   EXPECT_EQ(this->stream, buff.stream());
 }
 
@@ -97,7 +98,7 @@ TYPED_TEST(DeviceBufferTest, ExplicitMemoryResource)
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
-  EXPECT_EQ(async_resource_ref{this->mr}, buff.memory_resource());
+  EXPECT_EQ(rmm::device_async_resource_ref{this->mr}, buff.memory_resource());
   EXPECT_EQ(rmm::cuda_stream_view{}, buff.stream());
 }
 
@@ -108,7 +109,7 @@ TYPED_TEST(DeviceBufferTest, ExplicitMemoryResourceStream)
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
-  EXPECT_EQ(async_resource_ref{this->mr}, buff.memory_resource());
+  EXPECT_EQ(rmm::device_async_resource_ref{this->mr}, buff.memory_resource());
   EXPECT_EQ(this->stream, buff.stream());
 }
 
@@ -120,7 +121,8 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawDevicePointer)
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
-  EXPECT_EQ(async_resource_ref{rmm::mr::get_current_device_resource()}, buff.memory_resource());
+  EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()},
+            buff.memory_resource());
   EXPECT_EQ(rmm::cuda_stream_view{}, buff.stream());
 
   // TODO check for equality between the contents of the two allocations
@@ -136,7 +138,8 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
-  EXPECT_EQ(async_resource_ref{rmm::mr::get_current_device_resource()}, buff.memory_resource());
+  EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()},
+            buff.memory_resource());
   EXPECT_EQ(rmm::cuda_stream_view{}, buff.stream());
   buff.stream().synchronize();
   // TODO check for equality between the contents of the two allocations
@@ -149,7 +152,8 @@ TYPED_TEST(DeviceBufferTest, CopyFromNullptr)
   EXPECT_EQ(nullptr, buff.data());
   EXPECT_EQ(0, buff.size());
   EXPECT_EQ(0, buff.capacity());
-  EXPECT_EQ(async_resource_ref{rmm::mr::get_current_device_resource()}, buff.memory_resource());
+  EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()},
+            buff.memory_resource());
   EXPECT_EQ(rmm::cuda_stream_view{}, buff.stream());
 }
 
@@ -176,7 +180,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_EQ(buff.size(), buff_copy.size());
   EXPECT_EQ(buff.capacity(), buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
-            async_resource_ref{rmm::mr::get_current_device_resource()});
+            rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()});
   EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{});
 
   EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
@@ -219,7 +223,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   // The capacity of the copy should be equal to the `size()` of the original
   EXPECT_EQ(new_size, buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
-            async_resource_ref{rmm::mr::get_current_device_resource()});
+            rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()});
   EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{});
 
   EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),

--- a/tests/device_uvector_tests.cpp
+++ b/tests/device_uvector_tests.cpp
@@ -31,15 +31,15 @@ struct TypedUVectorTest : ::testing::Test {
   [[nodiscard]] rmm::cuda_stream_view stream() const noexcept { return rmm::cuda_stream_view{}; }
 };
 
-using TestTypes          = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
-using async_resource_ref = rmm::device_async_resource_ref;
+using TestTypes = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
 
 TYPED_TEST_CASE(TypedUVectorTest, TestTypes);
 
 TYPED_TEST(TypedUVectorTest, MemoryResource)
 {
   rmm::device_uvector<TypeParam> vec(128, this->stream());
-  EXPECT_EQ(vec.memory_resource(), async_resource_ref{rmm::mr::get_current_device_resource()});
+  EXPECT_EQ(vec.memory_resource(),
+            rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()});
 }
 
 TYPED_TEST(TypedUVectorTest, ZeroSizeConstructor)

--- a/tests/mr/device/mr_ref_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_ref_multithreaded_tests.cpp
@@ -118,7 +118,7 @@ TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeStream)
   spawn(test_mixed_random_async_allocation_free, this->ref, default_max_size, this->stream.view());
 }
 
-void allocate_async_loop(async_resource_ref ref,
+void allocate_async_loop(rmm::device_async_resource_ref ref,
                          std::size_t num_allocations,
                          std::list<allocation>& allocations,
                          std::mutex& mtx,
@@ -146,7 +146,7 @@ void allocate_async_loop(async_resource_ref ref,
   cudaEventSynchronize(event);
 }
 
-void deallocate_async_loop(async_resource_ref ref,
+void deallocate_async_loop(rmm::device_async_resource_ref ref,
                            std::size_t num_allocations,
                            std::list<allocation>& allocations,
                            std::mutex& mtx,
@@ -167,7 +167,7 @@ void deallocate_async_loop(async_resource_ref ref,
   cudaEventSynchronize(event);
 }
 
-void test_allocate_async_free_different_threads(async_resource_ref ref,
+void test_allocate_async_free_different_threads(rmm::device_async_resource_ref ref,
                                                 rmm::cuda_stream_view streamA,
                                                 rmm::cuda_stream_view streamB)
 {

--- a/tests/mr/device/mr_ref_test.hpp
+++ b/tests/mr/device/mr_ref_test.hpp
@@ -45,8 +45,7 @@
 #include <random>
 #include <utility>
 
-using resource_ref       = cuda::mr::resource_ref<cuda::mr::device_accessible>;
-using async_resource_ref = rmm::device_async_resource_ref;
+using resource_ref = cuda::mr::resource_ref<cuda::mr::device_accessible>;
 
 namespace rmm::test {
 
@@ -76,7 +75,7 @@ inline void test_allocate(resource_ref ref, std::size_t bytes)
   }
 }
 
-inline void test_allocate_async(async_resource_ref ref,
+inline void test_allocate_async(rmm::device_async_resource_ref ref,
                                 std::size_t bytes,
                                 cuda_stream_view stream = {})
 {
@@ -106,7 +105,7 @@ inline void concurrent_allocations_are_different(resource_ref ref)
   ref.deallocate(ptr2, size);
 }
 
-inline void concurrent_async_allocations_are_different(async_resource_ref ref,
+inline void concurrent_async_allocations_are_different(rmm::device_async_resource_ref ref,
                                                        cuda_stream_view stream)
 {
   const auto size{8_B};
@@ -147,7 +146,8 @@ inline void test_various_allocations(resource_ref ref)
   }
 }
 
-inline void test_various_async_allocations(async_resource_ref ref, cuda_stream_view stream)
+inline void test_various_async_allocations(rmm::device_async_resource_ref ref,
+                                           cuda_stream_view stream)
 {
   // test allocating zero bytes on non-default stream
   {
@@ -200,7 +200,7 @@ inline void test_random_allocations(resource_ref ref,
   });
 }
 
-inline void test_random_async_allocations(async_resource_ref ref,
+inline void test_random_async_allocations(rmm::device_async_resource_ref ref,
                                           std::size_t num_allocations = default_num_allocations,
                                           size_in_bytes max_size      = default_max_size,
                                           cuda_stream_view stream     = {})
@@ -273,7 +273,7 @@ inline void test_mixed_random_allocation_free(resource_ref ref,
   EXPECT_EQ(allocations.size(), active_allocations);
 }
 
-inline void test_mixed_random_async_allocation_free(async_resource_ref ref,
+inline void test_mixed_random_async_allocation_free(rmm::device_async_resource_ref ref,
                                                     size_in_bytes max_size  = default_max_size,
                                                     cuda_stream_view stream = {})
 {
@@ -344,11 +344,11 @@ struct mr_ref_test : public ::testing::TestWithParam<mr_factory> {
       GTEST_SKIP() << "Skipping tests since the memory resource is not supported with this CUDA "
                    << "driver/runtime version";
     }
-    ref = async_resource_ref{*mr};
+    ref = rmm::device_async_resource_ref{*mr};
   }
 
   std::shared_ptr<rmm::mr::device_memory_resource> mr;  ///< Pointer to resource to use in tests
-  async_resource_ref ref{*mr};
+  rmm::device_async_resource_ref ref{*mr};
   rmm::cuda_stream stream{};
 };
 

--- a/tests/mr/device/thrust_allocator_tests.cu
+++ b/tests/mr/device/thrust_allocator_tests.cu
@@ -33,7 +33,6 @@ namespace rmm::test {
 namespace {
 
 struct allocator_test : public mr_test {};
-using async_resource_ref = rmm::device_async_resource_ref;
 
 TEST_P(allocator_test, first)
 {
@@ -47,7 +46,7 @@ TEST_P(allocator_test, defaults)
   rmm::mr::thrust_allocator<int> allocator(rmm::cuda_stream_default);
   EXPECT_EQ(allocator.stream(), rmm::cuda_stream_default);
   EXPECT_EQ(allocator.memory_resource(),
-            async_resource_ref{rmm::mr::get_current_device_resource()});
+            rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()});
 }
 
 INSTANTIATE_TEST_CASE_P(ThrustAllocatorTests,


### PR DESCRIPTION
Before we had that alias we would introduce one locally. This is not needed anymore, so remove the local ones, as this helps readability.
