### PR TITLE
Set mempool hw_decompress flag if driver supports it

### DIFF
--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -53,7 +53,6 @@ cache:
       - ${{ compiler("cxx") }}
       - ${{ compiler("cuda") }}
       - cuda-version =${{ cuda_version }}
-      - cuda-driver-dev
       - ${{ stdlib("c") }}
     host:
       - rapids-logger =0.1
@@ -104,6 +103,7 @@ outputs:
     requirements:
       build:
         - cmake ${{ cmake_version }}
+        - cuda-driver-dev
         - ${{ stdlib("c") }}  # this is here to help with overlinking errors against libm.so.6 and friends
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -102,6 +102,8 @@ outputs:
       script: cmake --install build --component testing
       dynamic_linking:
         overlinking_behavior: "error"
+        missing_dso_allowlist:
+          - "libcuda.so.1"
     requirements:
       build:
         - cmake ${{ cmake_version }}

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -53,6 +53,7 @@ cache:
       - ${{ compiler("cxx") }}
       - ${{ compiler("cuda") }}
       - cuda-version =${{ cuda_version }}
+      - cuda-driver-dev
       - ${{ stdlib("c") }}
     host:
       - rapids-logger =0.1

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -56,6 +56,8 @@ cache:
       - ${{ stdlib("c") }}
     host:
       - rapids-logger =0.1
+      - if: cuda_major != "11"
+        then: cuda-driver-dev
 
 outputs:
   - package:
@@ -106,7 +108,8 @@ outputs:
         - ${{ stdlib("c") }}  # this is here to help with overlinking errors against libm.so.6 and friends
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}
-        - cuda-driver-dev
+        - if: cuda_major != "11"
+          then: cuda-driver-dev
         - cuda-version =${{ cuda_version }}
         - if: cuda_major == "11"
           then: cudatoolkit
@@ -115,7 +118,6 @@ outputs:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("librmm", exact=True) }}
         - rapids-logger =0.1
-        - cuda-compat-impl
         - if: cuda_major == "11"
           then: cudatoolkit
           else: cuda-cudart

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -115,7 +115,7 @@ outputs:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("librmm", exact=True) }}
         - rapids-logger =0.1
-        - cuda-driver-dev
+        - cuda-compat
         - if: cuda_major == "11"
           then: cudatoolkit
           else: cuda-cudart

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -107,6 +107,7 @@ outputs:
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}
         - cuda-driver-dev
+        - cuda-compat
         - cuda-version =${{ cuda_version }}
         - if: cuda_major == "11"
           then: cudatoolkit

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -116,6 +116,7 @@ outputs:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("librmm", exact=True) }}
         - rapids-logger =0.1
+        - cuda-driver-dev
         - cuda-compat
         - if: cuda_major == "11"
           then: cudatoolkit

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -103,10 +103,10 @@ outputs:
     requirements:
       build:
         - cmake ${{ cmake_version }}
-        - cuda-driver-dev
         - ${{ stdlib("c") }}  # this is here to help with overlinking errors against libm.so.6 and friends
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}
+        - cuda-driver-dev
         - cuda-version =${{ cuda_version }}
         - if: cuda_major == "11"
           then: cudatoolkit
@@ -115,6 +115,7 @@ outputs:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("librmm", exact=True) }}
         - rapids-logger =0.1
+        - cuda-driver-dev
         - if: cuda_major == "11"
           then: cudatoolkit
           else: cuda-cudart

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -107,7 +107,6 @@ outputs:
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}
         - cuda-driver-dev
-        - cuda-compat
         - cuda-version =${{ cuda_version }}
         - if: cuda_major == "11"
           then: cudatoolkit
@@ -116,8 +115,7 @@ outputs:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("librmm", exact=True) }}
         - rapids-logger =0.1
-        - cuda-driver-dev
-        - cuda-compat
+        - cuda-compat-impl
         - if: cuda_major == "11"
           then: cudatoolkit
           else: cuda-cudart

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,7 +84,7 @@ endfunction()
 # stream
 function(ConfigureTest TEST_NAME)
 
-  set(options)
+  set(options OPTIONAL LINK_DRIVER)
   set(one_value CUDART GPUS PERCENT)
   set(multi_value)
   cmake_parse_arguments(_RMM_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
@@ -110,12 +110,17 @@ function(ConfigureTest TEST_NAME)
   # Test with legacy default stream.
   ConfigureTestInternal(${TEST_NAME} ${_RMM_TEST_UNPARSED_ARGUMENTS})
   target_link_libraries(${TEST_NAME} PRIVATE ${cudart_link_libs})
-
+  if(_RMM_TEST_LINK_DRIVER)
+    target_link_libraries(${TEST_NAME} PRIVATE CUDA::cuda_driver)
+  endif()
   # Test with per-thread default stream.
   string(REGEX REPLACE "_TEST$" "_PTDS_TEST" PTDS_TEST_NAME "${TEST_NAME}")
   ConfigureTestInternal("${PTDS_TEST_NAME}" ${_RMM_TEST_UNPARSED_ARGUMENTS})
   target_compile_definitions("${PTDS_TEST_NAME}" PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
   target_link_libraries(${PTDS_TEST_NAME} PRIVATE ${cudart_link_libs})
+  if(_RMM_TEST_LINK_DRIVER)
+    target_link_libraries(${PTDS_TEST_NAME} PRIVATE CUDA::cuda_driver)
+  endif()
 
   foreach(name ${TEST_NAME} ${PTDS_TEST_NAME} ${NS_TEST_NAME})
     rapids_test_add(
@@ -141,10 +146,10 @@ ConfigureTest(ADAPTOR_TEST mr/device/adaptor_tests.cpp)
 ConfigureTest(POOL_MR_TEST mr/device/pool_mr_tests.cpp GPUS 1 PERCENT 100)
 
 # cuda_async mr tests
-ConfigureTest(CUDA_ASYNC_MR_STATIC_CUDART_TEST mr/device/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60
-              CUDART STATIC)
-ConfigureTest(CUDA_ASYNC_MR_SHARED_CUDART_TEST mr/device/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60
-              CUDART SHARED)
+ConfigureTest(CUDA_ASYNC_MR_STATIC_CUDART_TEST mr/device/cuda_async_mr_tests.cpp LINK_DRIVER GPUS 1
+              PERCENT 60 CUDART STATIC)
+ConfigureTest(CUDA_ASYNC_MR_SHARED_CUDART_TEST mr/device/cuda_async_mr_tests.cpp LINK_DRIVER GPUS 1
+              PERCENT 60 CUDART SHARED)
 
 # thrust allocator tests
 ConfigureTest(THRUST_ALLOCATOR_TEST mr/device/thrust_allocator_tests.cu GPUS 1 PERCENT 60)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,11 +145,13 @@ ConfigureTest(ADAPTOR_TEST mr/device/adaptor_tests.cpp)
 # pool mr tests
 ConfigureTest(POOL_MR_TEST mr/device/pool_mr_tests.cpp GPUS 1 PERCENT 100)
 
+ConfigureTest(HWDECOMPRESS_TEST mr/device/hwdecompress_tests.cpp LINK_DRIVER)
+
 # cuda_async mr tests
-ConfigureTest(CUDA_ASYNC_MR_STATIC_CUDART_TEST mr/device/cuda_async_mr_tests.cpp LINK_DRIVER GPUS 1
-              PERCENT 60 CUDART STATIC)
-ConfigureTest(CUDA_ASYNC_MR_SHARED_CUDART_TEST mr/device/cuda_async_mr_tests.cpp LINK_DRIVER GPUS 1
-              PERCENT 60 CUDART SHARED)
+ConfigureTest(CUDA_ASYNC_MR_STATIC_CUDART_TEST mr/device/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60
+              CUDART STATIC)
+ConfigureTest(CUDA_ASYNC_MR_SHARED_CUDART_TEST mr/device/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60
+              CUDART SHARED)
 
 # thrust allocator tests
 ConfigureTest(THRUST_ALLOCATOR_TEST mr/device/thrust_allocator_tests.cu GPUS 1 PERCENT 60)

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -67,6 +67,21 @@ TEST_F(AsyncMRTest, DifferentPoolsUnequal)
   EXPECT_FALSE(mr1.is_equal(mr2));
 }
 
+TEST_F(AsyncMRTest, HWDecompressEnabled)
+{
+  const auto pool_init_size{100};
+  cuda_async_mr mr{pool_init_size};
+  void* ptr = mr.allocate(pool_init_size);
+  int driver_version{};
+  RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
+  auto const min_hw_decompress_version{12080};
+  if (driver_version >= min_hw_decompress_version) {
+    // TODO: check allocated property includes support for hw compression.
+  }
+  mr.deallocate(ptr, pool_init_size);
+  RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
 class AsyncMRFabricTest : public AsyncMRTest {
   void SetUp() override
   {

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -68,27 +68,6 @@ TEST_F(AsyncMRTest, DifferentPoolsUnequal)
   EXPECT_FALSE(mr1.is_equal(mr2));
 }
 
-TEST_F(AsyncMRTest, HWDecompressEnabled)
-{
-  const auto pool_init_size{100};
-  cuda_async_mr mr{pool_init_size};
-  void* ptr = mr.allocate(pool_init_size);
-  int driver_version{};
-  RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
-  auto const min_hw_decompress_version{12080};
-  if (driver_version >= min_hw_decompress_version) {
-    bool is_capable{};
-    auto err = cuPointerGetAttribute(static_cast<void*>(&is_capable),
-                                     CU_POINTER_ATTRIBUTE_IS_HW_DECOMPRESS_CAPABLE,
-                                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-                                     reinterpret_cast<CUdeviceptr>(ptr));
-    EXPECT_EQ(err, CUDA_SUCCESS);
-    EXPECT_TRUE(is_capable);
-  }
-  mr.deallocate(ptr, pool_init_size);
-  RMM_CUDA_TRY(cudaDeviceSynchronize());
-}
-
 class AsyncMRFabricTest : public AsyncMRTest {
   void SetUp() override
   {

--- a/tests/mr/device/cuda_async_mr_tests.cpp
+++ b/tests/mr/device/cuda_async_mr_tests.cpp
@@ -17,7 +17,6 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/device/cuda_async_memory_resource.hpp>
 
-#include <cuda.h>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>

--- a/tests/mr/device/hwdecompress_tests.cpp
+++ b/tests/mr/device/hwdecompress_tests.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/device/cuda_async_memory_resource.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include <gtest/gtest.h>
+
+namespace rmm::test {
+namespace {
+
+class HWDecompressTest : public ::testing::Test {
+ protected:
+  static void check_decompress_capable(void* ptr)
+  {
+    int driver_version{};
+    RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
+    auto const min_hw_decompress_version{12080};
+    if (driver_version >= min_hw_decompress_version) {
+      bool is_capable{};
+      auto err =
+        cuPointerGetAttribute(static_cast<void*>(&is_capable),
+                              CU_POINTER_ATTRIBUTE_IS_HW_DECOMPRESS_CAPABLE,
+                              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                              reinterpret_cast<CUdeviceptr>(ptr));
+      EXPECT_EQ(err, CUDA_SUCCESS);
+      EXPECT_TRUE(is_capable);
+    }
+  }
+};
+
+TEST_F(HWDecompressTest, CudaMalloc)
+{
+  const auto allocation_size{100};
+  rmm::mr::cuda_memory_resource mr{};
+  void* ptr = mr.allocate(allocation_size);
+  HWDecompressTest::check_decompress_capable(ptr);
+  mr.deallocate(ptr, allocation_size);
+  RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
+TEST_F(HWDecompressTest, CudaMallocAsync)
+{
+  if (!rmm::detail::runtime_async_alloc::is_supported()) {
+    GTEST_SKIP() << "Skipping since cudaMallocAsync not supported with this CUDA "
+                 << "driver/runtime version";
+  }
+  const auto pool_init_size{100};
+  rmm::mr::cuda_async_memory_resource mr{pool_init_size};
+  void* ptr = mr.allocate(pool_init_size);
+  HWDecompressTest::check_decompress_capable(ptr);
+  mr.deallocate(ptr, pool_init_size);
+  RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
+}  // namespace
+}  // namespace rmm::test

--- a/tests/mr/device/hwdecompress_tests.cpp
+++ b/tests/mr/device/hwdecompress_tests.cpp
@@ -34,6 +34,7 @@ class HWDecompressTest : public ::testing::Test {
     RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
     auto const min_hw_decompress_version{12080};
     if (driver_version >= min_hw_decompress_version) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
       bool is_capable{};
       auto err =
         cuPointerGetAttribute(static_cast<void*>(&is_capable),
@@ -42,6 +43,7 @@ class HWDecompressTest : public ::testing::Test {
                               reinterpret_cast<CUdeviceptr>(ptr));
       EXPECT_EQ(err, CUDA_SUCCESS);
       EXPECT_TRUE(is_capable);
+#endif
     }
   }
 };


### PR DESCRIPTION
## Description

If the driver supports the flag, unconditionally set the async memory pool usage property to include a request to support HW decompression.

- Closes #1849

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
