### PR TITLE
Avoid `--find-links`.

### DIFF
--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -8,6 +8,6 @@ WHEELHOUSE="${PWD}/dist/"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python "${WHEELHOUSE}"
 
 # echo to expand wildcard before adding '[extra]' requires for pip
-python -m pip install -v "$(echo ./dist/rmm_${RAPIDS_PY_CUDA_SUFFIX}*.whl)[test]"
+python -m pip install -v "$(echo "${WHEELHOUSE}"/rmm_${RAPIDS_PY_CUDA_SUFFIX}*.whl)[test]"
 
 python -m pytest ./python/rmm/rmm/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -8,6 +8,6 @@ WHEELHOUSE="${PWD}/dist/"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python "${WHEELHOUSE}"
 
 # echo to expand wildcard before adding '[extra]' requires for pip
-python -m pip install "rmm-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find-links "${WHEELHOUSE}"
+python -m pip install -v "$(echo ./dist/rmm_${RAPIDS_PY_CUDA_SUFFIX}*.whl)[test]"
 
 python -m pytest ./python/rmm/rmm/tests


### PR DESCRIPTION
Avoid `pip --find-links` which can fail to install and fall back to older wheels. See https://github.com/rapidsai/build-planning/issues/69 for more information.
