### PR TITLE
fix(rattler): resolve all overlinking errors

### DIFF
--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -92,8 +92,6 @@ outputs:
       script: cmake --install build --component testing
       dynamic_linking:
         overlinking_behavior: "error"
-        missing_dso_allowlist:
-          - "libbenchmark.so*"
     requirements:
       build:
         - ${{ compiler("c") }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -95,7 +95,7 @@ outputs:
     requirements:
       build:
         - cmake ${{ cmake_version }}
-        - ${{ stdlib('c') }}  # this is here to help with overlinking errors against libm.so.6 and friends
+        - ${{ stdlib("c") }}  # this is here to help with overlinking errors against libm.so.6 and friends
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}
         - cuda-version =${{ cuda_version }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -99,10 +99,9 @@ outputs:
       version: ${{ version }}
     build:
       string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
-      script:
-        - cmake --install build --component testing --component benchmarks
-      dynamic_linking:
-        overlinking_behavior: "error"
+      script: cmake --install build --component testing
+      # dynamic_linking:
+        # overlinking_behavior: "error"
     requirements:
       build:
         - ${{ compiler('c') }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -95,6 +95,7 @@ outputs:
     requirements:
       build:
         - cmake ${{ cmake_version }}
+        - ${{ stdlib('c') }}  # this is here to help with overlinking errors against libm.so.6 and friends
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}
         - cuda-version =${{ cuda_version }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -94,9 +94,6 @@ outputs:
         overlinking_behavior: "error"
     requirements:
       build:
-        - ${{ compiler("c") }}
-        - ${{ compiler("cxx") }}
-        - ${{ compiler("cuda") }}
         - cmake ${{ cmake_version }}
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -100,8 +100,10 @@ outputs:
     build:
       string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
       script: cmake --install build --component testing
-      # dynamic_linking:
-        # overlinking_behavior: "error"
+      dynamic_linking:
+        overlinking_behavior: "error"
+        missing_dso_allowlist:
+          - "libbenchmark.so*"
     requirements:
       build:
         - ${{ compiler('c') }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -57,6 +57,8 @@ outputs:
       string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
       script:
         - cmake --install build
+      dynamic_linking:
+        overlinking_behavior: "error"
     requirements:
       build:
         - cmake ${{ cmake_version }}
@@ -72,6 +74,18 @@ outputs:
       ignore_run_exports:
         by_name:
           - cuda-version
+          - if: cuda_major == "11"
+            then: cudatoolkit
+          - if: linux
+            then:
+              - __glibc
+              - libgcc
+              - libstdcxx
+              - if: cuda_major == "11"
+                then:
+                  - libgcc-ng
+                  - libstdcxx-ng
+                  - sysroot_linux-64
     tests:
       - script:
           - "test -d \"${PREFIX}/include/rmm\""
@@ -79,33 +93,52 @@ outputs:
       homepage: ${{ load_from_file("python/librmm/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/librmm/pyproject.toml").project.license.text }}
       summary: ${{ load_from_file("python/librmm/pyproject.toml").project.description }}
+
   - package:
       name: librmm-tests
       version: ${{ version }}
     build:
       string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
       script:
-        - cmake --install build --component testing
+        - cmake --install build --component testing --component benchmarks
+      dynamic_linking:
+        overlinking_behavior: "error"
     requirements:
       build:
+        - ${{ compiler('c') }}
         - cmake ${{ cmake_version }}
       host:
+        - ${{ pin_subpackage("librmm", exact=True) }}
         - cuda-version =${{ cuda_version }}
         - if: cuda_major == "11"
           then: cudatoolkit
           else: cuda-cudart-dev
       run:
+        - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
+        - ${{ pin_subpackage("librmm", exact=True) }}
+        - rapids-logger =0.1
         - if: cuda_major == "11"
           then: cudatoolkit
           else: cuda-cudart
-        - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
-        - ${{ pin_subpackage("librmm", exact=True) }}
       ignore_run_exports:
         from_package:
           - if: cuda_major != "11"
             then: cuda-cudart-dev
         by_name:
           - cuda-version
+          - librmm
+          - if: cuda_major == "11"
+            then: cudatoolkit
+          - if: linux
+            then:
+              - __glibc
+              - libgcc
+              - libstdcxx
+              - if: cuda_major == "11"
+                then:
+                  - libgcc-ng
+                  - libstdcxx-ng
+                  - sysroot_linux-64
     about:
       homepage: ${{ load_from_file("python/librmm/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/librmm/pyproject.toml").project.license.text | replace(" ", "-") }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -76,16 +76,6 @@ outputs:
           - cuda-version
           - if: cuda_major == "11"
             then: cudatoolkit
-          - if: linux
-            then:
-              - __glibc
-              - libgcc
-              - libstdcxx
-              - if: cuda_major == "11"
-                then:
-                  - libgcc-ng
-                  - libstdcxx-ng
-                  - sysroot_linux-64
     tests:
       - script:
           - "test -d \"${PREFIX}/include/rmm\""
@@ -106,7 +96,9 @@ outputs:
           - "libbenchmark.so*"
     requirements:
       build:
-        - ${{ compiler('c') }}
+        - ${{ compiler("c") }}
+        - ${{ compiler("cxx") }}
+        - ${{ compiler("cuda") }}
         - cmake ${{ cmake_version }}
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}
@@ -127,19 +119,8 @@ outputs:
             then: cuda-cudart-dev
         by_name:
           - cuda-version
-          - librmm
           - if: cuda_major == "11"
             then: cudatoolkit
-          - if: linux
-            then:
-              - __glibc
-              - libgcc
-              - libstdcxx
-              - if: cuda_major == "11"
-                then:
-                  - libgcc-ng
-                  - libstdcxx-ng
-                  - sysroot_linux-64
     about:
       homepage: ${{ load_from_file("python/librmm/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/librmm/pyproject.toml").project.license.text | replace(" ", "-") }}


### PR DESCRIPTION
## Description
Turns on erroring for overlinking errors and fixes all of those errors.

I've reduced the number of overdepending warnings, but `rapids-logger` seems to
consistently cause an overdepending warning, so I haven't yet switched that to
error mode.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.