### PR TITLE
Use verify-alpha-spec hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,6 @@ repos:
       hooks:
           - id: trailing-whitespace
           - id: end-of-file-fixer
-    - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.13.11
-      hooks:
-          - id: rapids-dependency-file-generator
-            args: ["--clean"]
     - repo: https://github.com/PyCQA/isort
       rev: 5.12.0
       hooks:
@@ -82,9 +77,15 @@ repos:
         - id: ruff
           files: python/.*$
     - repo: https://github.com/rapidsai/pre-commit-hooks
-      rev: v0.0.3
+      rev: v0.2.0
       hooks:
         - id: verify-copyright
+        - id: verify-alpha-spec
+    - repo: https://github.com/rapidsai/dependency-file-generator
+      rev: v1.13.11
+      hooks:
+          - id: rapids-dependency-file-generator
+            args: ["--clean"]
 
 default_language_version:
     python: python3


### PR DESCRIPTION
With the deployment of rapids-build-backend, we need to make sure our dependencies have alpha specs.

Contributes to https://github.com/rapidsai/build-planning/issues/31

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
