### PR TITLE
Migrate thrust_allocator to modern thrust::mr::allocator API

### DIFF
--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,9 +12,15 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <thrust/device_malloc_allocator.h>
+#include <cuda/std/limits>
 #include <thrust/device_ptr.h>
+#include <thrust/device_reference.h>
 #include <thrust/memory.h>
+#include <thrust/mr/allocator.h>
+#include <thrust/mr/memory_resource.h>
+
+#include <cstddef>
+#include <type_traits>
 
 namespace RMM_NAMESPACE {
 namespace mr {
@@ -23,6 +29,107 @@ namespace mr {
  * @{
  * @file
  */
+
+/**
+ * @brief A Thrust-compatible memory resource that wraps an RMM device_async_resource_ref.
+ *
+ * This class adapts RMM's stream-ordered allocation interface to work with Thrust's
+ * memory resource system. Each instance is bound to a specific stream and resource.
+ *
+ * @note This class is marked `final` as required by `thrust::mr::allocator`.
+ */
+class rmm_thrust_device_resource final
+  : public thrust::mr::memory_resource<thrust::device_ptr<void>> {
+ public:
+  /**
+   * @brief Construct a memory resource with a stream and upstream resource.
+   *
+   * @param stream The stream to use for allocations
+   * @param mr The upstream RMM resource
+   * @param device The CUDA device associated with this resource
+   */
+  rmm_thrust_device_resource(cuda_stream_view stream,
+                             rmm::device_async_resource_ref mr,
+                             cuda_device_id device)
+    : _stream{stream}, _mr{mr}, _device{device}
+  {
+  }
+
+  /**
+   * @brief Allocates device memory.
+   *
+   * @param bytes The number of bytes to allocate
+   * @param alignment The alignment (unused, RMM uses 256-byte alignment)
+   * @return A device pointer to the allocated memory
+   */
+  pointer do_allocate(std::size_t bytes, [[maybe_unused]] std::size_t alignment) override
+  {
+    cuda_set_device_raii dev{_device};
+    return thrust::device_ptr<void>{_mr.allocate(_stream, bytes)};
+  }
+
+  /**
+   * @brief Deallocates device memory.
+   *
+   * @param ptr The pointer to deallocate
+   * @param bytes The number of bytes to deallocate
+   * @param alignment The alignment (unused)
+   */
+  void do_deallocate(pointer ptr,
+                     std::size_t bytes,
+                     [[maybe_unused]] std::size_t alignment) override
+  {
+    cuda_set_device_raii dev{_device};
+    _mr.deallocate(_stream, thrust::raw_pointer_cast(ptr), bytes);
+  }
+
+  /**
+   * @briefreturn{The stream used for allocations}
+   */
+  [[nodiscard]] cuda_stream_view stream() const noexcept { return _stream; }
+
+  /**
+   * @briefreturn{The upstream RMM resource}
+   */
+  [[nodiscard]] rmm::device_async_resource_ref resource() const noexcept { return _mr; }
+
+  /**
+   * @briefreturn{The CUDA device associated with this resource}
+   */
+  [[nodiscard]] cuda_device_id device() const noexcept { return _device; }
+
+ private:
+  cuda_stream_view _stream;            ///< Stream for allocations
+  rmm::device_async_resource_ref _mr;  ///< Upstream RMM resource
+  cuda_device_id _device;              ///< Associated CUDA device
+};
+
+/**
+ * @brief Helper base class to ensure rmm_thrust_device_resource is initialized
+ * before thrust::mr::allocator (which needs a pointer to it).
+ *
+ * In C++, base classes are initialized before members in declaration order.
+ * By inheriting from this class first, we ensure _resource exists before
+ * thrust::mr::allocator's constructor receives &_resource.
+ */
+struct thrust_allocator_resource_holder {
+  rmm_thrust_device_resource _resource;  ///< The memory resource instance
+
+  /**
+   * @brief Constructs the holder with a resource initialized for the given stream and device.
+   *
+   * @param stream The stream for allocations
+   * @param mr The upstream RMM resource
+   * @param device The CUDA device
+   */
+  thrust_allocator_resource_holder(cuda_stream_view stream,
+                                   rmm::device_async_resource_ref mr,
+                                   cuda_device_id device)
+    : _resource{stream, mr, device}
+  {
+  }
+};
+
 /**
  * @brief An `allocator` compatible with Thrust containers and algorithms using
  * a `device_async_resource_ref` for memory (de)allocation.
@@ -34,14 +141,19 @@ namespace mr {
  * The allocator records the current CUDA device and may only be used with a backing
  * `device_async_resource_ref` valid for the same device.
  *
+ * This allocator uses `thrust::mr::allocator` as its base class, which requires
+ * a `thrust::mr::memory_resource`. An internal `rmm_thrust_device_resource` adapts
+ * RMM's stream-ordered allocation to Thrust's memory resource interface.
+ *
  * @tparam T The type of the objects that will be allocated by this allocator
  */
 template <typename T>
-class thrust_allocator : public thrust::device_malloc_allocator<T> {
+class thrust_allocator : private thrust_allocator_resource_holder,
+                         public thrust::mr::allocator<T, rmm_thrust_device_resource> {
  public:
-  using Base      = thrust::device_malloc_allocator<T>;  ///< The base type of this allocator
-  using pointer   = typename Base::pointer;              ///< The pointer type
-  using size_type = typename Base::size_type;            ///< The size type
+  using base_type = thrust::mr::allocator<T, rmm_thrust_device_resource>;  ///< Base allocator type
+  using pointer   = typename base_type::pointer;    ///< Pointer type returned by allocate
+  using size_type = typename base_type::size_type;  ///< Type used for allocation sizes
 
   /**
    * @brief Provides the type of a `thrust_allocator` instantiated with another
@@ -58,7 +170,13 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @brief Default constructor creates an allocator using the default memory
    * resource and default stream.
    */
-  thrust_allocator() = default;
+  thrust_allocator()
+    : thrust_allocator_resource_holder{cuda_stream_view{},
+                                       rmm::mr::get_current_device_resource_ref(),
+                                       get_current_cuda_device()},
+      base_type{&_resource}
+  {
+  }
 
   /**
    * @brief Constructs a `thrust_allocator` using the default device memory
@@ -66,17 +184,23 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    *
    * @param stream The stream to be used for device memory (de)allocation
    */
-  explicit thrust_allocator(cuda_stream_view stream) : _stream{stream} {}
+  explicit thrust_allocator(cuda_stream_view stream)
+    : thrust_allocator_resource_holder{stream,
+                                       rmm::mr::get_current_device_resource_ref(),
+                                       get_current_cuda_device()},
+      base_type{&_resource}
+  {
+  }
 
   /**
    * @brief Constructs a `thrust_allocator` using a device memory resource and
    * stream.
    *
-   * @param mr The resource to be used for device memory allocation
    * @param stream The stream to be used for device memory (de)allocation
+   * @param mr The resource to be used for device memory allocation
    */
   thrust_allocator(cuda_stream_view stream, rmm::device_async_resource_ref mr)
-    : _stream{stream}, _mr(mr)
+    : thrust_allocator_resource_holder{stream, mr, get_current_cuda_device()}, base_type{&_resource}
   {
   }
 
@@ -85,35 +209,41 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    *
    * @param other The `thrust_allocator` to copy
    */
+  thrust_allocator(thrust_allocator const& other)
+    : thrust_allocator_resource_holder{other._resource.stream(),
+                                       other._resource.resource(),
+                                       other._resource.device()},
+      base_type{&_resource}
+  {
+  }
+
+  /**
+   * @brief Copy constructor from allocator of different type. Copies the resource pointer and
+   * stream.
+   *
+   * @param other The `thrust_allocator` to copy
+   */
   template <typename U>
   thrust_allocator(thrust_allocator<U> const& other)
-    : _mr(other.resource()), _stream{other.stream()}, _device{other._device}
+    : thrust_allocator_resource_holder{other.stream(), other.resource(), other.device()},
+      base_type{&_resource}
   {
   }
 
   /**
-   * @brief Allocate objects of type `T`
+   * @brief Copy assignment operator.
    *
-   * @param num  The number of elements of type `T` to allocate
-   * @return pointer Pointer to the newly allocated storage
+   * @param other The `thrust_allocator` to copy
+   * @return Reference to this allocator
    */
-  pointer allocate(size_type num)
+  thrust_allocator& operator=(thrust_allocator const& other)
   {
-    cuda_set_device_raii dev{_device};
-    return thrust::device_pointer_cast(static_cast<T*>(_mr.allocate(_stream, num * sizeof(T))));
-  }
-
-  /**
-   * @brief Deallocates objects of type `T`
-   *
-   * @param ptr Pointer returned by a previous call to `allocate`
-   * @param num number of elements, *must* be equal to the argument passed to the
-   * prior `allocate` call that produced `ptr`
-   */
-  void deallocate(pointer ptr, size_type num) noexcept
-  {
-    cuda_set_device_raii dev{_device};
-    return _mr.deallocate(_stream, thrust::raw_pointer_cast(ptr), num * sizeof(T));
+    if (this != &other) {
+      _resource = rmm_thrust_device_resource{
+        other._resource.stream(), other._resource.resource(), other._resource.device()};
+      // base_type stores a pointer to _resource, which remains valid
+    }
+    return *this;
   }
 
   /**
@@ -121,13 +251,27 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    */
   [[nodiscard]] rmm::device_async_resource_ref get_upstream_resource() const noexcept
   {
-    return _mr;
+    return _resource.resource();
   }
 
   /**
    * @briefreturn{The stream used by this allocator}
    */
-  [[nodiscard]] cuda_stream_view stream() const noexcept { return _stream; }
+  [[nodiscard]] cuda_stream_view stream() const noexcept { return _resource.stream(); }
+
+  /**
+   * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
+   * @deprecated Use get_upstream_resource() instead
+   */
+  [[nodiscard]] rmm::device_async_resource_ref resource() const noexcept
+  {
+    return _resource.resource();
+  }
+
+  /**
+   * @briefreturn{The CUDA device associated with this allocator}
+   */
+  [[nodiscard]] cuda_device_id device() const noexcept { return _resource.device(); }
 
   /**
    * @brief Enables the `cuda::mr::device_accessible` property
@@ -136,10 +280,8 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    */
   friend void get_property(thrust_allocator const&, cuda::mr::device_accessible) noexcept {}
 
- private:
-  cuda_stream_view _stream{};
-  rmm::device_async_resource_ref _mr{rmm::mr::get_current_device_resource_ref()};
-  cuda_device_id _device{get_current_cuda_device()};
+  template <typename U>
+  friend class thrust_allocator;
 };
 /** @} */  // end of group
 }  // namespace mr


### PR DESCRIPTION
This PR contributes to issue #2193 by migrating `rmm::mr::thrust_allocator` from the deprecated `thrust::device_malloc_allocator` to the modern `thrust::mr::allocator` API.

## Changes

- Added `rmm_thrust_device_resource`: A `thrust::mr::memory_resource` adapter that wraps RMM's `device_async_resource_ref` with stream support
- Migrated `thrust_allocator`: Now inherits from `thrust::mr::allocator` instead of the deprecated `thrust::device_malloc_allocator`
- Fixed initialization order: Implemented `thrust_allocator_resource_holder` helper base class to ensure correct initialization order (resource before allocator base class)
- Added `device()` accessor: For consistency with the resource API