### PR TITLE
Fix vtable cast error when converting resource_ref to any_resource

### DIFF
--- a/cpp/include/rmm/detail/cccl_adaptors.hpp
+++ b/cpp/include/rmm/detail/cccl_adaptors.hpp
@@ -565,6 +565,7 @@ class cccl_async_resource_ref {
   template <typename... Properties>
   operator cuda::mr::any_resource<Properties...>() const
   {
+    if (view_.has_value()) { return cuda::mr::any_resource<Properties...>{*view_}; }
     return cuda::mr::any_resource<Properties...>{ref_};
   }
 

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -50,6 +50,15 @@ struct DeviceBufferTest : public ::testing::Test {
 using resources = ::testing::Types<rmm::mr::cuda_memory_resource, rmm::mr::managed_memory_resource>;
 
 TYPED_TEST_SUITE(DeviceBufferTest, resources);
+
+// Test creating device_buffer with explicit resource_ref
+TEST(DeviceBufferSimpleTest, ExplicitResourceRef)
+{
+  auto mr = rmm::mr::cuda_memory_resource{};
+  rmm::device_async_resource_ref ref{mr};
+  auto buf = rmm::device_buffer(10, rmm::cuda_stream_default, ref);
+  EXPECT_EQ(buf.size(), 10);
+}
 
 TYPED_TEST(DeviceBufferTest, EmptyBuffer)
 {


### PR DESCRIPTION
## Summary
- Fix vtable mismatch error ("bad vtable cast detected") when converting `cccl_async_resource_ref` to `any_resource`
- When `view_` is present (constructed from `device_memory_resource*`), use it directly in the conversion operator to avoid DSO boundary vtable issues

## Test plan
- Added `DeviceBufferSimpleTest.ExplicitResourceRef` test that fails without the fix and passes with it
- Run `test-rmm-cpp -R DEVICE_BUFFER_TEST`