### PR TITLE
fix use-after-free in `tracking_resource_adaptor`

### DIFF
--- a/cpp/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -244,9 +244,9 @@ class tracking_resource_adaptor final : public device_memory_resource {
           bytes,
           this->allocations_.size());
       } else {
-        allocations_.erase(found);
-
         auto allocated_bytes = found->second.allocation_size;
+
+        allocations_.erase(found);
 
         if (allocated_bytes != bytes) {
           // Don't throw but log an error. Throwing in a destructor (or any noexcept) will call

--- a/cpp/include/rmm/mr/device/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/device/tracking_resource_adaptor.hpp
@@ -244,7 +244,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
           bytes,
           this->allocations_.size());
       } else {
-        auto allocated_bytes = found->second.allocation_size;
+        auto const allocated_bytes = found->second.allocation_size;
 
         allocations_.erase(found);
 


### PR DESCRIPTION
Erasing from `allocations_` invalidates all iterators, so dereferencing `found` is Undefined Behaviour. In practice, we're seeing completely messed up tracking.

closes #1965

