### PR TITLE
Update CCCL to get backports for XGBoost compatibility

### DIFF
--- a/cpp/cmake/thirdparty/get_cccl.cmake
+++ b/cpp/cmake/thirdparty/get_cccl.cmake
@@ -9,6 +9,11 @@
 function(find_and_configure_cccl)
 
   include(${rapids-cmake-dir}/cpm/cccl.cmake)
+  include(${rapids-cmake-dir}/cpm/package_override.cmake)
+
+  set(rmm_patch_dir "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/patches")
+  rapids_cpm_package_override("${rmm_patch_dir}/cccl_override.json")
+
   rapids_cpm_cccl(BUILD_EXPORT_SET rmm-exports INSTALL_EXPORT_SET rmm-exports)
 
 endfunction()

--- a/cpp/cmake/thirdparty/patches/cccl_override.json
+++ b/cpp/cmake/thirdparty/patches/cccl_override.json
@@ -1,0 +1,10 @@
+{
+  "packages": {
+    "CCCL": {
+      "version": "3.1.3",
+      "git_shallow": false,
+      "git_url": "https://github.com/bdice/cccl.git",
+      "git_tag": "bd34a2b8fe7cd5148dc90831b4da08eed6e11b02"
+    }
+  }
+}


### PR DESCRIPTION
## Description
Do not merge. Test PR for https://github.com/rapidsai/rapids-cmake/pull/944.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
