### PR TITLE
Update Readme for the logging `set_level`

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ of more detailed logging. The default is `INFO`. Available levels are `TRACE`, `
 
 Note that to see logging below the `INFO` level, the application must also set the logging level at
 run time. C++ applications must must call `rmm::default_logger().set_level()`, for example to enable all
-levels of logging down to `TRACE`, call `rmm::default_logger().set_level(spdlog::level::trace)` (and compile
+levels of logging down to `TRACE`, call `rmm::default_logger().set_level(rapids_logger::level_enum::trace)` (and compile
 librmm with `-DRMM_LOGGING_LEVEL=TRACE`). Python applications must call `rmm.set_logging_level()`,
 for example to enable all levels of logging down to `TRACE`, call `rmm.set_logging_level("trace")`
 (and compile the RMM Python module with `-DRMM_LOGGING_LEVEL=TRACE`).


### PR DESCRIPTION
## Description
This change updates the README for RMM logging details. The `set_level` call now depends on rapids_logger instead of the old SPD. It's a doc-only, non-breaking change.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
