### PR TITLE
update dependencies: cuda-python (>=12.9.2 / >=13.0.1)

### DIFF
--- a/conda/recipes/rmm/recipe.yaml
+++ b/conda/recipes/rmm/recipe.yaml
@@ -50,8 +50,8 @@ requirements:
     - cuda-version =${{ cuda_version }}
     - cuda-cudart-dev
     - if: cuda_major == "12"
-      then: cuda-python >=12.9.1,<13.0a0
-      else: cuda-python >=13.0.0,<14.0a0
+      then: cuda-python >=12.9.2,<13.0a0
+      else: cuda-python >=13.0.1,<14.0a0
     - cython >=3.0.0
     - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - librmm =${{ version }}
@@ -61,8 +61,8 @@ requirements:
   run:
     - cuda-cudart
     - if: cuda_major == "12"
-      then: cuda-python >=12.9.1,<13.0a0
-      else: cuda-python >=13.0.0,<14.0a0
+      then: cuda-python >=12.9.2,<13.0a0
+      else: cuda-python >=13.0.1,<14.0a0
     - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
     - numpy >=1.23,<3.0a0
     - python


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/214, updating pins to match the rest of RAPIDS:

* `cuda-python` (>=12.9.2 for CUDA 12, >=13.0.1 for CUDA 13)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
