### PR TITLE
Remove text builds of documentation

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -38,7 +38,7 @@ popd
 rapids-logger "Build Python docs"
 pushd python/rmm/docs
 make dirhtml
-mkdir -p "${RAPIDS_DOCS_DIR}/rmm/"html
+mkdir -p "${RAPIDS_DOCS_DIR}/rmm/html"
 mv _build/dirhtml/* "${RAPIDS_DOCS_DIR}/rmm/html"
 popd
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -38,10 +38,8 @@ popd
 rapids-logger "Build Python docs"
 pushd python/rmm/docs
 make dirhtml
-make text
-mkdir -p "${RAPIDS_DOCS_DIR}/rmm/"{html,txt}
+mkdir -p "${RAPIDS_DOCS_DIR}/rmm/"html
 mv _build/dirhtml/* "${RAPIDS_DOCS_DIR}/rmm/html"
-mv _build/text/* "${RAPIDS_DOCS_DIR}/rmm/txt"
 popd
 
 rapids-upload-docs


### PR DESCRIPTION
This PR removes text builds of the documentation, which we do not currently use for anything. Contributes to https://github.com/rapidsai/build-planning/issues/71.
