### PR TITLE
Improve docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ of more detailed logging. The default is `INFO`. Available levels are `TRACE`, `
 `WARN`, `ERROR`, `CRITICAL` and `OFF`.
 
 Note that to see logging below the `INFO` level, the application must also set the logging level at
-run time. C++ applications must must call `rmm::default_logger().set_level()`, for example to enable all
+run time. C++ applications must call `rmm::default_logger().set_level()`, for example to enable all
 levels of logging down to `TRACE`, call `rmm::default_logger().set_level(rapids_logger::level_enum::trace)` (and compile
 librmm with `-DRMM_LOGGING_LEVEL=TRACE`). Python applications must call `rmm.set_logging_level()`,
 for example to enable all levels of logging down to `TRACE`, call `rmm.set_logging_level("trace")`

--- a/cpp/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/cpp/benchmarks/utilities/simulated_memory_resource.hpp
@@ -65,7 +65,7 @@ class simulated_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by `p`.
+   * @brief Deallocate memory pointed to by `ptr`.
    *
    * @note This call is ignored.
    *

--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -580,7 +580,7 @@ INTERNAL_DOCS          = NO
 # filesystem is case sensitive (i.e. it supports files in the same directory
 # whose names only differ in casing), the option must be set to YES to properly
 # deal with such files in case they appear in the input. For filesystems that
-# are not case sensitive the option should be be set to NO to properly deal with
+# are not case sensitive the option should be set to NO to properly deal with
 # output files written for symbols that only differ in casing, such as for two
 # classes, one named CLASS and the other named Class, and to also support
 # references to files without having to specify the exact matching casing. On

--- a/cpp/include/rmm/detail/aligned.hpp
+++ b/cpp/include/rmm/detail/aligned.hpp
@@ -19,12 +19,12 @@ namespace detail {
  * @brief Allocates sufficient host-accessible memory to satisfy the requested size `bytes` with
  * alignment `alignment` using the unary callable `alloc` to allocate memory.
  *
- * Given a pointer `p` to an allocation of size `n` returned from the unary callable `alloc`, the
- * pointer `q` returned from `aligned_alloc` points to a location within the `n` bytes with
- * sufficient space for `bytes` that satisfies `alignment`.
+ * Given a pointer `base_ptr` to an allocation of size `n` returned from the unary callable `alloc`,
+ * the pointer `aligned_ptr` returned from `aligned_host_allocate` points to a location within the
+ * `n` bytes with sufficient space for `bytes` that satisfies `alignment`.
  *
- * In order to retrieve the original allocation pointer `p`, the offset between `p` and `q` is
- * stored at `q - sizeof(std::ptrdiff_t)`.
+ * In order to retrieve the original allocation pointer `base_ptr`, the offset between `base_ptr`
+ * and `aligned_ptr` is stored at `aligned_ptr - sizeof(std::ptrdiff_t)`.
  *
  * Allocations returned from `aligned_host_allocate` *MUST* be freed by calling
  * `aligned_host_deallocate` with the same arguments for `bytes` and `alignment` with a compatible
@@ -76,7 +76,7 @@ void* aligned_host_allocate(std::size_t bytes, std::size_t alignment, Alloc allo
  * `aligned_host_deallocate` with the same arguments for `bytes` and `alignment` with a compatible
  * unary `dealloc` callable capable of freeing the memory returned from `alloc`.
  *
- * @param p The aligned pointer to deallocate
+ * @param ptr The aligned pointer to deallocate
  * @param bytes The number of bytes requested from `aligned_host_allocate`
  * @param alignment The alignment required from `aligned_host_allocate`
  * @param dealloc A unary callable capable of freeing host-accessible memory returned from `alloc`

--- a/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
@@ -149,7 +149,7 @@ class aligned_resource_adaptor final : public device_memory_resource {
   }
 
   /**
-   * @brief Free allocation of size `bytes` pointed to to by `p` and log the deallocation.
+   * @brief Free allocation of size `bytes` pointed to by `ptr` and log the deallocation.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation

--- a/cpp/include/rmm/mr/binning_memory_resource.hpp
+++ b/cpp/include/rmm/mr/binning_memory_resource.hpp
@@ -189,11 +189,11 @@ class binning_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * value of `bytes` that was passed to the `allocate` call that returned `ptr`.
    * @param stream Stream on which to perform deallocation
    */
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) noexcept override

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -115,14 +115,14 @@ class callback_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * If supported by the callback, this operation may optionally be executed on
    * a stream.  Otherwise, the stream is ignored and the null stream is used.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * value of `bytes` that was passed to the `allocate` call that returned `ptr`.
    * @param stream Stream on which to perform deallocation
    */
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) noexcept override

--- a/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
@@ -92,11 +92,11 @@ class cuda_async_managed_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * value of `bytes` that was passed to the `allocate` call that returned `ptr`.
    * @param stream Stream on which to perform deallocation
    */
   void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) noexcept override

--- a/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
@@ -174,11 +174,11 @@ class cuda_async_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * value of `bytes` that was passed to the `allocate` call that returned `ptr`.
    * @param stream Stream on which to perform deallocation
    */
   void do_deallocate(void* ptr, std::size_t bytes, rmm::cuda_stream_view stream) noexcept override

--- a/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
@@ -91,11 +91,11 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * value of `bytes` that was passed to the `allocate` call that returned `ptr`.
    * @param stream Stream on which to perform deallocation
    */
   void do_deallocate(void* ptr,

--- a/cpp/include/rmm/mr/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_memory_resource.hpp
@@ -53,13 +53,13 @@ class cuda_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * The stream argument is ignored.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * value of `bytes` that was passed to the `allocate` call that returned `ptr`.
    * @param stream This argument is ignored.
    */
   void do_deallocate(void* ptr,

--- a/cpp/include/rmm/mr/detail/arena.hpp
+++ b/cpp/include/rmm/mr/detail/arena.hpp
@@ -591,7 +591,7 @@ class global_arena final {
    * @param stream Stream on which to perform deallocation.
    * @param ptr Pointer to be deallocated.
    * @param size The size in bytes of the allocation. This must be equal to the value of `size`
-   * that was passed to the `allocate` call that returned `p`.
+   * that was passed to the `allocate` call that returned `ptr`.
    * @return bool true if the allocation is found, false otherwise.
    */
   bool deallocate(cuda_stream_view stream, void* ptr, std::size_t size)
@@ -816,7 +816,7 @@ class arena {
    * @param stream Stream on which to perform deallocation.
    * @param ptr Pointer to be deallocated.
    * @param size The size in bytes of the allocation. This must be equal to the value of `size`
-   * that was passed to the `allocate` call that returned `p`.
+   * that was passed to the `allocate` call that returned `ptr`.
    * @return bool true if the allocation is found, false otherwise.
    */
   bool deallocate(cuda_stream_view stream, void* ptr, std::size_t size)
@@ -830,7 +830,7 @@ class arena {
    *
    * @param ptr Pointer to be deallocated.
    * @param size The size in bytes of the allocation. This must be equal to the value of `size`
-   * that was passed to the `allocate` call that returned `p`.
+   * that was passed to the `allocate` call that returned `ptr`.
    * @return bool true if the allocation is found, false otherwise.
    */
   bool deallocate_sync(void* ptr, std::size_t size)

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -62,7 +62,7 @@ struct crtp {
  * 1. `std::size_t get_maximum_allocation_size() const`
  * 2. `block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream)`
  * 3. `split_block allocate_from_block(block_type const& b, std::size_t size)`
- * 4. `block_type free_block(void* p, std::size_t size) noexcept`
+ * 4. `block_type free_block(void* ptr, std::size_t size) noexcept`
  */
 template <typename PoolResource, typename FreeListType>
 class stream_ordered_memory_resource : public crtp<PoolResource>, public device_memory_resource {
@@ -127,14 +127,14 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
   // split_block allocate_from_block(block_type const& b, std::size_t size)
 
   /*
-   * @brief Finds, frees and returns the block associated with pointer `p`.
+   * @brief Finds, frees and returns the block associated with pointer `ptr`.
    *
-   * @param p The pointer to the memory to free.
+   * @param ptr The pointer to the memory to free.
    * @param size The size of the memory to free. Must be equal to the original allocation size.
-   * @return The (now freed) block associated with `p`. The caller is expected to return the block
+   * @return The (now freed) block associated with `ptr`. The caller is expected to return the block
    * to the pool.
    */
-  // block_type free_block(void* p, std::size_t size) noexcept
+  // block_type free_block(void* ptr, std::size_t size) noexcept
 
   /**
    * @brief Returns the block `b` (last used on stream `stream_event`) to the pool.

--- a/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
+++ b/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
@@ -200,7 +200,7 @@ class fixed_size_memory_resource
    *
    * @param ptr The pointer to the memory to free.
    * @param size The size of the memory to free. Must be equal to the original allocation size.
-   * @return The (now freed) block associated with `p`. The caller is expected to return the block
+   * @return The (now freed) block associated with `ptr`. The caller is expected to return the block
    * to the pool.
    */
   block_type free_block(void* ptr, std::size_t size) noexcept

--- a/cpp/include/rmm/mr/managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/managed_memory_resource.hpp
@@ -39,7 +39,7 @@ class managed_memory_resource final : public device_memory_resource {
    *
    * The returned pointer will have at minimum 256 byte alignment.
    *
-   * The stream is ignored.
+   * The stream argument is ignored.
    *
    * @param bytes The size of the allocation
    * @param stream This argument is ignored
@@ -57,13 +57,13 @@ class managed_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
-   * The stream is ignored.
+   * The stream argument is ignored.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * value of `bytes` that was passed to the `allocate` call that returned `ptr`.
    * @param stream This argument is ignored
    */
   void do_deallocate(void* ptr,

--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -51,7 +51,7 @@ class pinned_host_memory_resource final : public device_memory_resource {
   /**
    * @brief Allocates pinned host memory of size at least \p bytes bytes.
    *
-   * @throws rmm::out_of_memory if the requested allocation could not be fulfilled due to to a
+   * @throws rmm::out_of_memory if the requested allocation could not be fulfilled due to a
    * CUDA out of memory error.
    * @throws rmm::bad_alloc if the requested allocation could not be fulfilled due to any other
    * reason.
@@ -78,13 +78,13 @@ class pinned_host_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * The stream argument is ignored.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes The size in bytes of the allocation. This must be equal to the
-   * value of `bytes` that was passed to the `allocate` call that returned `p`.
+   * value of `bytes` that was passed to the `allocate` call that returned `ptr`.
    * @param stream This argument is ignored.
    */
   void do_deallocate(void* ptr,

--- a/cpp/include/rmm/mr/pool_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pool_memory_resource.hpp
@@ -382,7 +382,7 @@ class pool_memory_resource final
    *
    * @param ptr The pointer to the memory to free.
    * @param size The size of the memory to free. Must be equal to the original allocation size.
-   * @return The (now freed) block associated with `p`. The caller is expected to return the block
+   * @return The (now freed) block associated with `ptr`. The caller is expected to return the block
    * to the pool.
    */
   block_type free_block(void* ptr, std::size_t size) noexcept

--- a/cpp/include/rmm/mr/sam_headroom_memory_resource.hpp
+++ b/cpp/include/rmm/mr/sam_headroom_memory_resource.hpp
@@ -103,7 +103,7 @@ class sam_headroom_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * The stream argument is ignored.
    *

--- a/cpp/include/rmm/mr/system_memory_resource.hpp
+++ b/cpp/include/rmm/mr/system_memory_resource.hpp
@@ -101,7 +101,7 @@ class system_memory_resource final : public device_memory_resource {
   }
 
   /**
-   * @brief Deallocate memory pointed to by \p p.
+   * @brief Deallocate memory pointed to by \p ptr.
    *
    * This function synchronizes the stream before deallocating the memory.
    *

--- a/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
@@ -93,7 +93,7 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
   }
 
   /**
-   * @brief Free allocation of size `bytes` pointed to to by `ptr`.s
+   * @brief Free allocation of size `bytes` pointed to by `ptr`.
    *
    * @param ptr Pointer to be deallocated
    * @param bytes Size of the allocation

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -108,7 +108,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    *
    * @param ptr Pointer returned by a previous call to `allocate`
    * @param num number of elements, *must* be equal to the argument passed to the
-   * prior `allocate` call that produced `p`
+   * prior `allocate` call that produced `ptr`
    */
   void deallocate(pointer ptr, size_type num) noexcept
   {

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -1285,7 +1285,7 @@ def get_log_filenames():
 
 def available_device_memory():
     """
-    Returns a tuple of free and total device memory memory.
+    Returns a tuple of free and total device memory.
     """
     cdef pair[size_t, size_t] res
     res = c_available_device_memory()


### PR DESCRIPTION
## Description
This fixes a few minor issues in the docs, like referencing the parameter `ptr` by the name `p` and duplicate words.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
