### PR TITLE
Make rmm.pylibrmm.stream.Stream hashable

### DIFF
--- a/python/rmm/rmm/pylibrmm/stream.pyx
+++ b/python/rmm/rmm/pylibrmm/stream.pyx
@@ -129,6 +129,9 @@ cdef class Stream:
             return self.view() == (<Stream>other).view()
         return False
 
+    def __hash__(self):
+        return hash(int(<uintptr_t>self._cuda_stream))
+
     cdef void _init_with_new_cuda_stream(self) except *:
         cdef CudaStream stream = CudaStream()
         self._cuda_stream = stream.value()

--- a/python/rmm/rmm/tests/test_stream.py
+++ b/python/rmm/rmm/tests/test_stream.py
@@ -122,3 +122,19 @@ def test_cuda_stream_pool(current_device, flags):
         # should not be the default stream
         assert streams[i] != default_rmm_stream
         assert streams[i] == stream_pool.get_stream(i)
+
+
+def test_hashable():
+    a = rmm.pylibrmm.stream.Stream()
+    b = rmm.pylibrmm.stream.Stream()
+    assert hash(a) == hash(a)
+    assert hash(a) != hash(b)
+
+    assert a == a
+    assert a != b
+
+    assert len({a, b}) == 2
+
+    a2 = rmm.pylibrmm.stream.Stream(a)
+    assert a2 == a
+    assert hash(a2) == hash(a)


### PR DESCRIPTION
Closes https://github.com/rapidsai/rmm/issues/2130

This makes the stream class hashable. The hash is based on the handle to the cudaStream_t, so that we meet Python's requirement that objects who compare equal also hash equal.
