### PR TITLE
fix(rattler): force `cuda_major` and `date_string` to be strings

### DIFF
--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -5,8 +5,8 @@ schema_version: 1
 context:
   version: ${{ env.get("RAPIDS_PACKAGE_VERSION") }}
   cuda_version: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[:2] | join(".") }}
-  cuda_major: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}
-  date_string: ${{ env.get("RAPIDS_DATE_STRING") }}
+  cuda_major: '${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}'
+  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   head_rev: ${{ git.head_rev(".")[:8] }}
 
 recipe:

--- a/conda/recipes/rmm/recipe.yaml
+++ b/conda/recipes/rmm/recipe.yaml
@@ -76,6 +76,7 @@ requirements:
     from_package:
       - ${{ compiler("cuda") }}
       - cuda-python
+      - python  # required to avoid an incorrect runtime python_abi requirement from `host`
       - if: not (cuda_major == "11")
         then: "cuda-cudart-dev"
 

--- a/conda/recipes/rmm/recipe.yaml
+++ b/conda/recipes/rmm/recipe.yaml
@@ -6,7 +6,8 @@ context:
   cuda_version: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[:2] | join(".") }}
   cuda_major: '${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}'
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
-  py_version: ${{ env.get("RAPIDS_PY_VERSION") | version_to_buildstring }}
+  py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
+  py_buildstring : ${{ py_version | version_to_buildstring }}
   head_rev: ${{ git.head_rev(".")[:8] }}
 
 package:
@@ -17,7 +18,7 @@ source:
   - path: ../../..
 
 build:
-  string: cuda${{ cuda_major }}_py${{ py_version }}_${{ date_string }}_${{ head_rev }}
+  string: cuda${{ cuda_major }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}
   script:
     content:
       - ./build.sh -v clean rmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
@@ -58,7 +59,7 @@ requirements:
     - cython >=3.0.0
     - rapids-build-backend >=0.3.0,<0.4.0.dev0
     - librmm =${{ version }}
-    - python
+    - python =${{ py_version }}
     - pip
     - scikit-build-core >=0.10.0
   run:
@@ -76,7 +77,6 @@ requirements:
     from_package:
       - ${{ compiler("cuda") }}
       - cuda-python
-      - python  # required to avoid an incorrect runtime python_abi requirement from `host`
       - if: not (cuda_major == "11")
         then: "cuda-cudart-dev"
 

--- a/conda/recipes/rmm/recipe.yaml
+++ b/conda/recipes/rmm/recipe.yaml
@@ -4,8 +4,8 @@
 context:
   version: ${{ env.get("RAPIDS_PACKAGE_VERSION") }}
   cuda_version: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[:2] | join(".") }}
-  cuda_major: ${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}
-  date_string: ${{ env.get("RAPIDS_DATE_STRING") }}
+  cuda_major: '${{ (env.get("RAPIDS_CUDA_VERSION") | split("."))[0] }}'
+  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") | version_to_buildstring }}
   head_rev: ${{ git.head_rev(".")[:8] }}
 


### PR DESCRIPTION
## Description

Downstream `cudf` is having trouble solving because `rmm` claims it needs `cuda12` for a `cuda11` environment.
This is because `rattler` likes to make things integers and the string comparisons fail for the selectors.

So we force them to be strings.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.