### PR TITLE
Refactor polymorphic allocator to use device_async_resource_ref

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,6 +46,7 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
+BreakAfterAttributes: Leave
 BreakAfterJavaFieldAnnotations: false
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: WebKit

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist/
 rmm.egg-info/
 python/build
 python/*/build
+python/rmm/docs/_build
 python/rmm/**/_lib/**/*.cpp
 !python/rmm/_lib/_torch_allocator.cpp
 python/rmm/**/_lib/**/*.h

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -56,7 +56,7 @@ class polymorphic_allocator {
    *
    * This constructor provides an implicit conversion from `device_async_resource_ref`.
    *
-   * @param mr The `device_memory_resource` to use as the underlying resource.
+   * @param mr The upstream memory resource to use for allocation.
    */
   polymorphic_allocator(device_async_resource_ref mr) : mr_{mr} {}
 
@@ -111,11 +111,11 @@ class polymorphic_allocator {
   /**
    * @brief Returns pointer to the underlying `rmm::mr::device_memory_resource`.
    *
-   * @deprecated Use `get_upstream_resource()` instead.
+   * @deprecated Use get_upstream_resource instead.
    *
-   * @return Pointer to the underlying resource.
+   * @return Reference to the underlying resource.
    */
-  [[deprecated("Use `get_upstream_resource()` instead.")]] [[nodiscard]]
+  [[deprecated("Use get_upstream_resource instead.")]] [[nodiscard]]
   rmm::device_async_resource_ref resource() const noexcept
   {
     return mr_;

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -117,12 +117,35 @@ class polymorphic_allocator {
     get_current_device_resource()};  ///< Underlying resource used for (de)allocation
 };
 
+/**
+ * @brief Compare two `polymorphic_allocator`s for equality.
+ *
+ * Two `polymorphic_allocator`s are equal if their underlying memory resources compare equal.
+ *
+ * @tparam T Type of the first allocator
+ * @tparam U Type of the second allocator
+ * @param lhs The first allocator to compare
+ * @param rhs The second allocator to compare
+ * @return true if the two allocators are equal, false otherwise
+ */
 template <typename T, typename U>
 bool operator==(polymorphic_allocator<T> const& lhs, polymorphic_allocator<U> const& rhs)
 {
   return lhs.get_upstream_resource() == rhs.get_upstream_resource();
 }
 
+/**
+ * @brief Compare two `polymorphic_allocator`s for inequality.
+ *
+ * Two `polymorphic_allocator`s are not equal if their underlying memory resources compare not
+ * equal.
+ *
+ * @tparam T Type of the first allocator
+ * @tparam U Type of the second allocator
+ * @param lhs The first allocator to compare
+ * @param rhs The second allocator to compare
+ * @return true if the two allocators are not equal, false otherwise
+ */
 template <typename T, typename U>
 bool operator!=(polymorphic_allocator<T> const& lhs, polymorphic_allocator<U> const& rhs)
 {
@@ -234,12 +257,34 @@ class stream_allocator_adaptor {
   cuda_stream_view stream_;  ///< Stream on which (de)allocations are performed
 };
 
+/**
+ * @brief Compare two `stream_allocator_adaptor`s for equality.
+ *
+ * Two `stream_allocator_adaptor`s are equal if their underlying allocators compare equal.
+ *
+ * @tparam A Type of the first allocator
+ * @tparam O Type of the second allocator
+ * @param lhs The first allocator to compare
+ * @param rhs The second allocator to compare
+ * @return true if the two allocators are equal, false otherwise
+ */
 template <typename A, typename O>
 bool operator==(stream_allocator_adaptor<A> const& lhs, stream_allocator_adaptor<O> const& rhs)
 {
   return lhs.underlying_allocator() == rhs.underlying_allocator();
 }
 
+/**
+ * @brief Compare two `stream_allocator_adaptor`s for inequality.
+ *
+ * Two `stream_allocator_adaptor`s are not equal if their underlying allocators compare not equal.
+ *
+ * @tparam A Type of the first allocator
+ * @tparam O Type of the second allocator
+ * @param lhs The first allocator to compare
+ * @param rhs The second allocator to compare
+ * @return true if the two allocators are not equal, false otherwise
+ */
 template <typename A, typename O>
 bool operator!=(stream_allocator_adaptor<A> const& lhs, stream_allocator_adaptor<O> const& rhs)
 {

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -25,7 +25,11 @@
 #include <type_traits>
 
 namespace rmm::mr {
-
+/**
+ * @addtogroup device_memory_resources
+ * @{
+ * @file
+ */
 /**
  * @brief A stream ordered Allocator using a `rmm::mr::device_memory_resource` to satisfy
  * (de)allocations.
@@ -61,14 +65,14 @@ class polymorphic_allocator {
   polymorphic_allocator(device_async_resource_ref mr) : mr_{mr} {}
 
   /**
-   * @brief Construct a `polymorphic_allocator` using `other.resource()` as the underlying memory
-   * resource.
+   * @brief Construct a `polymorphic_allocator` using the underlying memory resource of `other`.
    *
-   * @param other The `polymorphic_resource` whose `resource()` will be used as the underlying
+   * @param other The `polymorphic_allocator` whose memory resource will be used as the underlying
    * resource of the new `polymorphic_allocator`.
    */
   template <typename U>
-  polymorphic_allocator(polymorphic_allocator<U> const& other) noexcept : mr_{other.resource()}
+  polymorphic_allocator(polymorphic_allocator<U> const& other) noexcept
+    : mr_{other.get_upstream_resource()}
   {
   }
 
@@ -257,5 +261,5 @@ auto make_stream_allocator_adaptor(Allocator const& allocator, cuda_stream_view 
 {
   return stream_allocator_adaptor<Allocator>{allocator, stream};
 }
-
+/** @} */  // end of group
 }  // namespace rmm::mr

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -108,19 +108,6 @@ class polymorphic_allocator {
     return mr_;
   }
 
-  /**
-   * @brief Returns pointer to the underlying `rmm::mr::device_memory_resource`.
-   *
-   * @deprecated Use get_upstream_resource instead.
-   *
-   * @return Reference to the underlying resource.
-   */
-  [[deprecated("Use get_upstream_resource instead.")]] [[nodiscard]]
-  rmm::device_async_resource_ref resource() const noexcept
-  {
-    return mr_;
-  }
-
  private:
   rmm::device_async_resource_ref mr_{
     get_current_device_resource()};  ///< Underlying resource used for (de)allocation

--- a/tests/mr/device/polymorphic_allocator_tests.cpp
+++ b/tests/mr/device/polymorphic_allocator_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/mr/device/polymorphic_allocator_tests.cpp
+++ b/tests/mr/device/polymorphic_allocator_tests.cpp
@@ -33,14 +33,15 @@ struct allocator_test : public ::testing::Test {
 TEST_F(allocator_test, default_resource)
 {
   rmm::mr::polymorphic_allocator<int> allocator{};
-  EXPECT_EQ(allocator.resource(), rmm::mr::get_current_device_resource());
+  EXPECT_EQ(allocator.resource(),
+            rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()});
 }
 
 TEST_F(allocator_test, custom_resource)
 {
   rmm::mr::cuda_memory_resource mr;
   rmm::mr::polymorphic_allocator<int> allocator{&mr};
-  EXPECT_EQ(allocator.resource(), &mr);
+  EXPECT_EQ(allocator.resource(), rmm::device_async_resource_ref{mr});
 }
 
 void test_conversion(rmm::mr::polymorphic_allocator<int> /*unused*/) {}
@@ -48,7 +49,7 @@ void test_conversion(rmm::mr::polymorphic_allocator<int> /*unused*/) {}
 TEST_F(allocator_test, implicit_conversion)
 {
   rmm::mr::cuda_memory_resource mr;
-  test_conversion(&mr);
+  test_conversion(rmm::device_async_resource_ref{mr});
 }
 
 TEST_F(allocator_test, self_equality)

--- a/tests/mr/device/polymorphic_allocator_tests.cpp
+++ b/tests/mr/device/polymorphic_allocator_tests.cpp
@@ -33,7 +33,7 @@ struct allocator_test : public ::testing::Test {
 TEST_F(allocator_test, default_resource)
 {
   rmm::mr::polymorphic_allocator<int> allocator{};
-  EXPECT_EQ(allocator.resource(),
+  EXPECT_EQ(allocator.get_upstream_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()});
 }
 
@@ -41,7 +41,7 @@ TEST_F(allocator_test, custom_resource)
 {
   rmm::mr::cuda_memory_resource mr;
   rmm::mr::polymorphic_allocator<int> allocator{&mr};
-  EXPECT_EQ(allocator.resource(), rmm::device_async_resource_ref{mr});
+  EXPECT_EQ(allocator.get_upstream_resource(), rmm::device_async_resource_ref{mr});
 }
 
 void test_conversion(rmm::mr::polymorphic_allocator<int> /*unused*/) {}
@@ -85,7 +85,7 @@ TEST_F(allocator_test, copy_ctor_same_type)
   rmm::mr::polymorphic_allocator<int> alloc0;
   rmm::mr::polymorphic_allocator<int> alloc1{alloc0};
   EXPECT_EQ(alloc0, alloc1);
-  EXPECT_EQ(alloc0.resource(), alloc1.resource());
+  EXPECT_EQ(alloc0.get_upstream_resource(), alloc1.get_upstream_resource());
 }
 
 TEST_F(allocator_test, copy_ctor_different_type)
@@ -93,7 +93,7 @@ TEST_F(allocator_test, copy_ctor_different_type)
   rmm::mr::polymorphic_allocator<int> alloc0;
   rmm::mr::polymorphic_allocator<double> alloc1{alloc0};
   EXPECT_EQ(alloc0, alloc1);
-  EXPECT_EQ(alloc0.resource(), alloc1.resource());
+  EXPECT_EQ(alloc0.get_upstream_resource(), alloc1.get_upstream_resource());
 }
 
 TEST_F(allocator_test, rebind)


### PR DESCRIPTION
## Description

Fixes #1540.
Fixes #1453 by removing unused `polymorphic_allocator::resource()`.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
