### PR TITLE
Deprecate pointer-based per-device resource APIs

### DIFF
--- a/cpp/include/rmm/mr/per_device_resource.hpp
+++ b/cpp/include/rmm/mr/per_device_resource.hpp
@@ -174,7 +174,10 @@ RMM_EXPORT inline auto& get_ref_map()
  *
  * @param device_id The id of the target device
  * @return Pointer to the current `device_memory_resource` for device `device_id`
+ *
+ * @deprecated Use get_per_device_resource_ref() instead.
  */
+[[deprecated("Use get_per_device_resource_ref() instead")]]
 inline device_memory_resource* get_per_device_resource(cuda_device_id device_id)
 {
   std::lock_guard<std::mutex> lock{detail::map_lock()};
@@ -236,7 +239,10 @@ inline device_async_resource_ref set_per_device_resource_ref_unsafe(
  * @param new_mr If not `nullptr`, pointer to new `device_memory_resource` to use as new resource
  * for `id`
  * @return Pointer to the previous memory resource for `id`
+ *
+ * @deprecated Use set_per_device_resource_ref() instead.
  */
+[[deprecated("Use set_per_device_resource_ref() instead")]]
 inline device_memory_resource* set_per_device_resource(cuda_device_id device_id,
                                                        device_memory_resource* new_mr)
 {
@@ -277,10 +283,16 @@ inline device_memory_resource* set_per_device_resource(cuda_device_id device_id,
  * device_memory_resource was created.
  *
  * @return Pointer to the resource for the current device
+ *
+ * @deprecated Use get_current_device_resource_ref() instead.
  */
+[[deprecated("Use get_current_device_resource_ref() instead")]]
 inline device_memory_resource* get_current_device_resource()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return get_per_device_resource(rmm::get_current_cuda_device());
+#pragma GCC diagnostic pop
 }
 
 /**
@@ -306,10 +318,16 @@ inline device_memory_resource* get_current_device_resource()
  *
  * @param new_mr If not `nullptr`, pointer to new resource to use for the current device
  * @return Pointer to the previous resource for the current device
+ *
+ * @deprecated Use set_current_device_resource_ref() instead.
  */
+[[deprecated("Use set_current_device_resource_ref() instead")]]
 inline device_memory_resource* set_current_device_resource(device_memory_resource* new_mr)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return set_per_device_resource(rmm::get_current_cuda_device(), new_mr);
+#pragma GCC diagnostic pop
 }
 
 /**

--- a/cpp/tests/mr/mr_ref_default_tests.cpp
+++ b/cpp/tests/mr/mr_ref_default_tests.cpp
@@ -42,8 +42,11 @@ void spawn(Task task, Arguments&&... args)
 
 TEST(DefaultTest, CurrentDeviceResourceIsCUDA)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_NE(nullptr, rmm::mr::get_current_device_resource());
   EXPECT_TRUE(rmm::mr::get_current_device_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
+#pragma GCC diagnostic pop
 }
 
 TEST(DefaultTest, UseCurrentDeviceResource) { test_get_current_device_resource(); }
@@ -52,7 +55,10 @@ TEST(DefaultTest, UseCurrentDeviceResourceRef) { test_get_current_device_resourc
 
 TEST(DefaultTest, GetCurrentDeviceResource)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   auto* mr = rmm::mr::get_current_device_resource();
+#pragma GCC diagnostic pop
   EXPECT_NE(nullptr, mr);
   EXPECT_TRUE(mr->is_equal(rmm::mr::cuda_memory_resource{}));
 }
@@ -100,8 +106,11 @@ TEST(DefaultTest, UseCurrentDeviceResourceRef_mt) { spawn(test_get_current_devic
 TEST(DefaultTest, CurrentDeviceResourceIsCUDA_mt)
 {
   spawn([]() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     EXPECT_NE(nullptr, rmm::mr::get_current_device_resource());
     EXPECT_TRUE(rmm::mr::get_current_device_resource()->is_equal(rmm::mr::cuda_memory_resource{}));
+#pragma GCC diagnostic pop
   });
 }
 
@@ -116,7 +125,10 @@ TEST(DefaultTest, CurrentDeviceResourceRefIsCUDA_mt)
 TEST(DefaultTest, GetCurrentDeviceResource_mt)
 {
   spawn([]() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     rmm::mr::device_memory_resource* mr = rmm::mr::get_current_device_resource();
+#pragma GCC diagnostic pop
     EXPECT_NE(nullptr, mr);
     EXPECT_TRUE(mr->is_equal(rmm::mr::cuda_memory_resource{}));
   });

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -93,12 +93,15 @@ struct allocation {
 
 inline void test_get_current_device_resource()
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_NE(nullptr, rmm::mr::get_current_device_resource());
   void* ptr = rmm::mr::get_current_device_resource()->allocate_sync(1_MiB);
   EXPECT_NE(nullptr, ptr);
   EXPECT_TRUE(is_properly_aligned(ptr));
   EXPECT_TRUE(is_device_accessible_memory(ptr));
   rmm::mr::get_current_device_resource()->deallocate_sync(ptr, 1_MiB);
+#pragma GCC diagnostic pop
 }
 
 inline void test_get_current_device_resource_ref()

--- a/cpp/tests/mr/polymorphic_allocator_tests.cpp
+++ b/cpp/tests/mr/polymorphic_allocator_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,8 +23,11 @@ struct allocator_test : public ::testing::Test {
 TEST_F(allocator_test, default_resource)
 {
   rmm::mr::polymorphic_allocator<int> allocator{};
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   EXPECT_EQ(allocator.get_upstream_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource()});
+#pragma GCC diagnostic pop
 }
 
 TEST_F(allocator_test, custom_resource)

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -158,7 +158,10 @@ TEST(PoolTest, MultidevicePool)
     for (int i = 0; i < devices; ++i) {
       RMM_CUDA_TRY(cudaSetDevice(i));
       auto mr = std::make_shared<MemoryResource>(&general_mr, pool_size, pool_size);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       rmm::mr::set_per_device_resource(rmm::cuda_device_id{i}, mr.get());
+#pragma GCC diagnostic pop
       mrs.emplace_back(mr);
     }
 


### PR DESCRIPTION
## Description
Deprecate the following pointer-based APIs in favor of their `resource_ref` counterparts:
- `get_per_device_resource()` → `get_per_device_resource_ref()`
- `set_per_device_resource()` → `set_per_device_resource_ref()`
- `get_current_device_resource()` → `get_current_device_resource_ref()`
- `set_current_device_resource()` → `set_current_device_resource_ref()`

Add `[[deprecated]]` attributes with migration guidance. Suppress internal
deprecation warnings where deprecated functions call each other, and in
test code that intentionally exercises the deprecated APIs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
