### PR TITLE
Remove header existence tests.

### DIFF
--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -79,9 +79,6 @@ outputs:
         {% endif %}
         - fmt {{ fmt_version }}
         - spdlog {{ spdlog_version }}
-    test:
-      commands:
-        - test -f $PREFIX/include/rmm/device_buffer.hpp
     about:
       home: https://rapids.ai/
       license: Apache-2.0

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -79,6 +79,9 @@ outputs:
         {% endif %}
         - fmt {{ fmt_version }}
         - spdlog {{ spdlog_version }}
+    test:
+      commands:
+        - test -d "${PREFIX}/include/rmm"
     about:
       home: https://rapids.ai/
       license: Apache-2.0

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -81,37 +81,7 @@ outputs:
         - spdlog {{ spdlog_version }}
     test:
       commands:
-        - test -f $PREFIX/include/rmm/logger.hpp
-        - test -f $PREFIX/include/rmm/cuda_stream.hpp
-        - test -f $PREFIX/include/rmm/cuda_stream_view.hpp
-        - test -f $PREFIX/include/rmm/cuda_stream_pool.hpp
-        - test -f $PREFIX/include/rmm/device_uvector.hpp
-        - test -f $PREFIX/include/rmm/device_scalar.hpp
         - test -f $PREFIX/include/rmm/device_buffer.hpp
-        - test -f $PREFIX/include/rmm/detail/aligned.hpp
-        - test -f $PREFIX/include/rmm/detail/error.hpp
-        - test -f $PREFIX/include/rmm/detail/exec_check_disable.hpp
-        - test -f $PREFIX/include/rmm/mr/device/detail/arena.hpp
-        - test -f $PREFIX/include/rmm/mr/device/detail/free_list.hpp
-        - test -f $PREFIX/include/rmm/mr/device/detail/coalescing_free_list.hpp
-        - test -f $PREFIX/include/rmm/mr/device/detail/fixed_size_free_list.hpp
-        - test -f $PREFIX/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/arena_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/binning_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/cuda_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/device_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/fixed_size_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/limiting_resource_adaptor.hpp
-        - test -f $PREFIX/include/rmm/mr/device/logging_resource_adaptor.hpp
-        - test -f $PREFIX/include/rmm/mr/device/managed_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/owning_wrapper.hpp
-        - test -f $PREFIX/include/rmm/mr/device/per_device_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/pool_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
-        - test -f $PREFIX/include/rmm/mr/device/thrust_allocator_adaptor.hpp
-        - test -f $PREFIX/include/rmm/mr/host/host_memory_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/host/new_delete_resource.hpp
-        - test -f $PREFIX/include/rmm/mr/host/pinned_memory_resource.hpp
     about:
       home: https://rapids.ai/
       license: Apache-2.0


### PR DESCRIPTION
## Description
This PR removes header existence tests from the librmm conda recipe to reduce friction when code is moved. Closes https://github.com/rapidsai/rmm/issues/1549.

These changes are similar to https://github.com/rapidsai/cudf/pull/14072.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
