### PR TITLE
Use rapids-cmake for the logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,7 @@ rapids_find_package(
 # add third party dependencies using CPM
 rapids_cpm_init()
 
-CPMAddPackage(
-  NAME rapids_logger GITHUB_REPOSITORY rapidsai/rapids-logger GIT_SHALLOW FALSE GIT_TAG
-  1043e0f3989d75ad52f5212544b8154777e86fc9 VERSION 1043e0f3989d75ad52f5212544b8154777e86fc9)
+rapids_cpm_logger()
 rapids_make_logger(rmm EXPORT_SET rmm-exports)
 
 include(cmake/thirdparty/get_cccl.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,8 @@ rapids_find_package(
 # add third party dependencies using CPM
 rapids_cpm_init()
 
-include(${rapids-cmake-dir}/cpm/logger.cmake)
-rapids_cpm_logger()
+include(${rapids-cmake-dir}/cpm/rapids_logger.cmake)
+rapids_cpm_rapids_logger()
 rapids_make_logger(rmm EXPORT_SET rmm-exports)
 
 include(cmake/thirdparty/get_cccl.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ rapids_find_package(
 # add third party dependencies using CPM
 rapids_cpm_init()
 
+include(${rapids-cmake-dir}/cpm/logger.cmake)
 rapids_cpm_logger()
 rapids_make_logger(rmm EXPORT_SET rmm-exports)
 

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -12,6 +12,8 @@
 # the License.
 # =============================================================================
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _rapids_version)
+set(rapids-cmake-repo "vyasr/rapids-cmake")
+set(rapids-cmake-branch "feat/logger")
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")
   set(RAPIDS_VERSION_MINOR "${CMAKE_MATCH_2}")

--- a/rapids_config.cmake
+++ b/rapids_config.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -12,8 +12,6 @@
 # the License.
 # =============================================================================
 file(READ "${CMAKE_CURRENT_LIST_DIR}/VERSION" _rapids_version)
-set(rapids-cmake-repo "vyasr/rapids-cmake")
-set(rapids-cmake-branch "feat/logger")
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")
   set(RAPIDS_VERSION_MINOR "${CMAKE_MATCH_2}")


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This PR switches rmm to use rapids-cmake to fetch rapids-logger so that it uses a consistent version with the rest of RAPIDS to avoid any cases where transitive CPM loads result in multiple packages being built from source that require a different version of rapids-logger.

Depends on https://github.com/rapidsai/rapids-cmake/pull/737

Contributes to rapidsai/build-planning#104.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
