### PR TITLE
Fix run export on cudatoolkit

### DIFF
--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -177,6 +177,8 @@ outputs:
         by_name:
           - cuda-version
           - librmm
+          - if: cuda_major == "11"
+            then: cudatoolkit
     about:
       homepage: ${{ load_from_file("python/librmm/pyproject.toml").project.urls.Homepage }}
       license: ${{ load_from_file("python/librmm/pyproject.toml").project.license.text | replace(" ", "-") }}


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
rmm nightlies are currently failing on CUDA 11.4 because CUDA 11 librmm-examples package is overconstrained.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
