### PR TITLE
Fix test_python matrix

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -299,26 +299,8 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              arch: x86_64
-              cuda: "11.4"
-            packages:
-              - nvcc_linux-64=11.4
-          - matrix:
-              arch: aarch64
-              cuda: "11.4"
-            packages:
-              - nvcc_linux-aarch64=11.4
-          - matrix:
-              arch: x86_64
-              cuda: "11.8"
-            packages:
-              - nvcc_linux-64=11.8
-          - matrix:
-              arch: aarch64
-              cuda: "11.8"
-            packages:
-              - nvcc_linux-aarch64=11.8
-          - matrix:
               cuda: "12.*"
             packages:
               - cuda-nvcc
+          - matrix:
+            packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -294,10 +294,12 @@ dependencies:
         packages:
           - pytest
           - pytest-cov
-    # Needed for numba in tests
     specific:
       - output_types: conda
         matrices:
+          # Needed for numba in tests on CUDA 12+ since Conda CI environments
+          # do not have a CUDA compiler preinstalled. Wheel tests are run on
+          # images that supply a CUDA compiler.
           - matrix:
               cuda: "12.*"
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -300,6 +300,16 @@ dependencies:
         matrices:
           - matrix:
               arch: x86_64
+              cuda: "11.4"
+            packages:
+              - nvcc_linux-64=11.4
+          - matrix:
+              arch: aarch64
+              cuda: "11.4"
+            packages:
+              - nvcc_linux-aarch64=11.4
+          - matrix:
+              arch: x86_64
               cuda: "11.8"
             packages:
               - nvcc_linux-64=11.8


### PR DESCRIPTION
## Description
This fixes the matrix for `test_python` to allow for CUDA 11.4. Fixes a testing regression from https://github.com/rapidsai/rmm/pull/1542.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
