### PR TITLE
Explicitly mark RMM headers with `RMM_EXPORT`

### DIFF
--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -2176,7 +2176,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = RMM_EXPORT
+PREDEFINED             = RMM_NAMESPACE=rmm RMM_EXPORT
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -2176,7 +2176,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = RMM_NAMESPACE
+PREDEFINED             = RMM_EXPORT
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2185,7 +2185,7 @@ PREDEFINED             = RMM_NAMESPACE
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = RMM_NAMESPACE
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -2136,7 +2136,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2144,7 +2144,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2176,7 +2176,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = RMM_NAMESPACE
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/rmm/aligned.hpp
+++ b/include/rmm/aligned.hpp
@@ -22,7 +22,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 
 /**
  * @addtogroup utilities
@@ -125,4 +125,4 @@ static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
 
 /** @} */  // end of group
 
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/aligned.hpp
+++ b/include/rmm/aligned.hpp
@@ -16,11 +16,13 @@
 
 #pragma once
 
+#include <rmm/detail/export.hpp>
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 
 /**
  * @addtogroup utilities
@@ -123,4 +125,4 @@ static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
 
 /** @} */  // end of group
 
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/cuda_device.hpp
+++ b/include/rmm/cuda_device.hpp
@@ -21,7 +21,7 @@
 
 #include <cuda_runtime_api.h>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 
 struct cuda_device_id;
 inline cuda_device_id get_current_cuda_device();
@@ -176,4 +176,4 @@ struct cuda_set_device_raii {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/cuda_device.hpp
+++ b/include/rmm/cuda_device.hpp
@@ -17,10 +17,11 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 
 #include <cuda_runtime_api.h>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 
 struct cuda_device_id;
 inline cuda_device_id get_current_cuda_device();
@@ -175,4 +176,4 @@ struct cuda_set_device_raii {
 };
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/cuda_stream.hpp
+++ b/include/rmm/cuda_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/logging_assert.hpp>
 
 #include <cuda_runtime_api.h>
@@ -25,7 +26,7 @@
 #include <functional>
 #include <memory>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -139,4 +140,4 @@ class cuda_stream {
 };
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/cuda_stream.hpp
+++ b/include/rmm/cuda_stream.hpp
@@ -26,7 +26,7 @@
 #include <functional>
 #include <memory>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -140,4 +140,4 @@ class cuda_stream {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/cuda_stream_pool.hpp
+++ b/include/rmm/cuda_stream_pool.hpp
@@ -25,7 +25,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -103,4 +103,4 @@ class cuda_stream_pool {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/cuda_stream_pool.hpp
+++ b/include/rmm/cuda_stream_pool.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 
 #include <atomic>
 #include <cstddef>
 #include <vector>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -102,4 +103,4 @@ class cuda_stream_pool {
 };
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/cuda_stream_view.hpp
+++ b/include/rmm/cuda_stream_view.hpp
@@ -26,7 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -202,4 +202,4 @@ inline std::ostream& operator<<(std::ostream& os, cuda_stream_view stream)
 }
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/cuda_stream_view.hpp
+++ b/include/rmm/cuda_stream_view.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
@@ -25,7 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -201,4 +202,4 @@ inline std::ostream& operator<<(std::ostream& os, cuda_stream_view stream)
 }
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
+#include <rmm/detail/export.hpp>
 
 #include <cassert>
 #include <cstddef>
@@ -24,7 +25,8 @@
 #include <memory>
 #include <new>
 
-namespace rmm::detail {
+namespace RMM_EXPORT rmm {
+namespace detail {
 
 /**
  * @brief Allocates sufficient host-accessible memory to satisfy the requested size `bytes` with
@@ -112,4 +114,5 @@ void aligned_host_deallocate(void* ptr,
 
   dealloc(original);
 }
-}  // namespace rmm::detail
+}  // namespace detail
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <new>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace detail {
 
 /**
@@ -115,4 +115,4 @@ void aligned_host_deallocate(void* ptr,
   dealloc(original);
 }
 }  // namespace detail
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/detail/export.hpp>
 
 #include <cuda_runtime_api.h>
 
@@ -24,7 +25,8 @@
 #include <memory>
 #include <optional>
 
-namespace rmm::detail {
+namespace RMM_EXPORT rmm {
+namespace detail {
 
 /**
  * @brief `dynamic_load_runtime` loads the cuda runtime library at runtime
@@ -185,4 +187,5 @@ struct async_alloc {
 #endif
 
 #undef RMM_CUDART_API_WRAPPER
-}  // namespace rmm::detail
+}  // namespace detail
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/detail/dynamic_load_runtime.hpp
+++ b/include/rmm/detail/dynamic_load_runtime.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <optional>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace detail {
 
 /**
@@ -188,4 +188,4 @@ struct async_alloc {
 
 #undef RMM_CUDART_API_WRAPPER
 }  // namespace detail
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/detail/export.hpp
+++ b/include/rmm/detail/export.hpp
@@ -18,8 +18,8 @@
 
 // Macros used for defining symbol visibility, only GLIBC is supported
 #if (defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__))
-#define RMM_EXPORT __attribute__((visibility("default")))
-#define RMM_HIDDEN __attribute__((visibility("hidden")))
+#define RMM_EXPORT    __attribute__((visibility("default")))
+#define RMM_HIDDEN    __attribute__((visibility("hidden")))
 #define RMM_NAMESPACE RMM_EXPORT rmm
 #else
 #define RMM_EXPORT

--- a/include/rmm/detail/export.hpp
+++ b/include/rmm/detail/export.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #if (defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__))
 #define RMM_EXPORT __attribute__((visibility("default")))
 #define RMM_HIDDEN __attribute__((visibility("hidden")))
+#define RMM_NAMESPACE RMM_EXPORT rmm
 #else
 #define RMM_EXPORT
 #define RMM_HIDDEN

--- a/include/rmm/detail/stack_trace.hpp
+++ b/include/rmm/detail/stack_trace.hpp
@@ -37,7 +37,7 @@
 #include <vector>
 #endif
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace detail {
 
 /**
@@ -105,4 +105,4 @@ class stack_trace {
 };
 
 }  // namespace detail
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/detail/stack_trace.hpp
+++ b/include/rmm/detail/stack_trace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 
 // execinfo is a linux-only library, so stack traces will only be available on
 // linux systems.
@@ -36,7 +37,8 @@
 #include <vector>
 #endif
 
-namespace rmm::detail {
+namespace RMM_EXPORT rmm {
+namespace detail {
 
 /**
  * @brief stack_trace is a class that will capture a stack on instantiation for output later.
@@ -102,4 +104,5 @@ class stack_trace {
 #endif  // RMM_ENABLE_STACK_TRACES
 };
 
-}  // namespace rmm::detail
+}  // namespace detail
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -30,7 +30,7 @@
 #include <stdexcept>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 /**
  * @addtogroup data_containers
  * @{
@@ -480,4 +480,4 @@ class device_buffer {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -29,7 +30,7 @@
 #include <stdexcept>
 #include <utility>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 /**
  * @addtogroup data_containers
  * @{
@@ -479,4 +480,4 @@ class device_buffer {
 };
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -24,7 +24,7 @@
 
 #include <type_traits>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 /**
  * @addtogroup data_containers
  * @{
@@ -278,4 +278,4 @@ class device_scalar {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -17,13 +17,14 @@
 #pragma once
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <type_traits>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 /**
  * @addtogroup data_containers
  * @{
@@ -277,4 +278,4 @@ class device_scalar {
 };
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/exec_check_disable.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -28,7 +29,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 /**
  * @addtogroup data_containers
  * @{
@@ -565,4 +566,4 @@ class device_uvector {
 };
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -29,7 +29,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 /**
  * @addtogroup data_containers
  * @{
@@ -566,4 +566,4 @@ class device_uvector {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/device_vector.hpp
+++ b/include/rmm/device_vector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 #pragma once
 
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 
 #include <thrust/device_vector.h>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -35,4 +36,4 @@ template <typename T>
 using device_vector = thrust::device_vector<T, rmm::mr::thrust_allocator<T>>;
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/device_vector.hpp
+++ b/include/rmm/device_vector.hpp
@@ -22,7 +22,7 @@
 
 #include <thrust/device_vector.h>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -36,4 +36,4 @@ template <typename T>
 using device_vector = thrust::device_vector<T, rmm::mr::thrust_allocator<T>>;
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/error.hpp
+++ b/include/rmm/error.hpp
@@ -21,7 +21,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 
 /**
  * @brief Exception thrown when logical precondition is violated.
@@ -111,4 +111,4 @@ class out_of_range : public std::out_of_range {
   using std::out_of_range::out_of_range;
 };
 
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/error.hpp
+++ b/include/rmm/error.hpp
@@ -16,10 +16,12 @@
 
 #pragma once
 
+#include <rmm/detail/export.hpp>
+
 #include <stdexcept>
 #include <string>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 
 /**
  * @brief Exception thrown when logical precondition is violated.
@@ -109,4 +111,4 @@ class out_of_range : public std::out_of_range {
   using std::out_of_range::out_of_range;
 };
 
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -30,7 +30,7 @@
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -98,4 +98,4 @@ using exec_policy_nosync =
 #endif
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/exec_policy.hpp
+++ b/include/rmm/exec_policy.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/mr/device/thrust_allocator_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
@@ -29,7 +30,7 @@
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -97,4 +98,4 @@ using exec_policy_nosync =
 #endif
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <string>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 
 namespace detail {
 
@@ -127,7 +127,7 @@ inline spdlog::logger& logger()
 
 //! @endcond
 
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE
 
 // Doxygen doesn't like this because we're overloading something from fmt
 //! @cond Doxygen_Suppress

--- a/include/rmm/logger.hpp
+++ b/include/rmm/logger.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <rmm/detail/export.hpp>
+
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <spdlog/sinks/basic_file_sink.h>
@@ -25,7 +27,7 @@
 #include <iostream>
 #include <string>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 
 namespace detail {
 
@@ -125,7 +127,7 @@ inline spdlog::logger& logger()
 
 //! @endcond
 
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm
 
 // Doxygen doesn't like this because we're overloading something from fmt
 //! @cond Doxygen_Suppress

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -27,7 +27,8 @@
 #include <optional>
 #include <unordered_map>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -195,4 +196,5 @@ class aligned_resource_adaptor final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -27,7 +27,7 @@
 #include <optional>
 #include <unordered_map>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -197,4 +197,4 @@ class aligned_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -18,6 +18,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -26,7 +27,7 @@
 #include <optional>
 #include <unordered_map>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -17,6 +17,7 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/device/detail/arena.hpp>
@@ -31,7 +32,7 @@
 #include <shared_mutex>
 #include <thread>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -32,7 +32,8 @@
 #include <shared_mutex>
 #include <thread>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -343,4 +344,5 @@ class arena_memory_resource final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/arena_memory_resource.hpp
+++ b/include/rmm/mr/device/arena_memory_resource.hpp
@@ -32,7 +32,7 @@
 #include <shared_mutex>
 #include <thread>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -345,4 +345,4 @@ class arena_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -29,7 +29,8 @@
 #include <memory>
 #include <vector>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -195,4 +196,5 @@ class binning_memory_resource final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -29,7 +29,7 @@
 #include <memory>
 #include <vector>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -197,4 +197,4 @@ class binning_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/fixed_size_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -28,7 +29,7 @@
 #include <memory>
 #include <vector>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/callback_memory_resource.hpp
+++ b/include/rmm/mr/device/callback_memory_resource.hpp
@@ -22,7 +22,8 @@
 #include <functional>
 #include <utility>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -146,4 +147,5 @@ class callback_memory_resource final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/callback_memory_resource.hpp
+++ b/include/rmm/mr/device/callback_memory_resource.hpp
@@ -15,13 +15,14 @@
  */
 #pragma once
 
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cstddef>
 #include <functional>
 #include <utility>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/callback_memory_resource.hpp
+++ b/include/rmm/mr/device/callback_memory_resource.hpp
@@ -22,7 +22,7 @@
 #include <functional>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -148,4 +148,4 @@ class callback_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -37,7 +37,7 @@
 #endif
 #endif
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -223,4 +223,4 @@ class cuda_async_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -19,6 +19,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/dynamic_load_runtime.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/mr/device/cuda_async_view_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
@@ -36,7 +37,7 @@
 #endif
 #endif
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -37,7 +37,8 @@
 #endif
 #endif
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -221,4 +222,5 @@ class cuda_async_memory_resource final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -32,7 +32,8 @@
 #define RMM_CUDA_MALLOC_ASYNC_SUPPORT
 #endif
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -156,4 +157,5 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -32,7 +32,7 @@
 #define RMM_CUDA_MALLOC_ASYNC_SUPPORT
 #endif
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -158,4 +158,4 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -19,6 +19,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/dynamic_load_runtime.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
@@ -31,7 +32,7 @@
 #define RMM_CUDA_MALLOC_ASYNC_SUPPORT
 #endif
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -22,7 +22,8 @@
 
 #include <cstddef>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -95,4 +96,5 @@ class cuda_memory_resource final : public device_memory_resource {
   }
 };
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -22,7 +22,7 @@
 
 #include <cstddef>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -97,4 +97,4 @@ class cuda_memory_resource final : public device_memory_resource {
 };
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/cuda_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_memory_resource.hpp
@@ -17,11 +17,12 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cstddef>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -38,7 +38,8 @@
 #include <optional>
 #include <set>
 
-namespace RMM_EXPORT rmm::mr::detail::arena {
+namespace RMM_EXPORT rmm {
+namespace mr::detail::arena {
 
 /**
  * @brief Align up to nearest size class.
@@ -999,4 +1000,5 @@ class arena_cleaner {
   std::weak_ptr<arena<Upstream>> arena_;
 };
 
-}  // namespace rmm::mr::detail::arena
+}  // namespace mr::detail::arena
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -20,6 +20,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 
@@ -37,7 +38,7 @@
 #include <optional>
 #include <set>
 
-namespace rmm::mr::detail::arena {
+namespace RMM_EXPORT rmm::mr::detail::arena {
 
 /**
  * @brief Align up to nearest size class.

--- a/include/rmm/mr/device/detail/arena.hpp
+++ b/include/rmm/mr/device/detail/arena.hpp
@@ -38,7 +38,7 @@
 #include <optional>
 #include <set>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr::detail::arena {
 
 /**
@@ -1001,4 +1001,4 @@ class arena_cleaner {
 };
 
 }  // namespace mr::detail::arena
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/detail/coalescing_free_list.hpp
+++ b/include/rmm/mr/device/detail/coalescing_free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/detail/free_list.hpp>
 
 #include <fmt/core.h>
@@ -28,7 +29,7 @@
 #include <iterator>
 #include <list>
 
-namespace rmm::mr::detail {
+namespace RMM_EXPORT rmm::mr::detail {
 
 /**
  * @brief A simple block structure specifying the size and location of a block

--- a/include/rmm/mr/device/detail/coalescing_free_list.hpp
+++ b/include/rmm/mr/device/detail/coalescing_free_list.hpp
@@ -29,7 +29,7 @@
 #include <iterator>
 #include <list>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr::detail {
 
 /**
@@ -270,4 +270,4 @@ struct coalescing_free_list : free_list<block> {
 };  // coalescing_free_list
 
 }  // namespace mr::detail
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/detail/coalescing_free_list.hpp
+++ b/include/rmm/mr/device/detail/coalescing_free_list.hpp
@@ -29,7 +29,8 @@
 #include <iterator>
 #include <list>
 
-namespace RMM_EXPORT rmm::mr::detail {
+namespace RMM_EXPORT rmm {
+namespace mr::detail {
 
 /**
  * @brief A simple block structure specifying the size and location of a block
@@ -268,4 +269,5 @@ struct coalescing_free_list : free_list<block> {
 #endif
 };  // coalescing_free_list
 
-}  // namespace rmm::mr::detail
+}  // namespace mr::detail
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+++ b/include/rmm/mr/device/detail/fixed_size_free_list.hpp
@@ -22,7 +22,7 @@
 #include <cstddef>
 #include <iostream>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr::detail {
 
 struct fixed_size_free_list : free_list<block_base> {
@@ -78,4 +78,4 @@ struct fixed_size_free_list : free_list<block_base> {
 };
 
 }  // namespace mr::detail
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+++ b/include/rmm/mr/device/detail/fixed_size_free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,63 +16,64 @@
 
 #pragma once
 
+rmm::mr::detail
 #include <rmm/mr/device/detail/free_list.hpp>
 
 #include <cstddef>
 #include <iostream>
 
-namespace rmm::mr::detail {
+  namespace RMM_EXPORT rmm::mr::detail
+{
+  struct fixed_size_free_list : free_list<block_base> {
+    fixed_size_free_list()           = default;
+    ~fixed_size_free_list() override = default;
 
-struct fixed_size_free_list : free_list<block_base> {
-  fixed_size_free_list()           = default;
-  ~fixed_size_free_list() override = default;
+    fixed_size_free_list(fixed_size_free_list const&)            = delete;
+    fixed_size_free_list& operator=(fixed_size_free_list const&) = delete;
+    fixed_size_free_list(fixed_size_free_list&&)                 = delete;
+    fixed_size_free_list& operator=(fixed_size_free_list&&)      = delete;
 
-  fixed_size_free_list(fixed_size_free_list const&)            = delete;
-  fixed_size_free_list& operator=(fixed_size_free_list const&) = delete;
-  fixed_size_free_list(fixed_size_free_list&&)                 = delete;
-  fixed_size_free_list& operator=(fixed_size_free_list&&)      = delete;
+    /**
+     * @brief Construct a new free_list from range defined by input iterators
+     *
+     * @tparam InputIt Input iterator
+     * @param first The start of the range to insert into the free_list
+     * @param last The end of the range to insert into the free_list
+     */
+    template <class InputIt>
+    fixed_size_free_list(InputIt first, InputIt last)
+    {
+      std::for_each(first, last, [this](block_type const& block) { insert(block); });
+    }
 
-  /**
-   * @brief Construct a new free_list from range defined by input iterators
-   *
-   * @tparam InputIt Input iterator
-   * @param first The start of the range to insert into the free_list
-   * @param last The end of the range to insert into the free_list
-   */
-  template <class InputIt>
-  fixed_size_free_list(InputIt first, InputIt last)
-  {
-    std::for_each(first, last, [this](block_type const& block) { insert(block); });
-  }
+    /**
+     * @brief Inserts a block into the `free_list` in the correct order, coalescing it with the
+     *        preceding and following blocks if either is contiguous.
+     *
+     * @param block The block to insert.
+     */
+    void insert(block_type const& block) { push_back(block); }
 
-  /**
-   * @brief Inserts a block into the `free_list` in the correct order, coalescing it with the
-   *        preceding and following blocks if either is contiguous.
-   *
-   * @param block The block to insert.
-   */
-  void insert(block_type const& block) { push_back(block); }
+    /**
+     * @brief Inserts blocks from another free list into this free_list.
+     *
+     * @param other The free_list to insert into this free_list.
+     */
+    void insert(free_list&& other) { splice(cend(), std::move(other)); }
 
-  /**
-   * @brief Inserts blocks from another free list into this free_list.
-   *
-   * @param other The free_list to insert into this free_list.
-   */
-  void insert(free_list&& other) { splice(cend(), std::move(other)); }
+    /**
+     * @brief Returns the first block in the free list.
+     *
+     * @param size The size in bytes of the desired block (unused).
+     * @return A block large enough to store `size` bytes.
+     */
+    block_type get_block(std::size_t size)
+    {
+      if (is_empty()) { return block_type{}; }
+      block_type block = *begin();
+      pop_front();
+      return block;
+    }
+  };
 
-  /**
-   * @brief Returns the first block in the free list.
-   *
-   * @param size The size in bytes of the desired block (unused).
-   * @return A block large enough to store `size` bytes.
-   */
-  block_type get_block(std::size_t size)
-  {
-    if (is_empty()) { return block_type{}; }
-    block_type block = *begin();
-    pop_front();
-    return block;
-  }
-};
-
-}  // namespace rmm::mr::detail
+}  // namespace RMM_EXPORT rmm::mr::detail

--- a/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+++ b/include/rmm/mr/device/detail/fixed_size_free_list.hpp
@@ -16,64 +16,66 @@
 
 #pragma once
 
-rmm::mr::detail
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/detail/free_list.hpp>
 
 #include <cstddef>
 #include <iostream>
 
-  namespace RMM_EXPORT rmm::mr::detail
-{
-  struct fixed_size_free_list : free_list<block_base> {
-    fixed_size_free_list()           = default;
-    ~fixed_size_free_list() override = default;
+namespace RMM_EXPORT rmm {
+namespace mr::detail {
 
-    fixed_size_free_list(fixed_size_free_list const&)            = delete;
-    fixed_size_free_list& operator=(fixed_size_free_list const&) = delete;
-    fixed_size_free_list(fixed_size_free_list&&)                 = delete;
-    fixed_size_free_list& operator=(fixed_size_free_list&&)      = delete;
+struct fixed_size_free_list : free_list<block_base> {
+  fixed_size_free_list()           = default;
+  ~fixed_size_free_list() override = default;
 
-    /**
-     * @brief Construct a new free_list from range defined by input iterators
-     *
-     * @tparam InputIt Input iterator
-     * @param first The start of the range to insert into the free_list
-     * @param last The end of the range to insert into the free_list
-     */
-    template <class InputIt>
-    fixed_size_free_list(InputIt first, InputIt last)
-    {
-      std::for_each(first, last, [this](block_type const& block) { insert(block); });
-    }
+  fixed_size_free_list(fixed_size_free_list const&)            = delete;
+  fixed_size_free_list& operator=(fixed_size_free_list const&) = delete;
+  fixed_size_free_list(fixed_size_free_list&&)                 = delete;
+  fixed_size_free_list& operator=(fixed_size_free_list&&)      = delete;
 
-    /**
-     * @brief Inserts a block into the `free_list` in the correct order, coalescing it with the
-     *        preceding and following blocks if either is contiguous.
-     *
-     * @param block The block to insert.
-     */
-    void insert(block_type const& block) { push_back(block); }
+  /**
+   * @brief Construct a new free_list from range defined by input iterators
+   *
+   * @tparam InputIt Input iterator
+   * @param first The start of the range to insert into the free_list
+   * @param last The end of the range to insert into the free_list
+   */
+  template <class InputIt>
+  fixed_size_free_list(InputIt first, InputIt last)
+  {
+    std::for_each(first, last, [this](block_type const& block) { insert(block); });
+  }
 
-    /**
-     * @brief Inserts blocks from another free list into this free_list.
-     *
-     * @param other The free_list to insert into this free_list.
-     */
-    void insert(free_list&& other) { splice(cend(), std::move(other)); }
+  /**
+   * @brief Inserts a block into the `free_list` in the correct order, coalescing it with the
+   *        preceding and following blocks if either is contiguous.
+   *
+   * @param block The block to insert.
+   */
+  void insert(block_type const& block) { push_back(block); }
 
-    /**
-     * @brief Returns the first block in the free list.
-     *
-     * @param size The size in bytes of the desired block (unused).
-     * @return A block large enough to store `size` bytes.
-     */
-    block_type get_block(std::size_t size)
-    {
-      if (is_empty()) { return block_type{}; }
-      block_type block = *begin();
-      pop_front();
-      return block;
-    }
-  };
+  /**
+   * @brief Inserts blocks from another free list into this free_list.
+   *
+   * @param other The free_list to insert into this free_list.
+   */
+  void insert(free_list&& other) { splice(cend(), std::move(other)); }
 
-}  // namespace RMM_EXPORT rmm::mr::detail
+  /**
+   * @brief Returns the first block in the free list.
+   *
+   * @param size The size in bytes of the desired block (unused).
+   * @return A block large enough to store `size` bytes.
+   */
+  block_type get_block(std::size_t size)
+  {
+    if (is_empty()) { return block_type{}; }
+    block_type block = *begin();
+    pop_front();
+    return block;
+  }
+};
+
+}  // namespace mr::detail
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 
 #pragma once
 
+#include <rmm/detail/export.hpp>
+
 #include <algorithm>
 #include <iostream>
 #include <list>
 
-namespace rmm::mr::detail {
+namespace RMM_EXPORT rmm::mr::detail {
 
 struct block_base {
   void* ptr{};  ///< Raw memory pointer

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -22,7 +22,8 @@
 #include <iostream>
 #include <list>
 
-namespace RMM_EXPORT rmm::mr::detail {
+namespace RMM_EXPORT rmm {
+namespace mr::detail {
 
 struct block_base {
   void* ptr{};  ///< Raw memory pointer
@@ -181,4 +182,5 @@ class free_list {
   list_type blocks;  // The internal container of blocks
 };
 
-}  // namespace rmm::mr::detail
+}  // namespace mr::detail
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <list>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr::detail {
 
 struct block_base {
@@ -183,4 +183,4 @@ class free_list {
 };
 
 }  // namespace mr::detail
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -18,6 +18,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
@@ -30,7 +31,7 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace rmm::mr::detail {
+namespace RMM_EXPORT rmm::mr::detail {
 
 /**
  * @brief A CRTP helper function

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -31,7 +31,8 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace RMM_EXPORT rmm::mr::detail {
+namespace RMM_EXPORT rmm {
+namespace mr::detail {
 
 /**
  * @brief A CRTP helper function
@@ -491,4 +492,5 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
   rmm::cuda_device_id device_id_{rmm::get_current_cuda_device()};
 };  // namespace detail
 
-}  // namespace rmm::mr::detail
+}  // namespace mr::detail
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -31,7 +31,7 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr::detail {
 
 /**
@@ -493,4 +493,4 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
 };  // namespace detail
 
 }  // namespace mr::detail
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -25,7 +25,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -361,4 +361,4 @@ class device_memory_resource {
 static_assert(cuda::mr::async_resource_with<device_memory_resource, cuda::mr::device_accessible>);
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -25,7 +25,8 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -359,4 +360,5 @@ class device_memory_resource {
 };
 static_assert(cuda::mr::async_resource_with<device_memory_resource, cuda::mr::device_accessible>);
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -17,6 +17,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/nvtx/ranges.hpp>
 
 #include <cuda/memory_resource>
@@ -24,7 +25,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -24,7 +24,7 @@
 #include <functional>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -196,4 +196,4 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -24,7 +24,8 @@
 #include <functional>
 #include <utility>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -194,4 +195,5 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
+++ b/include/rmm/mr/device/failure_callback_resource_adaptor.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -23,7 +24,7 @@
 #include <functional>
 #include <utility>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -36,7 +36,7 @@
 #include <utility>
 #include <vector>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -265,4 +265,4 @@ class fixed_size_memory_resource
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -18,6 +18,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/mr/device/detail/fixed_size_free_list.hpp>
@@ -35,7 +36,7 @@
 #include <utility>
 #include <vector>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -36,7 +36,8 @@
 #include <utility>
 #include <vector>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -263,4 +264,5 @@ class fixed_size_memory_resource
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -23,7 +23,8 @@
 
 #include <cstddef>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -200,4 +201,5 @@ limiting_resource_adaptor<Upstream> make_limiting_adaptor(Upstream* upstream,
 }
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -17,12 +17,13 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cstddef>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -23,7 +23,7 @@
 
 #include <cstddef>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -202,4 +202,4 @@ limiting_resource_adaptor<Upstream> make_limiting_adaptor(Upstream* upstream,
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -32,7 +32,7 @@
 #include <sstream>
 #include <string_view>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -347,4 +347,4 @@ logging_resource_adaptor<Upstream> make_logging_adaptor(Upstream* upstream,
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -32,7 +32,8 @@
 #include <sstream>
 #include <string_view>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -345,4 +346,5 @@ logging_resource_adaptor<Upstream> make_logging_adaptor(Upstream* upstream,
 }
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -17,6 +17,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -31,7 +32,7 @@
 #include <sstream>
 #include <string_view>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -22,7 +22,7 @@
 
 #include <cstddef>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -102,4 +102,4 @@ class managed_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -17,11 +17,12 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cstddef>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/managed_memory_resource.hpp
+++ b/include/rmm/mr/device/managed_memory_resource.hpp
@@ -22,7 +22,8 @@
 
 #include <cstddef>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -100,4 +101,5 @@ class managed_memory_resource final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -23,7 +23,8 @@
 #include <memory>
 #include <utility>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 namespace detail {
 /**
  * @brief Converts a tuple into a parameter pack.
@@ -271,4 +272,5 @@ auto make_owning_wrapper(std::shared_ptr<Upstream> upstream, Args&&... args)
 }
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <functional>
@@ -22,7 +23,7 @@
 #include <memory>
 #include <utility>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 namespace detail {
 /**
  * @brief Converts a tuple into a parameter pack.

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -23,7 +23,7 @@
 #include <memory>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 /**
@@ -273,4 +273,4 @@ auto make_owning_wrapper(std::shared_ptr<Upstream> upstream, Args&&... args)
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -81,7 +81,7 @@
  * @endcode
  */
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -250,4 +250,4 @@ inline device_memory_resource* set_current_device_resource(device_memory_resourc
 }
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -81,7 +81,8 @@
  * @endcode
  */
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup memory_resources
  * @{
@@ -248,4 +249,5 @@ inline device_memory_resource* set_current_device_resource(device_memory_resourc
   return set_per_device_resource(rmm::get_current_cuda_device(), new_mr);
 }
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/per_device_resource.hpp
+++ b/include/rmm/mr/device/per_device_resource.hpp
@@ -81,7 +81,7 @@
  * @endcode
  */
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup memory_resources
  * @{

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -24,7 +25,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -25,7 +25,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -314,4 +314,4 @@ auto make_stream_allocator_adaptor(Allocator const& allocator, cuda_stream_view 
 }
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -25,7 +25,8 @@
 #include <memory>
 #include <type_traits>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -312,4 +313,5 @@ auto make_stream_allocator_adaptor(Allocator const& allocator, cuda_stream_view 
   return stream_allocator_adaptor<Allocator>{allocator, stream};
 }
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -47,7 +47,8 @@
 #include <unordered_map>
 #include <vector>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -478,4 +479,5 @@ class pool_memory_resource final
 };  // namespace mr
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -18,6 +18,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/logger.hpp>
@@ -46,7 +47,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -47,7 +47,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -480,4 +480,4 @@ class pool_memory_resource final
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/prefetch_resource_adaptor.hpp
+++ b/include/rmm/mr/device/prefetch_resource_adaptor.hpp
@@ -25,7 +25,8 @@
 #include <shared_mutex>
 #include <stack>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -127,4 +128,5 @@ class prefetch_resource_adaptor final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/prefetch_resource_adaptor.hpp
+++ b/include/rmm/mr/device/prefetch_resource_adaptor.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/prefetch.hpp>
 #include <rmm/resource_ref.hpp>
@@ -24,7 +25,7 @@
 #include <shared_mutex>
 #include <stack>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/prefetch_resource_adaptor.hpp
+++ b/include/rmm/mr/device/prefetch_resource_adaptor.hpp
@@ -25,7 +25,7 @@
 #include <shared_mutex>
 #include <stack>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -129,4 +129,4 @@ class prefetch_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/sam_headroom_memory_resource.hpp
+++ b/include/rmm/mr/device/sam_headroom_memory_resource.hpp
@@ -17,11 +17,12 @@
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/system_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_memory_resources
  * @{

--- a/include/rmm/mr/device/sam_headroom_memory_resource.hpp
+++ b/include/rmm/mr/device/sam_headroom_memory_resource.hpp
@@ -22,7 +22,8 @@
 #include <rmm/mr/device/system_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_memory_resources
  * @{
@@ -131,4 +132,5 @@ class sam_headroom_memory_resource final : public device_memory_resource {
   std::size_t headroom_;
 };
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/sam_headroom_memory_resource.hpp
+++ b/include/rmm/mr/device/sam_headroom_memory_resource.hpp
@@ -22,7 +22,7 @@
 #include <rmm/mr/device/system_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_memory_resources
@@ -133,4 +133,4 @@ class sam_headroom_memory_resource final : public device_memory_resource {
 };
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -24,7 +24,8 @@
 #include <shared_mutex>
 #include <stack>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -300,4 +301,5 @@ statistics_resource_adaptor<Upstream> make_statistics_adaptor(Upstream* upstream
 }
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -23,7 +24,7 @@
 #include <shared_mutex>
 #include <stack>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -24,7 +24,7 @@
 #include <shared_mutex>
 #include <stack>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -302,4 +302,4 @@ statistics_resource_adaptor<Upstream> make_statistics_adaptor(Upstream* upstream
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/system_memory_resource.hpp
+++ b/include/rmm/mr/device/system_memory_resource.hpp
@@ -18,9 +18,10 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 
 namespace detail {
 /**

--- a/include/rmm/mr/device/system_memory_resource.hpp
+++ b/include/rmm/mr/device/system_memory_resource.hpp
@@ -21,7 +21,7 @@
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 
 namespace detail {
@@ -156,4 +156,4 @@ static_assert(cuda::mr::async_resource_with<system_memory_resource, cuda::mr::de
 static_assert(cuda::mr::async_resource_with<system_memory_resource, cuda::mr::host_accessible>);
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/system_memory_resource.hpp
+++ b/include/rmm/mr/device/system_memory_resource.hpp
@@ -21,7 +21,8 @@
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 
 namespace detail {
 /**
@@ -154,4 +155,5 @@ class system_memory_resource final : public device_memory_resource {
 static_assert(cuda::mr::async_resource_with<system_memory_resource, cuda::mr::device_accessible>);
 static_assert(cuda::mr::async_resource_with<system_memory_resource, cuda::mr::host_accessible>);
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -17,13 +17,14 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cstddef>
 #include <mutex>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -24,7 +24,7 @@
 #include <cstddef>
 #include <mutex>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -132,4 +132,4 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
+++ b/include/rmm/mr/device/thread_safe_resource_adaptor.hpp
@@ -24,7 +24,8 @@
 #include <cstddef>
 #include <mutex>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -130,4 +131,5 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -27,7 +27,8 @@
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -153,4 +154,5 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   cuda_device_id _device{get_current_cuda_device()};
 };
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -27,7 +27,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -155,4 +155,4 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
 };
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -26,7 +27,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -30,7 +30,7 @@
 #include <shared_mutex>
 #include <sstream>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup device_resource_adaptors
@@ -295,4 +295,4 @@ tracking_resource_adaptor<Upstream> make_tracking_adaptor(Upstream* upstream)
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/stack_trace.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
@@ -29,7 +30,7 @@
 #include <shared_mutex>
 #include <sstream>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -30,7 +30,8 @@
 #include <shared_mutex>
 #include <sstream>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup device_resource_adaptors
  * @{
@@ -293,4 +294,5 @@ tracking_resource_adaptor<Upstream> make_tracking_adaptor(Upstream* upstream)
 }
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -23,7 +23,8 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup host_memory_resources
  * @{
@@ -203,4 +204,5 @@ class host_memory_resource {
 static_assert(cuda::mr::resource_with<host_memory_resource, cuda::mr::host_accessible>);
 /** @} */  // end of group
 
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -23,7 +23,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup host_memory_resources
@@ -205,4 +205,4 @@ static_assert(cuda::mr::resource_with<host_memory_resource, cuda::mr::host_acces
 /** @} */  // end of group
 
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/nvtx/ranges.hpp>
 
 #include <cuda/memory_resource>
@@ -22,7 +23,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup host_memory_resources
  * @{

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -23,7 +23,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup host_memory_resources
@@ -94,4 +94,4 @@ class new_delete_resource final : public host_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -23,7 +23,8 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup host_memory_resources
  * @{
@@ -92,4 +93,5 @@ class new_delete_resource final : public host_memory_resource {
 };
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -17,12 +17,13 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/detail/aligned.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/host/host_memory_resource.hpp>
 
 #include <cstddef>
 #include <utility>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup host_memory_resources
  * @{

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -19,12 +19,13 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/mr/host/host_memory_resource.hpp>
 
 #include <cstddef>
 #include <utility>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 /**
  * @addtogroup host_memory_resources
  * @{

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -25,7 +25,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup host_memory_resources
@@ -156,4 +156,4 @@ static_assert(cuda::mr::async_resource_with<pinned_memory_resource,
                                             cuda::mr::device_accessible>);
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -25,7 +25,8 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 /**
  * @addtogroup host_memory_resources
  * @{
@@ -154,4 +155,5 @@ static_assert(cuda::mr::async_resource_with<pinned_memory_resource,
                                             cuda::mr::host_accessible,
                                             cuda::mr::device_accessible>);
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/is_resource_adaptor.hpp
+++ b/include/rmm/mr/is_resource_adaptor.hpp
@@ -20,7 +20,8 @@
 #include <cuda/memory_resource>
 #include <cuda/std/type_traits>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 
 /**
  * @addtogroup memory_resources
@@ -42,4 +43,5 @@ inline constexpr bool is_resource_adaptor<
   cuda::mr::resource<Resource>;
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/is_resource_adaptor.hpp
+++ b/include/rmm/mr/is_resource_adaptor.hpp
@@ -20,7 +20,7 @@
 #include <cuda/memory_resource>
 #include <cuda/std/type_traits>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 
 /**
@@ -44,4 +44,4 @@ inline constexpr bool is_resource_adaptor<
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/is_resource_adaptor.hpp
+++ b/include/rmm/mr/is_resource_adaptor.hpp
@@ -15,10 +15,12 @@
  */
 #pragma once
 
+#include <rmm/detail/export.hpp>
+
 #include <cuda/memory_resource>
 #include <cuda/std/type_traits>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 
 /**
  * @addtogroup memory_resources

--- a/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -28,7 +28,8 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm::mr {
+namespace RMM_EXPORT rmm {
+namespace mr {
 
 /**
  * @addtogroup memory_resources
@@ -214,4 +215,5 @@ static_assert(cuda::mr::async_resource_with<pinned_host_memory_resource,
                                             cuda::mr::host_accessible>);
 
 /** @} */  // end of group
-}  // namespace rmm::mr
+}  // namespace mr
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -28,7 +28,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 namespace mr {
 
 /**
@@ -216,4 +216,4 @@ static_assert(cuda::mr::async_resource_with<pinned_host_memory_resource,
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -18,6 +18,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/detail/nvtx/ranges.hpp>
 
 #include <cuda/memory_resource>
@@ -27,7 +28,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace rmm::mr {
+namespace RMM_EXPORT rmm::mr {
 
 /**
  * @addtogroup memory_resources

--- a/include/rmm/prefetch.hpp
+++ b/include/rmm/prefetch.hpp
@@ -23,7 +23,7 @@
 
 #include <cuda/std/span>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 
 /**
  * @addtogroup utilities
@@ -75,4 +75,4 @@ void prefetch(cuda::std::span<T const> data,
 
 /** @} */  // end of group
 
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE

--- a/include/rmm/prefetch.hpp
+++ b/include/rmm/prefetch.hpp
@@ -18,11 +18,12 @@
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/export.hpp>
 #include <rmm/error.hpp>
 
 #include <cuda/std/span>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 
 /**
  * @addtogroup utilities
@@ -74,4 +75,4 @@ void prefetch(cuda::std::span<T const> data,
 
 /** @} */  // end of group
 
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/resource_ref.hpp
+++ b/include/rmm/resource_ref.hpp
@@ -15,9 +15,11 @@
  */
 #pragma once
 
+#include <rmm/detail/export.hpp>
+
 #include <cuda/memory_resource>
 
-namespace rmm {
+namespace RMM_EXPORT rmm {
 
 /**
  * @addtogroup memory_resources
@@ -64,4 +66,4 @@ using host_device_async_resource_ref =
   cuda::mr::async_resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>;
 
 /** @} */  // end of group
-}  // namespace rmm
+}  // namespace RMM_EXPORT rmm

--- a/include/rmm/resource_ref.hpp
+++ b/include/rmm/resource_ref.hpp
@@ -19,7 +19,7 @@
 
 #include <cuda/memory_resource>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_NAMESPACE {
 
 /**
  * @addtogroup memory_resources
@@ -66,4 +66,4 @@ using host_device_async_resource_ref =
   cuda::mr::async_resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>;
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_NAMESPACE


### PR DESCRIPTION
## Description
Fixes https://github.com/rapidsai/rmm/issues/1652

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
