### PR TITLE
Apply IWYU changes and fix deprecated GTest usage

### DIFF
--- a/include/rmm/cuda_device.hpp
+++ b/include/rmm/cuda_device.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@
 #include <rmm/detail/export.hpp>
 
 #include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <utility>
 
 namespace RMM_NAMESPACE {
 

--- a/include/rmm/cuda_stream_view.hpp
+++ b/include/rmm/cuda_stream_view.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
-#include <atomic>
 #include <cstddef>
-#include <cstdint>
 
 namespace RMM_NAMESPACE {
 /**

--- a/include/rmm/detail/aligned.hpp
+++ b/include/rmm/detail/aligned.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,7 @@
 
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
 #include <memory>
-#include <new>
 
 namespace RMM_NAMESPACE {
 namespace detail {

--- a/include/rmm/detail/runtime_async_alloc.hpp
+++ b/include/rmm/detail/runtime_async_alloc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,6 @@
 #include <cuda_runtime_api.h>
 
 #include <dlfcn.h>
-
-#include <memory>
-#include <optional>
 
 namespace RMM_NAMESPACE {
 namespace detail {

--- a/include/rmm/detail/stack_trace.hpp
+++ b/include/rmm/detail/stack_trace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@
 #if (defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__))
 #define RMM_ENABLE_STACK_TRACES
 #endif
-
-#include <sstream>
 
 #if defined(RMM_ENABLE_STACK_TRACES)
 #include <cxxabi.h>

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <stdexcept>
 #include <utility>
 
 namespace RMM_NAMESPACE {

--- a/include/rmm/device_scalar.hpp
+++ b/include/rmm/device_scalar.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ namespace RMM_NAMESPACE {
 template <typename T>
 class device_scalar {
  public:
-  static_assert(std::is_trivially_copyable<T>::value, "Scalar type must be trivially copyable");
+  static_assert(std::is_trivially_copyable_v<T>, "Scalar type must be trivially copyable");
 
   using value_type = typename device_uvector<T>::value_type;  ///< T, the type of the scalar element
   using size_type  = typename device_uvector<T>::size_type;   ///< The type used for the size

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -27,7 +27,8 @@
 #include <cuda/memory_resource>
 
 #include <cstddef>
-#include <vector>
+#include <type_traits>
+#include <utility>
 
 namespace RMM_NAMESPACE {
 /**
@@ -219,13 +220,13 @@ class device_uvector {
     RMM_EXPECTS(
       element_index < size(), "Attempt to access out of bounds element.", rmm::out_of_range);
 
-    if constexpr (std::is_same<value_type, bool>::value) {
+    if constexpr (std::is_same_v<value_type, bool>) {
       RMM_CUDA_TRY(
         cudaMemsetAsync(element_ptr(element_index), value, sizeof(value), stream.value()));
       return;
     }
 
-    if constexpr (std::is_fundamental<value_type>::value) {
+    if constexpr (std::is_fundamental_v<value_type>) {
       if (value == value_type{0}) {
         set_element_to_zero_async(element_index, stream);
         return;

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -75,7 +75,7 @@ namespace RMM_NAMESPACE {
  */
 template <typename T>
 class device_uvector {
-  static_assert(std::is_trivially_copyable<T>::value,
+  static_assert(std::is_trivially_copyable_v<T>,
                 "device_uvector only supports types that are trivially copyable.");
 
  public:

--- a/include/rmm/mr/device/aligned_resource_adaptor.hpp
+++ b/include/rmm/mr/device/aligned_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@
 
 #include <cstddef>
 #include <mutex>
-#include <optional>
 #include <unordered_map>
 
 namespace RMM_NAMESPACE {

--- a/include/rmm/mr/device/binning_memory_resource.hpp
+++ b/include/rmm/mr/device/binning_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 
 #include <cuda_runtime_api.h>
 
-#include <algorithm>
 #include <cassert>
 #include <map>
 #include <memory>

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
-#include <limits>
 #include <optional>
 
 namespace RMM_NAMESPACE {

--- a/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
-#include <limits>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/device/detail/coalescing_free_list.hpp
+++ b/include/rmm/mr/device/detail/coalescing_free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#ifdef RMM_DEBUG_PRINT
 #include <iostream>
+#endif
 #include <iterator>
-#include <list>
 
 namespace RMM_NAMESPACE {
 namespace mr::detail {

--- a/include/rmm/mr/device/detail/fixed_size_free_list.hpp
+++ b/include/rmm/mr/device/detail/fixed_size_free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 #include <rmm/mr/device/detail/free_list.hpp>
 
 #include <cstddef>
-#include <iostream>
 
 namespace RMM_NAMESPACE {
 namespace mr::detail {

--- a/include/rmm/mr/device/detail/free_list.hpp
+++ b/include/rmm/mr/device/detail/free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 #include <rmm/detail/export.hpp>
 
 #include <algorithm>
+#ifdef RMM_DEBUG_PRINT
 #include <iostream>
+#endif
 #include <list>
 
 namespace RMM_NAMESPACE {

--- a/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
+++ b/include/rmm/mr/device/detail/stream_ordered_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,14 @@
 
 #include <cuda_runtime_api.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <map>
 #include <mutex>
 #include <unordered_map>
+#ifdef RMM_DEBUG_PRINT
+#include <iostream>
+#endif
 
 namespace RMM_NAMESPACE {
 namespace mr::detail {

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 #include <cuda/memory_resource>
 
 #include <cstddef>
-#include <utility>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/device/fixed_size_memory_resource.hpp
+++ b/include/rmm/mr/device/fixed_size_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <list>
-#include <map>
 #include <utility>
 #include <vector>
 

--- a/include/rmm/mr/device/limiting_resource_adaptor.hpp
+++ b/include/rmm/mr/device/limiting_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <atomic>
 #include <cstddef>
 
 namespace RMM_NAMESPACE {

--- a/include/rmm/mr/device/logging_resource_adaptor.hpp
+++ b/include/rmm/mr/device/logging_resource_adaptor.hpp
@@ -25,9 +25,10 @@
 
 #include <cstddef>
 #include <cstdio>
+#include <initializer_list>
 #include <memory>
-#include <sstream>
-#include <string_view>
+#include <ostream>
+#include <string>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/device/owning_wrapper.hpp
+++ b/include/rmm/mr/device/owning_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-#include <functional>
-#include <iostream>
 #include <memory>
 #include <utility>
 

--- a/include/rmm/mr/device/polymorphic_allocator.hpp
+++ b/include/rmm/mr/device/polymorphic_allocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <type_traits>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@
 #include <cuda_runtime_api.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
-#include <thrust/optional.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/include/rmm/mr/device/pool_memory_resource.hpp
@@ -36,15 +36,9 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <iostream>
-#include <map>
 #include <mutex>
-#include <numeric>
 #include <optional>
 #include <set>
-#include <thread>
-#include <unordered_map>
-#include <vector>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/device/prefetch_resource_adaptor.hpp
+++ b/include/rmm/mr/device/prefetch_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,6 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cstddef>
-#include <mutex>
-#include <shared_mutex>
-#include <stack>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/device/sam_headroom_memory_resource.hpp
+++ b/include/rmm/mr/device/sam_headroom_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,9 @@
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/system_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <algorithm>
+#include <cstddef>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/device/system_memory_resource.hpp
+++ b/include/rmm/mr/device/system_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <cstddef>
+#include <string>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <map>
 #include <mutex>

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -21,7 +21,6 @@
 #include <cuda/memory_resource>
 
 #include <cstddef>
-#include <utility>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/host/new_delete_resource.hpp
+++ b/include/rmm/mr/host/new_delete_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
 #include <rmm/mr/host/host_memory_resource.hpp>
 
 #include <cstddef>
-#include <utility>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 #include <rmm/mr/host/host_memory_resource.hpp>
 
 #include <cstddef>
-#include <utility>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
-#include <utility>
 
 namespace RMM_NAMESPACE {
 namespace mr {

--- a/tests/container_multidevice_tests.cu
+++ b/tests/container_multidevice_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,12 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <gtest/gtest.h>
 
 #include <type_traits>
+#include <utility>
 
 template <typename ContainerType>
 struct ContainerMultiDeviceTest : public ::testing::Test {};
@@ -32,7 +35,7 @@ struct ContainerMultiDeviceTest : public ::testing::Test {};
 using containers =
   ::testing::Types<rmm::device_buffer, rmm::device_uvector<int>, rmm::device_scalar<int>>;
 
-TYPED_TEST_CASE(ContainerMultiDeviceTest, containers);
+TYPED_TEST_SUITE(ContainerMultiDeviceTest, containers);
 
 TYPED_TEST(ContainerMultiDeviceTest, CreateDestroyDifferentActiveDevice)
 {

--- a/tests/cuda_stream_pool_tests.cpp
+++ b/tests/cuda_stream_pool_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
+
+#include <cstdint>
 
 struct CudaStreamPoolTest : public ::testing::Test {
   rmm::cuda_stream_pool pool{};

--- a/tests/cuda_stream_tests.cpp
+++ b/tests/cuda_stream_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,9 @@
 #include <gtest/gtest-death-test.h>
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <sstream>
+#include <utility>
 
 struct CudaStreamTest : public ::testing::Test {};
 

--- a/tests/device_buffer_tests.cu
+++ b/tests/device_buffer_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ struct DeviceBufferTest : public ::testing::Test {
 
 using resources = ::testing::Types<rmm::mr::cuda_memory_resource, rmm::mr::managed_memory_resource>;
 
-TYPED_TEST_CASE(DeviceBufferTest, resources);
+TYPED_TEST_SUITE(DeviceBufferTest, resources);
 
 TYPED_TEST(DeviceBufferTest, EmptyBuffer)
 {

--- a/tests/device_scalar_tests.cpp
+++ b/tests/device_scalar_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,16 +42,15 @@ struct DeviceScalarTest : public ::testing::Test {
 
   DeviceScalarTest() : value{random_value()} {}
 
-  template <typename U = T, std::enable_if_t<std::is_same<U, bool>::value, bool> = true>
+  template <typename U = T, std::enable_if_t<std::is_same_v<U, bool>, bool> = true>
   U random_value()
   {
     static std::bernoulli_distribution distribution{};
     return distribution(generator);
   }
 
-  template <
-    typename U                                                                               = T,
-    std::enable_if_t<(std::is_integral<U>::value && not std::is_same<U, bool>::value), bool> = true>
+  template <typename U                                                                     = T,
+            std::enable_if_t<(std::is_integral_v<U> && not std::is_same_v<U, bool>), bool> = true>
   U random_value()
   {
     static std::uniform_int_distribution<U> distribution{std::numeric_limits<T>::lowest(),
@@ -59,7 +58,7 @@ struct DeviceScalarTest : public ::testing::Test {
     return distribution(generator);
   }
 
-  template <typename U = T, std::enable_if_t<std::is_floating_point<U>::value, bool> = true>
+  template <typename U = T, std::enable_if_t<std::is_floating_point_v<U>, bool> = true>
   U random_value()
   {
     auto const mean{100};
@@ -71,7 +70,7 @@ struct DeviceScalarTest : public ::testing::Test {
 
 using Types = ::testing::Types<bool, int8_t, int16_t, int32_t, int64_t, float, double>;
 
-TYPED_TEST_CASE(DeviceScalarTest, Types);
+TYPED_TEST_SUITE(DeviceScalarTest, Types);
 
 TYPED_TEST(DeviceScalarTest, Uninitialized)
 {

--- a/tests/device_uvector_tests.cpp
+++ b/tests/device_uvector_tests.cpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@
 #include <gtest/gtest.h>
 #include <gtest/internal/gtest-type-util.h>
 
+#include <cstdint>
+#include <iterator>
+#include <utility>
+
 // explicit instantiation for test coverage purposes.
 template class rmm::device_uvector<int32_t>;
 
@@ -33,7 +37,7 @@ struct TypedUVectorTest : ::testing::Test {
 
 using TestTypes = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
 
-TYPED_TEST_CASE(TypedUVectorTest, TestTypes);
+TYPED_TEST_SUITE(TypedUVectorTest, TestTypes);
 
 TYPED_TEST(TypedUVectorTest, MemoryResource)
 {

--- a/tests/logger_tests.cpp
+++ b/tests/logger_tests.cpp
@@ -20,12 +20,15 @@
 #include <rmm/mr/device/logging_resource_adaptor.hpp>
 
 #include <benchmarks/utilities/log_parser.hpp>
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <filesystem>
-#include <thread>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace rmm::test {
 namespace {

--- a/tests/mr/device/adaptor_tests.cpp
+++ b/tests/mr/device/adaptor_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 #include "../../byte_literals.hpp"
 
-#include <rmm/cuda_stream_view.hpp>
-#include <rmm/detail/error.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/device/aligned_resource_adaptor.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
@@ -36,6 +35,7 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <memory>
 #include <type_traits>
 
 using cuda_mr = rmm::mr::cuda_memory_resource;
@@ -110,7 +110,7 @@ struct AdaptorTest : public ::testing::Test {
   }
 };
 
-TYPED_TEST_CASE(AdaptorTest, adaptors);
+TYPED_TEST_SUITE(AdaptorTest, adaptors);
 
 TYPED_TEST(AdaptorTest, NullUpstream)
 {

--- a/tests/mr/device/aligned_mr_tests.cpp
+++ b/tests/mr/device/aligned_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,15 @@
 #include "../../mock_resource.hpp"
 
 #include <rmm/aligned.hpp>
-#include <rmm/detail/error.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/device/aligned_resource_adaptor.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <cstddef>
 
 namespace rmm::test {
 namespace {

--- a/tests/mr/device/arena_mr_tests.cpp
+++ b/tests/mr/device/arena_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,12 @@
 
 #include "../../byte_literals.hpp"
 
-#include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/detail/error.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/device/arena_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
-#include <rmm/resource_ref.hpp>
 
 #include <cuda/stream_ref>
 
@@ -31,8 +29,12 @@
 #include <gtest/gtest.h>
 #include <sys/stat.h>
 
+#include <cstddef>
+#include <limits>
 #include <memory>
+#include <set>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace rmm::test {

--- a/tests/mr/device/binning_mr_tests.cpp
+++ b/tests/mr/device/binning_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <rmm/error.hpp>
 #include <rmm/mr/device/binning_memory_resource.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 

--- a/tests/mr/device/callback_mr_tests.cpp
+++ b/tests/mr/device/callback_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@
 #include "../../mock_resource.hpp"
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/detail/error.hpp>
-#include <rmm/device_buffer.hpp>
 #include <rmm/mr/device/callback_memory_resource.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <iostream>
 #include <string>
 
 namespace rmm::test {

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-#include <rmm/cuda_device.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/cuda_async_memory_resource.hpp>
+
+#include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
 

--- a/tests/mr/device/failure_callback_mr_tests.cpp
+++ b/tests/mr/device/failure_callback_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,7 @@
 #include "../../byte_literals.hpp"
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/detail/error.hpp>
-#include <rmm/device_buffer.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/failure_callback_resource_adaptor.hpp>
 

--- a/tests/mr/device/limiting_mr_tests.cpp
+++ b/tests/mr/device/limiting_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 #include "../../byte_literals.hpp"
 
-#include <rmm/detail/error.hpp>
-#include <rmm/device_buffer.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/device/limiting_resource_adaptor.hpp>
 
 #include <gtest/gtest.h>

--- a/tests/mr/device/mr_ref_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_ref_multithreaded_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ namespace {
 
 struct mr_ref_test_mt : public mr_ref_test {};
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   MultiThreadResourceTests,
   mr_ref_test_mt,
   ::testing::Values("CUDA", "CUDA_Async", "Managed", "Pool", "Arena", "Binning"),

--- a/tests/mr/device/polymorphic_allocator_tests.cpp
+++ b/tests/mr/device/polymorphic_allocator_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <type_traits>
 
 namespace {
 
@@ -103,7 +104,7 @@ TEST_F(allocator_test, rebind)
 
   using Rebound = std::allocator_traits<Allocator>::rebind_alloc<double>;
 
-  EXPECT_TRUE((std::is_same<std::allocator_traits<Rebound>::value_type, double>::value));
+  EXPECT_TRUE((std::is_same_v<std::allocator_traits<Rebound>::value_type, double>));
 }
 
 TEST_F(allocator_test, allocate_deallocate)

--- a/tests/mr/device/pool_mr_tests.cpp
+++ b/tests/mr/device/pool_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-#include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/device_uvector.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/limiting_resource_adaptor.hpp>
@@ -26,6 +24,10 @@
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
 #include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
 
 // explicit instantiation for test coverage purposes
 template class rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>;

--- a/tests/mr/device/prefetch_resource_adaptor_tests.cpp
+++ b/tests/mr/device/prefetch_resource_adaptor_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ struct PrefetchAdaptorTest : public ::testing::Test {
 
 using resources = ::testing::Types<rmm::mr::cuda_memory_resource, rmm::mr::managed_memory_resource>;
 
-TYPED_TEST_CASE(PrefetchAdaptorTest, resources);
+TYPED_TEST_SUITE(PrefetchAdaptorTest, resources);
 
 // The following tests simply test compilation and that there are no exceptions thrown
 // due to prefetching non-managed memory.

--- a/tests/mr/device/statistics_mr_tests.cpp
+++ b/tests/mr/device/statistics_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,16 @@
 #include "../../byte_literals.hpp"
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/device/statistics_resource_adaptor.hpp>
 
 #include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <vector>
 
 namespace rmm::test {
 namespace {

--- a/tests/mr/device/stream_allocator_adaptor_tests.cpp
+++ b/tests/mr/device/stream_allocator_adaptor_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 #include <rmm/cuda_stream.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/polymorphic_allocator.hpp>
 
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <type_traits>
 
 namespace {
 
@@ -35,7 +35,7 @@ TEST_F(allocator_test, factory)
 {
   using Adaptor = rmm::mr::stream_allocator_adaptor<decltype(allocator)>;
   auto adapted  = rmm::mr::stream_allocator_adaptor(allocator, stream);
-  static_assert((std::is_same<decltype(adapted), Adaptor>::value));
+  static_assert((std::is_same_v<decltype(adapted), Adaptor>));
   EXPECT_EQ(adapted.underlying_allocator(), allocator);
   EXPECT_EQ(adapted.stream(), stream);
 }
@@ -98,10 +98,10 @@ TEST_F(allocator_test, rebind)
 {
   auto adapted  = rmm::mr::stream_allocator_adaptor(allocator, stream);
   using Rebound = std::allocator_traits<decltype(adapted)>::rebind_alloc<double>;
-  static_assert((std::is_same<std::allocator_traits<Rebound>::value_type, double>::value));
+  static_assert(std::is_same_v<std::allocator_traits<Rebound>::value_type, double>);
   static_assert(
-    std::is_same<Rebound,
-                 rmm::mr::stream_allocator_adaptor<rmm::mr::polymorphic_allocator<double>>>::value);
+    std::is_same_v<Rebound,
+                   rmm::mr::stream_allocator_adaptor<rmm::mr::polymorphic_allocator<double>>>);
 
   Rebound rebound{adapted};
 }

--- a/tests/mr/device/system_mr_tests.cu
+++ b/tests/mr/device/system_mr_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,15 @@
 #include "../../byte_literals.hpp"
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/detail/error.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/device/sam_headroom_memory_resource.hpp>
 #include <rmm/mr/device/system_memory_resource.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <gtest/gtest.h>
+
+#include <cstddef>
 
 namespace rmm::test {
 namespace {

--- a/tests/mr/device/thrust_allocator_tests.cu
+++ b/tests/mr/device/thrust_allocator_tests.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ TEST_P(allocator_test, multi_device)
   }());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   ThrustAllocatorTests,
   allocator_test,
   ::testing::Values("CUDA", "CUDA_Async", "Managed", "Pool", "Arena", "Binning"),

--- a/tests/mr/device/tracking_mr_tests.cpp
+++ b/tests/mr/device/tracking_mr_tests.cpp
@@ -24,6 +24,11 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace rmm::test {
 namespace {
 

--- a/tests/mr/host/mr_ref_tests.cpp
+++ b/tests/mr/host/mr_ref_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ using resources = ::testing::Types<rmm::mr::new_delete_resource, rmm::mr::pinned
 static_assert(cuda::mr::resource_with<rmm::mr::new_delete_resource, cuda::mr::host_accessible>);
 static_assert(cuda::mr::resource_with<rmm::mr::pinned_memory_resource, cuda::mr::host_accessible>);
 
-TYPED_TEST_CASE(MRRefTest, resources);
+TYPED_TEST_SUITE(MRRefTest, resources);
 
 TYPED_TEST(MRRefTest, SelfEquality) { EXPECT_TRUE(this->ref == this->ref); }
 

--- a/tests/mr/host/pinned_pool_mr_tests.cpp
+++ b/tests/mr/host/pinned_pool_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-#include <rmm/cuda_stream_view.hpp>
-#include <rmm/detail/aligned.hpp>
-#include <rmm/detail/error.hpp>
-#include <rmm/device_buffer.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 #include <rmm/mr/host/pinned_memory_resource.hpp>
 

--- a/tests/prefetch_tests.cpp
+++ b/tests/prefetch_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ struct PrefetchTest : public ::testing::Test {
 
 using resources = ::testing::Types<rmm::mr::cuda_memory_resource, rmm::mr::managed_memory_resource>;
 
-TYPED_TEST_CASE(PrefetchTest, resources);
+TYPED_TEST_SUITE(PrefetchTest, resources);
 
 // The following tests simply test compilation and that there are no exceptions thrown
 // due to prefetching non-managed memory.


### PR DESCRIPTION
## Description
This is a cleanup PR. I found that we were extraneously including `<thrust/optional.h>` in the pool memory resource (also `thrust::optional` is deprecated in favor of `cuda::std::optional` in the upcoming major release of CCCL). I did a pass with IWYU to see what else could be fixed. IWYU could only really analyze our tests, since RMM is header-only. There are a lot of false positives/negatives, so I don't think it is appropriate to automate IWYU in our CI. However, this felt valuable enough to open a refactoring PR.

I also updated some deprecated GTest code which was using `TYPED_TEST_CASE` instead of `TYPED_TEST_SUITE` and replaced some uses of `::value` with the corresponding `_v` STL features.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
