### PR TITLE
Make more warnings errors and fix associated issues

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -132,6 +132,12 @@ if(RMM_ENABLE_LEGACY_MR_INTERFACE)
   target_compile_definitions(rmm PUBLIC RMM_ENABLE_LEGACY_MR_INTERFACE)
 endif()
 
+set(RMM_CXX_FLAGS -Wall -Werror -Wextra -Wno-unknown-pragmas -Wno-error=deprecated-declarations)
+set(RMM_CUDA_FLAGS -Werror=all-warnings
+                   -Xcompiler=-Wall,-Werror,-Wextra,-Wno-error=deprecated-declarations)
+target_compile_options(rmm PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${RMM_CXX_FLAGS}>"
+                                   "$<$<COMPILE_LANGUAGE:CUDA>:${RMM_CUDA_FLAGS}>")
+
 # ##################################################################################################
 # * tests and benchmarks ---------------------------------------------------------------------------
 

--- a/cpp/include/rmm/mr/device/device_memory_resource.hpp
+++ b/cpp/include/rmm/mr/device/device_memory_resource.hpp
@@ -156,7 +156,7 @@ class device_memory_resource {
    * @param alignment The alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* allocate(std::size_t bytes, std::size_t alignment)
+  void* allocate(std::size_t bytes, [[maybe_unused]] std::size_t alignment)
   {
     RMM_FUNC_RANGE();
     return do_allocate(bytes, cuda_stream_view{});
@@ -175,7 +175,7 @@ class device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param alignment The alignment that was passed to the `allocate` call that returned `p`
    */
-  void deallocate(void* ptr, std::size_t bytes, std::size_t alignment) noexcept
+  void deallocate(void* ptr, std::size_t bytes, [[maybe_unused]] std::size_t alignment) noexcept
   {
     RMM_FUNC_RANGE();
     do_deallocate(ptr, bytes, cuda_stream_view{});
@@ -197,7 +197,9 @@ class device_memory_resource {
    * @param stream Stream on which to perform allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* allocate_async(std::size_t bytes, std::size_t alignment, cuda_stream_view stream)
+  void* allocate_async(std::size_t bytes,
+                       [[maybe_unused]] std::size_t alignment,
+                       cuda_stream_view stream)
   {
     RMM_FUNC_RANGE();
     return do_allocate(bytes, stream);
@@ -240,7 +242,7 @@ class device_memory_resource {
    */
   void deallocate_async(void* ptr,
                         std::size_t bytes,
-                        std::size_t alignment,
+                        [[maybe_unused]] std::size_t alignment,
                         cuda_stream_view stream) noexcept
   {
     RMM_FUNC_RANGE();
@@ -296,9 +298,10 @@ class device_memory_resource {
    * value of `bytes` that was passed to the `allocate` call that returned `p`.
    * @param alignment The alignment that was passed to the `allocate` call that returned `p`
    */
-  void deallocate_sync(void* ptr,
-                       std::size_t bytes,
-                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
+  void deallocate_sync(
+    void* ptr,
+    std::size_t bytes,
+    [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
     do_deallocate(ptr, bytes, cuda_stream_view{});
   }

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -35,7 +35,12 @@ function(ConfigureTestInternal TEST_NAME)
                CUDA_STANDARD_REQUIRED ON)
   target_compile_definitions(
     ${TEST_NAME} PUBLIC "RMM_LOG_ACTIVE_LEVEL=RAPIDS_LOGGER_LOG_LEVEL_${RMM_LOGGING_LEVEL}")
-  target_compile_options(${TEST_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang>:-Wall -Werror>)
+  target_compile_options(
+    ${TEST_NAME}
+    PRIVATE
+      "$<$<COMPILE_LANGUAGE:CXX>:-Wall;-Werror;-Wno-unknown-pragmas;-Wno-error=deprecated-declarations>"
+      "$<$<COMPILE_LANGUAGE:CUDA>:-Werror=all-warnings;-Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations>"
+  )
 
   if(DISABLE_DEPRECATION_WARNING)
     target_compile_options(

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -405,7 +405,10 @@ TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
   auto mr       = buff.memory_resource();
   auto stream   = buff.stream();
 
-  buff = std::move(buff);           // self-move-assignment shouldn't modify the buffer
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+  buff = std::move(buff);  // self-move-assignment shouldn't modify the buffer
+#pragma GCC diagnostic pop
   EXPECT_NE(nullptr, buff.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(ptr, buff.data());
   EXPECT_EQ(size, buff.size());


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
While rmm has not historically built with `-Wextra`, some of our consumers do, which uncovered some oversights in https://github.com/rapidsai/rmm/pull/2114/files#diff-736b3b3a3834eb620039da63b467b56dd1fe7d13faefabc469356f6cccae6c65R363 where a unused parameter (which we have to keep to align with CCCL mr concepts) was not marked as `[[maybe_unused]]`. This PR fixes that, and also turns on stricter warning checking in rmm builds so that we are protected from this going forward.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
