### PR TITLE
Fix codespell behavior.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,8 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+        additional_dependencies: [tomli]
+        args: ["--toml", "pyproject.toml"]
         exclude: |
           (?x)^(
             pyproject.toml|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@
 [tool.codespell]
 # note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
 # this is only to allow you to run codespell interactively
-skip = "./pyproject.toml,./.git,./.github,./cpp/build,.*egg-info.*,./.mypy_cache,./benchmarks/utilities/cxxopts.hpp"
+skip = "./.git,./build,./python/_skbuild/,.*egg-info.*,./.mypy_cache,./pyproject.toml,./benchmarks/utilities/cxxopts.hpp"
 # ignore short words, and typename parameters like OffsetT
 ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-ignore-words-list = "inout,thirdparty"
+ignore-words-list = "inout,thirdparty,couldn"
 builtin = "clear"
 quiet-level = 3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 skip = "./.git,./build,./python/_skbuild/,.*egg-info.*,./.mypy_cache,./pyproject.toml,./benchmarks/utilities/cxxopts.hpp"
 # ignore short words, and typename parameters like OffsetT
 ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-ignore-words-list = "inout,thirdparty,couldn"
+ignore-words-list = "thirdparty,couldn"
 builtin = "clear"
 quiet-level = 3
 


### PR DESCRIPTION
## Description
Recently, I added support for `codespell` in CCCL (https://github.com/NVIDIA/cccl/pull/3168). @shwina noticed some issues in my PR that were fixed in https://github.com/NVIDIA/cccl/pull/3182. This PR ports similar fixes to RMM, to make `codespell` work better when run both inside and outside of `pre-commit`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
