### PR TITLE
fix(pytest): disable warning that gets raised to INTERNALERROR in pytest8.4.0

### DIFF
--- a/python/rmm/.coveragerc
+++ b/python/rmm/.coveragerc
@@ -2,4 +2,4 @@
 [run]
 include = rmm/*
 omit = rmm/tests/*
-disable_warnings=include-ignored
+disable_warnings=include-ignored,no-data-collected


### PR DESCRIPTION
## Description

pytest 8.4.0 elevates new warnings to INTERNALERROR, so we disable those warnings

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
