### PR TITLE
Use std::for_each instead of std::equal in test

### DIFF
--- a/cpp/tests/logger_tests.cpp
+++ b/cpp/tests/logger_tests.cpp
@@ -19,6 +19,8 @@
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/logging_resource_adaptor.hpp>
 
+#include <thrust/iterator/zip_iterator.h>
+
 #include <benchmarks/utilities/log_parser.hpp>
 #include <gtest/gtest.h>
 
@@ -105,19 +107,22 @@ void expect_log_events(std::string const& filename,
 {
   auto actual_events = rmm::detail::parse_csv(filename);
 
-  EXPECT_TRUE(std::equal(expected_events.begin(),
-                         expected_events.end(),
-                         actual_events.begin(),
-                         [](auto expected, auto actual) {
-                           // We don't test the logged thread id since it may be different from what
-                           // we record. The actual value doesn't matter so long as events from
-                           // different threads have different ids EXPECT_EQ(expected.thread_id,
-                           // actual.thread_id); EXPECT_EQ(expected.stream, actual.stream);
-                           EXPECT_EQ(expected.act, actual.act);
-                           EXPECT_EQ(expected.size, actual.size);
-                           EXPECT_EQ(expected.pointer, actual.pointer);
-                           return true;
-                         }));
+  auto begin = thrust::make_zip_iterator(
+    cuda::std::make_tuple(expected_events.begin(), actual_events.begin()));
+  auto end =
+    thrust::make_zip_iterator(cuda::std::make_tuple(expected_events.end(), actual_events.end()));
+
+  std::for_each(begin, end, [](auto const& zipped) {
+    auto [expected, actual] = zipped;
+    // We don't test the logged thread id since it may be different from what
+    // we record. The actual value doesn't matter so long as events from
+    // different threads have different ids EXPECT_EQ(expected.thread_id,
+    // actual.thread_id); EXPECT_EQ(expected.stream, actual.stream);
+    EXPECT_EQ(expected.act, actual.act);
+    EXPECT_EQ(expected.size, actual.size);
+    EXPECT_EQ(expected.pointer, actual.pointer);
+    return true;
+  });
 }
 
 TEST(Adaptor, FilenameConstructor)


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
`std::equal` was basically being used to create a loop, which `std::for_each` is better suited for. See discussion at https://github.com/rapidsai/rmm/pull/1963#discussion_r2157538963

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
