### PR TITLE
Fixed documentation example for `DeviceBuffer.to_device`

### DIFF
--- a/python/rmm/docs/guide.md
+++ b/python/rmm/docs/guide.md
@@ -54,7 +54,7 @@ can be accessed via the `.size` and `.ptr` attributes respectively:
 >>> import rmm
 >>> import numpy as np
 >>> a = np.array([1, 2, 3], dtype='float64')
->>> buf = rmm.DeviceBuffer.to_device(a.view("int8"))  # to_device expects an 8-bit type or `bytes`
+>>> buf = rmm.DeviceBuffer.to_device(a.view("uint8"))  # to_device expects an unsigned 8-bit dtype
 >>> buf.size
 24
 ```


### PR DESCRIPTION
## Description

This fixes the example showing `rmm.DeviceBuffer.to_device` in the user guide by changing the dtype of the NumPy ndarray from `int8` to `uint8`.

Closes #1879

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
