### PR TITLE
add rapids-build-backend to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ GPU Support:
   may work on earlier architectures.
 
 Python requirements:
+* `rapids-build-backend` (available from PyPI or the `rapidsai` conda channel)
 * `scikit-build-core`
 * `cuda-python`
 * `cython`


### PR DESCRIPTION
## Description

Fixes #1609
Follow-up to #1502

Adds `rapids-build-backend` to the documentation on how to build `rmm` from source.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
