### PR TITLE
Implicitly construct span from scalar in a test

### DIFF
--- a/cpp/tests/prefetch_tests.cpp
+++ b/cpp/tests/prefetch_tests.cpp
@@ -111,10 +111,7 @@ TYPED_TEST(PrefetchTest, DeviceUVector)
 TYPED_TEST(PrefetchTest, DeviceScalar)
 {
   rmm::device_scalar<int> scalar(this->stream, &this->mr);
-  // TODO once we update to a version of CCCL with https://github.com/NVIDIA/cccl/pull/1836,
-  // remove this explicit conversion to span
-  rmm::prefetch<int>(cuda::std::span<int const>{scalar.data(), scalar.size()},
-                     rmm::get_current_cuda_device(),
-                     this->stream);
+  // Implicitly constructs a span from the data and size
+  rmm::prefetch<int>({scalar.data(), scalar.size()}, rmm::get_current_cuda_device(), this->stream);
   this->expect_prefetched(scalar.data(), sizeof(int), rmm::get_current_cuda_device());
 }


### PR DESCRIPTION
## Description
Resolves a small TODO left over from https://github.com/rapidsai/rmm/pull/1573.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
