### PR TITLE
Update requirements to CUDA 12.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,16 @@ See the [RAPIDS Installation Guide](https://docs.rapids.ai/install/) for system 
 Compiler requirements:
 
 * `gcc`     version 9.3+
-* `nvcc`    version 11.4+
+* `nvcc`    version 12.0+
 * `cmake`   version 3.30.4+
 
 CUDA/GPU requirements:
 
-* CUDA 11.4+. You can obtain CUDA from
+* CUDA 12.0+. You can obtain CUDA from
   [https://developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads)
 
 GPU Support:
-* RMM is tested and supported only on Volta architecture and newer (Compute Capability 7.0+). It
-  may work on earlier architectures.
+* RMM is tested and supported only on Volta architecture and newer (Compute Capability 7.0+).
 
 Python requirements:
 * `rapids-build-backend` (available from PyPI or the `rapidsai` conda channel)
@@ -90,7 +89,7 @@ $ cd rmm
 - Create the conda development environment `rmm_dev`
 ```bash
 # create the conda environment (assuming in base `rmm` directory)
-$ conda env create --name rmm_dev --file conda/environments/all_cuda-128_arch-x86_64.yaml
+$ conda env create --name rmm_dev --file conda/environments/all_cuda-129_arch-x86_64.yaml
 # activate the environment
 $ conda activate rmm_dev
 ```
@@ -676,7 +675,7 @@ be detected by CUDA tools such as
 
 Exceptions to this are `cuda_memory_resource`, which wraps `cudaMalloc`, and
 `cuda_async_memory_resource`, which uses `cudaMallocAsync` with CUDA's built-in memory pool
-functionality (CUDA 11.2 or later required). Illegal memory accesses to memory allocated by these
+functionality (introduced in CUDA 11.2). Illegal memory accesses to memory allocated by these
 resources are detectable with Compute Sanitizer Memcheck.
 
 It may be possible in the future to add support for memory bounds checking with other memory

--- a/cpp/include/rmm/detail/runtime_async_alloc.hpp
+++ b/cpp/include/rmm/detail/runtime_async_alloc.hpp
@@ -34,8 +34,9 @@ namespace detail {
  * @brief Determine at runtime if the CUDA driver supports the stream-ordered
  * memory allocator functions.
  *
- * This allows RMM users to compile/link against CUDA 11.2+ and run with
- * older drivers.
+ * Stream-ordered memory pools were introduced in CUDA 11.2. This allows RMM
+ * users to compile/link against newer CUDA versions and run with older
+ * drivers.
  */
 
 struct runtime_async_alloc {

--- a/cpp/include/rmm/mr/device/cuda_async_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/cuda_async_memory_resource.hpp
@@ -48,21 +48,25 @@ class cuda_async_memory_resource final : public device_memory_resource {
   /**
    * @brief Flags for specifying memory allocation handle types.
    *
-   * @note These values are exact copies from `cudaMemAllocationHandleType`. We need to
-   * define our own enum here because the earliest CUDA runtime version that supports asynchronous
-   * memory pools (CUDA 11.2) did not support these flags, so we need a placeholder that can be
-   * used consistently in the constructor of `cuda_async_memory_resource` with all versions of
-   * CUDA >= 11.2. See the `cudaMemAllocationHandleType` docs at
+   * @note These values are exact copies from `cudaMemAllocationHandleType`. We need a placeholder
+   * that can be used consistently in the constructor of `cuda_async_memory_resource` with all
+   * supported versions of CUDA. See the `cudaMemAllocationHandleType` docs at
    * https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html and ensure the enum
    * values are kept in sync with the CUDA documentation.
+   *
+   * @note cudaMemHandleTypeFabric can be used instead of 0x8 once we require
+   * CUDA 12.4+.
    */
   enum class allocation_handle_type : std::int32_t {
-    none                  = 0x0,  ///< Does not allow any export mechanism.
-    posix_file_descriptor = 0x1,  ///< Allows a file descriptor to be used for exporting. Permitted
-                                  ///< only on POSIX systems.
-    win32     = 0x2,              ///< Allows a Win32 NT handle to be used for exporting. (HANDLE)
-    win32_kmt = 0x4,  ///< Allows a Win32 KMT handle to be used for exporting. (D3DKMT_HANDLE)
-    fabric    = 0x8   ///< Allows a fabric handle to be used for exporting. (cudaMemFabricHandle_t)
+    none = cudaMemHandleTypeNone,  ///< Does not allow any export mechanism.
+    posix_file_descriptor =
+      cudaMemHandleTypePosixFileDescriptor,  ///< Allows a file descriptor to be used for exporting.
+                                             ///< Permitted only on POSIX systems.
+    win32 =
+      cudaMemHandleTypeWin32,  ///< Allows a Win32 NT handle to be used for exporting. (HANDLE)
+    win32_kmt = cudaMemHandleTypeWin32Kmt,  ///< Allows a Win32 KMT handle to be used for exporting.
+                                            ///< (D3DKMT_HANDLE)
+    fabric = 0x8  ///< Allows a fabric handle to be used for exporting. (cudaMemFabricHandle_t)
   };
 
   /**
@@ -123,18 +127,6 @@ class cuda_async_memory_resource final : public device_memory_resource {
     cudaMemPool_t cuda_pool_handle{};
     RMM_CUDA_TRY(cudaMemPoolCreate(&cuda_pool_handle, &pool_props));
     pool_ = cuda_async_view_memory_resource{cuda_pool_handle};
-
-    // CUDA drivers before 11.5 have known incompatibilities with the async allocator.
-    // We'll disable `cudaMemPoolReuseAllowOpportunistic` if cuda driver < 11.5.
-    // See https://github.com/NVIDIA/spark-rapids/issues/4710.
-    int driver_version{};
-    RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
-    constexpr auto min_async_driver_version{11050};
-    if (driver_version < min_async_driver_version) {
-      int disabled{0};
-      RMM_CUDA_TRY(
-        cudaMemPoolSetAttribute(pool_handle(), cudaMemPoolReuseAllowOpportunistic, &disabled));
-    }
 
     auto const [free, total] = rmm::available_device_memory();
 

--- a/python/rmm/rmm/tests/test_rmm.py
+++ b/python/rmm/rmm/tests/test_rmm.py
@@ -663,30 +663,10 @@ def test_cuda_async_memory_resource(dtype, nelem, alloc):
 
 
 def test_cuda_async_memory_resource_ipc():
-    # TODO: We don't have a great way to check if IPC is supported in Python,
-    # without using the C++ function
-    # rmm::detail::runtime_async_alloc::is_export_handle_type_supported.
-    # We can't accurately test this via Python because
-    # cuda-python always has the IPC handle enum defined (which normally
-    # requires a CUDA 11.3 runtime) and the cuda-compat package in Docker
-    # containers prevents us from assuming that the driver we see actually
-    # supports IPC handles even if its reported version is new enough (we may
-    # see a newer driver than what is present on the host). We can only know
-    # the expected behavior by checking the C++ function mentioned above, which
-    # is then a redundant check because the CudaAsyncMemoryResource constructor
-    # follows the same logic. Therefore, we cannot easily ensure this test
-    # passes in certain expected configurations -- we can only ensure that if
-    # it fails, it fails in a predictable way.
-    try:
-        mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
-    except RuntimeError as e:
-        # CUDA 11.3 is required for IPC memory handle support
-        assert str(e).endswith(
-            "Requested IPC memory handle type not supported"
-        )
-    else:
-        rmm.mr.set_current_device_resource(mr)
-        assert rmm.mr.get_current_device_resource_type() is type(mr)
+    # CUDA 11.3+ is required for IPC memory handle support
+    mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
+    rmm.mr.set_current_device_resource(mr)
+    assert rmm.mr.get_current_device_resource_type() is type(mr)
 
 
 def test_cuda_async_memory_resource_fabric():


### PR DESCRIPTION
## Description
This PR updates RMM to require CUDA 12.0+. This drops version checks less than 12.0 and updates some enums to use values defined in CUDA 12.0+.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
