### PR TITLE
Skip pytorch tests on CPU-only builds

### DIFF
--- a/python/rmm/rmm/tests/test_rmm_pytorch.py
+++ b/python/rmm/rmm/tests/test_rmm_pytorch.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import gc
@@ -12,6 +12,8 @@ torch = pytest.importorskip("torch")
 
 @pytest.fixture(scope="session")
 def torch_allocator():
+    if not torch.cuda.is_available():
+        pytest.skip("pytorch built without CUDA support")
     try:
         from torch.cuda.memory import change_current_allocator
     except ImportError:


### PR DESCRIPTION
## Description
RMM PyTorch integration tests require a GPU build of PyTorch. This skips the RMM PyTorch tests if CUDA support is not available in the installed PyTorch package.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
