### PR TITLE
Make mock_mr deallocation noexcept

### DIFF
--- a/cpp/tests/mr/device/arena_mr_tests.cpp
+++ b/cpp/tests/mr/device/arena_mr_tests.cpp
@@ -43,9 +43,12 @@ namespace {
 class mock_memory_resource {
  public:
   MOCK_METHOD(void*, allocate, (std::size_t, std::size_t));
-  MOCK_METHOD(void, deallocate, (void*, std::size_t, std::size_t));
+  MOCK_METHOD(void, deallocate, (void*, std::size_t, std::size_t), (noexcept));
   MOCK_METHOD(void*, allocate_async, (std::size_t, std::size_t, cuda::stream_ref));
-  MOCK_METHOD(void, deallocate_async, (void*, std::size_t, std::size_t, cuda::stream_ref));
+  MOCK_METHOD(void,
+              deallocate_async,
+              (void*, std::size_t, std::size_t, cuda::stream_ref),
+              (noexcept));
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment)
   {


### PR DESCRIPTION
## Description
Follow-up to #2077. This change was missed in that PR. Enforcing `noexcept` in CCCL makes the RMM build fail.

xref: #2076

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
