### PR TITLE
Update rapidsai/pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
         - id: ruff
           files: python/.*$
     - repo: https://github.com/rapidsai/pre-commit-hooks
-      rev: v0.3.1
+      rev: v0.4.0
       hooks:
         - id: verify-copyright
         - id: verify-alpha-spec


### PR DESCRIPTION
This PR updates rapidsai/pre-commit-hooks to the version 0.4.0.
