### PR TITLE
Require CCCL >=3.1.0 and add CMake option to disable legacy MR interface

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -37,6 +37,7 @@ option(BUILD_BENCHMARKS "Configure CMake to build (google) benchmarks" OFF)
 # This is mostly so that dependent libraries are configured in shared mode for downstream dependents
 # of RMM that get their common dependencies transitively.
 option(BUILD_SHARED_LIBS "Build RMM shared libraries" ON)
+option(RMM_ENABLE_LEGACY_MR_INTERFACE "Enable legacy memory resource interface" ON)
 set(RMM_LOGGING_LEVEL
     "INFO"
     CACHE STRING "Choose the logging level.")
@@ -47,6 +48,7 @@ message(VERBOSE "RMM: Build with NVTX support: ${RMM_NVTX}")
 # Set logging level. Must go before including gtests and benchmarks. Set the possible values of
 # build type for cmake-gui.
 message(STATUS "RMM: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'")
+message(STATUS "RMM: Legacy MR interface enabled: ${RMM_ENABLE_LEGACY_MR_INTERFACE}")
 
 # cudart can be linked statically or dynamically
 option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
@@ -123,6 +125,11 @@ target_compile_definitions(rmm PUBLIC LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESO
 # Enable NVTX if necessary
 if(RMM_NVTX)
   target_compile_definitions(rmm PUBLIC RMM_NVTX)
+endif()
+
+# Control legacy MR interface visibility
+if(RMM_ENABLE_LEGACY_MR_INTERFACE)
+  target_compile_definitions(rmm PUBLIC RMM_ENABLE_LEGACY_MR_INTERFACE)
 endif()
 
 # ##################################################################################################

--- a/cpp/include/rmm/detail/cccl_adaptors.hpp
+++ b/cpp/include/rmm/detail/cccl_adaptors.hpp
@@ -23,6 +23,7 @@ class cccl_resource_ref : public ResourceType {
 
   cccl_resource_ref(base&& other) : base(std::move(other)) {}
 
+#ifdef RMM_ENABLE_LEGACY_MR_INTERFACE
   void* allocate(std::size_t bytes) { return this->allocate_sync(bytes); }
 
   void* allocate(std::size_t bytes, std::size_t alignment)
@@ -39,8 +40,8 @@ class cccl_resource_ref : public ResourceType {
   {
     return this->deallocate_sync(ptr, bytes, alignment);
   }
+#endif  // RMM_ENABLE_LEGACY_MR_INTERFACE
 
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
   void* allocate_sync(std::size_t bytes) { return base::allocate_sync(bytes); }
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment)
@@ -57,24 +58,6 @@ class cccl_resource_ref : public ResourceType {
   {
     return base::deallocate_sync(ptr, bytes, alignment);
   }
-#else
-  void* allocate_sync(std::size_t bytes) { return base::allocate(bytes); }
-
-  void* allocate_sync(std::size_t bytes, std::size_t alignment)
-  {
-    return base::allocate(bytes, alignment);
-  }
-
-  void deallocate_sync(void* ptr, std::size_t bytes) noexcept
-  {
-    return base::deallocate(ptr, bytes);
-  }
-
-  void deallocate_sync(void* ptr, std::size_t bytes, std::size_t alignment) noexcept
-  {
-    return base::deallocate(ptr, bytes, alignment);
-  }
-#endif
 };
 
 template <typename ResourceType>
@@ -87,8 +70,7 @@ class cccl_async_resource_ref : public ResourceType {
   cccl_async_resource_ref(base const& other) : base(other) {}
   cccl_async_resource_ref(base&& other) : base(std::move(other)) {}
 
-  // BEGINNING OF LEGACY MR METHODS
-
+#ifdef RMM_ENABLE_LEGACY_MR_INTERFACE
   void* allocate(std::size_t bytes) { return this->allocate_sync(bytes); }
 
   void* allocate(std::size_t bytes, std::size_t alignment)
@@ -129,9 +111,8 @@ class cccl_async_resource_ref : public ResourceType {
     return this->deallocate(stream, ptr, bytes, alignment);
   }
 
-  // END OF LEGACY MR METHODS
+#endif  // RMM_ENABLE_LEGACY_MR_INTERFACE
 
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
   void* allocate_sync(std::size_t bytes) { return base::allocate_sync(bytes); }
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment)
@@ -171,47 +152,6 @@ class cccl_async_resource_ref : public ResourceType {
   {
     return base::deallocate(stream, ptr, bytes, alignment);
   }
-#else
-  void* allocate_sync(std::size_t bytes) { return base::allocate(bytes); }
-
-  void* allocate_sync(std::size_t bytes, std::size_t alignment)
-  {
-    return base::allocate(bytes, alignment);
-  }
-
-  void deallocate_sync(void* ptr, std::size_t bytes) noexcept
-  {
-    return base::deallocate(ptr, bytes);
-  }
-
-  void deallocate_sync(void* ptr, std::size_t bytes, std::size_t alignment) noexcept
-  {
-    return base::deallocate(ptr, bytes, alignment);
-  }
-
-  void* allocate(cuda_stream_view stream, std::size_t bytes)
-  {
-    return base::allocate_async(bytes, stream);
-  }
-
-  void* allocate(cuda_stream_view stream, std::size_t bytes, std::size_t alignment)
-  {
-    return base::allocate_async(bytes, alignment, stream);
-  }
-
-  void deallocate(cuda_stream_view stream, void* ptr, std::size_t bytes) noexcept
-  {
-    return base::deallocate_async(ptr, bytes, stream);
-  }
-
-  void deallocate(cuda_stream_view stream,
-                  void* ptr,
-                  std::size_t bytes,
-                  std::size_t alignment) noexcept
-  {
-    return base::deallocate_async(ptr, bytes, alignment, stream);
-  }
-#endif
 };
 
 }  // namespace detail

--- a/cpp/include/rmm/detail/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/detail/cuda_memory_resource.hpp
@@ -7,7 +7,7 @@
 #ifndef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 #error \
   "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined. Please add -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to the compiler flags (this is done automatically when using RMM via CMake)."
-#endif
+#endif  // LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
 #include <rmm/detail/export.hpp>
 
@@ -17,7 +17,6 @@ namespace RMM_NAMESPACE {
 namespace detail {
 namespace polyfill {
 
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
 template <class Resource>
 inline constexpr bool resource = cuda::mr::synchronous_resource<Resource>;
 template <class Resource, class... Properties>
@@ -26,16 +25,6 @@ template <class Resource>
 inline constexpr bool async_resource = cuda::mr::resource<Resource>;
 template <class Resource, class... Properties>
 inline constexpr bool async_resource_with = cuda::mr::resource_with<Resource, Properties...>;
-#else   // ^^^ CCCL >= 3.1 ^^^ / vvv CCCL < 3.1 vvv
-template <class Resource>
-inline constexpr bool resource = cuda::mr::resource<Resource>;
-template <class Resource, class... Properties>
-inline constexpr bool resource_with = cuda::mr::resource_with<Resource, Properties...>;
-template <class Resource>
-inline constexpr bool async_resource = cuda::mr::async_resource<Resource>;
-template <class Resource, class... Properties>
-inline constexpr bool async_resource_with = cuda::mr::async_resource_with<Resource, Properties...>;
-#endif  // CCCL < 3.1
 
 }  // namespace polyfill
 }  // namespace detail

--- a/cpp/include/rmm/mr/device/device_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/device_memory_resource.hpp
@@ -92,6 +92,7 @@ class device_memory_resource {
   device_memory_resource& operator=(device_memory_resource&&) noexcept =
     default;  ///< @default_move_assignment{device_memory_resource}
 
+#ifdef RMM_ENABLE_LEGACY_MR_INTERFACE
   /**
    * @brief Allocates memory of size at least \p bytes.
    *
@@ -138,24 +139,6 @@ class device_memory_resource {
   {
     RMM_FUNC_RANGE();
     do_deallocate(ptr, bytes, stream);
-  }
-
-  /**
-   * @brief Compare this resource to another.
-   *
-   * Two device_memory_resources compare equal if and only if memory allocated
-   * from one device_memory_resource can be deallocated from the other and vice
-   * versa.
-   *
-   * By default, simply checks if \p *this and \p other refer to the same
-   * object, i.e., does not check if they are two objects of the same class.
-   *
-   * @param other The other resource to compare to
-   * @returns If the two resources are equivalent
-   */
-  [[nodiscard]] bool is_equal(device_memory_resource const& other) const noexcept
-  {
-    return do_is_equal(other);
   }
 
   /**
@@ -282,9 +265,7 @@ class device_memory_resource {
     RMM_FUNC_RANGE();
     do_deallocate(ptr, bytes, stream);
   }
-
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
-  // CCCL >= 3.1 needs a different set of methods to satisfy the memory resource concepts
+#endif  // RMM_ENABLE_LEGACY_MR_INTERFACE
 
   /**
    * @brief Allocates memory of size at least \p bytes.
@@ -360,7 +341,24 @@ class device_memory_resource {
   {
     do_deallocate(ptr, rmm::align_up(bytes, alignment), stream);
   }
-#endif  // CCCL >= 3.1
+
+  /**
+   * @brief Compare this resource to another.
+   *
+   * Two device_memory_resources compare equal if and only if memory allocated
+   * from one device_memory_resource can be deallocated from the other and vice
+   * versa.
+   *
+   * By default, simply checks if \p *this and \p other refer to the same
+   * object, i.e., does not check if they are two objects of the same class.
+   *
+   * @param other The other resource to compare to
+   * @returns If the two resources are equivalent
+   */
+  [[nodiscard]] bool is_equal(device_memory_resource const& other) const noexcept
+  {
+    return do_is_equal(other);
+  }
 
   /**
    * @brief Comparison operator with another device_memory_resource

--- a/cpp/include/rmm/mr/host/host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/host/host_memory_resource.hpp
@@ -56,6 +56,7 @@ host_memory_resource {
   host_memory_resource& operator=(host_memory_resource&&) noexcept =
     default;  ///< @default_move_assignment{host_memory_resource}
 
+#ifdef RMM_ENABLE_LEGACY_MR_INTERFACE
   /**
    * @brief Allocates memory on the host of size at least `bytes` bytes.
    *
@@ -90,6 +91,46 @@ host_memory_resource {
   void deallocate(void* ptr,
                   std::size_t bytes,
                   std::size_t alignment = alignof(std::max_align_t)) noexcept
+  {
+    RMM_FUNC_RANGE();
+    do_deallocate(ptr, bytes, alignment);
+  }
+#endif  // RMM_ENABLE_LEGACY_MR_INTERFACE
+
+  /**
+   * @brief Allocates memory on the host of size at least `bytes` bytes.
+   *
+   * The returned storage is aligned to the specified `alignment` if provided, and to
+   * `alignof(std::max_align_t)` otherwise.
+   *
+   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be allocated.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment Alignment of the allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
+  {
+    RMM_FUNC_RANGE();
+    return do_allocate(bytes, alignment);
+  }
+
+  /**
+   * @brief Deallocate memory pointed to by `ptr`.
+   *
+   * `ptr` must have been returned by a prior call to `allocate(bytes, alignment)` on a
+   * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
+   * yet have been deallocated, otherwise behavior is undefined.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
+   *              that was passed to the `allocate` call that returned `ptr`.
+   * @param alignment Alignment of the allocation. This must be equal to the value of `alignment`
+   *                  that was passed to the `allocate` call that returned `ptr`.
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = alignof(std::max_align_t)) noexcept
   {
     RMM_FUNC_RANGE();
     do_deallocate(ptr, bytes, alignment);
@@ -192,46 +233,6 @@ host_memory_resource {
   {
     return this == &other;
   }
-
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
-
- public:
-  /**
-   * @brief Allocates memory on the host of size at least `bytes` bytes.
-   *
-   * The returned storage is aligned to the specified `alignment` if supported, and to
-   * `alignof(std::max_align_t)` otherwise.
-   *
-   * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be allocated.
-   *
-   * @param bytes The size of the allocation
-   * @param alignment Alignment of the allocation
-   * @return void* Pointer to the newly allocated memory
-   */
-  void* allocate_sync(std::size_t bytes, std::size_t alignment)
-  {
-    return allocate(bytes, alignment);
-  }
-
-  /**
-   * @brief Deallocate memory pointed to by `ptr`.
-   *
-   * `ptr` must have been returned by a prior call to `allocate(bytes,alignment)` on a
-   * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
-   * yet have been deallocated, otherwise behavior is undefined.
-   *
-   * @param ptr Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the value of `bytes`
-   *              that was passed to the `allocate` call that returned `ptr`.
-   * @param alignment Alignment of the allocation. This must be equal to the value of `alignment`
-   *                  that was passed to the `allocate` call that returned `ptr`.
-   */
-  void deallocate_sync(void* ptr, std::size_t bytes, std::size_t alignment)
-  {
-    return deallocate(ptr, bytes, alignment);
-  }
-
-#endif
 };
 
 // static property checks

--- a/cpp/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/cpp/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -45,6 +45,7 @@ class [[deprecated(
   pinned_memory_resource& operator=(pinned_memory_resource&&) =
     default;  ///< @default_move_assignment{pinned_memory_resource}
 
+#ifdef RMM_ENABLE_LEGACY_MR_INTERFACE
   /**
    * @brief Pretend to support the allocate_async interface, falling back to stream 0
    *
@@ -88,6 +89,48 @@ class [[deprecated(
                         cuda_stream_view) noexcept
   {
     do_deallocate(ptr, rmm::align_up(bytes, alignment));
+  }
+
+  // Explicitly inherit the allocate and deallocate functions from the host_memory_resource class.
+  // Due to inheritance and name hiding rules, we need to declare these with "using" when we
+  // override allocate and deallocate for CCCL 3.1.0+ compatibility.
+  using host_memory_resource::allocate;
+  using host_memory_resource::deallocate;
+#endif  // RMM_ENABLE_LEGACY_MR_INTERFACE
+
+  /**
+   * @brief Pretend to support the allocate_async interface, falling back to stream 0
+   *
+   * @throws rmm::bad_alloc When the requested `bytes` cannot be allocated on
+   * the specified `stream`.
+   *
+   * @param stream CUDA stream on which to perform the deallocation (ignored).
+   * @param bytes The size of the allocation
+   * @param alignment The expected alignment of the allocation
+   * @return void* Pointer to the newly allocated memory
+   */
+  void* allocate(cuda_stream_view stream,
+                 std::size_t bytes,
+                 std::size_t alignment = rmm::RMM_DEFAULT_HOST_ALIGNMENT)
+  {
+    return do_allocate(bytes, alignment);
+  }
+
+  /**
+   * @brief Pretend to support the deallocate_async interface, falling back to stream 0
+   *
+   * @param stream CUDA stream on which to perform the deallocation (ignored).
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation. This must be equal to the
+   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * @param alignment The alignment that was passed to the `allocate` call that returned `p`
+   */
+  void deallocate(cuda_stream_view stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::RMM_DEFAULT_HOST_ALIGNMENT) noexcept
+  {
+    return do_deallocate(ptr, bytes, alignment);
   }
 
   /**
@@ -147,50 +190,6 @@ class [[deprecated(
     rmm::detail::aligned_host_deallocate(
       ptr, bytes, alignment, [](void* ptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeHost(ptr)); });
   }
-
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
-
- public:
-  // Explicitly inherit the allocate and deallocate functions from the host_memory_resource class.
-  // Due to inheritance and name hiding rules, we need to declare these with "using" when we
-  // override allocate and deallocate for CCCL 3.1.0+ compatibility.
-  using host_memory_resource::allocate;
-  using host_memory_resource::deallocate;
-
-  /**
-   * @brief Pretend to support the allocate_async interface, falling back to stream 0
-   *
-   * @throws rmm::bad_alloc When the requested `bytes` cannot be allocated on
-   * the specified `stream`.
-   *
-   * @param stream CUDA stream on which to perform the deallocation (ignored).
-   * @param bytes The size of the allocation
-   * @param alignment The expected alignment of the allocation
-   * @return void* Pointer to the newly allocated memory
-   */
-  void* allocate(cuda_stream_view stream, std::size_t bytes, std::size_t alignment)
-  {
-    return this->allocate_async(bytes, alignment, stream);
-  }
-
-  /**
-   * @brief Pretend to support the deallocate_async interface, falling back to stream 0
-   *
-   * @param stream CUDA stream on which to perform the deallocation (ignored).
-   * @param ptr Pointer to be deallocated
-   * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
-   * @param alignment The alignment that was passed to the `allocate` call that returned `p`
-   */
-  void deallocate(cuda_stream_view stream,
-                  void* ptr,
-                  std::size_t bytes,
-                  std::size_t alignment) noexcept
-  {
-    return this->deallocate_async(ptr, bytes, alignment, stream);
-  }
-
-#endif
 };
 
 // static property checks

--- a/cpp/include/rmm/resource_ref.hpp
+++ b/cpp/include/rmm/resource_ref.hpp
@@ -17,8 +17,6 @@ namespace RMM_NAMESPACE {
  * @file
  */
 
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 1)
-
 /**
  * @brief Alias for a `cuda::mr::resource_ref` with the property
  * `cuda::mr::device_accessible`.
@@ -60,52 +58,6 @@ using host_device_resource_ref = detail::cccl_resource_ref<
  */
 using host_device_async_resource_ref = detail::cccl_async_resource_ref<
   cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>>;
-
-#else
-
-/**
- * @brief Alias for a `cuda::mr::resource_ref` with the property
- * `cuda::mr::device_accessible`.
- */
-using device_resource_ref =
-  detail::cccl_resource_ref<cuda::mr::resource_ref<cuda::mr::device_accessible>>;
-
-/**
- * @brief Alias for a `cuda::mr::async_resource_ref` with the property
- * `cuda::mr::device_accessible`.
- */
-using device_async_resource_ref =
-  detail::cccl_async_resource_ref<cuda::mr::async_resource_ref<cuda::mr::device_accessible>>;
-
-/**
- * @brief Alias for a `cuda::mr::resource_ref` with the property
- * `cuda::mr::host_accessible`.
- */
-using host_resource_ref =
-  detail::cccl_resource_ref<cuda::mr::resource_ref<cuda::mr::host_accessible>>;
-
-/**
- * @brief Alias for a `cuda::mr::async_resource_ref` with the property
- * `cuda::mr::host_accessible`.
- */
-using host_async_resource_ref =
-  detail::cccl_async_resource_ref<cuda::mr::async_resource_ref<cuda::mr::host_accessible>>;
-
-/**
- * @brief Alias for a `cuda::mr::resource_ref` with the properties
- * `cuda::mr::host_accessible` and `cuda::mr::device_accessible`.
- */
-using host_device_resource_ref = detail::cccl_resource_ref<
-  cuda::mr::resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>>;
-
-/**
- * @brief Alias for a `cuda::mr::async_resource_ref` with the properties
- * `cuda::mr::host_accessible` and `cuda::mr::device_accessible`.
- */
-using host_device_async_resource_ref = detail::cccl_async_resource_ref<
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>>;
-
-#endif
 
 /**
  * @brief Convert pointer to memory resource into `device_async_resource_ref`, checking for

--- a/cpp/tests/mr/device/arena_mr_tests.cpp
+++ b/cpp/tests/mr/device/arena_mr_tests.cpp
@@ -31,6 +31,7 @@ namespace {
 
 class mock_memory_resource {
  public:
+#ifdef RMM_ENABLE_LEGACY_MR_INTERFACE
   MOCK_METHOD(void*, allocate, (std::size_t, std::size_t));
   MOCK_METHOD(void, deallocate, (void*, std::size_t, std::size_t), (noexcept));
   MOCK_METHOD(void*, allocate_async, (std::size_t, std::size_t, cuda::stream_ref));
@@ -38,6 +39,7 @@ class mock_memory_resource {
               deallocate_async,
               (void*, std::size_t, std::size_t, cuda::stream_ref),
               (noexcept));
+#endif  // RMM_ENABLE_LEGACY_MR_INTERFACE
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment)
   {

--- a/cpp/tests/mr/device/pool_mr_tests.cpp
+++ b/cpp/tests/mr/device/pool_mr_tests.cpp
@@ -182,14 +182,17 @@ namespace test_properties {
 class fake_async_resource {
  public:
   // To model `async_resource`
+#ifdef RMM_ENABLE_LEGACY_MR_INTERFACE
   static void* allocate(std::size_t, std::size_t) { return nullptr; }
-  static void deallocate(void* ptr, std::size_t, std::size_t) {}
+  static void deallocate(void* ptr, std::size_t, std::size_t) noexcept {}
   static void* allocate_async(std::size_t, std::size_t, cuda::stream_ref) { return nullptr; }
-  static void deallocate_async(void* ptr, std::size_t, std::size_t, cuda::stream_ref) {}
+  static void deallocate_async(void* ptr, std::size_t, std::size_t, cuda::stream_ref) noexcept {}
+#endif  // RMM_ENABLE_LEGACY_MR_INTERFACE
+
   void* allocate_sync(std::size_t, std::size_t) { return nullptr; }
-  void deallocate_sync(void* ptr, std::size_t, std::size_t) {}
+  void deallocate_sync(void* ptr, std::size_t, std::size_t) noexcept {}
   void* allocate(cuda_stream_view, std::size_t, std::size_t) { return nullptr; }
-  void deallocate(cuda_stream_view, void*, std::size_t, std::size_t) { return; }
+  void deallocate(cuda_stream_view, void*, std::size_t, std::size_t) noexcept { return; }
 
   bool operator==(const fake_async_resource& other) const { return true; }
   bool operator!=(const fake_async_resource& other) const { return false; }


### PR DESCRIPTION
## Description
Part of #2011. Split up from #2089.

This PR makes the current (soon to be legacy) memory resource interface configurable. If the CMake option `RMM_ENABLE_LEGACY_MR_INTERFACE` is disabled, then legacy methods will not be exposed. This will allow us to incrementally update RAPIDS until everything builds with the legacy interface disabled.

This PR requires #2112 to support the "legacy memory resource interface disabled" state, but I am happy to merge in either order and then do further validation of the "disabled" state.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
