### PR TITLE
Fix sticky CUDA error in `prefetch_resource_adaptor` when upstream returns non-managed memory

### DIFF
--- a/cpp/src/prefetch.cpp
+++ b/cpp/src/prefetch.cpp
@@ -27,8 +27,13 @@ void prefetch(void const* ptr,
   cudaError_t result = cudaMemPrefetchAsync(ptr, size, device.value(), stream.value());
 #endif
   // cudaErrorInvalidValue is returned when non-managed memory is passed to
-  // cudaMemPrefetchAsync. We treat this as a no-op.
-  if (result != cudaErrorInvalidValue && result != cudaSuccess) { RMM_CUDA_TRY(result); }
+  // cudaMemPrefetchAsync. We treat this as a no-op but must clear the sticky
+  // error from the CUDA runtime to prevent downstream failures.
+  if (result == cudaErrorInvalidValue) {
+    (void)cudaGetLastError();
+  } else if (result != cudaSuccess) {
+    RMM_CUDA_TRY(result);
+  }
 }
 
 }  // namespace rmm


### PR DESCRIPTION
Closes [#7834](https://github.com/rapidsai/cuml/issues/7842).

The `prefetch_resource_adaptor` treats prefetching of non-managed memory as a no-op, but fails to clear the sticky error from the CUDA runtime. This causes the CUDA runtime to be invalidated when using a `PrefetchResourceAdaptor` with a `CudaMemoryResource` as upstream.