### PR TITLE
Require CCCL version 3.1 or newer

### DIFF
--- a/cpp/include/rmm/detail/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/detail/cuda_memory_resource.hpp
@@ -4,16 +4,16 @@
  */
 #pragma once
 
+#ifndef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+#error \
+  "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined. Please add -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to the compiler flags (this is done automatically when using RMM via CMake)."
+#endif  // LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
+
 #include <cuda/version>
 
 #if CCCL_MAJOR_VERSION < 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION < 1)
 #error "RMM requires CCCL version 3.1 or newer."
 #endif
-
-#ifndef LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
-#error \
-  "RMM requires LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to be defined. Please add -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE to the compiler flags (this is done automatically when using RMM via CMake)."
-#endif  // LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE
 
 #include <rmm/detail/export.hpp>
 


### PR DESCRIPTION
Add a compile-time check to error if CCCL version is older than 3.1. This makes errors much clearer. The current errors users would see for this are not easy to interpret or correct.