### PR TITLE
Use auditwheel to properly retag the wheel

### DIFF
--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -26,6 +26,7 @@ rapids-telemetry-record build.log rapids-pip-retry wheel . -w "${dist_dir}" -v -
 rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 python -m auditwheel repair \
+    --exclude librapids_logger.so \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     ${dist_dir}/*
 

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -20,11 +20,14 @@ sccache --zero-stats
 # Creates artifacts directory for telemetry
 source rapids-telemetry-setup
 
-rapids-telemetry-record build.log rapids-pip-retry wheel . -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" -v --no-deps --disable-pip-version-check
+dist_dir="$(mktemp -d)"
+rapids-telemetry-record build.log rapids-pip-retry wheel . -w "${dist_dir}" -v --no-deps --disable-pip-version-check
 
 rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
-python -m wheel tags --platform any "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"/* --remove
+python -m auditwheel repair \
+    -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
+    ${dist_dir}/*
 
 ../../ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
After #1896 the librmm wheel contains a compiled library, which means it is no longer accurate to tag the wheel as supported on any platform. We must tag it according to the suitable architecture tags to ensure that we do not get arm binaries on x86 and vice versa. We must also add a manylinux tag to indicate glibc compatibility.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
