### PR TITLE
Add option to create non-blocking streams

### DIFF
--- a/cpp/include/rmm/cuda_stream.hpp
+++ b/cpp/include/rmm/cuda_stream.hpp
@@ -39,6 +39,14 @@ namespace RMM_EXPORT rmm {
 class cuda_stream {
  public:
   /**
+   * @brief stream creation flags.
+   */
+  enum class flags : unsigned int {
+    sync_default = cudaStreamDefault,  ///< Created stream synchronises with the default stream.
+    non_blocking =
+      cudaStreamNonBlocking,  ///< Created stream does not synchronise with the default stream.
+  };
+  /**
    * @brief Move constructor (default)
    *
    * A moved-from cuda_stream is invalid and it is Undefined Behavior to call methods that access
@@ -61,9 +69,11 @@ class cuda_stream {
   /**
    * @brief Construct a new cuda stream object
    *
+   * @param flags Stream creation flags.
+   *
    * @throw rmm::cuda_error if stream creation fails
    */
-  cuda_stream();
+  cuda_stream(flags flags = flags::sync_default);
 
   /**
    * @brief Returns true if the owned stream is non-null

--- a/cpp/include/rmm/cuda_stream_pool.hpp
+++ b/cpp/include/rmm/cuda_stream_pool.hpp
@@ -48,8 +48,10 @@ class cuda_stream_pool {
    *
    * @throws logic_error if `pool_size` is zero
    * @param pool_size The number of streams in the pool
+   * @param flags Flags used when creating streams in the pool.
    */
-  explicit cuda_stream_pool(std::size_t pool_size = default_size);
+  explicit cuda_stream_pool(std::size_t pool_size    = default_size,
+                            cuda_stream::flags flags = cuda_stream::flags::sync_default);
   ~cuda_stream_pool() = default;
 
   cuda_stream_pool(cuda_stream_pool&&)                 = delete;

--- a/cpp/src/cuda_stream.cpp
+++ b/cpp/src/cuda_stream.cpp
@@ -22,10 +22,11 @@
 
 namespace rmm {
 
-cuda_stream::cuda_stream()
-  : stream_{[]() {
+cuda_stream::cuda_stream(cuda_stream::flags flags)
+  : stream_{[flags]() {
               auto* stream = new cudaStream_t;  // NOLINT(cppcoreguidelines-owning-memory)
-              RMM_CUDA_TRY(cudaStreamCreate(stream));
+              // TODO: use std::to_underlying once C++23 is allowed.
+              RMM_CUDA_TRY(cudaStreamCreateWithFlags(stream, static_cast<unsigned int>(flags)));
               return stream;
             }(),
             [](cudaStream_t* stream) {

--- a/cpp/src/cuda_stream_pool.cpp
+++ b/cpp/src/cuda_stream_pool.cpp
@@ -18,13 +18,17 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 
+#include <algorithm>
 #include <cstddef>
 
 namespace rmm {
 
-cuda_stream_pool::cuda_stream_pool(std::size_t pool_size) : streams_(pool_size)
+cuda_stream_pool::cuda_stream_pool(std::size_t pool_size, cuda_stream::flags flags)
 {
   RMM_EXPECTS(pool_size > 0, "Stream pool size must be greater than zero");
+  streams_.reserve(pool_size);
+  std::generate_n(
+    std::back_inserter(streams_), pool_size, [flags]() { return cuda_stream(flags); });
 }
 
 rmm::cuda_stream_view cuda_stream_pool::get_stream() const noexcept

--- a/cpp/src/cuda_stream_pool.cpp
+++ b/cpp/src/cuda_stream_pool.cpp
@@ -19,6 +19,7 @@
 #include <rmm/detail/error.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 
 namespace rmm {
@@ -33,7 +34,7 @@ cuda_stream_pool::cuda_stream_pool(std::size_t pool_size, cuda_stream::flags fla
 
 rmm::cuda_stream_view cuda_stream_pool::get_stream() const noexcept
 {
-  return streams_[(next_stream++) % streams_.size()].view();
+  return streams_[(next_stream.fetch_add(1, std::memory_order_relaxed)) % streams_.size()].view();
 }
 
 rmm::cuda_stream_view cuda_stream_pool::get_stream(std::size_t stream_id) const

--- a/cpp/tests/cuda_stream_pool_tests.cpp
+++ b/cpp/tests/cuda_stream_pool_tests.cpp
@@ -81,3 +81,24 @@ TEST_F(CudaStreamPoolTest, ValidLinearAccess)
   auto const stream_b = this->pool.get_stream(1);
   EXPECT_NE(stream_a, stream_b);
 }
+
+TEST_F(CudaStreamPoolTest, CreateDefault)
+{
+  for (std::size_t i = 0; i < this->pool.get_pool_size(); i++) {
+    auto stream = this->pool.get_stream(i);
+    unsigned int flags;
+    RMM_CUDA_TRY(cudaStreamGetFlags(stream.value(), &flags));
+    EXPECT_EQ(flags, cudaStreamDefault);
+  }
+}
+
+TEST_F(CudaStreamPoolTest, CreateNonBlocking)
+{
+  rmm::cuda_stream_pool pool{2, rmm::cuda_stream::flags::non_blocking};
+  for (std::size_t i = 0; i < pool.get_pool_size(); i++) {
+    auto stream = pool.get_stream(i);
+    unsigned int flags;
+    RMM_CUDA_TRY(cudaStreamGetFlags(stream.value(), &flags));
+    EXPECT_EQ(flags, cudaStreamNonBlocking);
+  }
+}

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -87,6 +87,22 @@ TEST_F(CudaStreamTest, TestSyncNoThrow)
   EXPECT_NO_THROW(stream_a.synchronize_no_throw());
 }
 
+TEST_F(CudaStreamTest, TestCreateDefault)
+{
+  rmm::cuda_stream stream(rmm::cuda_stream::flags::sync_default);
+  unsigned int flags;
+  RMM_CUDA_TRY(cudaStreamGetFlags(stream.value(), &flags));
+  EXPECT_EQ(flags, cudaStreamDefault);
+}
+
+TEST_F(CudaStreamTest, TestCreateNonBlocking)
+{
+  rmm::cuda_stream stream(rmm::cuda_stream::flags::non_blocking);
+  unsigned int flags;
+  RMM_CUDA_TRY(cudaStreamGetFlags(stream.value(), &flags));
+  EXPECT_EQ(flags, cudaStreamNonBlocking);
+}
+
 #ifndef NDEBUG
 using CudaStreamDeathTest = CudaStreamTest;
 


### PR DESCRIPTION
## Description

Add optional flag argument to both `cuda_stream` and `cuda_stream_pool` creation to allow caller to specify whether the resulting stream should be implicitly synchronising with the default stream.

- Closes #2029

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
