### PR TITLE
exclude 'gcovr' from list of development pip packages

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -232,13 +232,11 @@ dependencies:
             packages:
   develop:
     common:
-      - output_types: [conda, requirements]
-        packages:
-          - gcovr>=5.0
       - output_types: conda
         packages:
           - clang==16.0.6
           - clang-tools==16.0.6
+          - gcovr>=5.0
   docs:
     common:
       - output_types: conda


### PR DESCRIPTION
## Description

This project currently lists `gcovr` (https://pypi.org/project/gcovr/) as a pip dependency for development. I strongly suspect that that was unintentional... it doesn't look like it has any reliance on getting that package via `pip` (just conda, in the C++ test jobs and for local C++ development).

This proposes removing `gcovr` from the list of pip dependencies, so it won't get installed in the DLFW images or other places where `rapids-make-pip-env` from https://github.com/rapidsai/devcontainers is called.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
