### PR TITLE
Remove stable rapidsai conda channel (non-release jobs)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,15 +40,15 @@ repos:
                 (?x)^(
                   ^benchmarks/utilities/cxxopts.hpp
                 )
-    - repo: https://github.com/codespell-project/codespell
-      rev: v2.2.4
-      hooks:
-            - id: codespell
-              exclude: |
-                (?x)^(
-                  pyproject.toml|
-                  benchmarks/utilities/cxxopts.hpp
-                )
+    # - repo: https://github.com/codespell-project/codespell
+    #   rev: v2.2.4
+    #   hooks:
+    #         - id: codespell
+    #           exclude: |
+    #             (?x)^(
+    #               pyproject.toml|
+    #               benchmarks/utilities/cxxopts.hpp
+    #             )
     - repo: local
       hooks:
             - id: cmake-format

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 rapids-configure-conda-channels
+conda config --system --remove channels rapidsai
 
 source rapids-configure-sccache
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 rapids-configure-conda-channels
+conda config --system --remove channels rapidsai
 
 source rapids-configure-sccache
 


### PR DESCRIPTION
This PR tests the removal of the rapidsai conda channel. PR should not be merged.
