### PR TITLE
C++17 std::pmr::memory_resource for host_memory_resource

### DIFF
--- a/cpp/include/rmm/mr/host/host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/host/host_memory_resource.hpp
@@ -20,6 +20,7 @@
 #include <rmm/detail/nvtx/ranges.hpp>
 
 #include <cstddef>
+#include <memory_resource>
 
 namespace RMM_NAMESPACE {
 namespace mr {
@@ -34,9 +35,6 @@ namespace mr {
  *
  * This is based on `std::pmr::memory_resource`:
  * https://en.cppreference.com/w/cpp/memory/memory_resource
- *
- * When C++17 is available for use in RMM, `rmm::host_memory_resource` should
- * inherit from `std::pmr::memory_resource`.
  *
  * This class serves as the interface that all host memory resource
  * implementations must satisfy.
@@ -53,7 +51,7 @@ namespace mr {
  * derived class implementation is used.
  *
  */
-class host_memory_resource {
+class host_memory_resource : public std::pmr::memory_resource {
  public:
   host_memory_resource()                                = default;
   virtual ~host_memory_resource()                       = default;


### PR DESCRIPTION
## Description

`rmm::mr::host_memory_resource` mentions that when rmm uses C++17, it should extend `std::pmr::memory_resource` interface. This PR adds it, since rmm is on C++17 now. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
