### PR TITLE
Bump pre-commit-hooks to 1.3.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
         pass_filenames: false
         verbose: true
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.3.2
+    rev: v1.3.3
     hooks:
       - id: verify-copyright
         args: [--fix, --spdx]


### PR DESCRIPTION
## Description
This version has some additional heuristics which fix some of the false positives in `verify-hardcoded-version`.

Ops-Bot-Merge-Barrier: true

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
