### PR TITLE
Enable warnings as errors for Python tests

### DIFF
--- a/python/rmm/.coveragerc
+++ b/python/rmm/.coveragerc
@@ -2,3 +2,4 @@
 [run]
 include = rmm/*
 omit = rmm/tests/*
+disable_warnings=include-ignored

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -123,3 +123,7 @@ wheel.packages = ["rmm"]
 provider = "scikit_build_core.metadata.regex"
 input = "rmm/VERSION"
 regex = "(?P<value>.*)"
+
+filterwarnings = [
+    "error",
+]

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -124,6 +124,7 @@ provider = "scikit_build_core.metadata.regex"
 input = "rmm/VERSION"
 regex = "(?P<value>.*)"
 
+[tool.pytest.ini_options]
 filterwarnings = [
     "error",
 ]


### PR DESCRIPTION
## Description
As part of https://github.com/rapidsai/build-planning/issues/26, warnings in Python tests will cause that test to fail.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
