### PR TITLE
Remove compatibility code for CCCL earlier than 3.2

### DIFF
--- a/cpp/include/rmm/detail/cccl_adaptors.hpp
+++ b/cpp/include/rmm/detail/cccl_adaptors.hpp
@@ -7,12 +7,6 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/cuda_memory_resource.hpp>
 #include <rmm/detail/export.hpp>
-
-// CCCL 3.2 introduced a new basic_any-based resource_ref implementation that requires
-// composition instead of inheritance to avoid issues with copy/move semantics and
-// recursive constraint satisfaction. For CCCL < 3.2, we use the simpler inheritance-based
-// approach.
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 2)
 #include <rmm/mr/detail/device_memory_resource_view.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
 
@@ -22,13 +16,10 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>
-#endif
 
 namespace RMM_NAMESPACE {
 
 namespace detail {
-
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 2)
 
 /**
  * @brief Helper trait to check if a type is a specialization of a class template.
@@ -576,90 +567,6 @@ class cccl_async_resource_ref {
 #ifdef __CUDACC__
 #pragma nv_diagnostic pop
 #endif
-
-#else  // CCCL < 3.2: Use simpler inheritance-based implementation
-
-template <typename ResourceType>
-class cccl_resource_ref : public ResourceType {
- public:
-  using base = ResourceType;
-
-  using base::base;
-
-  cccl_resource_ref(base const& other) : base(other) {}
-
-  cccl_resource_ref(base&& other) : base(std::move(other)) {}
-
-  void* allocate_sync(std::size_t bytes) { return base::allocate_sync(bytes); }
-
-  void* allocate_sync(std::size_t bytes, std::size_t alignment)
-  {
-    return base::allocate_sync(bytes, alignment);
-  }
-
-  void deallocate_sync(void* ptr, std::size_t bytes) noexcept
-  {
-    return base::deallocate_sync(ptr, bytes);
-  }
-
-  void deallocate_sync(void* ptr, std::size_t bytes, std::size_t alignment) noexcept
-  {
-    return base::deallocate_sync(ptr, bytes, alignment);
-  }
-};
-
-template <typename ResourceType>
-class cccl_async_resource_ref : public ResourceType {
- public:
-  using base = ResourceType;
-
-  using base::base;
-
-  cccl_async_resource_ref(base const& other) : base(other) {}
-  cccl_async_resource_ref(base&& other) : base(std::move(other)) {}
-
-  void* allocate_sync(std::size_t bytes) { return base::allocate_sync(bytes); }
-
-  void* allocate_sync(std::size_t bytes, std::size_t alignment)
-  {
-    return base::allocate_sync(bytes, alignment);
-  }
-
-  void deallocate_sync(void* ptr, std::size_t bytes) noexcept
-  {
-    return base::deallocate_sync(ptr, bytes);
-  }
-
-  void deallocate_sync(void* ptr, std::size_t bytes, std::size_t alignment) noexcept
-  {
-    return base::deallocate_sync(ptr, bytes, alignment);
-  }
-
-  void* allocate(cuda_stream_view stream, std::size_t bytes)
-  {
-    return base::allocate(stream, bytes);
-  }
-
-  void* allocate(cuda_stream_view stream, std::size_t bytes, std::size_t alignment)
-  {
-    return base::allocate(stream, bytes, alignment);
-  }
-
-  void deallocate(cuda_stream_view stream, void* ptr, std::size_t bytes) noexcept
-  {
-    return base::deallocate(stream, ptr, bytes);
-  }
-
-  void deallocate(cuda_stream_view stream,
-                  void* ptr,
-                  std::size_t bytes,
-                  std::size_t alignment) noexcept
-  {
-    return base::deallocate(stream, ptr, bytes, alignment);
-  }
-};
-
-#endif  // CCCL version check
 
 }  // namespace detail
 }  // namespace RMM_NAMESPACE

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -66,15 +66,8 @@ auto const fake_address4 = reinterpret_cast<void*>(superblock::minimum_size * 2)
 struct ArenaTest : public ::testing::Test {
   void SetUp() override
   {
-// CCCL 3.2+ uses device_memory_resource_view which routes through do_allocate/do_deallocate
-#if CCCL_MAJOR_VERSION > 3 || (CCCL_MAJOR_VERSION == 3 && CCCL_MINOR_VERSION >= 2)
     EXPECT_CALL(mock_mr, do_allocate(arena_size, ::testing::_)).WillOnce(Return(fake_address3));
     EXPECT_CALL(mock_mr, do_deallocate(fake_address3, arena_size, ::testing::_));
-#else
-    EXPECT_CALL(mock_mr, allocate_sync(arena_size, ::testing::_)).WillOnce(Return(fake_address3));
-    EXPECT_CALL(mock_mr, deallocate_sync(fake_address3, arena_size, ::testing::_));
-#endif
-
     global     = std::make_unique<global_arena>(mock_mr, arena_size);
     per_thread = std::make_unique<arena>(*global);
   }


### PR DESCRIPTION
## Description
As of #2223, RMM requires CCCL >=3.2. This PR removes some outdated compatibility code.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
