### PR TITLE
Revert "Remove HTML builds of librmm (#1415)"

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -33,6 +33,8 @@ export RAPIDS_DOCS_DIR="$(mktemp -d)"
 rapids-logger "Build CPP docs"
 pushd doxygen
 doxygen Doxyfile
+mkdir -p "${RAPIDS_DOCS_DIR}/librmm/html"
+mv html/* "${RAPIDS_DOCS_DIR}/librmm/html"
 popd
 
 rapids-logger "Build Python docs"

--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -1135,7 +1135,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = NO
+GENERATE_HTML          = YES
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
## Description
This reverts commit 77b55003b5ae598b7c26553ff39c5dde369c73d8.

See: https://github.com/rapidsai/docs/pull/517#pullrequestreview-2105119364

We need to have librmm docs published in order to enable cross-linking of librmm from libcudf docs.

From discussion with @raydouglass, we don't need to link to them publicly on docs.rapids.ai, as they are already included in the rmm docs (both C++ and Python). The librmm docs will just be used to cross-reference from libcudf docs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
