### PR TITLE
Install headers into `${CMAKE_INSTALL_INCLUDEDIR}`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,8 @@ include(CPack)
 # install export targets
 install(TARGETS rmm EXPORT rmm-exports)
 install(DIRECTORY include/rmm/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rmm)
-install(FILES ${RMM_BINARY_DIR}/include/rmm/version_config.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rmm)
+install(FILES ${RMM_BINARY_DIR}/include/rmm/version_config.hpp
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rmm)
 
 set(doc_string
     [=[

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,12 +142,13 @@ endif()
 # ##################################################################################################
 # * install targets --------------------------------------------------------------------------------
 
+include(GNUInstallDirs)
 include(CPack)
 
 # install export targets
 install(TARGETS rmm EXPORT rmm-exports)
-install(DIRECTORY include/rmm/ DESTINATION include/rmm)
-install(FILES ${RMM_BINARY_DIR}/include/rmm/version_config.hpp DESTINATION include/rmm)
+install(DIRECTORY include/rmm/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rmm)
+install(FILES ${RMM_BINARY_DIR}/include/rmm/version_config.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rmm)
 
 set(doc_string
     [=[


### PR DESCRIPTION
## Description
Instead of installing into a hard-coded `include` directory, install to `${CMAKE_INSTALL_INCLUDEDIR}`, which defaults to `include`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
