### PR TITLE
Add a missing RMM_EXEC_CHECK_DISABLE in device_uvector constructors

### DIFF
--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -95,6 +95,7 @@ class device_uvector {
   RMM_EXEC_CHECK_DISABLE
   device_uvector(device_uvector&&) noexcept = default;  ///< @default_move_constructor
 
+  RMM_EXEC_CHECK_DISABLE
   device_uvector& operator=(device_uvector&&) noexcept =
     default;  ///< @default_move_assignment{device_uvector}
 


### PR DESCRIPTION
## Description
One of the constructor was missing a `RMM_EXEC_CHECK_DISABLE` annotation, resulting in (false positive ?) warnings:

```
error: calling a __host__ function("rmm::device_buffer::operator =(rmm::device_buffer&&)") from a __host__ __device__ function("rmm::device_uvector<unsigned long> ::operator =") is not allowed
```
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
