### PR TITLE
Revert "Update branches that trigger nightlies (#1954)"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,7 @@ name: build
 on:
   push:
     branches:
-      - "main"
-      - "release/*"
-      - "hotfix/*"
+      - "branch-*"
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
   workflow_dispatch:


### PR DESCRIPTION
This reverts commit db325e6cdc786020773180ffb36ec5fc965f9e1c.

We've rolled back most of the changes associated with the new branching model, but this also needs to be reverted.
