### PR TITLE
Reduce default pool sizes in Python tests to speed up suite

### DIFF
--- a/python/rmm/rmm/tests/test_allocations.py
+++ b/python/rmm/rmm/tests/test_allocations.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for basic RMM allocations."""
@@ -8,6 +8,7 @@ from itertools import product
 import pytest
 from test_helpers import (
     _SYSTEM_MEMORY_SUPPORTED,
+    _TEST_POOL_SIZE,
     _allocs,
     _dtypes,
     _nelems,
@@ -24,39 +25,21 @@ def test_rmm_alloc(dtype, nelem, alloc):
     array_tester(dtype, nelem, alloc)
 
 
-# Test all combinations of default/managed and pooled/non-pooled allocation
-@pytest.mark.parametrize("dtype", _dtypes)
-@pytest.mark.parametrize("nelem", _nelems)
-@pytest.mark.parametrize("alloc", _allocs)
-@pytest.mark.parametrize(
-    "managed, pool", list(product([False, True], [False, True]))
-)
-def test_rmm_modes(dtype, nelem, alloc, managed, pool):
-    assert rmm.is_initialized()
-    array_tester(dtype, nelem, alloc)
-
-    rmm.reinitialize(pool_allocator=pool, managed_memory=managed)
-
-    assert rmm.is_initialized()
-
-    array_tester(dtype, nelem, alloc)
+def _make_mr(managed, pool):
+    """Build a memory resource for the given managed/pool mode."""
+    if managed:
+        base_mr = rmm.mr.ManagedMemoryResource()
+    else:
+        base_mr = rmm.mr.CudaMemoryResource()
+    if pool:
+        return rmm.mr.PoolMemoryResource(
+            base_mr, initial_pool_size=_TEST_POOL_SIZE
+        )
+    return base_mr
 
 
-@pytest.mark.skipif(
-    not _SYSTEM_MEMORY_SUPPORTED,
-    reason="System memory not supported",
-)
-@pytest.mark.parametrize("dtype", _dtypes)
-@pytest.mark.parametrize("nelem", _nelems)
-@pytest.mark.parametrize("alloc", _allocs)
-@pytest.mark.parametrize(
-    "system, pool, headroom",
-    list(product([False, True], [False, True], [False, True])),
-)
-def test_rmm_modes_system_memory(dtype, nelem, alloc, system, pool, headroom):
-    assert rmm.is_initialized()
-    array_tester(dtype, nelem, alloc)
-
+def _make_system_memory_mr(system, pool, headroom):
+    """Build a memory resource for the given system memory test mode."""
     if system:
         if headroom:
             base_mr = rmm.mr.SamHeadroomMemoryResource(headroom=1 << 20)
@@ -65,11 +48,52 @@ def test_rmm_modes_system_memory(dtype, nelem, alloc, system, pool, headroom):
     else:
         base_mr = rmm.mr.CudaMemoryResource()
     if pool:
-        mr = rmm.mr.PoolMemoryResource(base_mr)
-    else:
-        mr = base_mr
-    rmm.mr.set_current_device_resource(mr)
+        return rmm.mr.PoolMemoryResource(
+            base_mr, initial_pool_size=_TEST_POOL_SIZE
+        )
+    return base_mr
 
-    assert rmm.is_initialized()
 
-    array_tester(dtype, nelem, alloc)
+# Test all combinations of default/managed and pooled/non-pooled allocation.
+# The mode fixture is class-scoped so that the (potentially expensive) memory
+# resource is created once per mode combo rather than once per dtype/nelem.
+@pytest.mark.parametrize(
+    "managed, pool",
+    list(product([False, True], [False, True])),
+    scope="class",
+)
+class TestRmmModes:
+    @pytest.fixture(autouse=True)
+    def _apply_mode(self, managed, pool):
+        mr = _make_mr(managed, pool)
+        rmm.mr.set_current_device_resource(mr)
+
+    @pytest.mark.parametrize("dtype", _dtypes)
+    @pytest.mark.parametrize("nelem", _nelems)
+    @pytest.mark.parametrize("alloc", _allocs)
+    def test_rmm_modes(self, dtype, nelem, alloc):
+        assert rmm.is_initialized()
+        array_tester(dtype, nelem, alloc)
+
+
+@pytest.mark.skipif(
+    not _SYSTEM_MEMORY_SUPPORTED,
+    reason="System memory not supported",
+)
+@pytest.mark.parametrize(
+    "system, pool, headroom",
+    list(product([False, True], [False, True], [False, True])),
+    scope="class",
+)
+class TestRmmModesSystemMemory:
+    @pytest.fixture(autouse=True)
+    def _apply_mode(self, system, pool, headroom):
+        mr = _make_system_memory_mr(system, pool, headroom)
+        rmm.mr.set_current_device_resource(mr)
+
+    @pytest.mark.parametrize("dtype", _dtypes)
+    @pytest.mark.parametrize("nelem", _nelems)
+    @pytest.mark.parametrize("alloc", _allocs)
+    def test_rmm_modes_system_memory(self, dtype, nelem, alloc):
+        assert rmm.is_initialized()
+        array_tester(dtype, nelem, alloc)

--- a/python/rmm/rmm/tests/test_arena_memory_resource.py
+++ b/python/rmm/rmm/tests/test_arena_memory_resource.py
@@ -1,10 +1,16 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for ArenaMemoryResource."""
 
 import pytest
-from test_helpers import _allocs, _dtypes, _nelems, array_tester
+from test_helpers import (
+    _TEST_POOL_SIZE,
+    _allocs,
+    _dtypes,
+    _nelems,
+    array_tester,
+)
 
 import rmm
 
@@ -24,7 +30,7 @@ import rmm
 )
 def test_arena_memory_resource(dtype, nelem, alloc, upstream_mr):
     upstream = upstream_mr()
-    mr = rmm.mr.ArenaMemoryResource(upstream)
+    mr = rmm.mr.ArenaMemoryResource(upstream, arena_size=_TEST_POOL_SIZE)
 
     rmm.mr.set_current_device_resource(mr)
     assert rmm.mr.get_current_device_resource_type() is type(mr)

--- a/python/rmm/rmm/tests/test_device_buffer.py
+++ b/python/rmm/rmm/tests/test_device_buffer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for DeviceBuffer class."""
@@ -13,6 +13,7 @@ from cuda.bindings import runtime
 from numba import cuda
 from test_helpers import (
     _CONCURRENT_MANAGED_ACCESS_SUPPORTED,
+    _TEST_POOL_SIZE,
     assert_prefetched,
 )
 
@@ -196,7 +197,11 @@ def test_rmm_device_buffer_pickle_roundtrip(hb):
     "managed, pool", list(product([False, True], [False, True]))
 )
 def test_rmm_device_buffer_prefetch(pool, managed):
-    rmm.reinitialize(pool_allocator=pool, managed_memory=managed)
+    rmm.reinitialize(
+        pool_allocator=pool,
+        managed_memory=managed,
+        initial_pool_size=_TEST_POOL_SIZE if pool else None,
+    )
     db = rmm.DeviceBuffer.to_device(np.zeros(256, dtype="u1"))
     if managed and _CONCURRENT_MANAGED_ACCESS_SUPPORTED:
         assert_prefetched(db, runtime.cudaInvalidDeviceId)

--- a/python/rmm/rmm/tests/test_helpers.py
+++ b/python/rmm/rmm/tests/test_helpers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Shared test utilities and constants for RMM tests."""
@@ -64,6 +64,8 @@ def assert_prefetched(buffer, device_id):
     assert err == runtime.cudaError_t.cudaSuccess
     assert dev == device_id
 
+
+_TEST_POOL_SIZE = 1 << 20  # 1 MiB; reduces pool memory resource creation time
 
 # Test parameter sets
 _dtypes = [

--- a/python/rmm/rmm/tests/test_pool_memory_resource.py
+++ b/python/rmm/rmm/tests/test_pool_memory_resource.py
@@ -1,11 +1,17 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for PoolMemoryResource."""
 
 import pytest
 from numba import cuda
-from test_helpers import _allocs, _dtypes, _nelems, array_tester
+from test_helpers import (
+    _TEST_POOL_SIZE,
+    _allocs,
+    _dtypes,
+    _nelems,
+    array_tester,
+)
 
 import rmm
 from rmm.pylibrmm.stream import Stream
@@ -42,7 +48,7 @@ def test_reinitialize_max_pool_size_exceeded():
 
 @pytest.mark.parametrize("stream", [cuda.default_stream(), cuda.stream()])
 def test_rmm_pool_numba_stream(stream):
-    rmm.reinitialize(pool_allocator=True)
+    rmm.reinitialize(pool_allocator=True, initial_pool_size=_TEST_POOL_SIZE)
 
     stream = Stream(stream)
     a = rmm.DeviceBuffer(size=3, stream=stream)
@@ -55,7 +61,9 @@ def test_mr_upstream_lifetime():
     # Simple test to ensure upstream MRs are deallocated before downstream MR
     cuda_mr = rmm.mr.CudaMemoryResource()
 
-    pool_mr = rmm.mr.PoolMemoryResource(cuda_mr)
+    pool_mr = rmm.mr.PoolMemoryResource(
+        cuda_mr, initial_pool_size=_TEST_POOL_SIZE
+    )
 
     # Delete cuda_mr first. Should be kept alive by pool_mr
     del cuda_mr


### PR DESCRIPTION
## Summary

As GPUs continue to grow, the cost of allocating half of the device memory for each test using a pool resource is no longer ideal.

Several Python tests create `PoolMemoryResource`, `ArenaMemoryResource`, or call `rmm.reinitialize(pool_allocator=True)` without specifying an initial pool size. This defaults to half of GPU memory (~60 GiB on a 120 GiB GPU), making each pool creation take **~1.3s** due to the underlying `cudaMalloc`. The tests only allocate at most 128 elements of float64 (1024 bytes), so the full default pool is unnecessary.

## Changes

- Add a `_TEST_POOL_SIZE` (1 MiB) constant to `test_helpers.py` and pass it wherever pools or arenas are created in tests that only need small allocations.
- Restructure `test_allocations.py` mode tests to use class-scoped parametrize so the memory resource is created once per mode combo rather than once per `(dtype, nelem, mode)` combination.
- Pass `initial_pool_size` to `rmm.reinitialize()` and `PoolMemoryResource()` in `test_device_buffer.py` and `test_pool_memory_resource.py`.
- Pass `arena_size` to `ArenaMemoryResource()` in `test_arena_memory_resource.py`.

## Results

Times measured on DGX Spark.

| Metric | Before | After |
|---|---|---|
| Full Python test suite | **~180s** | **~5s** |
| Peak per-file GPU memory | **30+ GiB** | **<200 MiB** |
| Test count | 1811 passed, 6 skipped | 1811 passed, 6 skipped |