### PR TITLE
split up CUDA-suffixed dependencies in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -165,21 +165,11 @@ dependencies:
               packages:
                 - librmm-cu12==24.8.*,>=0.0.0a0
             - matrix:
-                cuda: "12.*"
-                cuda_suffixed: "false"
-              packages:
-                - &librmm_unsuffixed librmm==24.8.*,>=0.0.0a0
-            - matrix:
                 cuda: "11.*"
                 cuda_suffixed: "true"
               packages:
                 - librmm-cu11==24.8.*,>=0.0.0a0
-            - matrix:
-                cuda: "11.*"
-                cuda_suffixed: "false"
-              packages: &cython_build_cu11_unsuffixed
-                - *librmm_unsuffixed
-            - {matrix: null, packages: *cython_build_cu11_unsuffixed}
+            - {matrix: null, packages: ['librmm==24.8.*,>=0.0.0a0']}
   checks:
     common:
       - output_types: [conda, requirements]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -161,15 +161,25 @@ dependencies:
         matrices:
             - matrix:
                 cuda: "12.*"
+                cuda_suffixed: "true"
               packages:
                 - librmm-cu12==24.8.*,>=0.0.0a0
             - matrix:
+                cuda: "12.*"
+                cuda_suffixed: "false"
+              packages:
+                - &librmm_unsuffixed librmm==24.8.*,>=0.0.0a0
+            - matrix:
                 cuda: "11.*"
+                cuda_suffixed: "true"
               packages:
                 - librmm-cu11==24.8.*,>=0.0.0a0
             - matrix:
-              packages:
-                - librmm==24.8.*,>=0.0.0a0
+                cuda: "11.*"
+                cuda_suffixed: "false"
+              packages: &cython_build_cu11_unsuffixed
+                - *librmm_unsuffixed
+            - {matrix: null, packages: *cython_build_cu11_unsuffixed}
   checks:
     common:
       - output_types: [conda, requirements]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -169,7 +169,9 @@ dependencies:
                 cuda_suffixed: "true"
               packages:
                 - librmm-cu11==24.8.*,>=0.0.0a0
-            - {matrix: null, packages: ['librmm==24.8.*,>=0.0.0a0']}
+            - matrix: null
+              packages:
+                - librmm==24.8.*,>=0.0.0a0
   checks:
     common:
       - output_types: [conda, requirements]

--- a/python/librmm/pyproject.toml
+++ b/python/librmm/pyproject.toml
@@ -46,6 +46,7 @@ librmm = "librmm"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
+matrix-entry = "cuda_suffixed=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "ninja",

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -124,6 +124,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 dependencies-file = "../../dependencies.yaml"
+matrix-entry = "cuda_suffixed=true"
 requires = [
     "cmake>=3.26.4,!=3.30.0",
     "cuda-python>=11.7.1,<12.0a0",


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/31

In short, RAPIDS DLFW builds want to produce wheels with unsuffixed dependencies, e.g. `cudf` depending on `rmm`, not `rmm-cu12`.

This PR is part of a series across all of RAPIDS to try to support that type of build by setting up CUDA-suffixed and CUDA-unsuffixed dependency lists in `dependencies.yaml`.

For more details, see:
* https://github.com/rapidsai/build-planning/issues/31#issuecomment-2245815818
* https://github.com/rapidsai/cudf/pull/16183

## Notes for Reviewers

### Why target 24.08?

This is targeting 24.08 because:

1. it should be very low-risk
2. getting these changes into 24.08 prevents the need to carry around patches for every library in DLFW builds using RAPIDS 24.08

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.