### PR TITLE
compare <= to accommodate unified systems

### DIFF
--- a/cpp/tests/mr/device/system_mr_tests.cu
+++ b/cpp/tests/mr/device/system_mr_tests.cu
@@ -95,7 +95,7 @@ TEST_F(SystemMRTest, FirstTouchOnGPU)
   void* ptr = mr.allocate_sync(size_mb);
   touch_on_gpu(ptr, size_mb);
   auto const free2 = rmm::available_device_memory().first;
-  EXPECT_LT(free2, free);
+  EXPECT_LE(free2, free);
   mr.deallocate_sync(ptr, size_mb);
 }
 


### PR DESCRIPTION
## Description
On unified systems available host and device memory will be equal, so this PR updates the `system_mr_tests.cu` to accommodate this.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
