### PR TITLE
Simplify cuda_async_view_memory_resource constructor

### DIFF
--- a/cpp/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/cuda_async_view_memory_resource.hpp
@@ -57,11 +57,7 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
       }()}
   {
     // Check if cudaMallocAsync Memory pool supported
-    auto const device = rmm::get_current_cuda_device();
-    int cuda_pool_supported{};
-    auto result =
-      cudaDeviceGetAttribute(&cuda_pool_supported, cudaDevAttrMemoryPoolsSupported, device.value());
-    RMM_EXPECTS(result == cudaSuccess && cuda_pool_supported,
+    RMM_EXPECTS(rmm::detail::runtime_async_alloc::is_supported(),
                 "cudaMallocAsync not supported with this CUDA driver/runtime version");
   }
 


### PR DESCRIPTION
## Description
This replaces a check for async pool support with an equivalent utility function.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
