### PR TITLE
Allow testing of earliest/latest dependencies

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -12,7 +12,7 @@ rapids-logger "Create test conda environment"
 rapids-dependency-file-generator \
   --output conda \
   --file-key test_python \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test
 set +u

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -6,8 +6,19 @@ set -eou pipefail
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 WHEELHOUSE="${PWD}/dist/"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python "${WHEELHOUSE}"
+PIP_PACKAGE=$(echo "${WHEELHOUSE}"/rmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl | head -n1)
 
-# echo to expand wildcard before adding '[extra]' requires for pip
-python -m pip install -v "$(echo "${WHEELHOUSE}"/rmm_${RAPIDS_PY_CUDA_SUFFIX}*.whl)[test]"
+# Use `package[test]` to install latest test dependencies or explicitly install oldest.
+if [[ $RAPIDS_DEPENDENCIES != "oldest" ]]; then
+  python -m pip install -v "${PIP_PACKAGE}[test]"
+else
+  rapids-dependency-file-generator \
+      --output requirements \
+      --file-key test_python \
+      --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
+    | tee oldest-dependencies.txt
+
+  python -m pip install -v "$PIP_PACKAGE" -r oldest-dependencies.txt
+fi
 
 python -m pytest ./python/rmm/rmm/tests

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -6,19 +6,21 @@ set -eou pipefail
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
 WHEELHOUSE="${PWD}/dist/"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python "${WHEELHOUSE}"
-PIP_PACKAGE=$(echo "${WHEELHOUSE}"/rmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl | head -n1)
 
-# Use `package[test]` to install latest test dependencies or explicitly install oldest.
-if [[ $RAPIDS_DEPENDENCIES != "oldest" ]]; then
-  python -m pip install -v "${PIP_PACKAGE}[test]"
-else
+# Constraint to minimum dependency versions if job is set up as "oldest"
+echo "" > ./constraints.txt
+if [[ $RAPIDS_DEPENDENCIES == "oldest" ]]; then
   rapids-dependency-file-generator \
-      --output requirements \
-      --file-key test_python \
-      --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
-    | tee oldest-dependencies.txt
-
-  python -m pip install -v "$PIP_PACKAGE" -r oldest-dependencies.txt
+        --output requirements \
+        --file-key test_python \
+        --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
+      | tee ./constraints.txt
 fi
+
+# echo to expand wildcard before adding '[extra]' requires for pip
+python -m pip install \
+    -v \
+    --constraint ./constraints.txt \
+    "$(echo "${WHEELHOUSE}"/rmm_${RAPIDS_PY_CUDA_SUFFIX}*.whl)[test]"
 
 python -m pytest ./python/rmm/rmm/tests

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -312,14 +312,13 @@ dependencies:
               - cuda-nvcc
           - matrix:
             packages:
-    specific:
-      - output_types: [conda, requirements, pyproject]
+      - output_types: [conda, requirements]
+        # Define additional constraints for testing with oldest dependencies.
         matrices:
           - matrix:
               dependencies: "oldest"
             packages:
               - numba==0.57.*
               - numpy==1.23.*
-          # No pinnings except for oldest dependencies
           - matrix:
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -312,3 +312,14 @@ dependencies:
               - cuda-nvcc
           - matrix:
             packages:
+    specific:
+      - output_types: [conda, requirements, pyproject]
+        matrices:
+          - matrix:
+              dependencies: "earliest"
+            packages:
+              - numba==0.57.*
+              - numpy==1.23.*
+          # No pinnings except for earliest dependencies
+          - matrix:
+            packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -316,10 +316,10 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         matrices:
           - matrix:
-              dependencies: "earliest"
+              dependencies: "oldest"
             packages:
               - numba==0.57.*
               - numpy==1.23.*
-          # No pinnings except for earliest dependencies
+          # No pinnings except for oldest dependencies
           - matrix:
             packages:


### PR DESCRIPTION
Mostly identical to gh-1606, which allows the testing of oldest/latest dependencies.  What oldest/latest dependencies means exactly has to be set by each project in their `dependencies.yaml` file for the test env.

See https://github.com/rapidsai/shared-workflows/pull/228 for the workflow changes.

This is part of preparing for 2.0 (which should just work, but in the end no need to include it in the same PR).

*Modifications from draft PR:*
- I renamed it to `oldest`, as suggested by Matthew.
- Noticed that the name is different between wheel and conda workflows, so modified both to include all matrix information.

(Draft, since the shared workflow should be pushed in first to revert the branch renaming probably.  Need to test that the wheel workflow is correct.)