### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ cd rmm
 
 ```bash
 # create the conda environment (assuming in base `rmm` directory)
-$ conda env create --name rmm_dev --file conda/environments/all_cuda-130_arch-$(arch).yaml
+$ conda env create --name rmm_dev --file conda/environments/all_cuda-130_arch-$(uname -m).yaml
 # activate the environment
 $ conda activate rmm_dev
 ```


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.