### PR TITLE
Remove numba-cuda upper bound

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - myst-parser
 - nbsphinx
 - ninja
-- numba-cuda>=0.24.0
+- numba-cuda>=0.22.1
 - numba>=0.60.0,<0.62.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - myst-parser
 - nbsphinx
 - ninja
-- numba-cuda>=0.24.0
+- numba-cuda>=0.22.1
 - numba>=0.60.0,<0.62.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - myst-parser
 - nbsphinx
 - ninja
-- numba-cuda>=0.24.0
+- numba-cuda>=0.22.1
 - numba>=0.60.0,<0.62.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - myst-parser
 - nbsphinx
 - ninja
-- numba-cuda>=0.24.0
+- numba-cuda>=0.22.1
 - numba>=0.60.0,<0.62.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -266,7 +266,7 @@ dependencies:
           - myst-parser
           - nbsphinx
           - &numba numba>=0.60.0,<0.62.0
-          - &numba_cuda numba-cuda>=0.24.0
+          - &numba_cuda numba-cuda>=0.22.1
           - numpydoc
           - pydata-sphinx-theme>=0.15.4
           - sphinx
@@ -339,7 +339,7 @@ dependencies:
           - matrix:
               dependencies: "oldest"
             packages:
-              - numba-cuda==0.24.0
+              - numba-cuda==0.22.1
           - matrix:
             packages:
               - *numba_cuda
@@ -348,17 +348,17 @@ dependencies:
           - matrix:
               dependencies: "oldest"
             packages:
-              - numba-cuda==0.24.0
+              - numba-cuda==0.22.1
           - matrix:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - &numba_cuda_cu12 numba-cuda[cu12]>=0.24.0
+              - &numba_cuda_cu12 numba-cuda[cu12]>=0.22.1
           - matrix:
               cuda: "13.*"
               cuda_suffixed: "true"
             packages:
-              - &numba_cuda_cu13 numba-cuda[cu13]>=0.24.0
+              - &numba_cuda_cu13 numba-cuda[cu13]>=0.22.1
           # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
           - matrix:
             packages:

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "numba-cuda>=0.24.0",
+    "numba-cuda>=0.22.1",
     "numba>=0.60.0,<0.62.0",
     "packaging",
     "pytest-cov",


### PR DESCRIPTION
This PR removes the upper bound from the numba-cuda dependency.

Ref: https://github.com/rapidsai/build-planning/issues/245