### PR TITLE
Remove deprecated factory functions from resource adaptors.

### DIFF
--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -194,25 +194,6 @@ class limiting_resource_adaptor final : public device_memory_resource {
   std::size_t alignment_;
 };
 
-/**
- * @brief Convenience factory to return a `limiting_resource_adaptor` around the
- * upstream resource `upstream`.
- *
- * @tparam Upstream Type of the upstream `device_memory_resource`.
- * @param upstream Pointer to the upstream resource
- * @param allocation_limit Maximum amount of memory to allocate
- * @return The new limiting resource adaptor
- */
-template <typename Upstream>
-[[deprecated(
-  "make_limiting_adaptor is deprecated in RMM 24.10. Use the limiting_resource_adaptor constructor "
-  "instead.")]]
-limiting_resource_adaptor<Upstream> make_limiting_adaptor(Upstream* upstream,
-                                                          std::size_t allocation_limit)
-{
-  return limiting_resource_adaptor<Upstream>{upstream, allocation_limit};
-}
-
 /** @} */  // end of group
 }  // namespace mr
 }  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -334,52 +334,6 @@ class logging_resource_adaptor final : public device_memory_resource {
                                         ///< allocation requests
 };
 
-/**
- * @brief Convenience factory to return a `logging_resource_adaptor` around the
- * upstream resource `upstream`.
- *
- * @tparam Upstream Type of the upstream `device_memory_resource`.
- * @param upstream Pointer to the upstream resource
- * @param filename Name of the file to write log info. If not specified,
- * retrieves the log file name from the environment variable "RMM_LOG_FILE".
- * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade
- * performance.
- * @return The new logging resource adaptor
- */
-template <typename Upstream>
-[[deprecated(
-  "make_logging_adaptor is deprecated in RMM 24.10. Use the logging_resource_adaptor constructor "
-  "instead.")]]
-logging_resource_adaptor<Upstream> make_logging_adaptor(
-  Upstream* upstream,
-  std::string const& filename = logging_resource_adaptor<Upstream>::get_default_filename(),
-  bool auto_flush             = false)
-{
-  return logging_resource_adaptor<Upstream>{upstream, filename, auto_flush};
-}
-
-/**
- * @brief Convenience factory to return a `logging_resource_adaptor` around the
- * upstream resource `upstream`.
- *
- * @tparam Upstream Type of the upstream `device_memory_resource`.
- * @param upstream Pointer to the upstream resource
- * @param stream The ostream to write log info.
- * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade
- * performance.
- * @return The new logging resource adaptor
- */
-template <typename Upstream>
-[[deprecated(
-  "make_logging_adaptor is deprecated in RMM 24.10. Use the logging_resource_adaptor constructor "
-  "instead.")]]
-logging_resource_adaptor<Upstream> make_logging_adaptor(Upstream* upstream,
-                                                        std::ostream& stream,
-                                                        bool auto_flush = false)
-{
-  return logging_resource_adaptor<Upstream>{upstream, stream, auto_flush};
-}
-
 /** @} */  // end of group
 }  // namespace mr
 }  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -293,25 +293,6 @@ bool operator!=(stream_allocator_adaptor<A> const& lhs, stream_allocator_adaptor
   return not(lhs == rhs);
 }
 
-/**
- * @brief Factory to construct a `stream_allocator_adaptor` from an existing stream-ordered
- * allocator.
- *
- * @tparam Allocator Type of the stream-ordered allocator
- * @param allocator The allocator to use as the underlying allocator of the
- * `stream_allocator_adaptor`
- * @param stream The stream on which the `stream_allocator_adaptor` will perform (de)allocations
- * @return A `stream_allocator_adaptor` wrapping `allocator` and `s`
- */
-template <typename Allocator>
-[[deprecated(
-  "make_stream_allocator_adaptor is deprecated in RMM 24.10. Use the stream_allocator_adaptor "
-  "constructor "
-  "instead.")]]
-auto make_stream_allocator_adaptor(Allocator const& allocator, cuda_stream_view stream)
-{
-  return stream_allocator_adaptor<Allocator>{allocator, stream};
-}
 /** @} */  // end of group
 }  // namespace mr
 }  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/statistics_resource_adaptor.hpp
+++ b/include/rmm/mr/device/statistics_resource_adaptor.hpp
@@ -287,23 +287,6 @@ class statistics_resource_adaptor final : public device_memory_resource {
   device_async_resource_ref upstream_;
 };
 
-/**
- * @brief Convenience factory to return a `statistics_resource_adaptor` around the
- * upstream resource `upstream`.
- *
- * @param upstream Pointer to the upstream resource
- * @return The new statistics resource adaptor
- */
-template <typename Upstream>
-[[deprecated(
-  "make_statistics_adaptor is deprecated in RMM 24.10. Use the statistics_resource_adaptor "
-  "constructor "
-  "instead.")]]
-statistics_resource_adaptor<Upstream> make_statistics_adaptor(Upstream* upstream)
-{
-  return statistics_resource_adaptor<rmm::mr::device_memory_resource>{upstream};
-}
-
 /** @} */  // end of group
 }  // namespace mr
 }  // namespace RMM_NAMESPACE

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -283,23 +283,6 @@ class tracking_resource_adaptor final : public device_memory_resource {
                                                   // allocation requests
 };
 
-/**
- * @brief Convenience factory to return a `tracking_resource_adaptor` around the
- * upstream resource `upstream`.
- *
- * @tparam Upstream Type of the upstream `device_memory_resource`.
- * @param upstream Pointer to the upstream resource
- * @return The new tracking resource adaptor
- */
-template <typename Upstream>
-[[deprecated(
-  "make_tracking_adaptor is deprecated in RMM 24.10. Use the tracking_resource_adaptor constructor "
-  "instead.")]]
-tracking_resource_adaptor<Upstream> make_tracking_adaptor(Upstream* upstream)
-{
-  return tracking_resource_adaptor<Upstream>{upstream};
-}
-
 /** @} */  // end of group
 }  // namespace mr
 }  // namespace RMM_NAMESPACE


### PR DESCRIPTION
## Description
Closes #1616.

This removes factory functions for resource adaptors that were previously deprecated in RMM 24.10, in PR #1626.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
