### PR TITLE
Remove ignored cuda-python deprecation warning.

### DIFF
--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -93,7 +93,6 @@ max_allowed_size_compressed = '75M'
 # treat warnings as errors
 filterwarnings = [
     "error",
-    "ignore:.*cuda..* module is deprecated.*:DeprecationWarning"
 ]
 
 [tool.ruff]

--- a/python/rmm/rmm/tests/test_rmm.py
+++ b/python/rmm/rmm/tests/test_rmm.py
@@ -20,9 +20,9 @@ import pickle
 import warnings
 from itertools import product
 
-import cuda.cudart as cudart
 import numpy as np
 import pytest
+from cuda.bindings import runtime
 from numba import cuda
 
 import rmm
@@ -34,7 +34,7 @@ from rmm.pylibrmm.logger import level_enum
 cuda.set_memory_manager(RMMNumbaManager)
 
 _SYSTEM_MEMORY_SUPPORTED = rmm._cuda.gpu.getDeviceAttribute(
-    cudart.cudaDeviceAttr.cudaDevAttrPageableMemoryAccess,
+    runtime.cudaDeviceAttr.cudaDevAttrPageableMemoryAccess,
     rmm._cuda.gpu.getDevice(),
 )
 
@@ -319,13 +319,13 @@ def test_rmm_device_buffer_pickle_roundtrip(hb):
 
 
 def assert_prefetched(buffer, device_id):
-    err, dev = cudart.cudaMemRangeGetAttribute(
+    err, dev = runtime.cudaMemRangeGetAttribute(
         4,
-        cudart.cudaMemRangeAttribute.cudaMemRangeAttributeLastPrefetchLocation,
+        runtime.cudaMemRangeAttribute.cudaMemRangeAttributeLastPrefetchLocation,
         buffer.ptr,
         buffer.size,
     )
-    assert err == cudart.cudaError_t.cudaSuccess
+    assert err == runtime.cudaError_t.cudaSuccess
     assert dev == device_id
 
 
@@ -336,11 +336,11 @@ def test_rmm_device_buffer_prefetch(pool, managed):
     rmm.reinitialize(pool_allocator=pool, managed_memory=managed)
     db = rmm.DeviceBuffer.to_device(np.zeros(256, dtype="u1"))
     if managed:
-        assert_prefetched(db, cudart.cudaInvalidDeviceId)
+        assert_prefetched(db, runtime.cudaInvalidDeviceId)
     db.prefetch()  # just test that it doesn't throw
     if managed:
-        err, device = cudart.cudaGetDevice()
-        assert err == cudart.cudaError_t.cudaSuccess
+        err, device = runtime.cudaGetDevice()
+        assert err == runtime.cudaError_t.cudaSuccess
         assert_prefetched(db, device)
 
 
@@ -830,15 +830,15 @@ def test_prefetch_resource_adaptor(managed):
     # This allocation should be prefetched
     db = rmm.DeviceBuffer.to_device(np.zeros(256, dtype="u1"))
 
-    err, device = cudart.cudaGetDevice()
-    assert err == cudart.cudaError_t.cudaSuccess
+    err, device = runtime.cudaGetDevice()
+    assert err == runtime.cudaError_t.cudaSuccess
 
     if managed:
         assert_prefetched(db, device)
     db.prefetch()  # just test that it doesn't throw
     if managed:
-        err, device = cudart.cudaGetDevice()
-        assert err == cudart.cudaError_t.cudaSuccess
+        err, device = runtime.cudaGetDevice()
+        assert err == runtime.cudaError_t.cudaSuccess
         assert_prefetched(db, device)
 
 


### PR DESCRIPTION
## Description
Following https://github.com/rapidsai/rmm/pull/1756, we no longer need to guard against this deprecation warning.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
