### PR TITLE
Use plain namespace for header-only classes to fix ODR violations

### DIFF
--- a/cpp/include/rmm/detail/aligned.hpp
+++ b/cpp/include/rmm/detail/aligned.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace detail {
 
 /**
@@ -104,4 +104,4 @@ void aligned_host_deallocate(void* ptr,
   }
 }
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/detail/cccl_adaptors.hpp
+++ b/cpp/include/rmm/detail/cccl_adaptors.hpp
@@ -24,7 +24,7 @@
 #include <utility>
 #endif
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 
 namespace detail {
 
@@ -661,4 +661,4 @@ class cccl_async_resource_ref : public ResourceType {
 #endif  // CCCL version check
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/detail/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/detail/cuda_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -19,7 +19,7 @@
 
 #include <cuda/memory_resource>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace detail {
 namespace polyfill {
 
@@ -34,4 +34,4 @@ inline constexpr bool async_resource_with = cuda::mr::resource_with<Resource, Pr
 
 }  // namespace polyfill
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/detail/export.hpp
+++ b/cpp/include/rmm/detail/export.hpp
@@ -1,11 +1,35 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
-// Macros used for defining symbol visibility, only GLIBC is supported
+// Macros used for defining symbol visibility, only GLIBC is supported.
+//
+// RMM_NAMESPACE vs plain `namespace rmm`:
+//
+// Use `namespace RMM_NAMESPACE` for symbols that meet ANY of these criteria:
+//   1. Compiled into librmm.so (i.e., have a corresponding .cpp file)
+//   2. Exception types that may be thrown/caught across DSO boundaries
+//   3. Base classes with virtual functions used polymorphically across DSOs
+//
+// Use plain `namespace rmm` for:
+//   1. All template classes (instantiated in downstream libraries)
+//   2. Header-only derived classes (compiled into downstream libraries)
+//   3. All detail/internal headers
+//
+// Rationale: RMM_NAMESPACE forces symbols to be publicly exported via
+// __attribute__((visibility("default"))), even when downstream libraries
+// compile with -fvisibility=hidden. For header-only and template code that
+// gets compiled into downstream libraries, this can cause ODR violations
+// when multiple libraries (compiled against different RMM versions) are
+// loaded together. Using plain `namespace rmm` allows downstream libraries
+// to control symbol visibility via their own compile flags.
+//
+// However, exception types and polymorphic base classes MUST have default
+// visibility for cross-DSO exception catching and dynamic_cast to work.
+// See GitHub issue #1652 and GCC wiki on visibility for details.
 #if (defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__))
 #define RMM_EXPORT    __attribute__((visibility("default")))
 #define RMM_HIDDEN    __attribute__((visibility("hidden")))

--- a/cpp/include/rmm/detail/format.hpp
+++ b/cpp/include/rmm/detail/format.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <string>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace detail {
 
 // Stringify a size in bytes to a human-readable value
@@ -39,4 +39,4 @@ inline std::string format_stream(rmm::cuda_stream_view stream)
 }
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -12,7 +12,7 @@
 
 #include <dlfcn.h>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace detail {
 
 /**
@@ -174,4 +174,4 @@ struct device_integrated_memory {
 };
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/detail/stack_trace.hpp
+++ b/cpp/include/rmm/detail/stack_trace.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,7 +25,7 @@
 #include <vector>
 #endif
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace detail {
 
 /**
@@ -93,4 +93,4 @@ class stack_trace {
 };
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 
 #include <type_traits>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 /**
  * @addtogroup data_containers
  * @{
@@ -267,4 +267,4 @@ class device_scalar {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 /**
  * @addtogroup data_containers
  * @{
@@ -640,4 +640,4 @@ class device_uvector {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/device_vector.hpp
+++ b/cpp/include/rmm/device_vector.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 
 #include <thrust/device_vector.h>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -25,4 +25,4 @@ template <typename T>
 using device_vector = thrust::device_vector<T, rmm::mr::thrust_allocator<T>>;
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -17,7 +17,7 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -225,4 +225,4 @@ class aligned_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/arena_memory_resource.hpp
+++ b/cpp/include/rmm/mr/arena_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -21,7 +21,7 @@
 #include <shared_mutex>
 #include <thread>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -353,4 +353,4 @@ class arena_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/binning_memory_resource.hpp
+++ b/cpp/include/rmm/mr/binning_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -18,7 +18,7 @@
 #include <optional>
 #include <vector>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -211,4 +211,4 @@ class binning_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -11,7 +11,7 @@
 #include <functional>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -138,4 +138,4 @@ class callback_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -128,4 +128,4 @@ static_assert(rmm::detail::polyfill::async_resource_with<cuda_async_managed_memo
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -202,4 +202,4 @@ class cuda_async_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
@@ -15,7 +15,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -122,4 +122,4 @@ class cuda_async_view_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_memory_resource.hpp
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -86,4 +86,4 @@ class cuda_memory_resource final : public device_memory_resource {
 };
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/detail/arena.hpp
+++ b/cpp/include/rmm/mr/detail/arena.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -26,7 +26,7 @@
 #include <optional>
 #include <set>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr::detail::arena {
 
 /**
@@ -983,4 +983,4 @@ class arena_cleaner {
 };
 
 }  // namespace mr::detail::arena
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/detail/coalescing_free_list.hpp
+++ b/cpp/include/rmm/mr/detail/coalescing_free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,7 +17,7 @@
 #endif
 #include <iterator>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr::detail {
 
 /**
@@ -255,4 +255,4 @@ struct coalescing_free_list : free_list<block> {
 };  // coalescing_free_list
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/detail/device_memory_resource_view.hpp
+++ b/cpp/include/rmm/mr/detail/device_memory_resource_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr::detail {
 
 /**
@@ -177,4 +177,4 @@ static_assert(cuda::std::copy_constructible<device_memory_resource_view>,
               "device_memory_resource_view must be copy constructible");
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/detail/fixed_size_free_list.hpp
+++ b/cpp/include/rmm/mr/detail/fixed_size_free_list.hpp
@@ -10,7 +10,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr::detail {
 
 struct fixed_size_free_list : free_list<block_base> {
@@ -66,4 +66,4 @@ struct fixed_size_free_list : free_list<block_base> {
 };
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/detail/free_list.hpp
+++ b/cpp/include/rmm/mr/detail/free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #endif
 #include <list>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr::detail {
 
 struct block_base {
@@ -174,4 +174,4 @@ class free_list {
 };
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -23,7 +23,7 @@
 #include <iostream>
 #endif
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr::detail {
 
 /**
@@ -486,4 +486,4 @@ class stream_ordered_memory_resource : public crtp<PoolResource>, public device_
 };  // namespace detail
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/failure_callback_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/failure_callback_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 #include <functional>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -198,4 +198,4 @@ class failure_callback_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
+++ b/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -272,4 +272,4 @@ class fixed_size_memory_resource
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/is_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/is_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,7 +9,7 @@
 
 #include <cuda/std/type_traits>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 
 /**
@@ -33,4 +33,4 @@ inline constexpr bool is_resource_adaptor<
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -15,7 +15,7 @@
 #include <atomic>
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -189,4 +189,4 @@ class limiting_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/logging_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/logging_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -19,7 +19,7 @@
 #include <ostream>
 #include <string>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 
 /**
@@ -329,4 +329,4 @@ class logging_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/managed_memory_resource.hpp
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -91,4 +91,4 @@ class managed_memory_resource final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/owning_wrapper.hpp
+++ b/cpp/include/rmm/mr/owning_wrapper.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,7 +10,7 @@
 #include <memory>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 namespace detail {
 /**
@@ -260,4 +260,4 @@ auto make_owning_wrapper(std::shared_ptr<Upstream> upstream, Args&&... args)
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/per_device_resource.hpp
+++ b/cpp/include/rmm/mr/per_device_resource.hpp
@@ -82,7 +82,7 @@
  * @endcode
  */
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -475,4 +475,4 @@ inline device_async_resource_ref reset_current_device_resource_ref()
 }
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -18,7 +18,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 
 /**
@@ -138,4 +138,4 @@ static_assert(rmm::detail::polyfill::async_resource_with<pinned_host_memory_reso
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -285,4 +285,4 @@ bool operator!=(stream_allocator_adaptor<A> const& lhs, stream_allocator_adaptor
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/pool_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pool_memory_resource.hpp
@@ -29,7 +29,7 @@
 #include <optional>
 #include <set>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -492,4 +492,4 @@ class pool_memory_resource final
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/prefetch_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/prefetch_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -119,4 +119,4 @@ class prefetch_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/sam_headroom_memory_resource.hpp
+++ b/cpp/include/rmm/mr/sam_headroom_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -140,4 +140,4 @@ class sam_headroom_memory_resource final : public device_memory_resource {
 };
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/statistics_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/statistics_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 #include <shared_mutex>
 #include <stack>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -278,4 +278,4 @@ class statistics_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/system_memory_resource.hpp
+++ b/cpp/include/rmm/mr/system_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 #include <cstddef>
 #include <string>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 
 namespace detail {
@@ -160,4 +160,4 @@ static_assert(
   rmm::detail::polyfill::async_resource_with<system_memory_resource, cuda::mr::host_accessible>);
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <mutex>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -127,4 +127,4 @@ class thread_safe_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,7 +16,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -143,4 +143,4 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
 };
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -19,7 +19,7 @@
 #include <shared_mutex>
 #include <sstream>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -274,4 +274,4 @@ class tracking_resource_adaptor final : public device_memory_resource {
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm

--- a/cpp/include/rmm/resource_ref.hpp
+++ b/cpp/include/rmm/resource_ref.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,7 +9,7 @@
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
 
-namespace RMM_NAMESPACE {
+namespace rmm {
 
 /**
  * @addtogroup memory_resources
@@ -136,4 +136,4 @@ static_assert(std::is_constructible_v<host_resource_ref, host_device_resource_re
               "host_resource_ref must be constructible from host_device_resource_ref");
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace rmm


### PR DESCRIPTION
## Summary
- Change `namespace RMM_NAMESPACE` to `namespace rmm` in header-only and template classes
- This allows downstream libraries to control symbol visibility, preventing ODR violations when multiple libraries use different RMM versions
- Closes #2219

Files that retain `RMM_NAMESPACE`:
- Files with .cpp implementations (symbols compiled into librmm.so)
- Exception types (must be catchable across DSO boundaries)
- Base classes with vtables used polymorphically across DSOs