### PR TITLE
Unset CUDAARCHS in librmm conda recipe

### DIFF
--- a/conda/recipes/librmm/recipe.yaml
+++ b/conda/recipes/librmm/recipe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 schema_version: 1
 
@@ -26,6 +26,10 @@ cache:
         export CFLAGS=$(echo $CFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         export CXXFLAGS=$(echo $CXXFLAGS | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
         set +x
+
+        # Unset CUDAARCHS set by conda-forge's cuda-nvcc activation script
+        # so that rapids-cmake selects the default RAPIDS architectures.
+        unset CUDAARCHS
 
         ./build.sh -n -v clean librmm tests benchmarks
       secrets:
@@ -154,6 +158,10 @@ outputs:
       string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
       script:
         content: |
+          # Unset CUDAARCHS set by conda-forge's cuda-nvcc activation script
+          # so that rapids-cmake selects the default RAPIDS architectures.
+          unset CUDAARCHS
+
           ./cpp/examples/build.sh --install
         env:
           CMAKE_C_COMPILER_LAUNCHER: ${{ env.get("CMAKE_C_COMPILER_LAUNCHER") }}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -141,7 +141,8 @@ if((BUILD_TESTS OR BUILD_BENCHMARKS) AND CMAKE_PROJECT_NAME STREQUAL PROJECT_NAM
   # Since RMM only enables CUDA optionally we need to manually include the file that
   # rapids_cuda_init_architectures relies on `project` calling
   include("${CMAKE_PROJECT_RMM_INCLUDE}")
-  message(STATUS "RMM: Building benchmarks with GPU Architectures: ${CMAKE_CUDA_ARCHITECTURES}")
+  message(
+    STATUS "RMM: Building tests/benchmarks with GPU Architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 endif()
 
 # ##################################################################################################


### PR DESCRIPTION
## Summary
- Unset `CUDAARCHS` environment variable in the librmm conda recipe build scripts
- The conda-forge `cuda-nvcc` package sets `CUDAARCHS` to all supported architectures (including pre-70 ones), which interferes with `rapids_cuda_init_architectures`
- This fix allows rapids-cmake to select the default RAPIDS architectures (70+) appropriate for the CUDA version

Closes #2238

## References
- https://github.com/conda-forge/cuda-feedstock/blob/main/recipe/doc/recipe_guide.md
- https://github.com/conda-forge/cuda-nvcc-feedstock/blob/main/recipe/activate.sh