### PR TITLE
Fix flaky system memory resource tests on integrated memory system

### DIFF
--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -146,5 +146,23 @@ struct runtime_async_managed_alloc {
   }
 };
 
+/**
+ * @brief Check if the current device is an integrated memory system.
+ *
+ * @return true if the device is an integrated memory system, false otherwise
+ */
+struct device_integrated_memory {
+  static bool is_supported()
+  {
+    static auto is_integrated{[] {
+      int integrated = 0;
+      auto result    = cudaDeviceGetAttribute(
+        &integrated, cudaDevAttrIntegrated, rmm::get_current_cuda_device().value());
+      return result == cudaSuccess and integrated == 1;
+    }()};
+    return is_integrated;
+  }
+};
+
 }  // namespace detail
 }  // namespace RMM_NAMESPACE

--- a/cpp/tests/mr/system_mr_tests.cu
+++ b/cpp/tests/mr/system_mr_tests.cu
@@ -6,6 +6,7 @@
 #include "../byte_literals.hpp"
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/sam_headroom_memory_resource.hpp>
 #include <rmm/mr/system_memory_resource.hpp>
@@ -79,6 +80,10 @@ TEST(SystemMRSimpleTest, ThrowIfNotSupported)
 
 TEST_F(SystemMRTest, FirstTouchOnCPU)
 {
+  // On integrated memory systems, available device memory changes based on system/CPU activity
+  if (rmm::detail::device_integrated_memory::is_supported()) {
+    GTEST_SKIP() << "Skipping memory comparison test on integrated memory system";
+  }
   auto const free = rmm::available_device_memory().first;
   system_mr mr;
   void* ptr = mr.allocate_sync(size_mb);
@@ -90,6 +95,10 @@ TEST_F(SystemMRTest, FirstTouchOnCPU)
 
 TEST_F(SystemMRTest, FirstTouchOnGPU)
 {
+  // On integrated memory systems, available device memory changes based on system/CPU activity
+  if (rmm::detail::device_integrated_memory::is_supported()) {
+    GTEST_SKIP() << "Skipping memory comparison test on integrated memory system";
+  }
   auto const free = rmm::available_device_memory().first;
   system_mr mr;
   void* ptr = mr.allocate_sync(size_mb);


### PR DESCRIPTION
## Description
Systems with integrated memory, like DGX Spark, report a varying amount of available device memory based on CPU/system activity. This skips some tests in `SYSTEM_MR_TEST` that assume the test has exclusive control of separate device memory, and are thus unreliable on integrated memory systems.

The code snippet below shows the behavior of calling `rmm.mr.available_device_memory()` a few times in a row on an integrated memory system under load (compiling another project while running these tests). Therefore, tests that check the available device memory before allocation/deallocation and again afterward will get inconsistent results.

```python
>>> import rmm
>>> rmm.mr.available_device_memory()
(30160613376, 128526278656)
>>> rmm.mr.available_device_memory()
(30075027456, 128526278656)
>>> rmm.mr.available_device_memory()
(30074269696, 128526278656)
>>> rmm.mr.available_device_memory()
(30522216448, 128526278656)
>>> rmm.mr.available_device_memory()
(30407151616, 128526278656)
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
