### PR TITLE
Error if LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE is not defined.

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -42,3 +42,7 @@ rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 
 rapids-upload-conda-to-s3 cpp
+
+# Run the libcudacxx flag test at build time, since compilers are available
+rapids-logger "Run libcudacxx_flag_test"
+./tests/libcudacxx_flag_test/libcudacxx_flag_test.sh

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -41,8 +41,8 @@ rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 # remove build_cache directory
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 
-rapids-upload-conda-to-s3 cpp
-
 # Run the libcudacxx flag test at build time, since compilers are available
 rapids-logger "Run libcudacxx_flag_test"
 ./tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
+
+rapids-upload-conda-to-s3 cpp

--- a/include/rmm/detail/cuda_memory_resource.hpp
+++ b/include/rmm/detail/cuda_memory_resource.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+// Check if LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE is defined
+#ifndef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+#error \
+  "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined. This is typically done by the build system. If you're seeing this error, you may be using a custom build setup that doesn't define this flag. Please add -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to your compiler flags."
+#endif
+
+#include <cuda/memory_resource>

--- a/include/rmm/detail/cuda_memory_resource.hpp
+++ b/include/rmm/detail/cuda_memory_resource.hpp
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-// Check if LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE is defined
 #ifndef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 #error \
   "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined. Please add -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to the compiler flags (this is done automatically when using RMM via CMake)."

--- a/include/rmm/detail/cuda_memory_resource.hpp
+++ b/include/rmm/detail/cuda_memory_resource.hpp
@@ -18,7 +18,7 @@
 // Check if LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE is defined
 #ifndef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 #error \
-  "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined. This is typically done by the build system. If you're seeing this error, you may be using a custom build setup that doesn't define this flag. Please add -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to your compiler flags."
+  "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined. Please add -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to the compiler flags (this is done automatically when using RMM via CMake)."
 #endif
 
 #include <cuda/memory_resource>

--- a/include/rmm/device_buffer.hpp
+++ b/include/rmm/device_buffer.hpp
@@ -22,7 +22,6 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
 #include <cassert>

--- a/include/rmm/device_uvector.hpp
+++ b/include/rmm/device_uvector.hpp
@@ -24,8 +24,6 @@
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/memory_resource>
-
 #include <cstddef>
 #include <type_traits>
 #include <utility>

--- a/include/rmm/mr/device/device_memory_resource.hpp
+++ b/include/rmm/mr/device/device_memory_resource.hpp
@@ -17,10 +17,9 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/nvtx/ranges.hpp>
-
-#include <cuda/memory_resource>
 
 #include <cstddef>
 

--- a/include/rmm/mr/device/thrust_allocator_adaptor.hpp
+++ b/include/rmm/mr/device/thrust_allocator_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 #pragma once
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/memory_resource>
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>

--- a/include/rmm/mr/host/host_memory_resource.hpp
+++ b/include/rmm/mr/host/host_memory_resource.hpp
@@ -15,10 +15,9 @@
  */
 #pragma once
 
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/nvtx/ranges.hpp>
-
-#include <cuda/memory_resource>
 
 #include <cstddef>
 

--- a/include/rmm/mr/is_resource_adaptor.hpp
+++ b/include/rmm/mr/is_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 #pragma once
 
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/detail/export.hpp>
 
-#include <cuda/memory_resource>
 #include <cuda/std/type_traits>
 
 namespace RMM_NAMESPACE {

--- a/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -17,11 +17,11 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/detail/aligned.hpp>
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/nvtx/ranges.hpp>
 
-#include <cuda/memory_resource>
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 

--- a/include/rmm/resource_ref.hpp
+++ b/include/rmm/resource_ref.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,9 @@
  */
 #pragma once
 
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
-
-#include <cuda/memory_resource>
 
 namespace RMM_NAMESPACE {
 

--- a/tests/device_scalar_tests.cpp
+++ b/tests/device_scalar_tests.cpp
@@ -15,12 +15,12 @@
  */
 
 #include <rmm/cuda_stream.hpp>
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/mr/device/device_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>

--- a/tests/libcudacxx_flag_test/README.md
+++ b/tests/libcudacxx_flag_test/README.md
@@ -1,0 +1,1 @@
+This directory contains test files to verify that RMM reports an error when the `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE` flag is not defined.

--- a/tests/libcudacxx_flag_test/README.md
+++ b/tests/libcudacxx_flag_test/README.md
@@ -1,1 +1,1 @@
-This directory contains test files to verify that RMM reports an error when the `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE` flag is not defined.
+This directory contains test files to verify that RMM reports a compile error when the `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE` preprocessor macro is not defined.

--- a/tests/libcudacxx_flag_test/libcudacxx_flag_test.cpp
+++ b/tests/libcudacxx_flag_test/libcudacxx_flag_test.cpp
@@ -16,15 +16,15 @@
 
 /**
  * @file libcudacxx_flag_test.cpp
- * @brief Test that verifies the error message when LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+ * @brief Test that verifies the error message when `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE`
  * is not defined.
  *
  * This test is expected to fail to compile with a clear error message.
  * To run this test, you need to compile it separately without defining
- * LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE.
+ * `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE`.
  *
  * Example:
- * g++ -std=c++17 -I../../include libcudacxx_flag_test.cpp
+ * `g++ -std=c++17 -I../../include libcudacxx_flag_test.cpp`
  */
 
 // Include a header that requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE

--- a/tests/libcudacxx_flag_test/libcudacxx_flag_test.cpp
+++ b/tests/libcudacxx_flag_test/libcudacxx_flag_test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file libcudacxx_flag_test.cpp
+ * @brief Test that verifies the error message when LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+ * is not defined.
+ *
+ * This test is expected to fail to compile with a clear error message.
+ * To run this test, you need to compile it separately without defining
+ * LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE.
+ *
+ * Example:
+ * g++ -std=c++17 -I../../include libcudacxx_flag_test.cpp
+ */
+
+// Include a header that requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+#include <rmm/detail/cuda_memory_resource.hpp>
+
+int main() { return 0; }

--- a/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
+++ b/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
@@ -25,8 +25,7 @@ else
   # Check if the error message contains the expected text
   if grep -q "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined" "${ERROR_FILE}"; then
     echo "Test passed: Compilation failed with the expected error message"
-    echo "Error message:"
-    cat "${ERROR_FILE}"
+    # Don't show the error message, to avoid confusing it with a real error in the CI logs.
   else
     echo "Test failed: Compilation failed but with an unexpected error message:"
     cat "${ERROR_FILE}"

--- a/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
+++ b/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
@@ -18,7 +18,8 @@ ERROR_FILE=$(mktemp)
 trap 'rm -f "${ERROR_FILE}"' EXIT
 
 # Try to compile the file without defining LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
-if g++ -std=c++17 -I"${RMM_INCLUDE_DIR}" libcudacxx_flag_test.cpp -o libcudacxx_flag_test 2> "${ERROR_FILE}"; then
+g++ -std=c++17 -I"${RMM_INCLUDE_DIR}" libcudacxx_flag_test.cpp -o libcudacxx_flag_test 2> "${ERROR_FILE}"
+if $?; then
   echo "Test failed: Compilation succeeded when it should have failed"
   exit 1
 else

--- a/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
+++ b/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
@@ -18,7 +18,9 @@ ERROR_FILE=$(mktemp)
 trap 'rm -f "${ERROR_FILE}"' EXIT
 
 # Try to compile the file without defining LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+set +e
 g++ -std=c++17 -I"${RMM_INCLUDE_DIR}" libcudacxx_flag_test.cpp -o libcudacxx_flag_test 2> "${ERROR_FILE}"
+set -e
 if $?; then
   echo "Test failed: Compilation succeeded when it should have failed"
   exit 1

--- a/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
+++ b/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
@@ -21,20 +21,19 @@ trap 'rm -f "${ERROR_FILE}"' EXIT
 set +e
 g++ -std=c++17 -I"${RMM_INCLUDE_DIR}" libcudacxx_flag_test.cpp -o libcudacxx_flag_test 2> "${ERROR_FILE}"
 set -e
+
 if $?; then
   echo "Test failed: Compilation succeeded when it should have failed"
   exit 1
-else
-  # Check if the error message contains the expected text
-  if grep -q "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined" "${ERROR_FILE}"; then
-    echo "Test passed: Compilation failed with the expected error message"
-    # Don't show the error message, to avoid confusing it with a real error in the CI logs.
-  else
-    echo "Test failed: Compilation failed but with an unexpected error message:"
-    cat "${ERROR_FILE}"
-    exit 1
-  fi
 fi
 
-echo "Test completed successfully"
+# Check if the error message contains the expected text
+if ! grep -q "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined" "${ERROR_FILE}"; then
+  echo "Test failed: Compilation failed but with an unexpected error message:"
+  cat "${ERROR_FILE}"
+  exit 1
+fi
+
+# Don't show the error message, to avoid confusing it with a real error in the CI logs.
+echo "Test passed: Compilation failed with the expected error message"
 exit 0

--- a/tests/mr/device/adaptor_tests.cpp
+++ b/tests/mr/device/adaptor_tests.cpp
@@ -16,6 +16,7 @@
 
 #include "../../byte_literals.hpp"
 
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/device/aligned_resource_adaptor.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
@@ -29,8 +30,6 @@
 #include <rmm/mr/device/tracking_resource_adaptor.hpp>
 #include <rmm/mr/is_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
-
-#include <cuda/memory_resource>
 
 #include <gtest/gtest.h>
 

--- a/tests/mr/device/cuda_async_view_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_view_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,9 @@
  */
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/cuda_async_view_memory_resource.hpp>
-
-#include <cuda/memory_resource>
 
 #include <gtest/gtest.h>
 

--- a/tests/mr/device/mr_ref_multithreaded_tests.cpp
+++ b/tests/mr/device/mr_ref_multithreaded_tests.cpp
@@ -24,8 +24,6 @@
 #include <rmm/mr/device/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/memory_resource>
-
 #include <gtest/gtest.h>
 
 #include <thread>

--- a/tests/mr/device/mr_ref_test.hpp
+++ b/tests/mr/device/mr_ref_test.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,6 @@
 #include <rmm/mr/device/system_memory_resource.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
-
-#include <cuda/memory_resource>
 
 #include <gtest/gtest.h>
 

--- a/tests/mr/device/mr_ref_tests.cpp
+++ b/tests/mr/device/mr_ref_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
-
-#include <cuda/memory_resource>
 
 #include <gtest/gtest.h>
 

--- a/tests/mr/host/mr_ref_tests.cpp
+++ b/tests/mr/host/mr_ref_tests.cpp
@@ -17,11 +17,11 @@
 #include "../../byte_literals.hpp"
 
 #include <rmm/aligned.hpp>
+#include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/mr/host/new_delete_resource.hpp>
 #include <rmm/mr/host/pinned_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
## Description
Closes #1783.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
