### PR TITLE
Draft: Use `std::optional` instead of `thrust::optional`

### DIFF
--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -23,12 +23,12 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <rmm/detail/thrust_namespace.h>
-#include <thrust/optional.h>
 
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
 #include <limits>
+#include <optional>
 
 #if CUDART_VERSION >= 11020  // 11.2 introduced cudaMallocAsync
 #ifndef RMM_DISABLE_CUDA_MALLOC_ASYNC
@@ -85,9 +85,9 @@ class cuda_async_memory_resource final : public device_memory_resource {
    * `cudaMemHandleTypeNone` for no IPC support.
    */
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  cuda_async_memory_resource(thrust::optional<std::size_t> initial_pool_size             = {},
-                             thrust::optional<std::size_t> release_threshold             = {},
-                             thrust::optional<allocation_handle_type> export_handle_type = {})
+  cuda_async_memory_resource(std::optional<std::size_t> initial_pool_size             = {},
+                             std::optional<std::size_t> release_threshold             = {},
+                             std::optional<allocation_handle_type> export_handle_type = {})
   {
 #ifdef RMM_CUDA_MALLOC_ASYNC_SUPPORT
     // Check if cudaMallocAsync Memory pool supported

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -22,7 +22,6 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <rmm/detail/thrust_namespace.h>
-#include <thrust/optional.h>
 
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -27,7 +27,6 @@
 #include <rmm/detail/thrust_namespace.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
-#include <thrust/optional.h>
 
 #include <fmt/core.h>
 
@@ -39,6 +38,7 @@
 #include <map>
 #include <mutex>
 #include <numeric>
+#include <optional>
 #include <set>
 #include <thread>
 #include <unordered_map>
@@ -128,8 +128,8 @@ class pool_memory_resource final
    */
   [[deprecated("Must specify initial_pool_size")]]  //
   explicit pool_memory_resource(Upstream* upstream_mr,
-                                thrust::optional<std::size_t> initial_pool_size = thrust::nullopt,
-                                thrust::optional<std::size_t> maximum_pool_size = thrust::nullopt)
+                                std::optional<std::size_t> initial_pool_size = std::nullopt,
+                                std::optional<std::size_t> maximum_pool_size = std::nullopt)
     : pool_memory_resource(upstream_mr, initial_pool_size.value_or(0), maximum_pool_size)
   {
   }
@@ -155,8 +155,8 @@ class pool_memory_resource final
             cuda::std::enable_if_t<cuda::mr::async_resource<Upstream2>, int> = 0>
   [[deprecated("Must specify initial_pool_size")]]  //
   explicit pool_memory_resource(Upstream2& upstream_mr,
-                                thrust::optional<std::size_t> initial_pool_size = thrust::nullopt,
-                                thrust::optional<std::size_t> maximum_pool_size = thrust::nullopt)
+                                std::optional<std::size_t> initial_pool_size = std::nullopt,
+                                std::optional<std::size_t> maximum_pool_size = std::nullopt)
     : pool_memory_resource(upstream_mr, initial_pool_size.value_or(0), maximum_pool_size)
   {
   }
@@ -178,7 +178,7 @@ class pool_memory_resource final
    */
   explicit pool_memory_resource(Upstream* upstream_mr,
                                 std::size_t initial_pool_size,
-                                thrust::optional<std::size_t> maximum_pool_size = thrust::nullopt)
+                                std::optional<std::size_t> maximum_pool_size = std::nullopt)
     : upstream_mr_{[upstream_mr]() {
         RMM_EXPECTS(nullptr != upstream_mr, "Unexpected null upstream pointer.");
         return upstream_mr;
@@ -211,7 +211,7 @@ class pool_memory_resource final
             cuda::std::enable_if_t<cuda::mr::async_resource<Upstream2>, int> = 0>
   explicit pool_memory_resource(Upstream2& upstream_mr,
                                 std::size_t initial_pool_size,
-                                thrust::optional<std::size_t> maximum_pool_size = thrust::nullopt)
+                                std::optional<std::size_t> maximum_pool_size = std::nullopt)
     : pool_memory_resource(cuda::std::addressof(upstream_mr), initial_pool_size, maximum_pool_size)
   {
   }
@@ -313,7 +313,7 @@ class pool_memory_resource final
    *
    * @throws logic_error if @p initial_size is larger than @p maximum_size (if set).
    */
-  void initialize_pool(std::size_t initial_size, thrust::optional<std::size_t> maximum_size)
+  void initialize_pool(std::size_t initial_size, std::optional<std::size_t> maximum_size)
   {
     current_pool_size_ = 0;  // try_to_expand will set this if it succeeds
     maximum_pool_size_ = maximum_size;
@@ -377,7 +377,7 @@ class pool_memory_resource final
    * @param stream The stream on which the memory is to be used.
    * @return block_type The allocated block
    */
-  thrust::optional<block_type> block_from_upstream(std::size_t size, cuda_stream_view stream)
+  std::optional<block_type> block_from_upstream(std::size_t size, cuda_stream_view stream)
   {
     RMM_LOG_DEBUG("[A][Stream {}][Upstream {}B]", fmt::ptr(stream.value()), size);
 
@@ -385,10 +385,10 @@ class pool_memory_resource final
 
     try {
       void* ptr = get_upstream()->allocate_async(size, stream);
-      return thrust::optional<block_type>{
+      return std::optional<block_type>{
         *upstream_blocks_.emplace(static_cast<char*>(ptr), size, true).first};
     } catch (std::exception const& e) {
-      return thrust::nullopt;
+      return std::nullopt;
     }
   }
 
@@ -516,7 +516,7 @@ class pool_memory_resource final
  private:
   Upstream* upstream_mr_;  // The "heap" to allocate the pool from
   std::size_t current_pool_size_{};
-  thrust::optional<std::size_t> maximum_pool_size_{};
+  std::optional<std::size_t> maximum_pool_size_{};
 
 #ifdef RMM_POOL_TRACK_ALLOCATIONS
   std::set<block_type, rmm::mr::detail::compare_blocks<block_type>> allocated_blocks_;

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -76,7 +76,7 @@ cdef extern from *:
 
 # NOTE: Keep extern declarations in .pyx file as much as possible to avoid
 # leaking dependencies when importing RMM Cython .pxd files
-cdef extern from "thrust/optional.h" namespace "thrust" nogil:
+cdef extern from "optional" namespace "std" nogil:
 
     struct nullopt_t:
         pass


### PR DESCRIPTION
We already require c++17, so there is no benefit on pulling in `thrust::optional` as a dependency.

In addition thrust versiones its types with the cuda architecture, so using those types in API boundaries is not recommended.

This could be a potentially breaking change if a user would explicitly pass in `thrust::optional` into those APIs which seems unlikely