### PR TITLE
Add SOURCE_SUBDIR cpp to CPM examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ instead:
 ```cmake
 CPMAddPackage(NAME rmm [VERSION]
               GITHUB_REPOSITORY rapidsai/rmm
-              SYSTEM Off)
+              SYSTEM Off
+              SOURCE_SUBDIR cpp)
 # ...
 target_link_libraries(<your-target> (PRIVATE|PUBLIC|INTERFACE) rmm::rmm)
 ```

--- a/cpp/examples/fetch_dependencies.cmake
+++ b/cpp/examples/fetch_dependencies.cmake
@@ -20,4 +20,7 @@ CPMFindPackage(
   FIND_PACKAGE_ARGUMENTS "PATHS ${rmm_ROOT} ${rmm_ROOT}/latest" GIT_REPOSITORY
                          https://github.com/rapidsai/rmm
   GIT_TAG ${RMM_TAG}
-  GIT_SHALLOW TRUE)
+  GIT_SHALLOW
+    TRUE
+    SOURCE_SUBDIR
+    cpp)


### PR DESCRIPTION
Add `SOURCE_SUBDIR cpp` to CPM examples to clarify that the CMake build configuration is located in the cpp subdirectory.

Fixes #2061