### PR TITLE
Add shellcheck to pre-commit and fix warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,11 @@ repos:
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        files: ^ci/
 
 default_language_version:
   python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,6 +90,7 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+        args: ["--severity=warning"]
         files: ^ci/
 
 default_language_version:

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -5,9 +5,7 @@ set -euo pipefail
 
 rapids-configure-conda-channels
 
-# shellcheck source=/dev/null
 source rapids-configure-sccache
-# shellcheck source=/dev/null
 source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 rapids-configure-conda-channels
 
+# shellcheck source=/dev/null
 source rapids-configure-sccache
-
+# shellcheck source=/dev/null
 source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 rapids-logger "Create test conda environment"
+
+# shellcheck source=/dev/null
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"
-export RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+RAPIDS_VERSION_MAJOR_MINOR="$(rapids-version-major-minor)"
+export RAPIDS_VERSION_MAJOR_MINOR
 
 rapids-dependency-file-generator \
   --output conda \
@@ -29,7 +32,9 @@ rapids-mamba-retry install \
   "rmm=${RAPIDS_VERSION}" \
   "librmm=${RAPIDS_VERSION}"
 
-export RAPIDS_DOCS_DIR="$(mktemp -d)"
+RAPIDS_DOCS_DIR="$(mktemp -d)"
+export RAPIDS_DOCS_DIR
+
 
 rapids-logger "Build CPP docs"
 pushd doxygen

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 
 rapids-logger "Create test conda environment"
 
-# shellcheck source=/dev/null
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -5,10 +5,7 @@ set -euo pipefail
 
 rapids-configure-conda-channels
 
-# shellcheck source=/dev/null
 source rapids-configure-sccache
-
-# shellcheck source=/dev/null
 source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 rapids-configure-conda-channels
 
+# shellcheck source=/dev/null
 source rapids-configure-sccache
 
+# shellcheck source=/dev/null
 source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -5,9 +5,7 @@ set -euo pipefail
 
 package_dir="python/librmm"
 
-# shellcheck source=/dev/null
 source rapids-configure-sccache
-# shellcheck source=/dev/null
 source rapids-date-string
 
 rapids-generate-version > ./VERSION

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 package_dir="python/librmm"
 
+# shellcheck source=/dev/null
 source rapids-configure-sccache
+# shellcheck source=/dev/null
 source rapids-date-string
 
 rapids-generate-version > ./VERSION
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_CUDA_SUFFIX=$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")
 
 cd "${package_dir}"
 

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -1,26 +1,28 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 package_name="rmm"
 package_dir="python/rmm"
 
+# shellcheck source=/dev/null
 source rapids-configure-sccache
+# shellcheck source=/dev/null
 source rapids-date-string
 
 rapids-generate-version > ./VERSION
 
 pushd "${package_dir}"
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_CUDA_SUFFIX=$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")
 CPP_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp /tmp/librmm_dist)
 
 # ensure 'rmm' wheel builds always use the 'librmm' just built in the same CI run
 #
 # using env variable PIP_CONSTRAINT is necessary to ensure the constraints
 # are used when created the isolated build environment
-echo "librmm-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo ${CPP_WHEELHOUSE}/librmm_${RAPIDS_PY_CUDA_SUFFIX}*.whl)" > ./build-constraints.txt
+echo "librmm-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${CPP_WHEELHOUSE}"/librmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)" > ./build-constraints.txt
 
 sccache --zero-stats
 

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -6,9 +6,7 @@ set -euo pipefail
 package_name="rmm"
 package_dir="python/rmm"
 
-# shellcheck source=/dev/null
 source rapids-configure-sccache
-# shellcheck source=/dev/null
 source rapids-date-string
 
 rapids-generate-version > ./VERSION

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 
 rapids-logger "Create checks conda environment"
 
-# shellcheck source=/dev/null
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-dependency-file-generator \

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 rapids-logger "Create checks conda environment"
+
+# shellcheck source=/dev/null
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-dependency-file-generator \
@@ -16,9 +18,10 @@ conda activate checks
 
 RAPIDS_VERSION_NUMBER="$(rapids-version-major-minor)"
 FORMAT_FILE_URL="https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION_NUMBER}/cmake-format-rapids-cmake.json"
-export RAPIDS_CMAKE_FORMAT_FILE=/tmp/rapids_cmake_ci/cmake-formats-rapids-cmake.json
-mkdir -p $(dirname ${RAPIDS_CMAKE_FORMAT_FILE})
-wget -O ${RAPIDS_CMAKE_FORMAT_FILE} ${FORMAT_FILE_URL}
+RAPIDS_CMAKE_FORMAT_FILE=/tmp/rapids_cmake_ci/cmake-formats-rapids-cmake.json
+export RAPIDS_CMAKE_FORMAT_FILE
+mkdir -p "$(dirname ${RAPIDS_CMAKE_FORMAT_FILE})"
+wget -O ${RAPIDS_CMAKE_FORMAT_FILE} "${FORMAT_FILE_URL}"
 
 # Run pre-commit checks
 pre-commit run --all-files --show-diff-on-failure

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 ########################
 # RMM Version Updater #
 ########################
@@ -13,14 +13,10 @@ NEXT_FULL_TAG=$1
 
 # Get current version
 CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
-CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
-CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
-CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')
-CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
 
 # Get <major>.<minor> for next version
-NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
-NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
+NEXT_MAJOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[2]}')
 NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
 # Need to distutils-normalize the original version
@@ -30,7 +26,7 @@ echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
-    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+    sed -i.bak ''"$1"'' "$2" && rm -f "${2}".bak
 }
 
 # Centralized version file update

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
 # Support invoking test_cpp.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
+# shellcheck source=/dev/null
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"
@@ -44,4 +45,4 @@ export GTEST_OUTPUT=xml:${RAPIDS_TESTS_DIR}/
 ./ci/run_ctests.sh -j20 && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
-exit ${EXITCODE}
+exit "${EXITCODE}"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 # Support invoking test_cpp.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
-# shellcheck source=/dev/null
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -7,6 +7,8 @@ set -euo pipefail
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 rapids-logger "Create test conda environment"
+
+# shellcheck source=/dev/null
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"
@@ -51,4 +53,4 @@ rapids-logger "pytest rmm"
  && EXITCODE=$? || EXITCODE=$?;
 
 rapids-logger "Test script exiting with value: $EXITCODE"
-exit ${EXITCODE}
+exit "${EXITCODE}"

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -8,7 +8,6 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 rapids-logger "Create test conda environment"
 
-# shellcheck source=/dev/null
 . /opt/conda/etc/profile.d/conda.sh
 
 RAPIDS_VERSION="$(rapids-version)"

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 
 set -eou pipefail
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
+RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 WHEELHOUSE="${PWD}/dist/"
 RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python "${WHEELHOUSE}"
 
@@ -14,6 +14,6 @@ rapids-generate-pip-constraints test_python ./constraints.txt
 python -m pip install \
     -v \
     --constraint ./constraints.txt \
-    "$(echo "${WHEELHOUSE}"/rmm_${RAPIDS_PY_CUDA_SUFFIX}*.whl)[test]"
+    "$(echo "${WHEELHOUSE}"/rmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)[test]"
 
 python -m pytest ./python/rmm/rmm/tests

--- a/ci/validate_wheel.sh
+++ b/ci/validate_wheel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -9,10 +9,10 @@ rapids-logger "validate packages with 'pydistcheck'"
 
 pydistcheck \
     --inspect \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"
 
 rapids-logger "validate packages with 'twine'"
 
 twine check \
     --strict \
-    "$(echo ${wheel_dir_relative_path}/*.whl)"
+    "$(echo "${wheel_dir_relative_path}"/*.whl)"


### PR DESCRIPTION
## Description

`shellcheck` is a fast, static analysis tool for shell scripts. It's good at
flagging up unused variables, unintentional glob expansions, and other potential
execution and security headaches that arise from the wonders of `bash` (and other shlangs).

This PR adds a `pre-commit` hook to run `shellcheck` on all of the `sh-lang` files in the `ci/` directory, and the changes requested by `shellcheck` to make the existing files pass the check.

xref: rapidsai/build-planning#135

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
