### PR TITLE
Fix dependencies.yaml for update-version.sh

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -218,17 +218,17 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - rmm=25.4.*,>=0.0.0a0
+          - rmm==25.4.*,>=0.0.0a0
   depends_on_librmm_tests:
     common:
       - output_types: conda
         packages:
-          - librmm-tests=25.4.*,>=0.0.0a0
+          - librmm-tests==25.4.*,>=0.0.0a0
   depends_on_librmm_example:
     common:
       - output_types: conda
         packages:
-          - librmm-example=25.4.*,>=0.0.0a0
+          - librmm-example==25.4.*,>=0.0.0a0
   checks:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
Updates several `dependencies.yaml` entries to match the others in the file which allows the `update-version.sh` script to work correctly.
