### PR TITLE
Remove align-up on base allocations.

### DIFF
--- a/cpp/include/rmm/aligned.hpp
+++ b/cpp/include/rmm/aligned.hpp
@@ -9,7 +9,6 @@
 
 #include <cassert>
 #include <cstddef>
-#include <cstdint>
 
 namespace RMM_EXPORT rmm {
 

--- a/cpp/include/rmm/mr/device/device_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/device_memory_resource.hpp
@@ -170,13 +170,13 @@ class device_memory_resource {
    * the specified `stream`.
    *
    * @param bytes The size of the allocation
-   * @param alignment The expected alignment of the allocation
+   * @param alignment The alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    */
   void* allocate(std::size_t bytes, std::size_t alignment)
   {
     RMM_FUNC_RANGE();
-    return do_allocate(rmm::align_up(bytes, alignment), cuda_stream_view{});
+    return do_allocate(bytes, cuda_stream_view{});
   }
 
   /**
@@ -195,7 +195,7 @@ class device_memory_resource {
   void deallocate(void* ptr, std::size_t bytes, std::size_t alignment) noexcept
   {
     RMM_FUNC_RANGE();
-    do_deallocate(ptr, rmm::align_up(bytes, alignment), cuda_stream_view{});
+    do_deallocate(ptr, bytes, cuda_stream_view{});
   }
 
   /**
@@ -217,7 +217,7 @@ class device_memory_resource {
   void* allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream)
   {
     RMM_FUNC_RANGE();
-    return do_allocate(rmm::align_up(bytes, alignment), stream);
+    return do_allocate(bytes, stream);
   }
 
   /**
@@ -261,7 +261,7 @@ class device_memory_resource {
                         cuda_stream_view stream) noexcept
   {
     RMM_FUNC_RANGE();
-    do_deallocate(ptr, rmm::align_up(bytes, alignment), stream);
+    do_deallocate(ptr, bytes, stream);
   }
 
   /**
@@ -289,21 +289,22 @@ class device_memory_resource {
   /**
    * @brief Allocates memory of size at least \p bytes.
    *
-   * The returned pointer will have at minimum 256 byte alignment.
+   * The returned pointer will have 256 byte alignment regardless of the value
+   * of alignment. Higher alignments must use the aligned_resource_adaptor.
    *
    * @throws rmm::bad_alloc When the requested `bytes` cannot be allocated.
    *
    * @param bytes The size of the allocation
-   * @param alignment The expected alignment of the allocation (must be a power of two and less than
-   * or equal to 256)
+   * @param alignment The alignment of the allocation (see notes above)
    * @return void* Pointer to the newly allocated memory
    */
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    RMM_EXPECTS(alignment <= 256 && rmm::is_supported_alignment(alignment),
-                "Alignment must be less than or equal to 256 and a power of two",
-                rmm::bad_alloc);
-    return do_allocate(rmm::align_up(bytes, alignment), cuda_stream_view{});
+    RMM_EXPECTS(
+      alignment <= rmm::CUDA_ALLOCATION_ALIGNMENT && rmm::is_supported_alignment(alignment),
+      "Alignment must be less than or equal to 256 and a power of two",
+      rmm::bad_alloc);
+    return do_allocate(bytes, cuda_stream_view{});
   }
 
   /**
@@ -318,30 +319,31 @@ class device_memory_resource {
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    do_deallocate(ptr, rmm::align_up(bytes, alignment), cuda_stream_view{});
+    do_deallocate(ptr, bytes, cuda_stream_view{});
   }
 
   /**
    * @brief Allocates memory of size at least \p bytes on the specified stream.
    *
-   * The returned pointer will have at minimum 256 byte alignment.
+   * The returned pointer will have 256 byte alignment regardless of the value
+   * of alignment. Higher alignments must use the aligned_resource_adaptor.
    *
    * @throws rmm::bad_alloc When the requested `bytes` cannot be allocated.
    *
    * @param stream The stream on which to perform the allocation
    * @param bytes The size of the allocation
-   * @param alignment The expected alignment of the allocation (must be a power of two and less than
-   * or equal to 256)
+   * @param alignment The alignment of the allocation (see notes above)
    * @return void* Pointer to the newly allocated memory
    */
   void* allocate(cuda_stream_view stream,
                  std::size_t bytes,
                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    RMM_EXPECTS(alignment <= 256 && rmm::is_supported_alignment(alignment),
-                "Alignment must be less than or equal to 256 and a power of two",
-                rmm::bad_alloc);
-    return do_allocate(rmm::align_up(bytes, alignment), stream);
+    RMM_EXPECTS(
+      alignment <= rmm::CUDA_ALLOCATION_ALIGNMENT && rmm::is_supported_alignment(alignment),
+      "Alignment must be less than or equal to 256 and a power of two",
+      rmm::bad_alloc);
+    return do_allocate(bytes, stream);
   }
 
   /**
@@ -358,7 +360,7 @@ class device_memory_resource {
                   std::size_t bytes,
                   std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    do_deallocate(ptr, rmm::align_up(bytes, alignment), stream);
+    do_deallocate(ptr, bytes, stream);
   }
 #endif  // CCCL >= 3.1
 

--- a/cpp/include/rmm/mr/device/pool_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/pool_memory_resource.hpp
@@ -328,9 +328,8 @@ class pool_memory_resource final
   {
     if (maximum_pool_size_.has_value()) {
       auto const unaligned_remaining = maximum_pool_size_.value() - pool_size();
-      using rmm::align_up;
-      auto const remaining    = align_up(unaligned_remaining, rmm::CUDA_ALLOCATION_ALIGNMENT);
-      auto const aligned_size = align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+      auto const remaining    = rmm::align_up(unaligned_remaining, rmm::CUDA_ALLOCATION_ALIGNMENT);
+      auto const aligned_size = rmm::align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT);
       return (aligned_size <= remaining) ? std::max(aligned_size, remaining / 2) : 0;
     }
     return std::max(size, pool_size());

--- a/cpp/include/rmm/mr/host/host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/host/host_memory_resource.hpp
@@ -59,7 +59,7 @@ host_memory_resource {
   /**
    * @brief Allocates memory on the host of size at least `bytes` bytes.
    *
-   * The returned storage is aligned to the specified `alignment` if supported, and to
+   * The returned storage is aligned to the specified `alignment` if provided, and to
    * `alignof(std::max_align_t)` otherwise.
    *
    * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be allocated.
@@ -77,7 +77,7 @@ host_memory_resource {
   /**
    * @brief Deallocate memory pointed to by `ptr`.
    *
-   * `ptr` must have been returned by a prior call to `allocate(bytes,alignment)` on a
+   * `ptr` must have been returned by a prior call to `allocate(bytes, alignment)` on a
    * `host_memory_resource` that compares equal to `*this`, and the storage it points to must not
    * yet have been deallocated, otherwise behavior is undefined.
    *

--- a/cpp/include/rmm/mr/host/pinned_memory_resource.hpp
+++ b/cpp/include/rmm/mr/host/pinned_memory_resource.hpp
@@ -87,7 +87,7 @@ class [[deprecated(
                         std::size_t alignment,
                         cuda_stream_view) noexcept
   {
-    do_deallocate(ptr, rmm::align_up(bytes, alignment));
+    do_deallocate(ptr, bytes);
   }
 
   /**
@@ -102,7 +102,7 @@ class [[deprecated(
    * @brief Allocates pinned memory on the host of size at least `bytes` bytes.
    *
    * The returned storage is aligned to the specified `alignment` if supported, and to
-   * `alignof(std::max_align_t)` otherwise.
+   * `rmm::RMM_DEFAULT_HOST_ALIGNMENT` otherwise.
    *
    * @throws std::bad_alloc When the requested `bytes` and `alignment` cannot be allocated.
    *
@@ -110,7 +110,8 @@ class [[deprecated(
    * @param alignment Alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* do_allocate(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t)) override
+  void* do_allocate(std::size_t bytes,
+                    std::size_t alignment = rmm::RMM_DEFAULT_HOST_ALIGNMENT) override
   {
     // don't allocate anything if the user requested zero bytes
     if (0 == bytes) { return nullptr; }
@@ -141,7 +142,7 @@ class [[deprecated(
    */
   void do_deallocate(void* ptr,
                      std::size_t bytes,
-                     std::size_t alignment = alignof(std::max_align_t)) noexcept override
+                     std::size_t alignment = rmm::RMM_DEFAULT_HOST_ALIGNMENT) noexcept override
   {
     if (nullptr == ptr) { return; }
     rmm::detail::aligned_host_deallocate(

--- a/cpp/tests/mr/device/arena_mr_tests.cpp
+++ b/cpp/tests/mr/device/arena_mr_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "../../byte_literals.hpp"
 
+#include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
 #include <rmm/error.hpp>

--- a/python/rmm/rmm/tests/test_rmm.py
+++ b/python/rmm/rmm/tests/test_rmm.py
@@ -806,7 +806,7 @@ def test_tracking_resource_adaptor():
     for i in range(9, 0, -2):
         del buffers[i]
 
-    assert mr.get_allocated_bytes() == 5040
+    assert mr.get_allocated_bytes() == 5000
 
     # Push a new Tracking adaptor
     mr2 = rmm.mr.TrackingResourceAdaptor(mr, capture_stacks=True)
@@ -815,8 +815,8 @@ def test_tracking_resource_adaptor():
     for _ in range(2):
         buffers.append(rmm.DeviceBuffer(size=1000))
 
-    assert mr2.get_allocated_bytes() == 2016
-    assert mr.get_allocated_bytes() == 7056
+    assert mr2.get_allocated_bytes() == 2000
+    assert mr.get_allocated_bytes() == 7000
 
     # Ensure we get back a non-empty string for the allocations
     assert len(mr.get_outstanding_allocations_str()) > 0

--- a/python/rmm/rmm/tests/test_statistics.py
+++ b/python/rmm/rmm/tests/test_statistics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
@@ -27,11 +27,11 @@ def test_context():
         )
         b1 = rmm.DeviceBuffer(size=20)
         stats = get_statistics()
-        assert stats.current_bytes == 32
+        assert stats.current_bytes == 20
         assert stats.current_count == 1
-        assert stats.peak_bytes == 32
+        assert stats.peak_bytes == 20
         assert stats.peak_count == 1
-        assert stats.total_bytes == 32
+        assert stats.total_bytes == 20
         assert stats.total_count == 1
 
         with statistics():
@@ -39,19 +39,19 @@ def test_context():
             assert mr1 is mr2
             b2 = rmm.DeviceBuffer(size=10)
             stats = get_statistics()
-            assert stats.current_bytes == 16
+            assert stats.current_bytes == 10
             assert stats.current_count == 1
-            assert stats.peak_bytes == 16
+            assert stats.peak_bytes == 10
             assert stats.peak_count == 1
-            assert stats.total_bytes == 16
+            assert stats.total_bytes == 10
             assert stats.total_count == 1
 
         stats = get_statistics()
-        assert stats.current_bytes == 48
+        assert stats.current_bytes == 30
         assert stats.current_count == 2
-        assert stats.peak_bytes == 48
+        assert stats.peak_bytes == 30
         assert stats.peak_count == 2
-        assert stats.total_bytes == 48
+        assert stats.total_bytes == 30
         assert stats.total_count == 2
 
         del b1
@@ -66,11 +66,11 @@ def test_multiple_mr(stats_mr):
         del buffers[i]
 
     stats = stats_mr.allocation_counts
-    assert stats.current_bytes == 5040
+    assert stats.current_bytes == 5000
     assert stats.current_count == 5
-    assert stats.peak_bytes == 10080
+    assert stats.peak_bytes == 10000
     assert stats.peak_count == 10
-    assert stats.total_bytes == 10080
+    assert stats.total_bytes == 10000
     assert stats.total_count == 10
 
     # Push a new Tracking adaptor
@@ -81,36 +81,36 @@ def test_multiple_mr(stats_mr):
             buffers.append(rmm.DeviceBuffer(size=1000))
 
         stats = mr2.allocation_counts
-        assert stats.current_bytes == 2016
+        assert stats.current_bytes == 2000
         assert stats.current_count == 2
-        assert stats.peak_bytes == 2016
+        assert stats.peak_bytes == 2000
         assert stats.peak_count == 2
-        assert stats.total_bytes == 2016
+        assert stats.total_bytes == 2000
         assert stats.total_count == 2
 
         stats = stats_mr.allocation_counts
-        assert stats.current_bytes == 7056
+        assert stats.current_bytes == 7000
         assert stats.current_count == 7
-        assert stats.peak_bytes == 10080
+        assert stats.peak_bytes == 10000
         assert stats.peak_count == 10
-        assert stats.total_bytes == 12096
+        assert stats.total_bytes == 12000
         assert stats.total_count == 12
 
         del buffers
         stats = mr2.allocation_counts
         assert stats.current_bytes == 0
         assert stats.current_count == 0
-        assert stats.peak_bytes == 2016
+        assert stats.peak_bytes == 2000
         assert stats.peak_count == 2
-        assert stats.total_bytes == 2016
+        assert stats.total_bytes == 2000
         assert stats.total_count == 2
 
         stats = stats_mr.allocation_counts
         assert stats.current_bytes == 0
         assert stats.current_count == 0
-        assert stats.peak_bytes == 10080
+        assert stats.peak_bytes == 10000
         assert stats.peak_count == 10
-        assert stats.total_bytes == 12096
+        assert stats.total_bytes == 12000
         assert stats.total_count == 12
 
     finally:
@@ -122,21 +122,21 @@ def test_counter_stack(stats_mr):
 
     # push returns the stats from the top before the push
     stats = stats_mr.push_counters()  # stats from stack level 0
-    assert stats.current_bytes == 160
+    assert stats.current_bytes == 100
     assert stats.current_count == 10
-    assert stats.peak_bytes == 160
+    assert stats.peak_bytes == 100
     assert stats.peak_count == 10
-    assert stats.total_bytes == 160
+    assert stats.total_bytes == 100
     assert stats.total_count == 10
 
     b1 = rmm.DeviceBuffer(size=10)
 
     stats = stats_mr.push_counters()  # stats from stack level 1
-    assert stats.current_bytes == 16
+    assert stats.current_bytes == 10
     assert stats.current_count == 1
-    assert stats.peak_bytes == 16
+    assert stats.peak_bytes == 10
     assert stats.peak_count == 1
-    assert stats.total_bytes == 16
+    assert stats.total_bytes == 10
     assert stats.total_count == 1
 
     del b1
@@ -144,7 +144,7 @@ def test_counter_stack(stats_mr):
     # pop returns the popped stats
     # Note, the bytes and counts can be negative
     stats = stats_mr.pop_counters()  # stats from stack level 2
-    assert stats.current_bytes == -16
+    assert stats.current_bytes == -10
     assert stats.current_count == -1
     assert stats.peak_bytes == 0
     assert stats.peak_count == 0
@@ -154,40 +154,40 @@ def test_counter_stack(stats_mr):
     b1 = rmm.DeviceBuffer(size=10)
 
     stats = stats_mr.push_counters()  # stats from stack level 1
-    assert stats.current_bytes == 16
+    assert stats.current_bytes == 10
     assert stats.current_count == 1
-    assert stats.peak_bytes == 16
+    assert stats.peak_bytes == 10
     assert stats.peak_count == 1
-    assert stats.total_bytes == 32
+    assert stats.total_bytes == 20
     assert stats.total_count == 2
 
     b2 = rmm.DeviceBuffer(size=10)
 
     stats = stats_mr.pop_counters()  # stats from stack level 2
-    assert stats.current_bytes == 16
+    assert stats.current_bytes == 10
     assert stats.current_count == 1
-    assert stats.peak_bytes == 16
+    assert stats.peak_bytes == 10
     assert stats.peak_count == 1
-    assert stats.total_bytes == 16
+    assert stats.total_bytes == 10
     assert stats.total_count == 1
 
     stats = stats_mr.pop_counters()  # stats from stack level 1
-    assert stats.current_bytes == 32
+    assert stats.current_bytes == 20
     assert stats.current_count == 2
-    assert stats.peak_bytes == 32
+    assert stats.peak_bytes == 20
     assert stats.peak_count == 2
-    assert stats.total_bytes == 48
+    assert stats.total_bytes == 30
     assert stats.total_count == 3
 
     del b1
     del b2
 
     stats = stats_mr.allocation_counts  # stats from stack level 0
-    assert stats.current_bytes == 160
+    assert stats.current_bytes == 100
     assert stats.current_count == 10
-    assert stats.peak_bytes == 192
+    assert stats.peak_bytes == 120
     assert stats.peak_count == 12
-    assert stats.total_bytes == 208
+    assert stats.total_bytes == 130
     assert stats.total_count == 13
 
     del buffers
@@ -198,25 +198,25 @@ def test_counter_stack(stats_mr):
 def test_current_statistics(stats_mr):
     b1 = rmm.DeviceBuffer(size=10)
     stats = get_statistics()
-    assert stats.current_bytes == 16
+    assert stats.current_bytes == 10
     assert stats.current_count == 1
-    assert stats.peak_bytes == 16
+    assert stats.peak_bytes == 10
     assert stats.peak_count == 1
-    assert stats.total_bytes == 16
+    assert stats.total_bytes == 10
     assert stats.total_count == 1
 
     b2 = rmm.DeviceBuffer(size=20)
     stats = push_statistics()
-    assert stats.current_bytes == 48
+    assert stats.current_bytes == 30
     assert stats.current_count == 2
-    assert stats.peak_bytes == 48
+    assert stats.peak_bytes == 30
     assert stats.peak_count == 2
-    assert stats.total_bytes == 48
+    assert stats.total_bytes == 30
     assert stats.total_count == 2
 
     del b1
     stats = pop_statistics()
-    assert stats.current_bytes == -16
+    assert stats.current_bytes == -10
     assert stats.current_count == -1
     assert stats.peak_bytes == 0
     assert stats.peak_count == 0
@@ -227,9 +227,9 @@ def test_current_statistics(stats_mr):
     stats = get_statistics()
     assert stats.current_bytes == 0
     assert stats.current_count == 0
-    assert stats.peak_bytes == 48
+    assert stats.peak_bytes == 30
     assert stats.peak_count == 2
-    assert stats.total_bytes == 48
+    assert stats.total_bytes == 30
     assert stats.total_count == 2
 
 
@@ -282,20 +282,20 @@ def test_profiler(stats_mr):
     assert records[
         _get_descriptive_name_of_object(f1)
     ] == ProfilerRecords.MemoryRecord(
-        num_calls=2, memory_total=64, memory_peak=32
+        num_calls=2, memory_total=40, memory_peak=20
     )
     assert records[
         _get_descriptive_name_of_object(f2)
     ] == ProfilerRecords.MemoryRecord(
-        num_calls=3, memory_total=96, memory_peak=32
+        num_calls=3, memory_total=60, memory_peak=20
     )
     assert records["g2"] == ProfilerRecords.MemoryRecord(
-        num_calls=3, memory_total=48, memory_peak=16
+        num_calls=3, memory_total=30, memory_peak=10
     )
     assert records[
         _get_descriptive_name_of_object(f3)
     ] == ProfilerRecords.MemoryRecord(
-        num_calls=1, memory_total=11200, memory_peak=11200
+        num_calls=1, memory_total=10000, memory_peak=10000
     )
 
     @profiler()  # use the default profiler records
@@ -315,10 +315,10 @@ def test_profiler(stats_mr):
     assert records[
         _get_descriptive_name_of_object(f4)
     ] == ProfilerRecords.MemoryRecord(
-        num_calls=1, memory_total=160, memory_peak=160
+        num_calls=1, memory_total=100, memory_peak=100
     )
     assert records["b1 and b2"] == ProfilerRecords.MemoryRecord(
-        num_calls=1, memory_total=224, memory_peak=224
+        num_calls=1, memory_total=200, memory_peak=200
     )
     assert records["del b1 and b2"] == ProfilerRecords.MemoryRecord(
         num_calls=1, memory_total=0, memory_peak=0


### PR DESCRIPTION
## Description
Resolves #2116.

This is breaking because allocation sizes may change due to the removed padding. However, allocations are still guaranteed to be aligned to 256 bytes (the CUDA alignment requirement).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
