### PR TITLE
Prefix Conda channels with `file://`

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -14,7 +14,7 @@ rapids-generate-version > ./VERSION
 
 rapids-logger "Begin py build"
 
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+CPP_CHANNEL="file://$(rapids-download-conda-from-github cpp)"
 
 sccache --zero-stats
 


### PR DESCRIPTION
## Description

It looks like rattler-build [0.42.0]( https://github.com/prefix-dev/rattler-build/releases/tag/v0.42.0 ) changed how channels are handled in that it now prepends `https://conda.anaconda.org/` in more cases. As a result it sometimes adds this prefix to file directory paths. To try and fix this prepend `file://` for file paths so it knows not to change these.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
