### PR TITLE
Use static gbench

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ endif()
 
 if(BUILD_BENCHMARKS AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   include(${rapids-cmake-dir}/cpm/gbench.cmake)
-  rapids_cpm_gbench()
+  rapids_cpm_gbench(BUILD_STATIC)
   add_subdirectory(benchmarks)
 endif()
 


### PR DESCRIPTION
## Description
RMM benchmarks should statically link Google Benchmark. We saw they were linking to `libbenchmark.so` while working with rattler-build: https://github.com/rapidsai/rmm/pull/1836#discussion_r1970206227

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
