### PR TITLE
Enable all tests for `arm` arch 

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -9,9 +9,4 @@ RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-
 # echo to expand wildcard before adding `[extra]` requires for pip
 python -m pip install $(echo ./dist/rmm*.whl)[test]
 
-# Run smoke tests for aarch64 pull requests
-if [[ "$(arch)" == "aarch64" && ${RAPIDS_BUILD_TYPE} == "pull-request" ]]; then
-    python ./ci/wheel_smoke_test.py
-else
-    python -m pytest ./python/rmm/tests
-fi
+python -m pytest ./python/rmm/tests


### PR DESCRIPTION
## Description
This PR enables running all pytests for `arm64` jobs.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
