### PR TITLE
fix GITHUB_WORKSPACE not being present locally

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  SHARED_ACTIONS_REF: add-actions-summary
-
 jobs:
   pr-builder:
     needs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -159,7 +159,7 @@ jobs:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4
     needs: pr-builder
-    if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
+    if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() && github.run_attempt == '1' }}
     continue-on-error: true
     steps:
       - name: Telemetry summarize

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SHARED_ACTIONS_REF: add-actions-summary
+
 jobs:
   pr-builder:
     needs:

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz -C /usr/local/bin --strip-components=2 gha-tools-rapids-telemetry-record/tools/*
 
 rapids-configure-conda-channels
 

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -33,9 +33,9 @@ rattler-build build --recipe conda/recipes/librmm \
                     --no-build-id \
                     --channel-priority disabled \
                     --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
-                    "${RATTLER_CHANNELS[@]}" 2>&1 | tee ${GITHUB_WORKSPACE}/telemetry-artifacts/build.log
+                    "${RATTLER_CHANNELS[@]}" 2>&1 | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/build.log
 
-sccache --show-adv-stats | tee ${GITHUB_WORKSPACE}/telemetry-artifacts/sccache-stats.txt
+sccache --show-adv-stats | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/sccache-stats.txt
 
 # remove build_cache directory
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -3,9 +3,6 @@
 
 set -euo pipefail
 
-# TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz -C /usr/local/bin --strip-components=2 gha-tools-rapids-telemetry-record/tools/*
-
 rapids-configure-conda-channels
 
 source rapids-configure-sccache

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz - gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
 
 rapids-configure-conda-channels
 

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+# TODO Erase this once rapids-telemetry-record is merged
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz - gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+
 rapids-configure-conda-channels
 
 source rapids-configure-sccache
@@ -28,14 +31,15 @@ source rapids-telemetry-setup
 # --no-build-id allows for caching with `sccache`
 # more info is available at
 # https://rattler.build/latest/tips_and_tricks/#using-sccache-or-ccache-with-rattler-build
-rattler-build build --recipe conda/recipes/librmm \
-                    --experimental \
-                    --no-build-id \
-                    --channel-priority disabled \
-                    --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
-                    "${RATTLER_CHANNELS[@]}" 2>&1 | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/build.log
+rapids-telemetry-record build.log rattler-build build \
+    --recipe conda/recipes/librmm \
+    --experimental \
+    --no-build-id \
+    --channel-priority disabled \
+    --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
+    "${RATTLER_CHANNELS[@]}"
 
-sccache --show-adv-stats | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/sccache-stats.txt
+rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 # remove build_cache directory
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz -C /usr/local/bin --strip-components=2 gha-tools-rapids-telemetry-record/tools/*
 
 rapids-configure-conda-channels
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -3,9 +3,6 @@
 
 set -euo pipefail
 
-# TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz -C /usr/local/bin --strip-components=2 gha-tools-rapids-telemetry-record/tools/*
-
 rapids-configure-conda-channels
 
 source rapids-configure-sccache

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz - gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
 
 rapids-configure-conda-channels
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -38,9 +38,9 @@ rattler-build build --recipe conda/recipes/rmm \
                     --channel-priority disabled \
                     --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
                     -c "${CPP_CHANNEL}" \
-                    "${RATTLER_CHANNELS[@]}" 2>&1 | tee ${GITHUB_WORKSPACE}/telemetry-artifacts/build.log
+                    "${RATTLER_CHANNELS[@]}" 2>&1 | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/build.log
 
-sccache --show-adv-stats | tee ${GITHUB_WORKSPACE}/telemetry-artifacts/sccache-stats.txt
+sccache --show-adv-stats | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/sccache-stats.txt
 
 # See https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -19,9 +19,9 @@ sccache --zero-stats
 # Creates artifacts directory for telemetry
 source rapids-telemetry-setup
 
-rapids-pip-retry wheel . -w dist -v --no-deps --disable-pip-version-check 2>&1 | tee ${GITHUB_WORKSPACE}/telemetry-artifacts/build.log
+rapids-pip-retry wheel . -w dist -v --no-deps --disable-pip-version-check 2>&1 | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/build.log
 
-sccache --show-adv-stats | tee ${GITHUB_WORKSPACE}/telemetry-artifacts/sccache-stats.txt
+sccache --show-adv-stats | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/sccache-stats.txt
 
 python -m wheel tags --platform any dist/* --remove
 

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz -C /usr/local/bin --strip-components=2 gha-tools-rapids-telemetry-record/tools/*
 
 package_dir="python/librmm"
 

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -3,9 +3,6 @@
 
 set -euo pipefail
 
-# TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz -C /usr/local/bin --strip-components=2 gha-tools-rapids-telemetry-record/tools/*
-
 package_dir="python/librmm"
 
 source rapids-configure-sccache

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+# TODO Erase this once rapids-telemetry-record is merged
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz - gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+
 package_dir="python/librmm"
 
 source rapids-configure-sccache
@@ -19,9 +22,9 @@ sccache --zero-stats
 # Creates artifacts directory for telemetry
 source rapids-telemetry-setup
 
-rapids-pip-retry wheel . -w dist -v --no-deps --disable-pip-version-check 2>&1 | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/build.log
+rapids-telemetry-record build.log rapids-pip-retry wheel . -w dist -v --no-deps --disable-pip-version-check
 
-sccache --show-adv-stats | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/sccache-stats.txt
+rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 python -m wheel tags --platform any dist/* --remove
 

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz - gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
 
 package_dir="python/librmm"
 

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -28,9 +28,9 @@ sccache --zero-stats
 source rapids-telemetry-setup
 
 PIP_CONSTRAINT="${PWD}/build-constraints.txt" \
-    rapids-pip-retry wheel . -w dist -v --no-deps --disable-pip-version-check 2>&1 | tee ${GITHUB_WORKSPACE}/telemetry-artifacts/build.log
+    rapids-pip-retry wheel . -w dist -v --no-deps --disable-pip-version-check 2>&1 | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/build.log
 
-sccache --show-adv-stats | tee ${GITHUB_WORKSPACE}/telemetry-artifacts/sccache-stats.txt
+sccache --show-adv-stats | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/sccache-stats.txt
 
 mkdir -p final_dist
 EXCLUDE_ARGS=(

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz - gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
 
 package_name="rmm"
 package_dir="python/rmm"

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz -C /usr/local/bin --strip-components=2 gha-tools-rapids-telemetry-record/tools/*
 
 package_name="rmm"
 package_dir="python/rmm"

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -3,9 +3,6 @@
 
 set -euo pipefail
 
-# TODO Erase this once rapids-telemetry-record is merged
-wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz -C /usr/local/bin --strip-components=2 gha-tools-rapids-telemetry-record/tools/*
-
 package_name="rmm"
 package_dir="python/rmm"
 

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+# TODO Erase this once rapids-telemetry-record is merged
+wget https://github.com/bdice/gha-tools/archive/refs/heads/rapids-telemetry-record.tar.gz -O - | tar -xz - gha-tools-rapids-telemetry-record/tools --strip-components=2 -C /usr/local/bin
+
 package_name="rmm"
 package_dir="python/rmm"
 
@@ -28,9 +31,9 @@ sccache --zero-stats
 source rapids-telemetry-setup
 
 PIP_CONSTRAINT="${PWD}/build-constraints.txt" \
-    rapids-pip-retry wheel . -w dist -v --no-deps --disable-pip-version-check 2>&1 | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/build.log
+    rapids-telemetry-record build.log rapids-pip-retry wheel . -w dist -v --no-deps --disable-pip-version-check
 
-sccache --show-adv-stats | tee ${GITHUB_WORKSPACE:-.}/telemetry-artifacts/sccache-stats.txt
+rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 mkdir -p final_dist
 EXCLUDE_ARGS=(


### PR DESCRIPTION
#1839 introduced a hard dependence on GITHUB_WORKSPACE being defined. That is not true outside of github actions. This PR fixes it to fall back to the current folder.
