### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/python/librmm/pyproject.toml
+++ b/python/librmm/pyproject.toml
@@ -27,7 +27,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Database",

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -27,7 +27,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cuda-python>=11.8.5,<12.0a0",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
