### PR TITLE
Improve host-device ignores for Thrust allocator

### DIFF
--- a/cpp/include/rmm/detail/cccl_adaptors.hpp
+++ b/cpp/include/rmm/detail/cccl_adaptors.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -286,6 +286,13 @@ class cccl_resource_ref {
  *
  * @tparam ResourceType The underlying CCCL resource_ref type (async)
  */
+// Suppress spurious warning about calling a __host__ function from __host__ __device__ context
+// when this class is used as a member in thrust allocators that inherit __host__ __device__
+// attributes.
+#ifdef __CUDACC__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 20011
+#endif
 template <typename ResourceType>
 class cccl_async_resource_ref {
  public:
@@ -535,6 +542,9 @@ class cccl_async_resource_ref {
   cuda::std::optional<rmm::mr::detail::device_memory_resource_view> view_;
   ResourceType ref_;
 };
+#ifdef __CUDACC__
+#pragma nv_diagnostic pop
+#endif
 
 #else  // CCCL < 3.2: Use simpler inheritance-based implementation
 

--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -84,9 +84,10 @@ struct export_handle_type {
  * @return true if supported
  * @return false if unsupported
  */
-#ifdef __CUDACC__
 // This suppression was needed due to a false positive warning from nvcc. We
 // should be able to remove it altogether once we rework the thrust allocator.
+#ifdef __CUDACC__
+#pragma nv_diagnostic push
 #pragma nv_diag_suppress 20011
 #endif
 struct hwdecompress {
@@ -106,7 +107,7 @@ struct hwdecompress {
   }
 };
 #ifdef __CUDACC__
-#pragma nv_diag_default 20011
+#pragma nv_diagnostic pop
 #endif
 
 /**


### PR DESCRIPTION
## Description

This is an extension of the workaround in #2192 / #2193 to address the warnings seen in RMM benchmarks:

```
[220/231] Building CUDA object benchmarks/CMakeFiles/UVECTOR_BENCH.dir/device_uvector/device_uvector_bench.cu.o
/home/coder/rmm/cpp/include/rmm/detail/cccl_adaptors.hpp(306): warning #20011-D: calling a __host__ function("rmm::detail::cccl_async_resource_ref< ::cuda::mr::__4::resource_ref< ::cuda::mr::__4::device_accessible > > ::cccl_async_resource_ref(const rmm::detail::cccl_async_resource_ref< ::cuda::mr::__4::resource_ref< ::cuda::mr::__4::device_accessible > > &)") from a __host__ __device__ function("rmm::mr::thrust_allocator<int> ::thrust_allocator") is not allowed

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
