### PR TITLE
Run system MR tests in isolation.

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -214,7 +214,7 @@ ConfigureTest(BINNING_MR_TEST mr/device/binning_mr_tests.cpp)
 ConfigureTest(CALLBACK_MR_TEST mr/device/callback_mr_tests.cpp)
 
 # system memory resource tests
-ConfigureTest(SYSTEM_MR_TEST mr/device/system_mr_tests.cu)
+ConfigureTest(SYSTEM_MR_TEST mr/device/system_mr_tests.cu GPUS 1 PERCENT 100)
 
 # container multidevice tests
 ConfigureTest(CONTAINER_MULTIDEVICE_TEST container_multidevice_tests.cu)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -214,7 +214,8 @@ ConfigureTest(BINNING_MR_TEST mr/device/binning_mr_tests.cpp)
 ConfigureTest(CALLBACK_MR_TEST mr/device/callback_mr_tests.cpp)
 
 # system memory resource tests
-ConfigureTest(SYSTEM_MR_TEST mr/device/system_mr_tests.cu GPUS 1 PERCENT 100)
+ConfigureTest(SYSTEM_MR_TEST mr/device/system_mr_tests.cu)
+set_property(TEST SYSTEM_MR_TEST PROPERTY RUN_SERIAL TRUE)
 
 # container multidevice tests
 ConfigureTest(CONTAINER_MULTIDEVICE_TEST container_multidevice_tests.cu)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -214,8 +214,7 @@ ConfigureTest(BINNING_MR_TEST mr/device/binning_mr_tests.cpp)
 ConfigureTest(CALLBACK_MR_TEST mr/device/callback_mr_tests.cpp)
 
 # system memory resource tests
-ConfigureTest(SYSTEM_MR_TEST mr/device/system_mr_tests.cu)
-set_property(TEST SYSTEM_MR_TEST PROPERTY RUN_SERIAL TRUE)
+ConfigureTest(SYSTEM_MR_TEST mr/device/system_mr_tests.cu GPUS 1 PERCENT 100)
 
 # container multidevice tests
 ConfigureTest(CONTAINER_MULTIDEVICE_TEST container_multidevice_tests.cu)


### PR DESCRIPTION
## Description
This fixes one of the problems reported in #1935, where system MR tests need to run in isolation (in serial, rather than in parallel with other tests). This test checks the free memory before and after an allocation, so running it with other tests in parallel is flaky.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
