### PR TITLE
Explicitly use the current device resource in DeviceBuffer

### DIFF
--- a/python/rmm/_lib/device_buffer.pxd
+++ b/python/rmm/_lib/device_buffer.pxd
@@ -17,17 +17,31 @@ from libcpp.memory cimport unique_ptr
 
 from rmm._cuda.stream cimport Stream
 from rmm._lib.cuda_stream_view cimport cuda_stream_view
-from rmm._lib.memory_resource cimport DeviceMemoryResource
+from rmm._lib.memory_resource cimport (
+    DeviceMemoryResource,
+    device_memory_resource,
+)
 
 
 cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
     cdef cppclass device_buffer:
         device_buffer()
-        device_buffer(size_t size, cuda_stream_view stream) except +
-        device_buffer(const void* source_data,
-                      size_t size, cuda_stream_view stream) except +
-        device_buffer(const device_buffer buf,
-                      cuda_stream_view stream) except +
+        device_buffer(
+            size_t size,
+            cuda_stream_view stream,
+            device_memory_resource *
+        ) except +
+        device_buffer(
+            const void* source_data,
+            size_t size,
+            cuda_stream_view stream,
+            device_memory_resource *
+        ) except +
+        device_buffer(
+            const device_buffer buf,
+            cuda_stream_view stream,
+            device_memory_resource *
+        ) except +
         void reserve(size_t new_capacity, cuda_stream_view stream) except +
         void resize(size_t new_size, cuda_stream_view stream) except +
         void shrink_to_fit(cuda_stream_view stream) except +

--- a/python/rmm/_lib/memory_resource.pxd
+++ b/python/rmm/_lib/memory_resource.pxd
@@ -34,7 +34,7 @@ cdef extern from "rmm/mr/device/device_memory_resource.hpp" \
 
 cdef class DeviceMemoryResource:
     cdef shared_ptr[device_memory_resource] c_obj
-    cdef device_memory_resource* get_mr(self)
+    cdef device_memory_resource* get_mr(self) noexcept nogil
 
 cdef class UpstreamResourceAdaptor(DeviceMemoryResource):
     cdef readonly DeviceMemoryResource upstream_mr

--- a/python/rmm/_lib/memory_resource.pyx
+++ b/python/rmm/_lib/memory_resource.pyx
@@ -218,7 +218,7 @@ cdef extern from "rmm/mr/device/failure_callback_resource_adaptor.hpp" \
 
 cdef class DeviceMemoryResource:
 
-    cdef device_memory_resource* get_mr(self):
+    cdef device_memory_resource* get_mr(self) noexcept nogil:
         """Get the underlying C++ memory resource object."""
         return self.c_obj.get()
 


### PR DESCRIPTION
## Description

Previously we were relying on the C++ and Python-level device resources to agree. But this need not be the case.

To avoid this, first get the current device resource and then use it when allocating the wrapped C++ device_buffer when creating DeviceBuffers.

- Closes #1506

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
