### PR TITLE
Change pylibrmm Stream.view() method to noexcept

### DIFF
--- a/python/rmm/rmm/pylibrmm/stream.pxd
+++ b/python/rmm/rmm/pylibrmm/stream.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ cdef class Stream:
     @staticmethod
     cdef Stream _from_cudaStream_t(cudaStream_t s, object owner=*)
 
-    cdef cuda_stream_view view(self) except * nogil
+    cdef cuda_stream_view view(self) noexcept nogil
     cdef void c_synchronize(self) except * nogil
-    cdef bool c_is_default(self) except * nogil
+    cdef bool c_is_default(self) noexcept nogil
     cdef void _init_with_new_cuda_stream(self) except *
     cdef void _init_from_stream(self, Stream stream) except *

--- a/python/rmm/rmm/pylibrmm/stream.pyx
+++ b/python/rmm/rmm/pylibrmm/stream.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ cdef class Stream:
         obj._owner = owner
         return obj
 
-    cdef cuda_stream_view view(self) except * nogil:
+    cdef cuda_stream_view view(self) noexcept nogil:
         """
         Generate a rmm::cuda_stream_view from this Stream instance
         """
@@ -77,7 +77,7 @@ cdef class Stream:
         with nogil:
             self.c_synchronize()
 
-    cdef bool c_is_default(self) except * nogil:
+    cdef bool c_is_default(self) noexcept nogil:
         """
         Check if we are the default CUDA stream
         """


### PR DESCRIPTION
## Description
Changes the pylibrmm `Stream.view()` method from `except *` to `noexcept`.
This prevents  many warnings where the `view()` method. Here is an example:
https://github.com/rapidsai/cudf/actions/runs/17040978623/job/48305629155?pr=19446#step:12:735

```
  performance hint: /__w/cudf/cudf/python/pylibcudf/pylibcudf/reduce.pyx:57:20: Exception check after calling 'view' will always require the GIL to be acquired. Declare 'view' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
```

Also changed the `is_default()` to `noexcept` since the underlying librmm function is also declared as `noexcept`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
