### PR TITLE
Update Thrust CMake Guide link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ automatically pulls in `Thrust` by means of a dependency on the
 `rmm::Thrust` target. By default it uses the standard configuration of
 Thrust. If you want to customize it, you can set the variables
 `THRUST_HOST_SYSTEM` and `THRUST_DEVICE_SYSTEM`; see
-[Thrust's CMake documentation](https://github.com/NVIDIA/thrust/blob/main/thrust/cmake/README.md).
+[Thrust's CMake documentation](https://github.com/NVIDIA/cccl/blob/main/thrust/thrust/cmake/README.md).
 
 # Using RMM in C++
 


### PR DESCRIPTION
## Description
The README still linked to the archived Thrust repo instead of the new CCCL repo for the Thrust CMake Guide.

Replace link.

- Closes  #1592

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
