### PR TITLE
Auto-sync draft PRs

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -2,4 +2,4 @@
 # https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/
 
 enabled: true
-auto_sync_draft: false
+auto_sync_draft: true


### PR DESCRIPTION
## Description
Currently draft PRs require `/ok to test`. There is a new requirement that this also needs a hash. Since RMM CI is very fast and there aren't very many developers, I would appreciate having lower friction for working on draft PRs and getting CI feedback before opening for review.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
