### PR TITLE
[MINOR] [DOC] Adding a note to stream operations in `device_buffer`

### DIFF
--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -205,6 +205,10 @@ class device_buffer {
    * copied on `stream` to the new allocation. The old allocation is then freed.
    * The bytes from `[size(), new_capacity)` are uninitialized.
    *
+   * @note This function does not synchronize `stream`. `new_capacity` is allocated on `stream`, so
+   * the caller is responsible for synchroning the current stream (accessed by `stream()`) before
+   * calling this function to ensure that the data is valid when the allocation occurs (if any).
+   *
    * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error if the copy from the old to new allocation
    * fails
@@ -232,6 +236,10 @@ class device_buffer {
    *
    * The invariant `size() <= capacity()` holds.
    *
+   * @note This function does not synchronize `stream`. `new_size` is allocated on `stream`, so
+   * the caller is responsible for synchroning the current stream (accessed by `stream()`) before
+   * calling this function to ensure that the data is valid when the allocation occurs (if any).
+   *
    * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error if the copy from the old to new allocation
    * fails
@@ -248,6 +256,10 @@ class device_buffer {
    * allocation to reduce `capacity()` to `size()`.
    *
    * If `size() == capacity()`, no allocations or copies occur.
+   *
+   * @note This function does not synchronize `stream`. The new buffer is allocated on `stream`, so
+   * the caller is responsible for synchroning the current stream (accessed by `stream()`) before
+   * calling this function to ensure that the data is valid when the allocation occurs (if any).
    *
    * @throws rmm::bad_alloc If creating the new allocation fails
    * @throws rmm::cuda_error If the copy from the old to new allocation fails


### PR DESCRIPTION
## Description
Closes #2080 

<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
