### PR TITLE
Avoid accessing statistics_resource_adaptor stack top if it is empty

### DIFF
--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -122,8 +122,6 @@ class statistics_resource_adaptor final : public device_memory_resource {
   statistics_resource_adaptor(Upstream* upstream) : upstream_{upstream}
   {
     RMM_EXPECTS(nullptr != upstream, "Unexpected null upstream resource pointer.");
-    // Initially, we push a single counter pair on the stack
-    push_counters();
   }
 
   statistics_resource_adaptor()                                              = delete;
@@ -186,7 +184,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
   std::pair<counter, counter> push_counters()
   {
     write_lock_t lock(mtx_);
-    auto ret = counter_stack_.empty() ? std::make_pair(counter{}, counter{}) : counter_stack_.top();
+    auto ret = counter_stack_.top();
     counter_stack_.push({counter{}, counter{}});
     return ret;
   }
@@ -196,6 +194,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
    *
    * @return top pair of counters <bytes, allocations> from the stack _before_
    * the pop
+   * @throws std::out_of_range if the counter stack has fewer than two entries.
    */
   std::pair<counter, counter> pop_counters()
   {
@@ -275,7 +274,8 @@ class statistics_resource_adaptor final : public device_memory_resource {
   }
 
   // Stack of counter pairs <bytes, allocations>
-  std::stack<std::pair<counter, counter>> counter_stack_;
+  // Invariant: the stack always contains at least one entry
+  std::stack<std::pair<counter, counter>> counter_stack_{{std::make_pair(counter{}, counter{})}};
   std::shared_mutex mutable mtx_;  // mutex for thread safe access to allocations_
   Upstream* upstream_;             // the upstream resource used for satisfying allocation requests
 };

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -110,7 +110,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
       total += val.total;
     }
   };
-  
+
   /**
    * @brief Construct a new statistics resource adaptor using `upstream` to satisfy
    * allocation requests.

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -110,7 +110,7 @@ class statistics_resource_adaptor final : public device_memory_resource {
       total += val.total;
     }
   };
-
+  
   /**
    * @brief Construct a new statistics resource adaptor using `upstream` to satisfy
    * allocation requests.
@@ -186,8 +186,8 @@ class statistics_resource_adaptor final : public device_memory_resource {
   std::pair<counter, counter> push_counters()
   {
     write_lock_t lock(mtx_);
-    auto ret = counter_stack_.top();
-    counter_stack_.push(std::make_pair(counter{}, counter{}));
+    auto ret = counter_stack_.empty() ? std::make_pair(counter{}, counter{}) : counter_stack_.top();
+    counter_stack_.push({counter{}, counter{}});
     return ret;
   }
 


### PR DESCRIPTION
## Description
Fixes #1587 

Note: the only time UB could occur was in the constructor, because the ctor pushes a pair onto the stack and `pop_counters()` does not allow the last pair to be popped. Therefore, we only need to check for empty in `push_counters()`.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
