### PR TITLE
test changes to rapids-github-run-id

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,7 @@ jobs:
   wheel-publish-cpp:
     needs: wheel-build-cpp
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@test-gha-tools
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -121,7 +121,7 @@ jobs:
   wheel-publish-python:
     needs: wheel-build-python
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@test-gha-tools
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 source rapids-configure-sccache
 source rapids-date-string
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 rapids-logger "Downloading artifacts from previous jobs"
 CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
 PYTHON_CHANNEL=$(rapids-download-conda-from-github python)

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 source rapids-configure-sccache
 source rapids-date-string
 

--- a/ci/build_wheel_cpp.sh
+++ b/ci/build_wheel_cpp.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 package_dir="python/librmm"
 
 source rapids-configure-sccache

--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 package_dir="python/rmm"
 
 source rapids-configure-sccache

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 rapids-logger "Create checks conda environment"
 
 . /opt/conda/etc/profile.d/conda.sh

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 # Support invoking test_cpp.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 # Support invoking test_python.sh outside the script directory
 cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -3,6 +3,8 @@
 
 set -eou pipefail
 
+source ./ci/use_gha_tools_from_branch.sh
+
 source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"

--- a/ci/use_gha_tools_from_branch.sh
+++ b/ci/use_gha_tools_from_branch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.
+
+if [[ ! -d "/tmp/gha-tools" ]]; then
+
+    git clone \
+    --branch "gha-artifacts/make-lookup-more-flexible" \
+    https://github.com/rapidsai/gha-tools.git \
+    /tmp/gha-tools
+
+    export PATH="/tmp/gha-tools/tools":$PATH
+fi


### PR DESCRIPTION
## Description

Testing the changes from https://github.com/rapidsai/gha-tools/pull/196, which contribute to https://github.com/rapidsai/shared-workflows/issues/377

I'm proposing that we **merge this as-is**, to test that these changes work in the following situations on `main`:

* `branch` build triggered by a merge
* manually-triggered `nightly` test run

Then merge a follow-up PR reverting all of this, after https://github.com/rapidsai/gha-tools/pull/196 is merged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
