### PR TITLE
Expand documentation on Buffer and Memory Resource lifetimes

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -164,7 +164,7 @@ Similarly, to use a pool of managed memory:
 >
 > Note that a Python exception that's raised in a scope that allocates
 > buffers can keep references to the buffers that will keep them alive.
-> Use {ref}`traceback.clear_frames` to ensure those buffers are freed
+> Use ``traceback.clear_frames`` to ensure those buffers are freed
 > before destroying the memory resource.
 
 Other `MemoryResource`s include:


### PR DESCRIPTION
## Description

This notes that buffers need to be freed before the MR itself is freed, motivated by some debugging in https://github.com/rapidsai/cudf/pull/19895/commits/958face1d7378d2883cdc414bb37d14d5fe7670e.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
