### PR TITLE
add RAPIDS copyright pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,10 @@ repos:
       hooks:
         - id: ruff
           files: python/.*$
+    - repo: https://github.com/rapidsai/pre-commit-hooks
+      rev: v0.0.3
+      hooks:
+        - id: verify-copyright
 
 default_language_version:
     python: python3

--- a/python/librmm/CMakeLists.txt
+++ b/python/librmm/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -21,7 +21,7 @@ project(
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES CXX)
 
-# Check if rmm is already available. If so, it is the user's responsibility to ensure that the CMake
+# Check if rmm is already available. If so, it's the user's responsibility to ensure that the CMake
 # package is also available at build time of the Python rmm package.
 find_package(rmm "${RAPIDS_VERSION}")
 


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/30.

Proposes adding the RAPIDS `verify-copyright` pre-commit hook, which automatically updates copyright dates for modified files.

This also fixes one date in a file from #1529.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
