### PR TITLE
Use consistent signature for target_link_libraries

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,7 +69,7 @@ function(ConfigureTestInternal TEST_NAME)
         ${TEST_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-O0 --coverage -fprofile-abs-path
                             -fkeep-inline-functions -fno-elide-constructors>)
       target_link_options(${TEST_NAME} PRIVATE --coverage)
-      target_link_libraries(${TEST_NAME} gcov)
+      target_link_libraries(${TEST_NAME} PRIVATE gcov)
     endif()
 
     # Add coverage-generated files to clean target
@@ -111,13 +111,13 @@ function(ConfigureTest TEST_NAME)
 
   # Test with legacy default stream.
   ConfigureTestInternal(${TEST_NAME} ${_RMM_TEST_UNPARSED_ARGUMENTS})
-  target_link_libraries(${TEST_NAME} ${cudart_link_libs})
+  target_link_libraries(${TEST_NAME} PRIVATE ${cudart_link_libs})
 
   # Test with per-thread default stream.
   string(REGEX REPLACE "_TEST$" "_PTDS_TEST" PTDS_TEST_NAME "${TEST_NAME}")
   ConfigureTestInternal("${PTDS_TEST_NAME}" ${_RMM_TEST_UNPARSED_ARGUMENTS})
   target_compile_definitions("${PTDS_TEST_NAME}" PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
-  target_link_libraries(${PTDS_TEST_NAME} ${cudart_link_libs})
+  target_link_libraries(${PTDS_TEST_NAME} PRIVATE ${cudart_link_libs})
 
   foreach(name ${TEST_NAME} ${PTDS_TEST_NAME} ${NS_TEST_NAME})
     rapids_test_add(


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
It looks like while #1722 introduced usage of the modern target_link_libraries syntax it did not adjust all other calls because I wasn't setting up coverage usage locally or anywhere else in CI.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
