### PR TITLE
Add missing include to `resource_ref.hpp`

### DIFF
--- a/include/rmm/resource_ref.hpp
+++ b/include/rmm/resource_ref.hpp
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>


### PR DESCRIPTION
This has been found breaking CCCL CI when building cuDF
