### PR TITLE
wheel builds: react to changes in pip's handling of build constraints

### DIFF
--- a/ci/build_wheel_python.sh
+++ b/ci/build_wheel_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -22,8 +22,8 @@ LIBRMM_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="librmm_${RAPIDS_PY_CUDA_SUFFIX}" rapid
 
 # ensure 'rmm' wheel builds always use the 'librmm' just built in the same CI run
 #
-# Using env variable PIP_CONSTRAINT (initialized by 'rapids-init-pip') is necessary to ensure the constraints
-# are used when creating the isolated build environment.
+# env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
+# 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
 echo "librmm-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBRMM_WHEELHOUSE}"/librmm_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)" >> "${PIP_CONSTRAINT}"
 
 sccache --stop-server 2>/dev/null || true
@@ -31,11 +31,19 @@ sccache --stop-server 2>/dev/null || true
 # Creates artifacts directory for telemetry
 source rapids-telemetry-setup
 
+RAPIDS_PIP_WHEEL_ARGS=(
+  -w dist
+  -v
+  --no-deps
+  --disable-pip-version-check
+  --build-constraint="${PIP_CONSTRAINT}"
+)
+
+# unset PIP_CONSTRAINT (set by rapids-init-pip)... it doesn't affect builds as of pip 25.3, and
+# results in an error from 'pip wheel' when set and --build-constraint is also passed
+unset PIP_CONSTRAINT
 rapids-telemetry-record build.log rapids-pip-retry wheel \
-  -v \
-  -w dist \
-  --no-deps \
-  --disable-pip-version-check \
+  "${RAPIDS_PIP_WHEEL_ARGS[@]}" \
   .
 
 rapids-telemetry-record sccache-stats.txt sccache --show-adv-stats


### PR DESCRIPTION
#2212 was into `main` after `main` had already been updated to RAPIDS 26.04.

This change is intended for RAPIDS 26.02, so this PR backports it to the `release/26.02` branch.

## Notes for Reviewers

### How this should be merged

I think normal squash and merge should be fine? The commit SHA is different because of the direction of the `cherry-pick` anyway.

### How I made this branch

```shell
git checkout main
git pull upstream main
git fetch upstream release/26.02
git checkout release/26.02
git checkout -b pip-changes
git cherry-pick f380effb
```