### PR TITLE
Derive pinned_host_memory_resource from device_memory_resource

### DIFF
--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -11,6 +11,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/nvtx/ranges.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
@@ -33,12 +34,20 @@ namespace mr {
  * `cuda::mr::memory_resource` and `cuda::mr::device_memory_resource` concepts, and
  * the `cuda::mr::host_accessible` and `cuda::mr::device_accessible` properties.
  */
-class pinned_host_memory_resource {
+class pinned_host_memory_resource final : public device_memory_resource {
  public:
-  // Disable clang-tidy complaining about the easily swappable size and alignment parameters
-  // of allocate and deallocate
-  // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+  pinned_host_memory_resource()           = default;
+  ~pinned_host_memory_resource() override = default;
+  pinned_host_memory_resource(pinned_host_memory_resource const&) =
+    default;  ///< @default_copy_constructor
+  pinned_host_memory_resource(pinned_host_memory_resource&&) =
+    default;  ///< @default_move_constructor
+  pinned_host_memory_resource& operator=(pinned_host_memory_resource const&) =
+    default;  ///< @default_copy_assignment{pinned_host_memory_resource}
+  pinned_host_memory_resource& operator=(pinned_host_memory_resource&&) =
+    default;  ///< @default_move_assignment{pinned_host_memory_resource}
 
+ private:
   /**
    * @brief Allocates pinned host memory of size at least \p bytes bytes.
    *
@@ -47,19 +56,20 @@ class pinned_host_memory_resource {
    * @throws rmm::bad_alloc if the requested allocation could not be fulfilled due to any other
    * reason.
    *
+   * The stream argument is ignored.
+   *
    * @param bytes The size, in bytes, of the allocation.
-   * @param alignment Alignment in bytes. Default alignment is used if unspecified.
+   * @param stream CUDA stream on which to perform the allocation (ignored).
    *
    * @return Pointer to the newly allocated memory.
    */
-  static void* allocate(std::size_t bytes,
-                        [[maybe_unused]] std::size_t alignment = rmm::RMM_DEFAULT_HOST_ALIGNMENT)
+  void* do_allocate(std::size_t bytes, [[maybe_unused]] cuda_stream_view stream) override
   {
-    RMM_FUNC_RANGE();
-
     // don't allocate anything if the user requested zero bytes
     if (0 == bytes) { return nullptr; }
 
+    // TODO: Use the alignment parameter as an argument to do_allocate
+    std::size_t constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
     return rmm::detail::aligned_host_allocate(bytes, alignment, [](std::size_t size) {
       void* ptr{nullptr};
       RMM_CUDA_TRY_ALLOC(cudaHostAlloc(&ptr, size, cudaHostAllocDefault), size);
@@ -68,117 +78,39 @@ class pinned_host_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p ptr of size \p bytes bytes.
+   * @brief Deallocate memory pointed to by \p p.
    *
-   * @param ptr Pointer to be deallocated.
-   * @param bytes Size of the allocation.
-   * @param alignment Alignment in bytes. Default alignment is used if unspecified.
+   * The stream argument is ignored.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the
+   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * @param stream This argument is ignored.
    */
-  static void deallocate(void* ptr,
-                         std::size_t bytes,
-                         std::size_t alignment = rmm::RMM_DEFAULT_HOST_ALIGNMENT) noexcept
+  void do_deallocate(void* ptr,
+                     std::size_t bytes,
+                     [[maybe_unused]] cuda_stream_view stream) noexcept override
   {
-    RMM_FUNC_RANGE();
-
+    // TODO: Use the alignment parameter as an argument to do_deallocate
+    std::size_t constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
     rmm::detail::aligned_host_deallocate(
       ptr, bytes, alignment, [](void* ptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeHost(ptr)); });
   }
 
   /**
-   * @brief Allocates pinned host memory of size at least \p bytes bytes.
+   * @brief Compare this resource to another.
    *
-   * @note Stream argument is ignored and behavior is identical to allocate.
+   * Two pinned_host_memory_resources always compare equal, because they can each
+   * deallocate memory allocated by the other.
    *
-   * @throws rmm::out_of_memory if the requested allocation could not be fulfilled due to to a
-   * CUDA out of memory error.
-   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled due to any other
-   * error.
-   *
-   * @param bytes The size, in bytes, of the allocation.
-   * @param stream CUDA stream on which to perform the allocation (ignored).
-   * @return Pointer to the newly allocated memory.
+   * @param other The other resource to compare to
+   * @return true If the two resources are equivalent
+   * @return false If the two resources are not equal
    */
-  static void* allocate_async(std::size_t bytes, [[maybe_unused]] cuda::stream_ref stream)
+  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override
   {
-    RMM_FUNC_RANGE();
-
-    return allocate(bytes);
+    return dynamic_cast<pinned_host_memory_resource const*>(&other) != nullptr;
   }
-
-  /**
-   * @brief Allocates pinned host memory of size at least \p bytes bytes and alignment \p alignment.
-   *
-   * @note Stream argument is ignored and behavior is identical to allocate.
-   *
-   * @throws rmm::out_of_memory if the requested allocation could not be fulfilled due to to a
-   * CUDA out of memory error.
-   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled due to any other
-   * error.
-   *
-   * @param bytes The size, in bytes, of the allocation.
-   * @param alignment Alignment in bytes.
-   * @param stream CUDA stream on which to perform the allocation (ignored).
-   * @return Pointer to the newly allocated memory.
-   */
-  static void* allocate_async(std::size_t bytes,
-                              std::size_t alignment,
-                              [[maybe_unused]] cuda::stream_ref stream)
-  {
-    RMM_FUNC_RANGE();
-
-    return allocate(bytes, alignment);
-  }
-
-  /**
-   * @brief Deallocate memory pointed to by \p ptr of size \p bytes bytes.
-   *
-   * @note Stream argument is ignored and behavior is identical to deallocate.
-   *
-   * @param ptr Pointer to be deallocated.
-   * @param bytes Size of the allocation.
-   * @param stream CUDA stream on which to perform the deallocation (ignored).
-   */
-  static void deallocate_async(void* ptr,
-                               std::size_t bytes,
-                               [[maybe_unused]] cuda::stream_ref stream) noexcept
-  {
-    RMM_FUNC_RANGE();
-
-    return deallocate(ptr, bytes);
-  }
-
-  /**
-   * @brief Deallocate memory pointed to by \p ptr of size \p bytes bytes and alignment \p
-   * alignment bytes.
-   *
-   * @note Stream argument is ignored and behavior is identical to deallocate.
-   *
-   * @param ptr Pointer to be deallocated.
-   * @param bytes Size of the allocation.
-   * @param alignment Alignment in bytes.
-   * @param stream CUDA stream on which to perform the deallocation (ignored).
-   */
-  static void deallocate_async(void* ptr,
-                               std::size_t bytes,
-                               std::size_t alignment,
-                               [[maybe_unused]] cuda::stream_ref stream) noexcept
-  {
-    RMM_FUNC_RANGE();
-
-    return deallocate(ptr, bytes, alignment);
-  }
-  // NOLINTEND(bugprone-easily-swappable-parameters)
-
-  /**
-   * @briefreturn{true if the specified resource is the same type as this resource.}
-   */
-  bool operator==(const pinned_host_memory_resource&) const { return true; }
-
-  /**
-   * @briefreturn{true if the specified resource is not the same type as this resource, otherwise
-   * false.}
-   */
-  bool operator!=(const pinned_host_memory_resource&) const { return false; }
 
   /**
    * @brief Enables the `cuda::mr::device_accessible` property
@@ -197,80 +129,6 @@ class pinned_host_memory_resource {
   friend void get_property(pinned_host_memory_resource const&, cuda::mr::host_accessible) noexcept
   {
   }
-
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
-
- public:
-  /**
-   * @brief Allocates pinned host memory of size at least \p bytes bytes.
-   *
-   * @throws rmm::out_of_memory if the requested allocation could not be fulfilled due to to a
-   * CUDA out of memory error.
-   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled due to any other
-   * reason.
-   *
-   * @param bytes The size, in bytes, of the allocation.
-   * @param alignment Alignment in bytes. Default alignment is used if unspecified.
-   *
-   * @return Pointer to the newly allocated memory.
-   */
-  static void* allocate_sync(std::size_t bytes, std::size_t alignment)
-  {
-    return allocate(bytes, alignment);
-  }
-
-  /**
-   * @brief Deallocate memory pointed to by \p ptr of size \p bytes bytes.
-   *
-   * @param ptr Pointer to be deallocated.
-   * @param bytes Size of the allocation.
-   * @param alignment Alignment in bytes. Default alignment is used if unspecified.
-   */
-  static void deallocate_sync(void* ptr, std::size_t bytes, std::size_t alignment)
-  {
-    return deallocate(ptr, bytes, alignment);
-  }
-
-  /**
-   * @brief Allocates pinned host memory of size at least \p bytes bytes and alignment \p alignment.
-   *
-   * @note Stream argument is ignored and behavior is identical to allocate.
-   *
-   * @throws rmm::out_of_memory if the requested allocation could not be fulfilled due to to a
-   * CUDA out of memory error.
-   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled due to any other
-   * error.
-   *
-   * @param stream CUDA stream on which to perform the allocation (ignored).
-   * @param bytes The size, in bytes, of the allocation.
-   * @param alignment Alignment in bytes.
-   * @return Pointer to the newly allocated memory.
-   */
-  static void* allocate(cuda_stream_view stream, std::size_t bytes, std::size_t alignment)
-  {
-    return allocate_async(bytes, alignment, stream);
-  }
-
-  /**
-   * @brief Deallocate memory pointed to by \p ptr of size \p bytes bytes and alignment \p
-   * alignment bytes.
-   *
-   * @note Stream argument is ignored and behavior is identical to deallocate.
-   *
-   * @param stream CUDA stream on which to perform the deallocation (ignored).
-   * @param ptr Pointer to be deallocated.
-   * @param bytes Size of the allocation.
-   * @param alignment Alignment in bytes.
-   */
-  static void deallocate(cuda_stream_view stream,
-                         void* ptr,
-                         std::size_t bytes,
-                         std::size_t alignment) noexcept
-  {
-    return deallocate_async(ptr, bytes, alignment, stream);
-  }
-
-#endif
 };
 
 static_assert(rmm::detail::polyfill::async_resource_with<pinned_host_memory_resource,

--- a/cpp/tests/mr/device/mr_ref_test.hpp
+++ b/cpp/tests/mr/device/mr_ref_test.hpp
@@ -371,7 +371,7 @@ inline void test_mixed_random_async_allocation_free(rmm::device_async_resource_r
 /// MR factory functions
 inline auto make_cuda() { return std::make_shared<rmm::mr::cuda_memory_resource>(); }
 
-inline auto make_host_pinned() { return std::make_shared<rmm::mr::pinned_host_memory_resource>(); }
+inline auto make_pinned() { return std::make_shared<rmm::mr::pinned_host_memory_resource>(); }
 
 inline auto make_cuda_async()
 {
@@ -403,10 +403,9 @@ inline auto make_pool()
     make_cuda(), rmm::percent_of_free_device_memory(50));
 }
 
-inline auto make_host_pinned_pool()
+inline auto make_pinned_pool()
 {
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-    make_host_pinned(), 2_GiB, 8_GiB);
+  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(make_pinned(), 2_GiB, 8_GiB);
 }
 
 inline auto make_arena()
@@ -471,9 +470,8 @@ inline std::shared_ptr<mr_factory_base> mr_factory_dispatch(std::string name)
 {
   if (name == "CUDA") {
     return std::make_shared<mr_factory<cuda_mr, decltype(make_cuda)>>("CUDA", make_cuda);
-  } else if (name == "Host_Pinned") {
-    return std::make_shared<mr_factory<pinned_mr, decltype(make_host_pinned)>>("Host_Pinned",
-                                                                               make_host_pinned);
+  } else if (name == "Pinned") {
+    return std::make_shared<mr_factory<pinned_mr, decltype(make_pinned)>>("Pinned", make_pinned);
   } else if (name == "CUDA_Async") {
     return std::make_shared<mr_factory<cuda_async_mr, decltype(make_cuda_async)>>("CUDA_Async",
                                                                                   make_cuda_async);
@@ -484,9 +482,9 @@ inline std::shared_ptr<mr_factory_base> mr_factory_dispatch(std::string name)
     return std::make_shared<mr_factory<system_mr, decltype(make_system)>>("System", make_system);
   } else if (name == "Pool") {
     return std::make_shared<mr_factory<pool_mr, decltype(make_pool)>>("Pool", make_pool);
-  } else if (name == "Host_Pinned_Pool") {
-    return std::make_shared<mr_factory<pinned_pool_mr, decltype(make_host_pinned_pool)>>(
-      "Host_Pinned_Pool", make_host_pinned_pool);
+  } else if (name == "Pinned_Pool") {
+    return std::make_shared<mr_factory<pinned_pool_mr, decltype(make_pinned_pool)>>(
+      "Pinned_Pool", make_pinned_pool);
   } else if (name == "Arena") {
     return std::make_shared<mr_factory<arena_mr, decltype(make_arena)>>("Arena", make_arena);
   } else if (name == "Binning") {


### PR DESCRIPTION
Makes `pinned_host_memory_resource` derive from `device_memory_resource` by implementing the standard `do_allocate`, `do_deallocate`, and `do_is_equal` interface.

This is one step contributing to #2090 and is a prerequisite for #1429 / #2105.

Unblocks follow-up work:
- https://github.com/rapidsai/cudf/issues/20003
- https://github.com/rapidsai/cuvs/pull/1466