### PR TITLE
Pin to recent breathe, to prevent getting an unsupported sphinx version.

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -4,7 +4,7 @@ channels:
 - rapidsai
 - conda-forge
 dependencies:
-- breathe
+- breathe>=4.35.0
 - c-compiler
 - clang-tools==16.0.6
 - clang==16.0.6

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -4,7 +4,7 @@ channels:
 - rapidsai
 - conda-forge
 dependencies:
-- breathe
+- breathe>=4.35.0
 - c-compiler
 - clang-tools==16.0.6
 - clang==16.0.6

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -182,7 +182,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - breathe
+          - breathe>=4.35.0
           - *doxygen
           - graphviz
           - ipython


### PR DESCRIPTION
## Description
The RMM nightly docs builds failed. https://github.com/rapidsai/rmm/actions/runs/8151286975/job/22279173933#step:9:973

It ran into an error reported in https://github.com/sphinx-doc/sphinx/issues/11490. It seems like a viable fix is to pin to a recent version of `breathe`, which in turn forces a compatible version of sphinx. This is the same pinning used by cudf.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
