### PR TITLE
Fix `cuda11.8` nvcc dependency

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -9,7 +9,6 @@ dependencies:
 - clang-tools==16.0.6
 - clang==16.0.6
 - cmake>=3.26.4
-- cuda-nvcc
 - cuda-python>=11.7.1,<12.0a0
 - cuda-version=11.8
 - cudatoolkit

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -249,7 +249,21 @@ dependencies:
         packages:
           - pytest
           - pytest-cov
+    # Needed for numba in tests
+    specific:
       - output_types: conda
-        packages:
-          # Needed for numba in tests
-          - cuda-nvcc
+        matrices:
+          - matrix:
+              arch: x86_64
+              cuda: "11.8"
+            packages:
+              - nvcc_linux-64=11.8
+          - matrix:
+              arch: aarch64
+              cuda: "11.8"
+            packages:
+              - nvcc_linux-aarch64=11.8
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - cuda-nvcc


### PR DESCRIPTION
`cuda-nvcc` is the CUDA 12 package name but was being included in the CUDA 11 dependencies, making the conda solve impossible. This PR uses the same nvcc matrix as defined in the build dependencies list.
