### PR TITLE
Remove prefetch factory.

### DIFF
--- a/include/rmm/mr/device/prefetch_resource_adaptor.hpp
+++ b/include/rmm/mr/device/prefetch_resource_adaptor.hpp
@@ -125,19 +125,5 @@ class prefetch_resource_adaptor final : public device_memory_resource {
   Upstream* upstream_;  // the upstream resource used for satisfying allocation requests
 };
 
-/**
- * @brief Convenience factory to return a `prefetch_resource_adaptor` around the
- * upstream resource `upstream`.
- *
- * @tparam Upstream Type of the upstream `device_memory_resource`.
- * @param upstream Pointer to the upstream resource
- * @return The new prefetch resource adaptor
- */
-template <typename Upstream>
-prefetch_resource_adaptor<Upstream> make_prefetch_adaptor(Upstream* upstream)
-{
-  return prefetch_resource_adaptor<Upstream>{upstream};
-}
-
 /** @} */  // end of group
 }  // namespace rmm::mr


### PR DESCRIPTION
## Description
PR #1608 added a prefetch resource adaptor. However, per issue #1616, we want to remove the adaptor factories like `make_prefetch_adaptor` in favor of constructors with CTAD. I am removing the prefetch adaptor factory because it has not yet been released, and thus can be deleted without deprecation.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
