### PR TITLE
Use strict priority for conda builds

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -32,7 +32,7 @@ rapids-telemetry-record build.log rattler-build build \
     --recipe conda/recipes/librmm \
     --experimental \
     --no-build-id \
-    --channel-priority disabled \
+    --channel-priority strict \
     --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
     "${RATTLER_CHANNELS[@]}"
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -36,7 +36,7 @@ rapids-telemetry-record build.log rattler-build build \
     --recipe conda/recipes/rmm \
     --experimental \
     --no-build-id \
-    --channel-priority disabled \
+    --channel-priority strict \
     --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
     -c "${CPP_CHANNEL}" \
     "${RATTLER_CHANNELS[@]}"


### PR DESCRIPTION
## Description
This PR enables strict priority in conda builds.

xref: https://github.com/rapidsai/build-planning/issues/84

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
