### PR TITLE
Add host_resource_ref and async_host_resource ref as aliases to cudf resource types.

### DIFF
--- a/include/rmm/resource_ref.hpp
+++ b/include/rmm/resource_ref.hpp
@@ -31,5 +31,17 @@ namespace rmm {
  */
 using device_async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::device_accessible>;
 
+/**
+ * @brief Alias for a `cuda::mr::resource_ref` with the property
+ * `cuda::mr::host_accessible`.
+ */
+using host_resource_ref = cuda::mr::resource_ref<cuda::mr::host_accessible>;
+
+/**
+ * @brief Alias for a `cuda::mr::async_resource_ref` with the property
+ * `cuda::mr::host_accessible`.
+ */
+using host_async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible>;
+
 /** @} */  // end of group
 }  // namespace rmm

--- a/include/rmm/resource_ref.hpp
+++ b/include/rmm/resource_ref.hpp
@@ -26,6 +26,12 @@ namespace rmm {
  */
 
 /**
+ * @brief Alias for a `cuda::mr::resource_ref` with the property
+ * `cuda::mr::device_accessible`.
+ */
+using device_resource_ref = cuda::mr::resource_ref<cuda::mr::device_accessible>;
+
+/**
  * @brief Alias for a `cuda::mr::async_resource_ref` with the property
  * `cuda::mr::device_accessible`.
  */
@@ -42,6 +48,20 @@ using host_resource_ref = cuda::mr::resource_ref<cuda::mr::host_accessible>;
  * `cuda::mr::host_accessible`.
  */
 using host_async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible>;
+
+/**
+ * @brief Alias for a `cuda::mr::resource_ref` with the properties
+ * `cuda::mr::host_accessible` and `cuda::mr::device_accessible`.
+ */
+using host_device_resource_ref =
+  cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>;
+
+/**
+ * @brief Alias for a `cuda::mr::async_resource_ref` with the properties
+ * `cuda::mr::host_accessible` and `cuda::mr::device_accessible`.
+ */
+using host_device_async_resource_ref =
+  cuda::mr::async_resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>;
 
 /** @} */  // end of group
 }  // namespace rmm

--- a/tests/mr/host/mr_ref_tests.cpp
+++ b/tests/mr/host/mr_ref_tests.cpp
@@ -20,6 +20,7 @@
 #include <rmm/mr/host/host_memory_resource.hpp>
 #include <rmm/mr/host/new_delete_resource.hpp>
 #include <rmm/mr/host/pinned_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <cuda_runtime_api.h>
 
@@ -73,7 +74,7 @@ struct allocation {
 template <typename MemoryResourceType>
 struct MRRefTest : public ::testing::Test {
   MemoryResourceType mr;
-  cuda::mr::resource_ref<cuda::mr::host_accessible> ref;
+  rmm::host_resource_ref ref;
 
   MRRefTest() : mr{}, ref{mr} {}
 };
@@ -249,7 +250,7 @@ TYPED_TEST(MRRefTest, UnsupportedAlignmentTest)
 TEST(PinnedResource, isPinned)
 {
   rmm::mr::pinned_memory_resource mr;
-  cuda::mr::resource_ref<cuda::mr::host_accessible> ref{mr};
+  rmm::host_resource_ref ref{mr};
   void* ptr{nullptr};
   EXPECT_NO_THROW(ptr = ref.allocate(100));
   EXPECT_TRUE(is_pinned_memory(ptr));


### PR DESCRIPTION
Adds new aliases to `resource_ref.hpp`

`using host_resource_ref = cuda::mr::resource_ref<cuda::mr::host_accessible>;`

`using host_async_resource_ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible>;`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
