### PR TITLE
Fix search path for torch allocator in editable installs and ensure CUDA support is available

### DIFF
--- a/python/rmm/allocators/torch.py
+++ b/python/rmm/allocators/torch.py
@@ -18,9 +18,14 @@ except ImportError:
 else:
     import pathlib
 
-    sofile = (
-        pathlib.Path(__file__).parent.parent / "_lib" / "_torch_allocator.so"
-    )
+    # To support editable installs, we cannot search for the compiled torch
+    # allocator so relative to the current file because the current files is
+    # pure Python and will therefore be in the source directory. Instead, we
+    # search relative to an arbitrary file in the compiled package. We use the
+    # _lib.lib module because it is small.
+    from rmm._lib import lib
+
+    sofile = pathlib.Path(lib.__file__).parent / "_torch_allocator.so"
     rmm_torch_allocator = CUDAPluggableAllocator(
         str(sofile.absolute()),
         alloc_fn_name="allocate",

--- a/python/rmm/allocators/torch.py
+++ b/python/rmm/allocators/torch.py
@@ -25,7 +25,7 @@ else:
         import pathlib
 
         # To support editable installs, we cannot search for the compiled torch
-        # allocator so relative to the current file because the current files
+        # allocator .so relative to the current file because the current file
         # is pure Python and will therefore be in the source directory.
         # Instead, we search relative to an arbitrary file in the compiled
         # package. We use the _lib.lib module because it is small.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The current logic for finding the allocator .so file presumes that torch.py is in the same directory tree as the compiled allocator. While this is true when the package is installed, it is not true for editable installs of the package where py files are left in the source tree while compiled modules are placed into a build tree (both are found by indirection).

The current allocator logic also assumes that if pytorch is available it is a version compiled with CUDA support. This PR also adds a check to verify that we don't try to set the allocator on a CPU-only build of torch.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
