### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ conda install -c rapidsai -c conda-forge -c nvidia rmm cuda-version=12.0
 We also provide [nightly Conda packages](https://anaconda.org/rapidsai-nightly) built from the HEAD
 of our latest development branch.
 
-Note: RMM is supported only on Linux, and only tested with Python versions 3.9, 3.10, and 3.11.
+Note: RMM is supported only on Linux, and only tested with Python versions 3.10 and 3.11.
 
 Note: The RMM package from Conda requires building with GCC 9 or later. Otherwise, your application may fail to build.
 

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -32,7 +32,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
-- python>=3.9,<3.12
+- python>=3.10,<3.12
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core >=0.10.0
 - spdlog>=1.12.0,<1.13

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -31,7 +31,7 @@ dependencies:
 - pre-commit
 - pytest
 - pytest-cov
-- python>=3.9,<3.12
+- python>=3.10,<3.12
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core >=0.10.0
 - spdlog>=1.12.0,<1.13

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -259,10 +259,6 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              py: "3.9"
-            packages:
-              - python=3.9
-          - matrix:
               py: "3.10"
             packages:
               - python=3.10
@@ -272,7 +268,7 @@ dependencies:
               - python=3.11
           - matrix:
             packages:
-              - python>=3.9,<3.12
+              - python>=3.10,<3.12
   run:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
     { name = "NVIDIA Corporation" },
 ]
 license = { text = "Apache 2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "cuda-python>=11.7.1,<12.0a0",
     "numba>=0.57",
@@ -40,7 +40,6 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
@@ -56,7 +55,7 @@ Homepage = "https://github.com/rapidsai/rmm"
 
 [tool.black]
 line-length = 79
-target-version = ["py39"]
+target-version = ["py310"]
 include = '\.py?$'
 exclude = '''
 /(


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/88

Finishes the work of dropping Python 3.9 support.

This project stopped building / testing against Python 3.9 as of https://github.com/rapidsai/shared-workflows/pull/235.
This PR updates configuration and docs to reflect that.

## Notes for Reviewers

### How I tested this

Checked that there were no remaining uses like this:

```shell
git grep -E '3\.9'
git grep '39'
git grep 'py39'
```

And similar for variations on Python 3.8 (to catch things that were missed the last time this was done).
