### PR TITLE
Add missing array header include

### DIFF
--- a/include/rmm/detail/stack_trace.hpp
+++ b/include/rmm/detail/stack_trace.hpp
@@ -35,6 +35,7 @@
 #include <cstddef>
 #include <memory>
 #include <vector>
+#include <array>
 #endif
 
 namespace RMM_NAMESPACE {

--- a/include/rmm/detail/stack_trace.hpp
+++ b/include/rmm/detail/stack_trace.hpp
@@ -32,10 +32,10 @@
 #include <dlfcn.h>
 #include <execinfo.h>
 
+#include <array>
 #include <cstddef>
 #include <memory>
 #include <vector>
-#include <array>
 #endif
 
 namespace RMM_NAMESPACE {


### PR DESCRIPTION
## Description
When stack trace is enabled we would run into compile failures since `array.h` wasn't explicitly included. We only work currently due to other headers bringing this include in.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
