### PR TITLE
Set mempool hw_decompress flag if driver supports it

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,6 +96,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
+      matrix_type: nightly
   conda-python-build:
     needs: conda-cpp-build
     secrets: inherit
@@ -109,6 +110,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
+      matrix_type: nightly
   docs-build:
     needs: conda-python-build
     secrets: inherit
@@ -141,6 +143,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python
     with:
       build_type: pull-request
+      matrix_type: nightly
       script: ci/test_wheel.sh
   devcontainer:
     secrets: inherit

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -56,6 +56,8 @@ cache:
       - ${{ stdlib("c") }}
     host:
       - rapids-logger =0.1
+      - if: cuda_major != "11"
+        then: cuda-driver-dev
 
 outputs:
   - package:
@@ -100,12 +102,16 @@ outputs:
       script: cmake --install build --component testing
       dynamic_linking:
         overlinking_behavior: "error"
+        missing_dso_allowlist:
+          - "libcuda.so.1"
     requirements:
       build:
         - cmake ${{ cmake_version }}
         - ${{ stdlib("c") }}  # this is here to help with overlinking errors against libm.so.6 and friends
       host:
         - ${{ pin_subpackage("librmm", exact=True) }}
+        - if: cuda_major != "11"
+          then: cuda-driver-dev
         - cuda-version =${{ cuda_version }}
         - if: cuda_major == "11"
           then: cudatoolkit

--- a/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -65,6 +65,17 @@ class cuda_async_memory_resource final : public device_memory_resource {
   };
 
   /**
+   * @brief Flags for specifying memory pool usage.
+   *
+   * @note These values are exact copies from the runtime API. The only value so far is
+   * `cudaMemPoolCreateUsageHwDecompress`
+   */
+  enum class mempool_usage : unsigned short {
+    hw_decompress = 0x2,  ///< If set indicates that the memory can be used as a buffer for hardware
+                          ///< accelerated decompression.
+  };
+
+  /**
    * @brief Constructs a cuda_async_memory_resource with the optionally specified initial pool size
    * and release threshold.
    *
@@ -90,11 +101,16 @@ class cuda_async_memory_resource final : public device_memory_resource {
     RMM_EXPECTS(rmm::detail::runtime_async_alloc::is_supported(),
                 "cudaMallocAsync not supported with this CUDA driver/runtime version");
 
+    int driver_version{};
+    RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
     // Construct explicit pool
     cudaMemPoolProps pool_props{};
     pool_props.allocType   = cudaMemAllocationTypePinned;
     pool_props.handleTypes = static_cast<cudaMemAllocationHandleType>(
       export_handle_type.value_or(allocation_handle_type::none));
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 12080
+    pool_props.usage = static_cast<unsigned short>(mempool_usage::hw_decompress);
+#endif
     RMM_EXPECTS(
       rmm::detail::runtime_async_alloc::is_export_handle_type_supported(pool_props.handleTypes),
       "Requested IPC memory handle type not supported");
@@ -107,8 +123,6 @@ class cuda_async_memory_resource final : public device_memory_resource {
     // CUDA drivers before 11.5 have known incompatibilities with the async allocator.
     // We'll disable `cudaMemPoolReuseAllowOpportunistic` if cuda driver < 11.5.
     // See https://github.com/NVIDIA/spark-rapids/issues/4710.
-    int driver_version{};
-    RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
     constexpr auto min_async_version{11050};
     if (driver_version < min_async_version) {
       int disabled{0};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,7 +84,7 @@ endfunction()
 # stream
 function(ConfigureTest TEST_NAME)
 
-  set(options)
+  set(options OPTIONAL LINK_DRIVER)
   set(one_value CUDART GPUS PERCENT)
   set(multi_value)
   cmake_parse_arguments(_RMM_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
@@ -110,12 +110,17 @@ function(ConfigureTest TEST_NAME)
   # Test with legacy default stream.
   ConfigureTestInternal(${TEST_NAME} ${_RMM_TEST_UNPARSED_ARGUMENTS})
   target_link_libraries(${TEST_NAME} PRIVATE ${cudart_link_libs})
-
+  if(_RMM_TEST_LINK_DRIVER)
+    target_link_libraries(${TEST_NAME} PRIVATE CUDA::cuda_driver)
+  endif()
   # Test with per-thread default stream.
   string(REGEX REPLACE "_TEST$" "_PTDS_TEST" PTDS_TEST_NAME "${TEST_NAME}")
   ConfigureTestInternal("${PTDS_TEST_NAME}" ${_RMM_TEST_UNPARSED_ARGUMENTS})
   target_compile_definitions("${PTDS_TEST_NAME}" PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
   target_link_libraries(${PTDS_TEST_NAME} PRIVATE ${cudart_link_libs})
+  if(_RMM_TEST_LINK_DRIVER)
+    target_link_libraries(${PTDS_TEST_NAME} PRIVATE CUDA::cuda_driver)
+  endif()
 
   foreach(name ${TEST_NAME} ${PTDS_TEST_NAME} ${NS_TEST_NAME})
     rapids_test_add(
@@ -139,6 +144,8 @@ ConfigureTest(ADAPTOR_TEST mr/device/adaptor_tests.cpp)
 
 # pool mr tests
 ConfigureTest(POOL_MR_TEST mr/device/pool_mr_tests.cpp GPUS 1 PERCENT 100)
+
+ConfigureTest(HWDECOMPRESS_TEST mr/device/hwdecompress_tests.cpp LINK_DRIVER)
 
 # cuda_async mr tests
 ConfigureTest(CUDA_ASYNC_MR_STATIC_CUDART_TEST mr/device/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60

--- a/tests/mr/device/hwdecompress_tests.cpp
+++ b/tests/mr/device/hwdecompress_tests.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/device/cuda_async_memory_resource.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include <gtest/gtest.h>
+
+namespace rmm::test {
+namespace {
+
+class HWDecompressTest : public ::testing::Test {
+ protected:
+  static void check_decompress_capable(void* ptr)
+  {
+    int driver_version{};
+    RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
+    auto const min_hw_decompress_version{12080};
+    if (driver_version >= min_hw_decompress_version) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+      bool is_capable{};
+      auto err =
+        cuPointerGetAttribute(static_cast<void*>(&is_capable),
+                              CU_POINTER_ATTRIBUTE_IS_HW_DECOMPRESS_CAPABLE,
+                              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                              reinterpret_cast<CUdeviceptr>(ptr));
+      EXPECT_EQ(err, CUDA_SUCCESS);
+      EXPECT_TRUE(is_capable);
+#endif
+    }
+  }
+};
+
+TEST_F(HWDecompressTest, CudaMalloc)
+{
+  const auto allocation_size{100};
+  rmm::mr::cuda_memory_resource mr{};
+  void* ptr = mr.allocate(allocation_size);
+  HWDecompressTest::check_decompress_capable(ptr);
+  mr.deallocate(ptr, allocation_size);
+  RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
+TEST_F(HWDecompressTest, CudaMallocAsync)
+{
+  if (!rmm::detail::runtime_async_alloc::is_supported()) {
+    GTEST_SKIP() << "Skipping since cudaMallocAsync not supported with this CUDA "
+                 << "driver/runtime version";
+  }
+  const auto pool_init_size{100};
+  rmm::mr::cuda_async_memory_resource mr{pool_init_size};
+  void* ptr = mr.allocate(pool_init_size);
+  HWDecompressTest::check_decompress_capable(ptr);
+  mr.deallocate(ptr, pool_init_size);
+  RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
+}  // namespace
+}  // namespace rmm::test


### PR DESCRIPTION
## Description
If the driver supports the flag, unconditionally set the async memory pool usage property to include a request to support HW decompression.

This was attempted in #1854 and reverted in #1873. This second attempt tries to fix a driver compatibility issue recorded in #1872. Closes #1872, closes #1849.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
