### PR TITLE
Set default value for PARALLEL_LEVEL to nproc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ RAN_CMAKE=0
 # If INSTALL_PREFIX is not set, check PREFIX, then check
 # CONDA_PREFIX, then fall back to install inside of $LIBRMM_BUILD_DIR
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX:=$LIBRMM_BUILD_DIR/install}}}
-export PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc --all)}
 
 function hasArg {
     (( NUMARGS != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")

--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ RAN_CMAKE=0
 # If INSTALL_PREFIX is not set, check PREFIX, then check
 # CONDA_PREFIX, then fall back to install inside of $LIBRMM_BUILD_DIR
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX:=$LIBRMM_BUILD_DIR/install}}}
-export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
 
 function hasArg {
     (( NUMARGS != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")


### PR DESCRIPTION
## Description
The `PARALLEL_LEVEL` variable is used in CI to set parallel level while building. Currently this variable is set on the GHA runners to `nproc`, but as this is a RAPIDS specific variable, this variable will soon be removed from the runners, so RAPIDS projects must explicitly set this variable to `nproc`. This PR is setting the default value of `PARALLEL_LEVEL` to `nproc` to match what is done by other RAPIDS projects

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
