### PR TITLE
Remove the friend declaration with an attribute

### DIFF
--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -283,16 +283,6 @@ class logging_resource_adaptor final : public device_memory_resource {
     return get_upstream_resource() == cast->get_upstream_resource();
   }
 
-  // make_logging_adaptor needs access to private get_default_filename
-  template <typename T>
-  // NOLINTNEXTLINE(readability-redundant-declaration)
-  [[deprecated(
-    "make_logging_adaptor is deprecated in RMM 24.10. Use the logging_resource_adaptor constructor "
-    "instead.")]]
-  friend logging_resource_adaptor<T> make_logging_adaptor(T* upstream,
-                                                          std::string const& filename,
-                                                          bool auto_flush);
-
   std::shared_ptr<spdlog::logger> logger_;  ///< spdlog logger object
 
   Upstream* upstream_;  ///< The upstream resource used for satisfying


### PR DESCRIPTION
## Description
The `logging_resource_adaptor` has a friend declaration (which is not a definition) preceded by an attribute, whereas C++ standard requires that such [declaration must be a definition](https://eel.is/c++draft/dcl.attr.grammar#5). gcc 11.4.0 used in the dev container does not correctly identify this, but gcc 12.1 and newer are able to, and will report a compile error (converted from a warning) when building RMM:

```
an attribute that appertains to a friend declaration that is not a definition is ignored
```
This simple PR removes the friend declaration from the `logging_resource_adaptor` class. This is valid since in recent releases of RMM the friended function no longer accesses any private (or protected) data or methods of `logging_resource_adaptor`.

closes #1668 

<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
