### PR TITLE
Download build artifacts from Github for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,6 +89,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_cpp.sh
+      package-name: rmm
       package-type: cpp
   wheel-build-python:
     needs: [telemetry-setup, wheel-build-cpp]
@@ -100,6 +101,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_python.sh
+      package-name: rmm
       package-type: python
   wheel-publish-cpp:
     needs: wheel-build-cpp

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -127,6 +127,7 @@ jobs:
       matrix_filter: group_by([.ARCH, (.CUDA_VER|split(".")|map(tonumber)|.[0])]) | map(max_by(.PY_VER|split(".")|map(tonumber)))
       build_type: pull-request
       script: ci/build_wheel_cpp.sh
+      package-name: rmm
       package-type: cpp
   wheel-build-python:
     needs: wheel-build-cpp
@@ -135,6 +136,7 @@ jobs:
     with:
       build_type: pull-request
       script: ci/build_wheel_python.sh
+      package-name: rmm
       package-type: python
   wheel-tests:
     needs: [wheel-build-python, changed-files]

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -4,8 +4,8 @@
 set -euo pipefail
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-logger "Create test conda environment"
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -14,7 +14,7 @@ rapids-generate-version > ./VERSION
 
 rapids-logger "Begin py build"
 
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 
 sccache --zero-stats
 

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 package_dir="python/librmm"
-wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
 
 source rapids-configure-sccache
 source rapids-date-string
@@ -20,12 +19,12 @@ sccache --zero-stats
 # Creates artifacts directory for telemetry
 source rapids-telemetry-setup
 
-rapids-telemetry-record build.log rapids-pip-retry wheel . -w "${wheel_dir}" -v --no-deps --disable-pip-version-check
+rapids-telemetry-record build.log rapids-pip-retry wheel . -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" -v --no-deps --disable-pip-version-check
 
 rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
-python -m wheel tags --platform any "${wheel_dir}"/* --remove
+python -m wheel tags --platform any "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"/* --remove
 
-../../ci/validate_wheel.sh "${wheel_dir}"
+../../ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 cpp "${wheel_dir}"
+RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 cpp "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 package_name="rmm"
 package_dir="python/rmm"
 
-wheel_dir=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}
-
 source rapids-configure-sccache
 source rapids-date-string
 
@@ -16,7 +14,7 @@ rapids-generate-version > ./VERSION
 pushd "${package_dir}"
 
 RAPIDS_PY_CUDA_SUFFIX=$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")
-CPP_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp /tmp/librmm_dist)
+CPP_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
 
 # ensure 'rmm' wheel builds always use the 'librmm' just built in the same CI run
 #
@@ -37,13 +35,13 @@ rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 EXCLUDE_ARGS=(
   --exclude "librapids_logger.so"
 )
-python -m auditwheel repair "${EXCLUDE_ARGS[@]}" -w "${wheel_dir}" dist/*
+python -m auditwheel repair "${EXCLUDE_ARGS[@]}" -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" dist/*
 
-../../ci/validate_wheel.sh "${wheel_dir}"
+../../ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${wheel_dir}"
+RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-absolute_wheel_dir=$(realpath "${wheel_dir}")
+absolute_wheel_dir=$(realpath "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}")
 # switch back to the root of the repo and check symbol visibility
 popd
 ci/check_symbols.sh "$(echo ${absolute_wheel_dir}/rmm_*.whl)"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 
 . /opt/conda/etc/profile.d/conda.sh
 
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}/
 mkdir -p "${RAPIDS_TESTS_DIR}"
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -11,8 +11,8 @@ rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-s3 cpp)
-PYTHON_CHANNEL=$(rapids-download-conda-from-s3 python)
+CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+PYTHON_CHANNEL=$(rapids-download-conda-from-github python)
 
 rapids-dependency-file-generator \
   --output conda \

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -4,9 +4,8 @@
 set -eou pipefail
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
-WHEELHOUSE="${PWD}/dist/"
-RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 cpp "${WHEELHOUSE}"
-RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-s3 python "${WHEELHOUSE}"
+CPP_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+PYTHON_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rmm_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github python)
 
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python ./constraints.txt
@@ -15,7 +14,7 @@ rapids-generate-pip-constraints test_python ./constraints.txt
 rapids-pip-retry install \
     -v \
     --constraint ./constraints.txt \
-    "$(echo "${WHEELHOUSE}"/librmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)" \
-    "$(echo "${WHEELHOUSE}"/rmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)[test]"
+    "$(echo "${CPP_WHEELHOUSE}"/librmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)" \
+    "$(echo "${PYTHON_WHEELHOUSE}"/rmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)[test]"
 
 python -m pytest ./python/rmm/rmm/tests


### PR DESCRIPTION
## Description
This work is towards moving build artifacts from `downloads.rapids.ai` to Github Artifact Store (see https://github.com/rapidsai/ops/issues/2982)

Updates conda and wheel artifact download source from S3 to GitHub across CI scripts, wherever applicable. 

Uses dynamic temporary paths for wheel downloads returned by `rapids-download-wheels-from-github` instead of using fixed directories, to streamline wheel downloads in the same way as conda downloads. 

Removes the usage of the `wheel-dir` variable, to directly use the env-var `RAPIDS_WHEEL_BLD_OUTPUT_DIR` for wheel build location

Also updates CI workflows to follow `package-name` convention between wheel build and wheel publish jobs. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
