### PR TITLE
Fix bug in pinned_memory_resource with CCCL 3.1.x.

### DIFF
--- a/cpp/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/cpp/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -152,6 +152,12 @@ class pinned_memory_resource final : public host_memory_resource {
 #if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
 
  public:
+  // Explicitly inherit the allocate and deallocate functions from the host_memory_resource class.
+  // Due to inheritance and name hiding rules, we need to declare these with "using" when we
+  // override allocate and deallocate for CCCL 3.1.0+ compatibility.
+  using host_memory_resource::allocate;
+  using host_memory_resource::deallocate;
+
   /**
    * @brief Pretend to support the allocate_async interface, falling back to stream 0
    *

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -183,6 +183,9 @@ ConfigureTest(LIMITING_TEST mr/device/limiting_mr_tests.cpp)
 # host mr_ref tests
 ConfigureTest(HOST_MR_REF_TEST mr/host/mr_ref_tests.cpp)
 
+# pinned mr tests
+ConfigureTest(PINNED_MR_TEST mr/host/pinned_mr_tests.cpp)
+
 # pinned pool mr tests
 ConfigureTest(PINNED_POOL_MR_TEST mr/host/pinned_pool_mr_tests.cpp)
 

--- a/cpp/tests/mr/host/pinned_mr_tests.cpp
+++ b/cpp/tests/mr/host/pinned_mr_tests.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <rmm/mr/host/pinned_memory_resource.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <gtest/gtest.h>
+
+namespace rmm::test {
+namespace {
+
+// Returns true if a pointer points to pinned host memory.
+inline bool is_pinned_memory(void* ptr)
+{
+  cudaPointerAttributes attributes{};
+  if (cudaSuccess != cudaPointerGetAttributes(&attributes, ptr)) { return false; }
+  return attributes.type == cudaMemoryTypeHost;
+}
+
+}  // namespace
+
+// Issue 2057: Ensure the inherited host_memory_resource overload allocate(bytes) is usable
+TEST(PinnedMemoryResource, AllocateBytesOverload)
+{
+  rmm::mr::pinned_memory_resource mr;
+
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = mr.allocate(128));
+  EXPECT_NE(nullptr, ptr);
+  EXPECT_TRUE(is_pinned_memory(ptr));
+  EXPECT_NO_THROW(mr.deallocate(ptr, 128));
+}
+
+}  // namespace rmm::test


### PR DESCRIPTION
## Description
Closes #2057.

This fix only affects builds with CCCL 3.1.0+.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
