### PR TITLE
Update to use CUDA runtime APIs that work in CUDA 12 and 13

### DIFF
--- a/cpp/include/rmm/mr/device/sam_headroom_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/sam_headroom_memory_resource.hpp
@@ -82,17 +82,32 @@ class sam_headroom_memory_resource final : public device_memory_resource {
     auto const gpu_portion =
       rmm::align_down(std::min(allocatable, bytes), rmm::CUDA_ALLOCATION_ALIGNMENT);
     auto const cpu_portion = bytes - gpu_portion;
+
     if (gpu_portion != 0) {
-      RMM_CUDA_TRY(cudaMemAdvise(pointer,
-                                 gpu_portion,
-                                 cudaMemAdviseSetPreferredLocation,
-                                 rmm::get_current_cuda_device().value()));
+      cudaMemLocation location{cudaMemLocationTypeDevice, rmm::get_current_cuda_device().value()};
+
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
+      RMM_CUDA_TRY(
+        cudaMemAdvise(pointer, gpu_portion, cudaMemAdviseSetPreferredLocation, location));
+#else
+      RMM_CUDA_TRY(
+        cudaMemAdvise_v2(pointer, gpu_portion, cudaMemAdviseSetPreferredLocation, location));
+#endif
     }
     if (cpu_portion != 0) {
+      cudaMemLocation location{cudaMemLocationTypeHost, 0};
+
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
       RMM_CUDA_TRY(cudaMemAdvise(static_cast<char*>(pointer) + gpu_portion,
                                  cpu_portion,
                                  cudaMemAdviseSetPreferredLocation,
-                                 cudaCpuDeviceId));
+                                 location));
+#else
+      RMM_CUDA_TRY(cudaMemAdvise_v2(static_cast<char*>(pointer) + gpu_portion,
+                                    cpu_portion,
+                                    cudaMemAdviseSetPreferredLocation,
+                                    location));
+#endif
     }
 
     return pointer;

--- a/cpp/include/rmm/mr/device/sam_headroom_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/sam_headroom_memory_resource.hpp
@@ -96,7 +96,6 @@ class sam_headroom_memory_resource final : public device_memory_resource {
 #endif
     }
     if (cpu_portion != 0) {
-
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
       cudaMemLocation location{cudaMemLocationTypeHost, 0};
       RMM_CUDA_TRY(cudaMemAdvise(static_cast<char*>(pointer) + gpu_portion,

--- a/cpp/src/prefetch.cpp
+++ b/cpp/src/prefetch.cpp
@@ -27,11 +27,11 @@ void prefetch(void const* ptr,
 {
   cudaError_t result;
 #if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
-    cudaMemLocation location{
+  cudaMemLocation location{
     (device.value() == cudaCpuDeviceId) ? cudaMemLocationTypeHost : cudaMemLocationTypeDevice,
     device.value()};
   constexpr int flags = 0;
-  result = cudaMemPrefetchAsync(ptr, size, location, flags, stream.value());
+  result              = cudaMemPrefetchAsync(ptr, size, location, flags, stream.value());
 #else
   result = cudaMemPrefetchAsync(ptr, size, device.value(), stream.value());
 #endif

--- a/cpp/src/prefetch.cpp
+++ b/cpp/src/prefetch.cpp
@@ -25,7 +25,16 @@ void prefetch(void const* ptr,
               rmm::cuda_device_id device,
               rmm::cuda_stream_view stream)
 {
-  auto result = cudaMemPrefetchAsync(ptr, size, device.value(), stream.value());
+  cudaMemLocation location{
+    (device.value() == cudaCpuDeviceId) ? cudaMemLocationTypeHost : cudaMemLocationTypeDevice,
+    device.value()};
+  constexpr int flags = 0;
+  auto result =
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
+    cudaMemPrefetchAsync(ptr, size, location, flags, stream.value());
+#else
+    cudaMemPrefetchAsync_v2(ptr, size, location, flags, stream.value());
+#endif
   // cudaErrorInvalidValue is returned when non-managed memory is passed to
   // cudaMemPrefetchAsync. We treat this as a no-op.
   if (result != cudaErrorInvalidValue && result != cudaSuccess) { RMM_CUDA_TRY(result); }


### PR DESCRIPTION
## Description
CUDA 13 removes the `cudaMemAdvise` and `cudaMemPrefetchAsync` function signatures used by RMM. To continue to support CUDA 12 and 13 we move over to the v2 APIs when in CUDA 12, which are now the unversioned APIs in 13.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
