### PR TITLE
Suppress host/device usage warning 

### DIFF
--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -85,6 +85,8 @@ struct export_handle_type {
  * @return false if unsupported
  */
 #ifdef __CUDACC__
+// This suppression was needed due to a false positive warning from nvcc. We
+// should be able to remove it altogether once we rework the thrust allocator.
 #pragma nv_diag_suppress 20011
 #endif
 struct hwdecompress {


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This pragma is a workaround for cudf build issues, see e.g. https://github.com/rapidsai/cudf/actions/runs/20384141895/job/58581416851?pr=20929. The thrust allocator class needs to be reworked eventually anyway due to the upstream allocator being deprecated, so this workaround is acceptable for now. I'm entirely confused as to why this line is where the suppression is needed and I suspect that this is a completely false diagnostic from nvcc, but for now I think it's acceptable to add this as a workaround to get builds passing. I verified that this fixes cudf builds in a local devcontainer reproducing the issue.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
