### PR TITLE
update copyright dates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set_property(CACHE RMM_LOGGING_LEVEL PROPERTY STRINGS "TRACE" "DEBUG" "INFO" "WA
                                               "CRITICAL" "OFF")
 
 # Set logging level. Must go before including gtests and benchmarks. Set the possible values of
-# build type for cmake-gui
+# build type for cmake-gui.
 message(STATUS "RMM: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'")
 
 # cudart can be linked statically or dynamically

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 # rmm build script
 

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 
 # This script is used to build the component(s) in this repo from
 # source, and can be called with various options to customize the
-# build as needed (see the help output for details)
+# build as needed (see the help output for details).
 
 # Abort script on first error
 set -e

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -14,7 +14,7 @@ commit=$(git rev-parse HEAD)
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 
-# This is the version of the suffix with a preceding hyphen. It's used
+# This is the version of the suffix with a preceding hyphen. It is used
 # everywhere except in the final wheel name.
 PACKAGE_CUDA_SUFFIX="-${RAPIDS_PY_CUDA_SUFFIX}"
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -eou pipefail
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -7,7 +7,7 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 WHEELHOUSE="${PWD}/dist/"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python "${WHEELHOUSE}"
 
-# echo to expand wildcard before adding `[extra]` requires for pip
+# echo to expand wildcard before adding '[extra]' requires for pip
 python -m pip install "rmm-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find-links "${WHEELHOUSE}"
 
 python -m pytest ./python/rmm/rmm/tests

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
 {% set cuda_version = '.'.join(environ['RAPIDS_CUDA_VERSION'].split('.')[:2]) %}

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - {{ stdlib("c") }}
   host:
     - cuda-version ={{ cuda_version }}
-    # We require spdlog and fmt (which was devendored from spdlog
+    # We require spdlog and fmt (which was de-vendored from spdlog
     # conda-forge packages in 1.11.0) so that the spdlog headers are not
     # pulled by CPM and installed as a part of the rmm packages. However,
     # building against librmm still requires these headers. They are also

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
 {% set cuda_version = '.'.join(environ['RAPIDS_CUDA_VERSION'].split('.')[:2]) %}

--- a/conda/recipes/rmm/meta.yaml
+++ b/conda/recipes/rmm/meta.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2019-2024, NVIDIA CORPORATION.
 
-{% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
+{% set version = environ['RAPIDS_PACKAGE_VERSION'].strip().lstrip('v') %}
 {% set cuda_version = '.'.join(environ['RAPIDS_CUDA_VERSION'].split('.')[:2]) %}
 {% set cuda_major = cuda_version.split('.')[0] %}
 {% set py_version = environ['CONDA_PY'] %}

--- a/python/rmm/CMakeLists.txt
+++ b/python/rmm/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/python/rmm/CMakeLists.txt
+++ b/python/rmm/CMakeLists.txt
@@ -8,10 +8,9 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 # =============================================================================
-
 
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 

--- a/python/rmm/CMakeLists.txt
+++ b/python/rmm/CMakeLists.txt
@@ -12,6 +12,7 @@
 # the License.
 # =============================================================================
 
+
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
 include(../../rapids_config.cmake)

--- a/python/rmm/CMakeLists.txt
+++ b/python/rmm/CMakeLists.txt
@@ -8,8 +8,8 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and
-# limitations under the License.
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
 # =============================================================================
 
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
@@ -26,6 +26,7 @@ find_package(rmm "${RAPIDS_VERSION}" REQUIRED)
 include(rapids-cython-core)
 rapids_cython_init()
 
+# pass through logging level to spdlog
 add_compile_definitions("SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${RMM_LOGGING_LEVEL}")
 
 add_subdirectory(rmm/_cuda)

--- a/python/rmm/docs/conf.py
+++ b/python/rmm/docs/conf.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -126,6 +126,7 @@ input = "rmm/VERSION"
 regex = "(?P<value>.*)"
 
 [tool.pytest.ini_options]
+# treat warnings as errors
 filterwarnings = [
     "error",
 ]


### PR DESCRIPTION
## Description

Updates some copyright dates. These were updated in 2024, but their copyright dates were not automatically modified because #1553 hadn't been merged yet.

On each file, I made a trivial change to convince the `verify-copyright` pre-commit hook that the files have changed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
