### PR TITLE
[WIP, RFC] Use relative paths for `__FILE__`

### DIFF
--- a/conda/recipes/rmm/recipe.yaml
+++ b/conda/recipes/rmm/recipe.yaml
@@ -21,6 +21,14 @@ build:
   string: cuda${{ cuda_major }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}
   script:
     content:
+        # Remove `-fdebug-prefix-map` line from CFLAGS and CXXFLAGS so the
+        # incrementing version number in the compile line doesn't break the
+        # cache
+        set -x
+        export CFLAGS=$(echo $CFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+        export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+        set +x
+
       - ./build.sh -v clean rmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
     secrets:
       - AWS_ACCESS_KEY_ID

--- a/conda/recipes/rmm/recipe.yaml
+++ b/conda/recipes/rmm/recipe.yaml
@@ -29,6 +29,13 @@ build:
         export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         set +x
 
+        # Use relative paths for `__FILE__` by passing `-fmacro-prefix-map`
+        # https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Preprocessor-Options.html#index-fmacro-prefix-map
+        set -x
+        export CFLAGS="${CFLAGS} -fmacro-prefix-map=$(pwd)/=''"
+        export CXXFLAGS="${CXXFLAGS} -fmacro-prefix-map=$(pwd)/=''"
+        set +x
+
       - ./build.sh -v clean rmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
     secrets:
       - AWS_ACCESS_KEY_ID

--- a/conda/recipes/rmm/recipe.yaml
+++ b/conda/recipes/rmm/recipe.yaml
@@ -20,23 +20,23 @@ source:
 build:
   string: cuda${{ cuda_major }}_py${{ py_buildstring }}_${{ date_string }}_${{ head_rev }}
   script:
-    content:
-        # Remove `-fdebug-prefix-map` line from CFLAGS and CXXFLAGS so the
-        # incrementing version number in the compile line doesn't break the
-        # cache
-        set -x
-        export CFLAGS=$(echo $CFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
-        export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
-        set +x
+    content: |
+      # Remove `-fdebug-prefix-map` line from CFLAGS and CXXFLAGS so the
+      # incrementing version number in the compile line doesn't break the
+      # cache
+      set -x
+      export CFLAGS=$(echo $CFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+      export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+      set +x
 
-        # Use relative paths for `__FILE__` by passing `-fmacro-prefix-map`
-        # https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Preprocessor-Options.html#index-fmacro-prefix-map
-        set -x
-        export CFLAGS="${CFLAGS} -fmacro-prefix-map=$(pwd)/=''"
-        export CXXFLAGS="${CXXFLAGS} -fmacro-prefix-map=$(pwd)/=''"
-        set +x
+      # Use relative paths for `__FILE__` by passing `-fmacro-prefix-map`
+      # https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Preprocessor-Options.html#index-fmacro-prefix-map
+      set -x
+      export CFLAGS="${CFLAGS} -fmacro-prefix-map=$(pwd)/=''"
+      export CXXFLAGS="${CXXFLAGS} -fmacro-prefix-map=$(pwd)/=''"
+      set +x
 
-      - ./build.sh -v clean rmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
+      ./build.sh -v clean rmm --cmake-args=\"-DCMAKE_INSTALL_LIBDIR=lib\"
     secrets:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Description

Explore using [GCC's `-fmacro-prefix-map`]( https://gcc.gnu.org/onlinedocs/gcc-13.3.0/gcc/Preprocessor-Options.html#index-fmacro-prefix-map ) to remap `__FILE__` from absolute paths to source directory relative paths.

Related to issue: https://github.com/rapidsai/build-planning/issues/159

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
