### PR TITLE
Disable exec checks for `device_uvector::operator=`

### DIFF
--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -2180,7 +2180,7 @@ INCLUDE_FILE_PATTERNS  =
 # Since we are excluding detail files in EXCLUDE_PATTERNS there
 # appears to be no way of getting doxygen to still parse that file and
 # make the definitions available via the preprocessor :(
-PREDEFINED             = RMM_EXPORT RMM_HIDDEN RMM_NAMESPACE=rmm
+PREDEFINED             = RMM_EXPORT RMM_HIDDEN RMM_EXEC_CHECK_DISABLE RMM_NAMESPACE=rmm
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,7 @@ class device_uvector {
   RMM_EXEC_CHECK_DISABLE
   device_uvector(device_uvector&&) noexcept = default;  ///< @default_move_constructor
 
+  RMM_EXEC_CHECK_DISABLE
   device_uvector& operator=(device_uvector&&) noexcept =
     default;  ///< @default_move_assignment{device_uvector}
 


### PR DESCRIPTION
We already suppress those for the constructors

