### PR TITLE
Add spdlog back as a requirement for now

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -35,6 +35,7 @@ dependencies:
 - python>=3.10,<3.13
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core >=0.10.0
+- spdlog>=1.14.1,<1.15
 - sphinx
 - sphinx-copybutton
 - sphinx-markdown-tables

--- a/conda/environments/all_cuda-125_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-125_arch-x86_64.yaml
@@ -34,6 +34,7 @@ dependencies:
 - python>=3.10,<3.13
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - scikit-build-core >=0.10.0
+- spdlog>=1.14.1,<1.15
 - sphinx
 - sphinx-copybutton
 - sphinx-markdown-tables

--- a/conda/recipes/librmm/meta.yaml
+++ b/conda/recipes/librmm/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION.
 
 {% set version = environ['RAPIDS_PACKAGE_VERSION'].lstrip('v') %}
 {% set cuda_version = '.'.join(environ['RAPIDS_CUDA_VERSION'].split('.')[:2]) %}
@@ -26,13 +26,8 @@ requirements:
     - {{ stdlib("c") }}
   host:
     - cuda-version ={{ cuda_version }}
-    # We need fmt here for now because the conda spdlog package is hard-coded
-    # to use fmt as a compiled library, not header-only, so we must ensure that
-    # the library is present for now so that if a downstream library tries to
-    # build against rmm and some other package in its build environment uses
-    # fmt (or spdlog) that the default rmm build is consistent with such
-    # environments.
     - fmt {{ fmt_version }}
+    - spdlog {{ spdlog_version }}
 
 build:
   script_env:
@@ -77,8 +72,8 @@ outputs:
         {% if cuda_major == "11" %}
         - cudatoolkit
         {% endif %}
-        # See comment about fmt in the build section above.
         - fmt {{ fmt_version }}
+        - spdlog {{ spdlog_version }}
     test:
       commands:
         - test -d "${PREFIX}/include/rmm"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -112,6 +112,7 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - fmt>=11.0.2,<12
+          - spdlog>=1.14.1,<1.15
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
See discussion in https://github.com/rapidsai/rapids-logger/issues/10#issuecomment-2578787497 and https://github.com/rapidsai/rmm/issues/1779. spdlog will remain a requirement for 25.02, but we will remove it in favor of a precompiled rapids-logger library in 25.04 (and that library will completely hide everything related to spdlog: APIs, package requirements, symbols, etc).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
