### PR TITLE
Depend on rapids-logger in host to prevent redistribution

### DIFF
--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -46,6 +46,8 @@ cache:
       - ${{ compiler("cuda") }}
       - cuda-version =${{ cuda_version }}
       - ${{ stdlib("c") }}
+    host:
+      - rapids-logger =0.1
 
 outputs:
   - package:


### PR DESCRIPTION
## Description
Fixes redistribution of `rapids-logger` code which can cause clobbering. See #1833.

After this change, the following paths should _not_ be in the `librmm` package:
- `lib/librapids_logger.so`
- `lib/cmake/rapids_logger/*`
- `include/rapids_logger/*`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
