### PR TITLE
Add RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN macro for destructor cleanup

### DIFF
--- a/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -147,7 +147,7 @@ class cuda_async_memory_resource final : public device_memory_resource {
 
   ~cuda_async_memory_resource() override
   {
-    RMM_ASSERT_CUDA_SUCCESS(cudaMemPoolDestroy(pool_handle()));
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaMemPoolDestroy(pool_handle()));
   }
   cuda_async_memory_resource(cuda_async_memory_resource const&)            = delete;
   cuda_async_memory_resource(cuda_async_memory_resource&&)                 = delete;

--- a/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -102,7 +102,9 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
                      [[maybe_unused]] std::size_t bytes,
                      rmm::cuda_stream_view stream) noexcept override
   {
-    if (ptr != nullptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeAsync(ptr, stream.value())); }
+    if (ptr != nullptr) {
+      RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFreeAsync(ptr, stream.value()));
+    }
   }
 
   /**

--- a/cpp/include/rmm/mr/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -66,7 +66,7 @@ class cuda_memory_resource final : public device_memory_resource {
                      [[maybe_unused]] std::size_t bytes,
                      [[maybe_unused]] cuda_stream_view stream) noexcept override
   {
-    RMM_ASSERT_CUDA_SUCCESS(cudaFree(ptr));
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFree(ptr));
   }
 
   /**

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -442,8 +442,8 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
     lock_guard lock(mtx_);
 
     for (auto s_e : stream_events_) {
-      RMM_ASSERT_CUDA_SUCCESS(cudaEventSynchronize(s_e.second.event));
-      RMM_ASSERT_CUDA_SUCCESS(cudaEventDestroy(s_e.second.event));
+      RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaEventSynchronize(s_e.second.event));
+      RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaEventDestroy(s_e.second.event));
     }
 
     stream_events_.clear();

--- a/cpp/include/rmm/mr/managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/managed_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -70,7 +70,7 @@ class managed_memory_resource final : public device_memory_resource {
                      [[maybe_unused]] std::size_t bytes,
                      [[maybe_unused]] cuda_stream_view stream) noexcept override
   {
-    RMM_ASSERT_CUDA_SUCCESS(cudaFree(ptr));
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFree(ptr));
   }
 
   /**

--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -93,8 +93,9 @@ class pinned_host_memory_resource final : public device_memory_resource {
   {
     // TODO: Use the alignment parameter as an argument to do_deallocate
     std::size_t constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
-    rmm::detail::aligned_host_deallocate(
-      ptr, bytes, alignment, [](void* ptr) { RMM_ASSERT_CUDA_SUCCESS(cudaFreeHost(ptr)); });
+    rmm::detail::aligned_host_deallocate(ptr, bytes, alignment, [](void* ptr) {
+      RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFreeHost(ptr));
+    });
   }
 
   /**

--- a/cpp/src/cuda_stream.cpp
+++ b/cpp/src/cuda_stream.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,7 +22,7 @@ cuda_stream::cuda_stream(cuda_stream::flags flags)
               return stream;
             }(),
             [](cudaStream_t* stream) {
-              RMM_ASSERT_CUDA_SUCCESS(cudaStreamDestroy(*stream));
+              RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamDestroy(*stream));
               delete stream;  // NOLINT(cppcoreguidelines-owning-memory)
             }}
 {

--- a/cpp/tests/error_macros_tests.cpp
+++ b/cpp/tests/error_macros_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -98,6 +98,24 @@ TEST(ErrorMacrosTest, AssertCudaSuccess)
 #ifdef NDEBUG
   // In release builds, this should not crash
   EXPECT_NO_FATAL_FAILURE(RMM_ASSERT_CUDA_SUCCESS([]() { return cudaErrorInvalidValue; }()));
+#endif
+}
+
+// Test RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN macro
+// This variant also accepts cudaErrorCudartUnloading as success
+TEST(ErrorMacrosTest, AssertCudaSuccessSafeShutdown)
+{
+  // cudaSuccess should always work
+  EXPECT_NO_FATAL_FAILURE(RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN([]() { return cudaSuccess; }()));
+
+  // cudaErrorCudartUnloading should be treated as success (the key difference from the base macro)
+  EXPECT_NO_FATAL_FAILURE(
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN([]() { return cudaErrorCudartUnloading; }()));
+
+#ifdef NDEBUG
+  // In release builds, other errors should not crash (macro just executes the call)
+  EXPECT_NO_FATAL_FAILURE(
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN([]() { return cudaErrorInvalidValue; }()));
 #endif
 }
 


### PR DESCRIPTION
Closes #2203

## Summary

CUDA API calls in destructors can return `cudaErrorCudartUnloading` when the CUDA runtime is shutting down (e.g., during static object destruction after `main()` exits). This previously caused assertion failures in debug builds.

This PR:
- Adds a new macro `RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN` that treats `cudaErrorCudartUnloading` as success
- Applies the macro to all destructor and cleanup paths:
  - `cuda_async_memory_resource` destructor (`cudaMemPoolDestroy`)
  - `cuda_memory_resource` `do_deallocate` (`cudaFree`)
  - `managed_memory_resource` `do_deallocate` (`cudaFree`)
  - `pinned_host_memory_resource` `do_deallocate` (`cudaFreeHost`)
  - `cuda_async_view_memory_resource` `do_deallocate` (`cudaFreeAsync`)
  - `stream_ordered_memory_resource` `release` (`cudaEventSynchronize`/`cudaEventDestroy`)
  - `cuda_stream` deleter (`cudaStreamDestroy`)
- Adds tests for the new macro