### PR TITLE
ci(labeler): update labeler action to @v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,19 +3,25 @@
 # Labels culled from https://github.com/rapidsai/rmm/labels
 
 Python:
-  - 'python/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'python/**'
 CMake:
-  - '**/CMakeLists.txt'
-  - '**/cmake/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - '**/CMakeLists.txt'
+        - '**/cmake/**'
 conda:
-  - 'conda/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'conda/**'
 cpp:
-  - 'include/**'
-  - 'tests/**'
-  - 'doxygen/**'
-
+  - changed-files:
+      any-glob-to-any-file:
+        - 'include/**'
+        - 'tests/**'
+        - 'doxygen/**'
 ci:
-  - 'ci/**'
+  - changed-files:
+      any-glob-to-any-file:
+        - 'ci/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,6 +18,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Bumps the version of `actions/labeler` to `@v5` and updates the syntax in
the `labeler.yml` file to account for breaking changes in that version bump.

xref: rapidsai/ops#2968
