### PR TITLE
Embed `__FILE__` as C-string for prefix replacement

### DIFF
--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -24,6 +24,7 @@
 #include <exception>
 #include <iostream>
 #include <string>
+#include <type_traits>
 
 #define STRINGIFY_DETAIL(x) #x
 #define RMM_STRINGIFY(x)    STRINGIFY_DETAIL(x)

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -57,13 +57,14 @@
   GET_RMM_EXPECTS_MACRO(__VA_ARGS__, RMM_EXPECTS_3, RMM_EXPECTS_2) \
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
-#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                                 \
-  do {                                                                                      \
-    static_assert(std::is_base_of_v<std::exception, _exception_type>);                      \
-    /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                          \
-    (!!(_condition)) ? static_cast<void>(0)                                                 \
-                 : throw _exception_type{std::string{"RMM failure at: "} + __FILE__ + ":" + \
-                                         RMM_STRINGIFY(__LINE__) + ": " + _reason};         \
+#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                    \
+  do {                                                                         \
+    static_assert(std::is_base_of_v<std::exception, _exception_type>);         \
+    /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                             \
+    (!!(_condition)) ? static_cast<void>(0)                                    \
+                     : throw _exception_type{                                  \
+                           std::string{"RMM failure at: "} + __FILE__ + ":" +  \
+                           RMM_STRINGIFY(__LINE__) + ": " + _reason};          \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -55,12 +55,13 @@
   GET_RMM_EXPECTS_MACRO(__VA_ARGS__, RMM_EXPECTS_3, RMM_EXPECTS_2) \
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
-#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                             \
-  (!!(_condition)) ? static_cast<void>(0)                                               \
-                   : throw _exception_type /*NOLINT(bugprone-macro-parentheses)*/       \
-  {                                                                                     \
-    std::string("RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": ") + _reason \
-  }
+#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                    \
+  do {                                                                          \
+    static_assert(std::is_base_of_v<std::exception, _exception_type>);          \
+    (_condition) ? static_cast<void>(0)                                         \
+                 : throw _exception_type /*NOLINT(bugprone-macro-parentheses)*/ \
+      {"CUDF failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason}; \
+  } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 
 /**

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -57,13 +57,12 @@
   GET_RMM_EXPECTS_MACRO(__VA_ARGS__, RMM_EXPECTS_3, RMM_EXPECTS_2) \
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
-#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                     \
-  do {                                                                          \
-    static_assert(std::is_base_of_v<std::exception, _exception_type>);          \
-    (_condition) ? static_cast<void>(0)                                         \
-                 : throw _exception_type{                                       \
-      "RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason      \
-    };                                                                          \
+#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                         \
+  do {                                                                              \
+    static_assert(std::is_base_of_v<std::exception, _exception_type>);              \
+    (_condition) ? static_cast<void>(0)                                             \
+                 : throw _exception_type{"RMM failure at: " __FILE__                \
+                                         ":" RMM_STRINGIFY(__LINE__) ": " _reason}; \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -57,14 +57,13 @@
   GET_RMM_EXPECTS_MACRO(__VA_ARGS__, RMM_EXPECTS_3, RMM_EXPECTS_2) \
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
-#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                    \
-  do {                                                                         \
-    static_assert(std::is_base_of_v<std::exception, _exception_type>);         \
-    /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                             \
-    (!!(_condition)) ? static_cast<void>(0)                                    \
-                     : throw _exception_type{                                  \
-                           std::string{"RMM failure at: "} + __FILE__ + ":" +  \
-                           RMM_STRINGIFY(__LINE__) + ": " + _reason};          \
+#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                                     \
+  do {                                                                                          \
+    static_assert(std::is_base_of_v<std::exception, _exception_type>);                          \
+    /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                              \
+    (!!(_condition)) ? static_cast<void>(0)                                                     \
+                     : throw _exception_type{std::string{"RMM failure at: "} + __FILE__ + ":" + \
+                                             RMM_STRINGIFY(__LINE__) + ": " + _reason};         \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -61,8 +61,8 @@
   do {                                                                                      \
     static_assert(std::is_base_of_v<std::exception, _exception_type>);                      \
     (_condition) ? static_cast<void>(0)                                                     \
-                 : throw _exception_type{ std::string{"RMM failure at: "} + __FILE__ +      \
-                                         ":" + RMM_STRINGIFY(__LINE__) + ": " + _reason };  \
+                 : throw _exception_type{std::string{"RMM failure at: "} + __FILE__ + ":" + \
+                                         RMM_STRINGIFY(__LINE__) + ": " + _reason};         \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 
@@ -82,9 +82,12 @@
   GET_RMM_FAIL_MACRO(__VA_ARGS__, RMM_FAIL_2, RMM_FAIL_1) \
   (__VA_ARGS__)
 #define GET_RMM_FAIL_MACRO(_1, _2, NAME, ...) NAME
-#define RMM_FAIL_2(_what, _exception_type)       \
-  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/ \
-  throw _exception_type{ std::string{"RMM failure at:"} + __FILE__ + ":" + RMM_STRINGIFY(__LINE__) + ": " + _what }
+#define RMM_FAIL_2(_what, _exception_type)                                                   \
+  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                             \
+  throw _exception_type                                                                      \
+  {                                                                                          \
+    std::string{"RMM failure at:"} + __FILE__ + ":" + RMM_STRINGIFY(__LINE__) + ": " + _what \
+  }
 #define RMM_FAIL_1(_what) RMM_FAIL_2(_what, rmm::logic_error)
 
 /**

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -62,7 +62,7 @@
     static_assert(std::is_base_of_v<std::exception, _exception_type>);          \
     (_condition) ? static_cast<void>(0)                                         \
                  : throw _exception_type /*NOLINT(bugprone-macro-parentheses)*/ \
-      {"CUDF failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason};  \
+      {"RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason};  \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -60,7 +60,7 @@
 #define RMM_EXPECTS_3(_condition, _reason, _exception_type)                                 \
   do {                                                                                      \
     static_assert(std::is_base_of_v<std::exception, _exception_type>);                      \
-  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                            \
+    /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                          \
     (!!(_condition)) ? static_cast<void>(0)                                                 \
                  : throw _exception_type{std::string{"RMM failure at: "} + __FILE__ + ":" + \
                                          RMM_STRINGIFY(__LINE__) + ": " + _reason};         \

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -55,12 +55,12 @@
   GET_RMM_EXPECTS_MACRO(__VA_ARGS__, RMM_EXPECTS_3, RMM_EXPECTS_2) \
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
-#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                    \
+#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                     \
   do {                                                                          \
     static_assert(std::is_base_of_v<std::exception, _exception_type>);          \
     (_condition) ? static_cast<void>(0)                                         \
                  : throw _exception_type /*NOLINT(bugprone-macro-parentheses)*/ \
-      {"CUDF failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason}; \
+      {"CUDF failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason};  \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -21,6 +21,7 @@
 #include <cuda_runtime_api.h>
 
 #include <cassert>
+#include <exception>
 #include <iostream>
 #include <string>
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -61,7 +61,7 @@
   do {                                                                              \
     static_assert(std::is_base_of_v<std::exception, _exception_type>);              \
     (_condition) ? static_cast<void>(0)                                             \
-                 : throw _exception_type{"RMM failure at: " __FILE__                \
+                 : throw _exception_type {"RMM failure at: " __FILE__               \
                                          ":" RMM_STRINGIFY(__LINE__) ": " _reason}; \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -82,7 +82,7 @@
   GET_RMM_FAIL_MACRO(__VA_ARGS__, RMM_FAIL_2, RMM_FAIL_1) \
   (__VA_ARGS__)
 #define GET_RMM_FAIL_MACRO(_1, _2, NAME, ...) NAME
-#define RMM_FAIL_2(_what, _exception_type)      \
+#define RMM_FAIL_2(_what, _exception_type)       \
   /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/ \
   throw _exception_type { "RMM failure at:" __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what }
 #define RMM_FAIL_1(_what) RMM_FAIL_2(_what, rmm::logic_error)

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -60,8 +60,8 @@
 #define RMM_EXPECTS_3(_condition, _reason, _exception_type)                                 \
   do {                                                                                      \
     static_assert(std::is_base_of_v<std::exception, _exception_type>);                      \
-  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                                \
-    (!!(_condition)) ? static_cast<void>(0)                                                     \
+  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                            \
+    (!!(_condition)) ? static_cast<void>(0)                                                 \
                  : throw _exception_type{std::string{"RMM failure at: "} + __FILE__ + ":" + \
                                          RMM_STRINGIFY(__LINE__) + ": " + _reason};         \
   } while (0)

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -82,10 +82,9 @@
   GET_RMM_FAIL_MACRO(__VA_ARGS__, RMM_FAIL_2, RMM_FAIL_1) \
   (__VA_ARGS__)
 #define GET_RMM_FAIL_MACRO(_1, _2, NAME, ...) NAME
-#define RMM_FAIL_2(_what, _exception_type)                                                         \
-  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                                   \
-  throw _exception_type{std::string{"RMM failure at:" __FILE__ ":" RMM_STRINGIFY(__LINE__) ": "} + \
-                        _what};
+#define RMM_FAIL_2(_what, _exception_type)      \
+  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/ \
+  throw _exception_type { "RMM failure at:" __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what }
 #define RMM_FAIL_1(_what) RMM_FAIL_2(_what, rmm::logic_error)
 
 /**

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -60,7 +60,8 @@
 #define RMM_EXPECTS_3(_condition, _reason, _exception_type)                                 \
   do {                                                                                      \
     static_assert(std::is_base_of_v<std::exception, _exception_type>);                      \
-    (_condition) ? static_cast<void>(0)                                                     \
+  /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/                                                \
+    (!!(_condition)) ? static_cast<void>(0)                                                     \
                  : throw _exception_type{std::string{"RMM failure at: "} + __FILE__ + ":" + \
                                          RMM_STRINGIFY(__LINE__) + ": " + _reason};         \
   } while (0)

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -61,8 +61,9 @@
   do {                                                                          \
     static_assert(std::is_base_of_v<std::exception, _exception_type>);          \
     (_condition) ? static_cast<void>(0)                                         \
-                 : throw _exception_type /*NOLINT(bugprone-macro-parentheses)*/ \
-      {"RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason};   \
+                 : throw _exception_type{                                       \
+      "RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason      \
+    };                                                                          \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -57,12 +57,12 @@
   GET_RMM_EXPECTS_MACRO(__VA_ARGS__, RMM_EXPECTS_3, RMM_EXPECTS_2) \
   (__VA_ARGS__)
 #define GET_RMM_EXPECTS_MACRO(_1, _2, _3, NAME, ...) NAME
-#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                         \
-  do {                                                                              \
-    static_assert(std::is_base_of_v<std::exception, _exception_type>);              \
-    (_condition) ? static_cast<void>(0)                                             \
-                 : throw _exception_type {"RMM failure at: " __FILE__               \
-                                         ":" RMM_STRINGIFY(__LINE__) ": " _reason}; \
+#define RMM_EXPECTS_3(_condition, _reason, _exception_type)                                 \
+  do {                                                                                      \
+    static_assert(std::is_base_of_v<std::exception, _exception_type>);                      \
+    (_condition) ? static_cast<void>(0)                                                     \
+                 : throw _exception_type{ std::string{"RMM failure at: "} + __FILE__ +      \
+                                         ":" + RMM_STRINGIFY(__LINE__) + ": " + _reason };  \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 
@@ -84,7 +84,7 @@
 #define GET_RMM_FAIL_MACRO(_1, _2, NAME, ...) NAME
 #define RMM_FAIL_2(_what, _exception_type)       \
   /*NOLINTNEXTLINE(bugprone-macro-parentheses)*/ \
-  throw _exception_type { "RMM failure at:" __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _what }
+  throw _exception_type{ std::string{"RMM failure at:"} + __FILE__ + ":" + RMM_STRINGIFY(__LINE__) + ": " + _what }
 #define RMM_FAIL_1(_what) RMM_FAIL_2(_what, rmm::logic_error)
 
 /**

--- a/include/rmm/detail/error.hpp
+++ b/include/rmm/detail/error.hpp
@@ -62,7 +62,7 @@
     static_assert(std::is_base_of_v<std::exception, _exception_type>);          \
     (_condition) ? static_cast<void>(0)                                         \
                  : throw _exception_type /*NOLINT(bugprone-macro-parentheses)*/ \
-      {"RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason};  \
+      {"RMM failure at: " __FILE__ ":" RMM_STRINGIFY(__LINE__) ": " _reason};   \
   } while (0)
 #define RMM_EXPECTS_2(_condition, _reason) RMM_EXPECTS_3(_condition, _reason, rmm::logic_error)
 


### PR DESCRIPTION
## Description

Recently PR ( https://github.com/rapidsai/rmm/pull/1844 ) changed how error messages were generated when pointing to a particular file and line number. In particular they changed from using the typical C-string (`const char*`), which is `\0` terminated, to a C++ `std::string` object, which is not `\0` terminated. This change in turn was picked up when RMM headers are used to compile libraries (like cuDF) including file paths in strings that are not `\0` terminated.

Conda in turn would detect the paths in these error messages and attempt to fix them as part of the prefix replacement process. When Conda did the prefix replacement would add an additional `\0` terminating character to string. However as the strings are now `std::string` based which lack `\0` terminating characters the final string written out by Conda would be one byte longer. This could mean overwriting other text data in the library or writing outside the text block. This is known bug in Conda ( https://github.com/conda/conda-build/issues/1674 ).

Thus when cuDF started building with the aforementioned RMM change last week, the packages it created lacked had file paths in error messages lacking the `\0` terminating character. These in turn would be inadvertently corrupted by Conda when installing the packages in an environment. This led to a quite hairy bug detailed in issue ( https://github.com/rapidsai/cudf/issues/18251 ).

To correct this issue, we drop the `std::string` constructor that was added in the aforementioned PR. More specifically we adapted the following code from cuDF's [`CUDF_EXPECTS_3`]( https://github.com/rapidsai/cudf/blob/8041ac8e370b092229841508fdfd1efb88fef034/cpp/include/cudf/utilities/error.hpp#L186-L192 ) and [`CUDF_FAIL_2`]( https://github.com/rapidsai/cudf/blob/86eb82399f0e056731e2062dc95a4583c26e9af1/cpp/include/cudf/utilities/error.hpp#L225-L227 ), which still uses a C-style string. Also to address the need for runtime generation of some errors. We use `std::string` for only an initial snippet of the string and add other contents like the `__FILE__` after. This keeps the latter bits as C-style strings.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
