### PR TITLE
Fixes for rattler recipe

### DIFF
--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -58,8 +58,9 @@ outputs:
       script:
         - cmake --install build
     requirements:
-      host:
+      build:
         - cmake ${{ cmake_version }}
+      host:
         - cuda-version =${{ cuda_version }}
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
@@ -69,8 +70,8 @@ outputs:
       run_exports:
         - ${{ pin_subpackage("librmm", upper_bound="x.x") }}
       ignore_run_exports:
-        from_package:
-          - ${{ compiler("cuda") }}
+        by_name:
+          - cuda-version
     tests:
       - script:
           - "test -d \"${PREFIX}/include/rmm\""
@@ -86,8 +87,9 @@ outputs:
       script:
         - cmake --install build --component testing
     requirements:
-      host:
+      build:
         - cmake ${{ cmake_version }}
+      host:
         - cuda-version =${{ cuda_version }}
         - if: cuda_major == "11"
           then: cudatoolkit
@@ -100,9 +102,10 @@ outputs:
         - ${{ pin_subpackage("librmm", exact=True) }}
       ignore_run_exports:
         from_package:
-          - ${{ compiler("cuda") }}
-          - if: cuda_major == "11"
+          - if: cuda_major != "11"
             then: cuda-cudart-dev
+        by_name:
+          - cuda-version
     about:
       homepage: ${{ load_from_file("python/librmm/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/librmm/pyproject.toml").project.license.text | replace(" ", "-") }}


### PR DESCRIPTION
## Description
Fixes for `build`/`host` dependencies in the rattler recipe for librmm.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
