### PR TITLE
Test manually merging pool free lists in replay benchmark

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -39,6 +39,8 @@ rapids_cmake_build_type(Release)
 # * build options ----------------------------------------------------------------------------------
 
 option(RMM_NVTX "Build RMM with NVTX support" OFF)
+option(RMM_DEBUG_PRINT "Build RMM with debug print support" OFF)
+option(RMM_POOL_TRACK_ALLOCATIONS "Build RMM with pool allocation tracking" OFF)
 option(BUILD_TESTS "Configure CMake to build tests" ON)
 option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 # This is mostly so that dependent libraries are configured in shared mode for downstream dependents
@@ -51,6 +53,8 @@ set_property(CACHE RMM_LOGGING_LEVEL PROPERTY STRINGS "TRACE" "DEBUG" "INFO" "WA
                                               "CRITICAL" "OFF")
 
 message(VERBOSE "RMM: Build with NVTX support: ${RMM_NVTX}")
+message(VERBOSE "RMM: Build with debug print support: ${RMM_DEBUG_PRINT}")
+message(VERBOSE "RMM: Build with pool allocation tracking: ${RMM_POOL_TRACK_ALLOCATIONS}")
 # Set logging level. Must go before including gtests and benchmarks. Set the possible values of
 # build type for cmake-gui.
 message(STATUS "RMM: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'")
@@ -130,6 +134,16 @@ target_compile_definitions(rmm PUBLIC LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESO
 # Enable NVTX if necessary
 if(RMM_NVTX)
   target_compile_definitions(rmm PUBLIC RMM_NVTX)
+endif()
+
+# Enable debug print if necessary
+if(RMM_DEBUG_PRINT)
+  target_compile_definitions(rmm PUBLIC RMM_DEBUG_PRINT)
+endif()
+
+# Enable pool allocation tracking if necessary
+if(RMM_POOL_TRACK_ALLOCATIONS)
+  target_compile_definitions(rmm PUBLIC RMM_POOL_TRACK_ALLOCATIONS)
 endif()
 
 # ##################################################################################################

--- a/cpp/benchmarks/CMakeLists.txt
+++ b/cpp/benchmarks/CMakeLists.txt
@@ -40,6 +40,16 @@ function(ConfigureBench BENCH_NAME)
   target_compile_definitions(
     ${BENCH_NAME} PUBLIC "RMM_LOG_ACTIVE_LEVEL=RAPIDS_LOGGER_LOG_LEVEL_${RMM_LOGGING_LEVEL}")
 
+  # Enable debug print if necessary
+  if(RMM_DEBUG_PRINT)
+    target_compile_definitions(${BENCH_NAME} PUBLIC RMM_DEBUG_PRINT)
+  endif()
+
+  # Enable pool allocation tracking if necessary
+  if(RMM_POOL_TRACK_ALLOCATIONS)
+    target_compile_definitions(${BENCH_NAME} PUBLIC RMM_POOL_TRACK_ALLOCATIONS)
+  endif()
+
   if(PER_THREAD_DEFAULT_STREAM)
     target_compile_definitions(${BENCH_NAME} PUBLIC CUDA_API_PER_THREAD_DEFAULT_STREAM)
   endif()

--- a/cpp/benchmarks/replay/replay.cpp
+++ b/cpp/benchmarks/replay/replay.cpp
@@ -242,6 +242,14 @@ struct replay_benchmark {
         } else if (rmm::detail::action::FREE == event.act) {
           auto alloc = remove_allocation(event.pointer);
           mr_->deallocate(alloc.ptr, event.size);
+        } else if (rmm::detail::action::MERGE_LISTS == event.act) {
+          if (auto pool =
+                dynamic_cast<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>*>(
+                  mr_.get())) {
+            pool->merge_lists_for_all_streams();
+          } else {
+            std::cout << "Error: merge lists is not supported for this memory resource\n";
+          }
         }
 
         event_index++;

--- a/cpp/benchmarks/utilities/log_parser.hpp
+++ b/cpp/benchmarks/utilities/log_parser.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 
 namespace rmm::detail {
 
-enum class action { ALLOCATE, FREE, ALLOCATE_FAILURE };
+enum class action { ALLOCATE, FREE, ALLOCATE_FAILURE, MERGE_LISTS };
 
 /**
  * @brief Represents an allocation event
@@ -89,6 +89,7 @@ inline std::ostream& operator<<(std::ostream& os, event const& evt)
     switch (evt.act) {
       case action::ALLOCATE: return "allocate";
       case action::FREE: return "free";
+      case action::MERGE_LISTS: return "merge lists";
       default: return "allocate failure";
     }
   }()};
@@ -169,13 +170,16 @@ inline std::vector<event> parse_csv(std::string const& filename)
 
   for (std::size_t i = 0; i < actions.size(); ++i) {
     auto const& action = actions[i];
-    RMM_EXPECTS((action == "allocate") or (action == "allocate failure") or (action == "free"),
+    RMM_EXPECTS((action == "allocate") or (action == "allocate failure") or (action == "free") or
+                  (action == "merge lists"),
                 "Invalid action string.");
     auto act{action::ALLOCATE_FAILURE};
     if (action == "allocate") {
       act = action::ALLOCATE;
     } else if (action == "free") {
       act = action::FREE;
+    } else if (action == "merge lists") {
+      act = action::MERGE_LISTS;
     }
     events[i] = event{tids[i], act, sizes[i], pointers[i], streams[i], i};
   }

--- a/cpp/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/pool_memory_resource.hpp
@@ -258,6 +258,10 @@ class pool_memory_resource final
                     reason);
       auto const msg = std::string("Maximum pool size exceeded (failed to allocate ") +
                        rmm::detail::format_bytes(min_size) + std::string("): ") + reason;
+      // Call print method
+#ifdef RMM_DEBUG_PRINT
+      this->print();
+#endif
       RMM_FAIL(msg.c_str(), rmm::out_of_memory);
     };
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -42,6 +42,17 @@ function(ConfigureTestInternal TEST_NAME)
                CUDA_STANDARD_REQUIRED ON)
   target_compile_definitions(
     ${TEST_NAME} PUBLIC "RMM_LOG_ACTIVE_LEVEL=RAPIDS_LOGGER_LOG_LEVEL_${RMM_LOGGING_LEVEL}")
+
+  # Enable debug print if necessary
+  if(RMM_DEBUG_PRINT)
+    target_compile_definitions(${TEST_NAME} PUBLIC RMM_DEBUG_PRINT)
+  endif()
+
+  # Enable pool allocation tracking if necessary
+  if(RMM_POOL_TRACK_ALLOCATIONS)
+    target_compile_definitions(${TEST_NAME} PUBLIC RMM_POOL_TRACK_ALLOCATIONS)
+  endif()
+
   target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror>)
 
   if(DISABLE_DEPRECATION_WARNING)


### PR DESCRIPTION
This PR adds a "merge lists" feature to the replay benchmark.

This is meant to help with some temporary testing work for #2039. It is just for testing and is not intended to merge.
