### PR TITLE
WIP: stop uploading packages to downloads.rapids.ai

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -41,5 +41,3 @@ rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 # Run the libcudacxx flag test at build time, since compilers are available
 rapids-logger "Run libcudacxx_flag_test"
 ./cpp/tests/libcudacxx_flag_test/libcudacxx_flag_test.sh
-
-rapids-upload-conda-to-s3 cpp

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -42,5 +42,3 @@ rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats
 
 # See https://github.com/prefix-dev/rattler-build/issues/1424
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
-
-rapids-upload-conda-to-s3 python

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -3,7 +3,6 @@
 
 set -euo pipefail
 
-package_name="librmm"
 package_dir="python/librmm"
 
 source rapids-configure-sccache
@@ -11,8 +10,6 @@ source rapids-date-string
 source rapids-init-pip
 
 rapids-generate-version > ./VERSION
-
-RAPIDS_PY_CUDA_SUFFIX=$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")
 
 cd "${package_dir}"
 
@@ -32,5 +29,3 @@ python -m auditwheel repair \
     ${dist_dir}/*
 
 ../../ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
-
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 cpp "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -3,7 +3,6 @@
 
 set -euo pipefail
 
-package_name="rmm"
 package_dir="python/rmm"
 
 source rapids-configure-sccache
@@ -47,8 +46,6 @@ python -m auditwheel repair \
     dist/*
 
 ../../ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
-
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
 absolute_wheel_dir=$(realpath "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}")
 # switch back to the root of the repo and check symbol visibility


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/181

* removse all uploads of conda packages and wheels to `downloads.rapids.ai`

## Notes for Reviewers

### How I identified changes

Looked for uses of the relevant `gha-tools` tools, as well as documentation about `downloads.rapids.ai`, being on the NVIDIA VPN, using S3, etc. like this:

```shell
git grep -i -E 's3|upload|downloads\.rapids|vpn'
```

### How I tested this

See "How I tested this" on https://github.com/rapidsai/shared-workflows/pull/364

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
