### PR TITLE
fix(docker): use versioned `-latest` tag for all `rapidsai` images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
       date: ${{ inputs.date }}
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:25.08-latest"
       script: ci/build_docs.sh
   wheel-build-cpp:
     needs: [telemetry-setup]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -117,7 +117,7 @@ jobs:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:latest"
+      container_image: "rapidsai/ci-conda:25.08-latest"
       script: "ci/build_docs.sh"
   wheel-build-cpp:
     needs: checks

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -38,6 +38,7 @@ sed_runner "s/RMM_TAG branch-[0-9.]*/RMM_TAG branch-${NEXT_SHORT_TAG}/" cpp/exam
 # CI files
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
 
 # .devcontainer files
@@ -61,3 +62,6 @@ for DEP in "${DEPENDENCIES[@]}"; do
     sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" "${FILE}"
   done
 done
+# Update CI image tags of the form {rapids_version}-{something}
+
+sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" ./CONTRIBUTING.md

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -62,6 +62,6 @@ for DEP in "${DEPENDENCIES[@]}"; do
     sed_runner "/\"${DEP}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" "${FILE}"
   done
 done
-# Update CI image tags of the form {rapids_version}-{something}
 
+# Update CI image tags of the form {rapids_version}-{something}
 sed_runner "s/:[0-9]*\\.[0-9]*-/:${NEXT_SHORT_TAG}-/g" ./CONTRIBUTING.md


### PR DESCRIPTION
In rapidsai/build-planning#187 we switched the docker image tagging scheme
over to include the CalVer information.  This was done to allow us to make
changes to the images during burndown without breaking release pipelines.

This PR moves all of the existing `latest` tags to the newer versioned tag
`25.08-latest` and also modifies the `update_version.sh` script to bump
that version at branch creation time.

xref: https://github.com/rapidsai/build-planning/issues/187
