### PR TITLE
Instruct to create associated issue in PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
 ## Description
+<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
+<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
+<!-- create a new issue. -->
+
 <!-- Provide a standalone description of changes in this PR. -->
 <!-- Reference any issues closed by this PR with "closes #1234". -->
 <!-- Note: The pull request title will be included in the CHANGELOG. -->


### PR DESCRIPTION
We use issues for tracking work and new features in RMM. This adds instruction to the PR template to suggest contributors should create an associated issue if it doesn't already exist.

Fixes #1623 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
