### PR TITLE
Fix cuda_async_memory_resource thrust::optional ctor

### DIFF
--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -95,10 +95,16 @@ class cuda_async_memory_resource final : public device_memory_resource {
     Optional initial_pool_size,
     Optional release_threshold                                  = {},
     thrust::optional<allocation_handle_type> export_handle_type = {})
-    : cuda_async_memory_resource(initial_pool_size.value_or(std::nullopt),
-                                 release_threshold.value_or(std::nullopt),
-                                 export_handle_type.value_or(std::nullopt))
-
+    : cuda_async_memory_resource(
+        std::optional<size_t>(initial_pool_size.has_value()
+                                ? std::make_optional(initial_pool_size.value())
+                                : std::nullopt),
+        std::optional<size_t>(release_threshold.has_value()
+                                ? std::make_optional(release_threshold.value())
+                                : std::nullopt),
+        std::optional<allocation_handle_type>(export_handle_type.has_value()
+                                                ? std::make_optional(export_handle_type.value())
+                                                : std::nullopt))
   {
   }
 


### PR DESCRIPTION
## Description
This PR resolves a compiler diagnostic error observed in 24.04 where invalid code was called in a template constructor which is not always invoked.

This PR closes #1530 

I believe this should also be merged into `branch-24.04`, but I'm unsure of that process (so I switched the target branch back to `branch-24.06`)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes. (**no change** since the API is already deprecated)
- [x] The documentation is up to date with these changes. (**no change**)
