### PR TITLE
ensure update-version.sh preserves alpha specs

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -53,9 +53,9 @@ DEPENDENCIES=(
 )
 for DEP in "${DEPENDENCIES[@]}"; do
   for FILE in dependencies.yaml conda/environments/*.yaml; do
-    sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*/g" "${FILE}"
+    sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0/g" "${FILE}"
   done
   for FILE in python/*/pyproject.toml; do
-    sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*\"/g" "${FILE}"
+    sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" "${FILE}"
   done
 done

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -33,7 +33,7 @@ dependencies:
 - pytest
 - pytest-cov
 - python>=3.9,<3.12
-- rapids-build-backend >=0.3.0,<0.4.0.dev0
+- rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core >=0.7.0
 - spdlog>=1.12.0,<1.13
 - sphinx

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -32,7 +32,7 @@ dependencies:
 - pytest
 - pytest-cov
 - python>=3.9,<3.12
-- rapids-build-backend >=0.3.0,<0.4.0.dev0
+- rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core >=0.7.0
 - spdlog>=1.12.0,<1.13
 - sphinx

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -92,13 +92,14 @@ channels:
 dependencies:
   rapids_build_skbuild:
     common:
+      - output_types: [conda, requirements, pyproject]
+        packages:
+          - rapids-build-backend>=0.3.0,<0.4.0.dev0
       - output_types: conda
         packages:
-          - rapids-build-backend >=0.3.0,<0.4.0.dev0
           - scikit-build-core >=0.7.0
       - output_types: [requirements, pyproject]
         packages:
-          - rapids-build-backend>=0.3.0,<0.4.0.dev0
           - scikit-build-core[pyproject]>=0.7.0
   build:
     common:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/31

Follow-up to #1502

* ensures that `update-version.sh` does not remove alpha specs like `,>=0.0.0a0` in `pyproject.toml` and conda environment files
* consolidates `rapids-build-backend` versions in `dependencies.yaml`
   - *since I was pushing a new commit here anyway, figured I'd take the opportunity to include that simplification recommended in https://github.com/rapidsai/cudf/pull/15245#discussion_r1617724287*

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Notes for Reviewers

### Shouldn't this also be adding a test on the `__git_commit__` and `__version__` constants?

I'd said previously that I didn't include that in #1502, but looks like I actually did:

https://github.com/rapidsai/rmm/blob/15c04666e20712f30882a903bfad79e208d8e852/python/rmm/rmm/tests/test_version.py#L18