### PR TITLE
Add cuda_async_managed_memory_resource.

### DIFF
--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -32,6 +32,11 @@ namespace detail {
 #define RMM_MIN_HWDECOMPRESS_CUDA_DRIVER_VERSION 12080
 
 /**
+ * @brief Minimum CUDA driver version for stream-ordered managed memory allocator support
+ */
+#define RMM_MIN_ASYNC_MANAGED_ALLOC_CUDA_DRIVER_VERSION 13000
+
+/**
  * @brief Determine at runtime if the CUDA driver supports the stream-ordered
  * memory allocator functions.
  *
@@ -50,6 +55,25 @@ struct runtime_async_alloc {
       return result == cudaSuccess and cuda_pool_supported == 1;
     }()};
     return driver_supports_pool;
+  }
+};
+
+/**
+ * @brief Determine at runtime if the CUDA driver/runtime supports the stream-ordered
+ * managed memory allocator functions.
+ *
+ * Stream-ordered managed memory pools were introduced in CUDA 13.0.
+ */
+struct runtime_async_managed_alloc {
+  static bool is_supported()
+  {
+    static auto driver_supports_async_managed_pool{[] {
+      int cuda_driver_version{};
+      auto result = cudaDriverGetVersion(&cuda_driver_version);
+      return result == cudaSuccess and
+             cuda_driver_version >= RMM_MIN_ASYNC_MANAGED_ALLOC_CUDA_DRIVER_VERSION;
+    }()};
+    return driver_supports_async_managed_pool;
   }
 };
 

--- a/cpp/include/rmm/mr/device/cuda_async_managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/cuda_async_managed_memory_resource.hpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/error.hpp>
+#include <rmm/detail/export.hpp>
+#include <rmm/detail/runtime_capabilities.hpp>
+#include <rmm/detail/thrust_namespace.h>
+#include <rmm/mr/device/cuda_async_view_memory_resource.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
+
+#include <cuda/std/type_traits>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+/**
+ * @addtogroup device_memory_resources
+ * @{
+ * @file
+ */
+
+/**
+ * @brief `device_memory_resource` derived class that uses
+ * `cudaMallocFromPoolAsync`/`cudaFreeFromPoolAsync` with a managed memory pool
+ * for allocation/deallocation.
+ */
+class cuda_async_managed_memory_resource final : public device_memory_resource {
+ public:
+  /**
+   * @brief Constructs a cuda_async_managed_memory_resource with the default managed memory pool for
+   * the current device.
+   *
+   * The default managed memory pool is the pool that is created when the device is created.
+   * Pool properties such as the release threshold are not modified.
+   *
+   * @throws rmm::logic_error if the CUDA version does not support `cudaMallocFromPoolAsync` with
+   * managed memory pool
+   */
+  cuda_async_managed_memory_resource()
+  {
+    // Check if cudaMallocFromPoolAsync supported
+    RMM_EXPECTS(rmm::detail::runtime_async_managed_alloc::is_supported(),
+                "cudaMallocFromPoolAsync with managed memory pool requires CUDA 13.0 or higher");
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= RMM_MIN_ASYNC_MANAGED_ALLOC_CUDA_DRIVER_VERSION
+    cudaMemPool_t managed_pool_handle{};
+    cudaMemLocation location{};
+    location.type              = cudaMemLocationTypeDevice;
+    location.id                = rmm::get_current_cuda_device().value();
+    cudaMemAllocationType type = cudaMemAllocationTypeManaged;
+    RMM_CUDA_TRY(cudaMemGetDefaultMemPool(&managed_pool_handle, &location, type));
+    pool_ = cuda_async_view_memory_resource{managed_pool_handle};
+#else
+    RMM_EXPECTS(false,
+                "cudaMallocFromPoolAsync with managed memory pool requires CUDA 13.0 or higher");
+#endif
+  }
+
+  /**
+   * @brief Returns the underlying native handle to the CUDA pool
+   *
+   * @return cudaMemPool_t Handle to the underlying CUDA pool
+   */
+  [[nodiscard]] cudaMemPool_t pool_handle() const noexcept { return pool_.pool_handle(); }
+
+  ~cuda_async_managed_memory_resource() override {}
+  cuda_async_managed_memory_resource(cuda_async_managed_memory_resource const&)            = delete;
+  cuda_async_managed_memory_resource(cuda_async_managed_memory_resource&&)                 = delete;
+  cuda_async_managed_memory_resource& operator=(cuda_async_managed_memory_resource const&) = delete;
+  cuda_async_managed_memory_resource& operator=(cuda_async_managed_memory_resource&&)      = delete;
+
+ private:
+  cuda_async_view_memory_resource pool_{};
+
+  /**
+   * @brief Allocates memory of size at least \p bytes.
+   *
+   * The returned pointer will have at minimum 256 byte alignment.
+   *
+   * @param bytes The size of the allocation
+   * @param stream Stream on which to perform allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* do_allocate(std::size_t bytes, rmm::cuda_stream_view stream) override
+  {
+    void* ptr{nullptr};
+    ptr = pool_.allocate(bytes, stream);
+    return ptr;
+  }
+
+  /**
+   * @brief Deallocate memory pointed to by \p p.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the
+   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * @param stream Stream on which to perform deallocation
+   */
+  void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) override
+  {
+    pool_.deallocate(ptr, bytes, stream);
+  }
+
+  /**
+   * @brief Compare this resource to another.
+   *
+   * @param other The other resource to compare to
+   * @return true If the two resources are equivalent
+   * @return false If the two resources are not equal
+   */
+  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
+  {
+    auto const* async_mr = dynamic_cast<cuda_async_managed_memory_resource const*>(&other);
+    return (async_mr != nullptr) && (this->pool_handle() == async_mr->pool_handle());
+  }
+};
+
+/** @} */  // end of group
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -153,6 +153,10 @@ ConfigureTest(CUDA_ASYNC_MR_STATIC_CUDART_TEST mr/device/cuda_async_mr_tests.cpp
 ConfigureTest(CUDA_ASYNC_MR_SHARED_CUDART_TEST mr/device/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60
               CUDART SHARED)
 
+# cuda_async managed mr tests (available with CUDA 13+ runtime/driver)
+ConfigureTest(CUDA_ASYNC_MANAGED_MR_TEST mr/device/cuda_async_managed_mr_tests.cpp GPUS 1 PERCENT
+              60)
+
 # thrust allocator tests
 ConfigureTest(THRUST_ALLOCATOR_TEST mr/device/thrust_allocator_tests.cu GPUS 1 PERCENT 60)
 

--- a/cpp/tests/mr/device/cuda_async_managed_mr_tests.cpp
+++ b/cpp/tests/mr/device/cuda_async_managed_mr_tests.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <rmm/detail/error.hpp>
+#include <rmm/detail/runtime_capabilities.hpp>
+#include <rmm/mr/device/cuda_async_managed_memory_resource.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <gtest/gtest.h>
+
+namespace rmm::test {
+namespace {
+
+using cuda_async_managed_mr = rmm::mr::cuda_async_managed_memory_resource;
+
+// static property checks
+static_assert(
+  rmm::detail::polyfill::resource_with<cuda_async_managed_mr, cuda::mr::device_accessible>);
+static_assert(
+  rmm::detail::polyfill::async_resource_with<cuda_async_managed_mr, cuda::mr::device_accessible>);
+
+class AsyncManagedMRTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    if (!rmm::detail::runtime_async_managed_alloc::is_supported()) {
+      GTEST_SKIP() << "Skipping tests since cudaMallocFromPoolAsync with managed pools is not "
+                   << "supported with this CUDA driver/runtime version";
+    }
+  }
+};
+
+TEST_F(AsyncManagedMRTest, BasicAllocateDeallocate)
+{
+  const auto alloc_size{100};
+  cuda_async_managed_mr mr{};
+  void* ptr = mr.allocate(alloc_size);
+  ASSERT_NE(nullptr, ptr);
+  mr.deallocate(ptr, alloc_size);
+  RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
+TEST_F(AsyncManagedMRTest, EqualityWithSamePool)
+{
+  // Two instances wrapping the same default managed pool should compare equal if they
+  // ultimately refer to the same underlying pool handle. Construct two and compare.
+  cuda_async_managed_mr mr1{};
+  cuda_async_managed_mr mr2{};
+  EXPECT_TRUE(mr1.is_equal(mr2));
+}
+
+}  // namespace
+}  // namespace rmm::test


### PR DESCRIPTION
## Description
Draft! Not yet ready for feedback. Contributes to #2054.

TODO:
- [ ] Look over C++ tests and make sure they're providing sufficient coverage (AI generated)
- [ ] Python bindings
- [ ] Docs
- [ ] Decide whether to reimplement `managed_memory_resource` on CUDA 13 with this?
- [ ] Determine whether decompression engine flags work, if provided (if so, should we use the default pool?)
- [ ] Determine whether we need to implement a release threshold argument, or provide docs on how to set that.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
