### PR TITLE
Revert "Default to static linking of libcudart"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,8 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd "$(dirname "$0")"; pwd)
 
-VALIDARGS="clean librmm rmm -v -g -n --ptds -h tests benchmarks"
-HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [--ptds] [--cmake-args=\"<args>\"] [-h]
+VALIDARGS="clean librmm rmm -v -g -n -s --ptds -h tests benchmarks"
+HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [-s] [--ptds] [--cmake-args=\"<args>\"] [-h]
    clean                       - remove all existing build artifacts and configuration (start over)
    librmm                      - build and install the librmm C++ code
    rmm                         - build and install the rmm Python package
@@ -29,6 +29,7 @@ HELP="$0 [clean] [librmm] [rmm] [-v] [-g] [-n] [--ptds] [--cmake-args=\"<args>\"
    -v                          - verbose build mode
    -g                          - build for debug
    -n                          - no install step (does not affect Python)
+   -s                          - statically link against cudart
    --ptds                      - enable per-thread default stream
    --cmake-args=\\\"<args>\\\" - pass arbitrary list of CMake configuration options (escape all quotes in argument)
    -h                          - print this text
@@ -45,6 +46,7 @@ BUILD_TYPE=Release
 INSTALL_TARGET=install
 BUILD_BENCHMARKS=OFF
 BUILD_TESTS=OFF
+CUDA_STATIC_RUNTIME=OFF
 PER_THREAD_DEFAULT_STREAM=OFF
 RAN_CMAKE=0
 
@@ -90,6 +92,7 @@ function ensureCMakeRan {
         echo "Executing cmake for librmm..."
         cmake -S "${REPODIR}"/cpp -B "${LIBRMM_BUILD_DIR}" \
               -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+              -DCUDA_STATIC_RUNTIME="${CUDA_STATIC_RUNTIME}" \
               -DPER_THREAD_DEFAULT_STREAM="${PER_THREAD_DEFAULT_STREAM}" \
               -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
               -DBUILD_TESTS=${BUILD_TESTS} \
@@ -132,6 +135,9 @@ if hasArg benchmarks; then
 fi
 if hasArg tests; then
     BUILD_TESTS=ON
+fi
+if hasArg -s; then
+    CUDA_STATIC_RUNTIME=ON
 fi
 if hasArg --ptds; then
     PER_THREAD_DEFAULT_STREAM=ON

--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -92,13 +92,17 @@ outputs:
         - ${{ stdlib("c") }}
       host:
         - cuda-version =${{ cuda_version }}
+        - cuda-cudart-dev
         - rapids-logger =0.2
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
+        - cuda-cudart
         - rapids-logger =0.2
       run_exports:
         - ${{ pin_subpackage("librmm", upper_bound="x.x") }}
       ignore_run_exports:
+        from_package:
+          - cuda-cudart-dev
         by_name:
           - cuda-version
     tests:
@@ -127,11 +131,15 @@ outputs:
         - ${{ pin_subpackage("librmm", exact=True) }}
         - cuda-driver-dev
         - cuda-version =${{ cuda_version }}
+        - cuda-cudart-dev
       run:
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("librmm", exact=True) }}
         - rapids-logger =0.2
+        - cuda-cudart
       ignore_run_exports:
+        from_package:
+          - cuda-cudart-dev
         by_name:
           - cuda-version
     about:
@@ -182,11 +190,15 @@ outputs:
         - cuda-version =${{ cuda_version }}
       host:
         - cuda-version =${{ cuda_version }}
+        - cuda-cudart-dev
         - ${{ pin_subpackage("librmm", exact=True) }}
       run:
+        - cuda-cudart
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - ${{ pin_subpackage("librmm", exact=True) }}
       ignore_run_exports:
+        from_package:
+          - cuda-cudart-dev
         by_name:
           - cuda-version
           - librmm

--- a/conda/recipes/rmm/recipe.yaml
+++ b/conda/recipes/rmm/recipe.yaml
@@ -64,6 +64,7 @@ requirements:
     - ${{ stdlib("c") }}
   host:
     - cuda-version =${{ cuda_version }}
+    - cuda-cudart-dev
     - if: cuda_major == "12"
       then: cuda-python >=12.9.2,<13.0
       else: cuda-python >=13.0.1,<14.0
@@ -74,6 +75,7 @@ requirements:
     - pip
     - scikit-build-core >=0.10.0
   run:
+    - cuda-cudart
     - if: cuda_major == "12"
       then: cuda-python >=12.9.2,<13.0
       else: cuda-python >=13.0.1,<14.0
@@ -83,6 +85,7 @@ requirements:
   ignore_run_exports:
     from_package:
       - cuda-python
+      - cuda-cudart-dev
     by_name:
       - cuda-version
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -48,6 +48,9 @@ message(VERBOSE "RMM: Build with NVTX support: ${RMM_NVTX}")
 # build type for cmake-gui.
 message(STATUS "RMM: RMM_LOGGING_LEVEL = '${RMM_LOGGING_LEVEL}'")
 
+# cudart can be linked statically or dynamically
+option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
+
 # ##################################################################################################
 # * compiler options -------------------------------------------------------------------------------
 
@@ -96,7 +99,12 @@ target_include_directories(
          "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
   INTERFACE "$<INSTALL_INTERFACE:include>")
 
-target_link_libraries(rmm PUBLIC CUDA::cudart_static)
+if(CUDA_STATIC_RUNTIME)
+  message(STATUS "RMM: Enabling static linking of cudart")
+  target_link_libraries(rmm PUBLIC CUDA::cudart_static)
+else()
+  target_link_libraries(rmm PUBLIC CUDA::cudart)
+endif()
 
 target_link_libraries(rmm PUBLIC CCCL::CCCL ${CMAKE_DL_LIBS} nvtx3::nvtx3-cpp
                                  rapids_logger::rapids_logger)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -83,7 +83,7 @@ endfunction()
 function(ConfigureTest TEST_NAME)
 
   set(options LINK_DRIVER)
-  set(one_value GPUS PERCENT)
+  set(one_value CUDART GPUS PERCENT)
   set(multi_value)
   cmake_parse_arguments(_RMM_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
   if(NOT DEFINED _RMM_TEST_GPUS AND NOT DEFINED _RMM_TEST_PERCENT)
@@ -97,7 +97,13 @@ function(ConfigureTest TEST_NAME)
     set(_RMM_TEST_PERCENT 100)
   endif()
 
-  set(cudart_link_libs $<COMPILE_ONLY:rmm> CUDA::cudart_static)
+  if(_RMM_TEST_CUDART STREQUAL SHARED)
+    set(cudart_link_libs $<COMPILE_ONLY:rmm> CUDA::cudart)
+  elseif(_RMM_TEST_CUDART STREQUAL STATIC)
+    set(cudart_link_libs $<COMPILE_ONLY:rmm> CUDA::cudart_static)
+  else()
+    set(cudart_link_libs rmm)
+  endif()
 
   # Test with legacy default stream.
   ConfigureTestInternal(${TEST_NAME} ${_RMM_TEST_UNPARSED_ARGUMENTS})
@@ -140,7 +146,10 @@ ConfigureTest(POOL_MR_TEST mr/pool_mr_tests.cpp GPUS 1 PERCENT 100)
 ConfigureTest(HWDECOMPRESS_TEST mr/hwdecompress_tests.cpp LINK_DRIVER)
 
 # cuda_async mr tests
-ConfigureTest(CUDA_ASYNC_MR_TEST mr/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60)
+ConfigureTest(CUDA_ASYNC_MR_STATIC_CUDART_TEST mr/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60 CUDART
+              STATIC)
+ConfigureTest(CUDA_ASYNC_MR_SHARED_CUDART_TEST mr/cuda_async_mr_tests.cpp GPUS 1 PERCENT 60 CUDART
+              SHARED)
 
 # cuda_async managed mr tests (available with CUDA 13+ runtime/driver)
 ConfigureTest(CUDA_ASYNC_MANAGED_MR_TEST mr/cuda_async_managed_mr_tests.cpp)

--- a/python/librmm/CMakeLists.txt
+++ b/python/librmm/CMakeLists.txt
@@ -26,5 +26,6 @@ unset(rmm_FOUND)
 
 set(BUILD_TESTS OFF)
 set(BUILD_BENCHMARKS OFF)
+set(CUDA_STATIC_RUNTIME ON)
 
 add_subdirectory(../../cpp rmm-cpp)


### PR DESCRIPTION
Reverts rapidsai/rmm#2178

These changes are currently breaking stream testing in cudf, see https://github.com/rapidsai/cudf/actions/runs/20147392038/job/57905334054?pr=20824#step:11:1782 for example. My guess is that while the changes in #2178 are fine for C++ consumers of rmm to continue hijacking CUDA symbols (like the libcudf tests do), there is a problem when rmm Python is also in the mix since now rmm Python will instantiate the rmm C++ templates and therefore embed cudart symbols due to the newly enforced static linkage. I'll reopen this PR once I can get #20814 resolved.