### PR TITLE
Fix injected class name bug in cccl_resource_ref constraints, use cuda::std::optional

### DIFF
--- a/cpp/include/rmm/detail/cccl_adaptors.hpp
+++ b/cpp/include/rmm/detail/cccl_adaptors.hpp
@@ -16,8 +16,9 @@
 #include <rmm/mr/detail/device_memory_resource_view.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
 
+#include <cuda/std/optional>
+
 #include <cstddef>
-#include <optional>
 #include <type_traits>
 #include <utility>
 #endif
@@ -95,7 +96,7 @@ class cccl_resource_ref {
    */
   template <typename... Properties>
   cccl_resource_ref(cuda::mr::synchronous_resource_ref<Properties...> const& ref)
-    : view_{std::nullopt}, ref_{ref}
+    : view_{cuda::std::nullopt}, ref_{ref}
   {
   }
 
@@ -110,7 +111,7 @@ class cccl_resource_ref {
    */
   template <typename... Properties>
   cccl_resource_ref(cuda::mr::synchronous_resource_ref<Properties...>&& ref)
-    : view_{std::nullopt}, ref_{std::move(ref)}
+    : view_{cuda::std::nullopt}, ref_{std::move(ref)}
   {
   }
 
@@ -271,7 +272,7 @@ class cccl_resource_ref {
   }
 
  protected:
-  std::optional<rmm::mr::detail::device_memory_resource_view> view_;
+  cuda::std::optional<rmm::mr::detail::device_memory_resource_view> view_;
   ResourceType ref_;
 };
 
@@ -324,7 +325,7 @@ class cccl_async_resource_ref {
    */
   template <typename... Properties>
   cccl_async_resource_ref(cuda::mr::resource_ref<Properties...> const& ref)
-    : view_{std::nullopt}, ref_{ref}
+    : view_{cuda::std::nullopt}, ref_{ref}
   {
   }
 
@@ -339,7 +340,7 @@ class cccl_async_resource_ref {
    */
   template <typename... Properties>
   cccl_async_resource_ref(cuda::mr::resource_ref<Properties...>&& ref)
-    : view_{std::nullopt}, ref_{std::move(ref)}
+    : view_{cuda::std::nullopt}, ref_{std::move(ref)}
   {
   }
 
@@ -531,7 +532,7 @@ class cccl_async_resource_ref {
   }
 
  protected:
-  std::optional<rmm::mr::detail::device_memory_resource_view> view_;
+  cuda::std::optional<rmm::mr::detail::device_memory_resource_view> view_;
   ResourceType ref_;
 };
 


### PR DESCRIPTION
Inside a class template like `cccl_resource_ref<ResourceType>`, the bare name `cccl_resource_ref` refers to the injected class name (the current instantiation), not the class template. The `is_specialization_of_v` trait requires a class template as its second argument, causing a type/value mismatch error.

Use fully qualified names (`::rmm::detail::cccl_resource_ref` and `::rmm::detail::cccl_async_resource_ref`) to bypass the injected class name and correctly refer to the class template.

Also replaced `std::optional` with `cuda::std::optional` to fix a failure where `rmm::mr::thrust_allocator` derives from `thrust::device_malloc_allocator` which has `__device__` constructors.

This fixes bugs observed in https://github.com/rapidsai/rmm/actions/runs/20351412120/job/58476756910?pr=2106.