### PR TITLE
remove mkdir and test corresponding shared workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -148,12 +148,11 @@ jobs:
     secrets: inherit
     needs:
       - telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@add-mkdir-to-devcontainer-setup
     with:
       arch: '["amd64"]'
       cuda: '["12.8"]'
       build_command: |
-        mkdir -p telemetry-artifacts;
         sccache --zero-stats;
         build-all -DBUILD_BENCHMARKS=ON --verbose 2>&1 | tee telemetry-artifacts/build.log;
         sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -148,7 +148,7 @@ jobs:
     secrets: inherit
     needs:
       - telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@add-mkdir-to-devcontainer-setup
+    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-25.06
     with:
       arch: '["amd64"]'
       cuda: '["12.8"]'


### PR DESCRIPTION
## Description

This is a tiny cleanup PR to remove one line of vestigial code for mkdir that was moved into the shared workflow. This PR was used to test that functionality.