### PR TITLE
Revert Sphinx pinning

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,7 +44,7 @@ jobs:
       RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check if nightly CI is passing
-        uses: rapidsai/shared-actions/check_nightly_success/dispatch@allow-main-branch-nightly-ci
+        uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: rmm
   changed-files:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,7 +44,7 @@ jobs:
       RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check if nightly CI is passing
-        uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
+        uses: rapidsai/shared-actions/check_nightly_success/dispatch@allow-main-branch-nightly-ci
         with:
           repo: rmm
   changed-files:

--- a/conda/environments/all_cuda-128_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-128_arch-aarch64.yaml
@@ -34,9 +34,9 @@ dependencies:
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - rapids-logger==0.1.*,>=0.0.0a0
 - scikit-build-core >=0.10.0
+- sphinx
 - sphinx-copybutton
 - sphinx-markdown-tables
-- sphinx<8.2.0
 - sphinx_rtd_theme
 - sysroot_linux-aarch64==2.28
 name: all_cuda-128_arch-aarch64

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -34,9 +34,9 @@ dependencies:
 - rapids-build-backend>=0.3.0,<0.4.0.dev0
 - rapids-logger==0.1.*,>=0.0.0a0
 - scikit-build-core >=0.10.0
+- sphinx
 - sphinx-copybutton
 - sphinx-markdown-tables
-- sphinx<8.2.0
 - sphinx_rtd_theme
 - sysroot_linux-64==2.28
 name: all_cuda-128_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -259,8 +259,7 @@ dependencies:
           - nbsphinx
           - &numba numba>=0.59.1,<0.62.0a0
           - numpydoc
-          # this pin can be reverted when https://github.com/spatialaudio/nbsphinx/issues/825 is resolved
-          - sphinx<8.2.0
+          - sphinx
           - sphinx_rtd_theme
           - sphinx-copybutton
           - sphinx-markdown-tables


### PR DESCRIPTION
## Description
https://github.com/spatialaudio/nbsphinx/issues/825 appears to be resolved, so we can remove the `sphinx` upper bound.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
