### PR TITLE
Revert "Store any_resource in device_buffer and device_uvector (#2201)"

### DIFF
--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -11,7 +11,6 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
 #include <cassert>
@@ -321,7 +320,7 @@ class device_buffer {
   /**
    * @briefreturn{The resource used to allocate and deallocate}
    */
-  [[nodiscard]] rmm::device_async_resource_ref memory_resource() noexcept { return _mr; }
+  [[nodiscard]] rmm::device_async_resource_ref memory_resource() const noexcept { return _mr; }
 
  private:
   void* _data{nullptr};        ///< Pointer to device memory allocation
@@ -329,8 +328,9 @@ class device_buffer {
   std::size_t _capacity{};     ///< The actual size of the device memory allocation
   cuda_stream_view _stream{};  ///< Stream to use for device memory deallocation
 
-  cuda::mr::any_resource<cuda::mr::device_accessible> _mr;  ///< The memory resource used to
-                                                            ///< allocate/deallocate device memory
+  rmm::device_async_resource_ref _mr{
+    rmm::mr::get_current_device_resource_ref()};  ///< The memory resource used to
+                                                  ///< allocate/deallocate device memory
   cuda_device_id _device{get_current_cuda_device()};
 
   /**

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -602,7 +602,7 @@ class device_uvector {
    * @briefreturn{The resource used to allocate and deallocate the device
    * storage}
    */
-  [[nodiscard]] rmm::device_async_resource_ref memory_resource() noexcept
+  [[nodiscard]] rmm::device_async_resource_ref memory_resource() const noexcept
   {
     return _storage.memory_resource();
   }

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -44,7 +44,7 @@ device_buffer::device_buffer(device_buffer&& other) noexcept
     _size{other._size},
     _capacity{other._capacity},
     _stream{other.stream()},
-    _mr{std::move(other._mr)},
+    _mr{other._mr},
     _device{other._device}
 {
   other._data     = nullptr;
@@ -64,7 +64,7 @@ device_buffer& device_buffer::operator=(device_buffer&& other) noexcept
     _size     = other._size;
     _capacity = other._capacity;
     set_stream(other.stream());
-    _mr     = std::move(other._mr);
+    _mr     = other._mr;
     _device = other._device;
 
     other._data     = nullptr;

--- a/cpp/tests/mr/mr_ref_default_tests.cpp
+++ b/cpp/tests/mr/mr_ref_default_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -61,34 +61,6 @@ TEST(DefaultTest, GetCurrentDeviceResourceRef)
 {
   auto mr = rmm::mr::get_current_device_resource_ref();
   EXPECT_EQ(mr, rmm::device_async_resource_ref{rmm::mr::detail::initial_resource()});
-}
-
-TEST(DefaultTest, SetCurrentDeviceResourceRefFromPointer)
-{
-  // Construct a cuda_memory_resource
-  rmm::mr::cuda_memory_resource cuda_mr{};
-
-  // Get a pointer to it (device_memory_resource*)
-  rmm::mr::device_memory_resource* mr_ptr = &cuda_mr;
-
-  // Set with set_current_device_resource_ref using the pointer
-  rmm::mr::set_current_device_resource_ref(mr_ptr);
-
-  // Get the ref with get_current_device_resource_ref
-  auto ref = rmm::mr::get_current_device_resource_ref();
-
-  // Use that ref to allocate
-  constexpr std::size_t size{1024};
-  void* ptr = ref.allocate_sync(size);
-  EXPECT_NE(ptr, nullptr);
-  EXPECT_TRUE(is_properly_aligned(ptr));
-  EXPECT_TRUE(is_device_accessible_memory(ptr));
-
-  // Deallocate
-  ref.deallocate_sync(ptr, size);
-
-  // Reset to initial resource
-  rmm::mr::reset_current_device_resource_ref();
 }
 
 // Multi-threaded default resource tests


### PR DESCRIPTION
## Description
This reverts commit aac8e28364d8bd0d5d37b0b1d3a9b4c9167795f2.

CI appears to be failing for cudf with errors like:
```
C++ exception with description "CUDA error at: ''include/rmm/mr/detail/stream_ordered_memory_resource.hpp:429: cudaErrorIllegalAddress an illegal memory access was encountered" thrown in the test body.
```

I suspect this change is the root cause.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
