### PR TITLE
Refactor thread_safe_resource_adaptor to shared CCCL MR design

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -103,11 +103,13 @@ add_library(
   src/mr/detail/pool_memory_resource_impl.cpp
   src/mr/detail/statistics_resource_adaptor_impl.cpp
   src/mr/detail/tracking_resource_adaptor_impl.cpp
+  src/mr/detail/thread_safe_resource_adaptor_impl.cpp
   src/mr/fixed_size_memory_resource.cpp
   src/mr/logging_resource_adaptor.cpp
   src/mr/pool_memory_resource.cpp
   src/mr/statistics_resource_adaptor.cpp
   src/mr/tracking_resource_adaptor.cpp
+  src/mr/thread_safe_resource_adaptor.cpp
   src/prefetch.cpp)
 add_library(rmm::rmm ALIAS rmm)
 

--- a/cpp/include/rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <rmm/detail/export.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
+
+#include <cstddef>
+#include <mutex>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+namespace detail {
+
+/**
+ * @brief Implementation class for thread_safe_resource_adaptor.
+ *
+ * Wraps allocations and deallocations from the upstream in a mutex lock.
+ * This class satisfies the CCCL `cuda::mr::resource` concept and is held by
+ * `thread_safe_resource_adaptor` via `cuda::mr::shared_resource` for
+ * reference-counted ownership.
+ */
+class thread_safe_resource_adaptor_impl {
+ public:
+  explicit thread_safe_resource_adaptor_impl(device_async_resource_ref upstream);
+
+  ~thread_safe_resource_adaptor_impl() = default;
+
+  thread_safe_resource_adaptor_impl(thread_safe_resource_adaptor_impl const&)            = delete;
+  thread_safe_resource_adaptor_impl(thread_safe_resource_adaptor_impl&&)                 = delete;
+  thread_safe_resource_adaptor_impl& operator=(thread_safe_resource_adaptor_impl const&) = delete;
+  thread_safe_resource_adaptor_impl& operator=(thread_safe_resource_adaptor_impl&&)      = delete;
+
+  bool operator==(thread_safe_resource_adaptor_impl const& other) const noexcept
+  {
+    return this == std::addressof(other);
+  }
+
+  bool operator!=(thread_safe_resource_adaptor_impl const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  [[nodiscard]] device_async_resource_ref get_upstream_resource() const noexcept;
+
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 std::size_t alignment = alignof(std::max_align_t));
+
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = alignof(std::max_align_t)) noexcept;
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t));
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = alignof(std::max_align_t)) noexcept;
+
+  RMM_CONSTEXPR_FRIEND void get_property(thread_safe_resource_adaptor_impl const&,
+                                         cuda::mr::device_accessible) noexcept
+  {
+  }
+
+ private:
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr_;
+  mutable std::mutex mtx_;
+};
+
+}  // namespace detail
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
@@ -5,13 +5,14 @@
 #pragma once
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
+#include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/memory_resource>
+
 #include <cstddef>
-#include <memory>
 #include <mutex>
 
 namespace RMM_NAMESPACE {
@@ -22,109 +23,87 @@ namespace mr {
  * @file
  */
 /**
- * @brief Resource that adapts `Upstream` memory resource adaptor to be thread safe.
+ * @brief Resource that adapts an upstream resource to be thread safe.
  *
- * An instance of this resource can be constructured with an existing, upstream resource in order
- * to satisfy allocation requests. This adaptor wraps allocations and deallocations from Upstream
- * in a mutex lock.
+ * An instance of this resource can be constructed with an existing, upstream resource in order
+ * to satisfy allocation requests. This adaptor wraps allocations and deallocations from the
+ * upstream in a mutex lock.
  *
- * @tparam Upstream Type of the upstream resource used for allocation/deallocation.
+ * This class is copyable and shares ownership of its internal state via
+ * `cuda::mr::shared_resource`.
  */
-template <typename Upstream>
-class thread_safe_resource_adaptor final : public device_memory_resource {
+class RMM_EXPORT thread_safe_resource_adaptor
+  : public device_memory_resource,
+    private cuda::mr::shared_resource<detail::thread_safe_resource_adaptor_impl> {
+  using shared_base = cuda::mr::shared_resource<detail::thread_safe_resource_adaptor_impl>;
+
  public:
   using lock_t = std::lock_guard<std::mutex>;  ///< Type of lock used to synchronize access
 
-  /**
-   * @brief Construct a new thread safe resource adaptor using `upstream` to satisfy
-   * allocation requests.
-   *
-   * All allocations and frees are protected by a mutex lock
-   *
-   * @param upstream The resource used for allocating/deallocating device memory.
-   */
-  thread_safe_resource_adaptor(device_async_resource_ref upstream) : upstream_{upstream} {}
+  // Begin legacy device_memory_resource compatibility layer
+  using device_memory_resource::allocate;
+  using device_memory_resource::allocate_sync;
+  using device_memory_resource::deallocate;
+  using device_memory_resource::deallocate_sync;
 
   /**
-   * @brief Construct a new thread safe resource adaptor using `upstream` to satisfy
-   * allocation requests.
+   * @brief Compare two adaptors for equality (shared-impl identity).
    *
-   * All allocations and frees are protected by a mutex lock
-   *
-   * @throws rmm::logic_error if `upstream == nullptr`
-   *
-   * @param upstream The resource used for allocating/deallocating device memory.
+   * @param other The other thread_safe_resource_adaptor to compare against.
+   * @return true if both adaptors share the same underlying state.
    */
-  thread_safe_resource_adaptor(Upstream* upstream)
-    : upstream_{to_device_async_resource_ref_checked(upstream)}
+  [[nodiscard]] bool operator==(thread_safe_resource_adaptor const& other) const noexcept
+  {
+    return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+  }
+
+  /**
+   * @brief Compare two adaptors for inequality.
+   *
+   * @param other The other thread_safe_resource_adaptor to compare against.
+   * @return true if the adaptors do not share the same underlying state.
+   */
+  [[nodiscard]] bool operator!=(thread_safe_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+  // End legacy device_memory_resource compatibility layer
+
+  /**
+   * @brief Enables the `cuda::mr::device_accessible` property
+   */
+  RMM_CONSTEXPR_FRIEND void get_property(thread_safe_resource_adaptor const&,
+                                         cuda::mr::device_accessible) noexcept
   {
   }
 
-  thread_safe_resource_adaptor()                                               = delete;
-  ~thread_safe_resource_adaptor() override                                     = default;
-  thread_safe_resource_adaptor(thread_safe_resource_adaptor const&)            = delete;
-  thread_safe_resource_adaptor(thread_safe_resource_adaptor&&)                 = delete;
-  thread_safe_resource_adaptor& operator=(thread_safe_resource_adaptor const&) = delete;
-  thread_safe_resource_adaptor& operator=(thread_safe_resource_adaptor&&)      = delete;
+  /**
+   * @brief Construct a new thread safe resource adaptor using `upstream` to satisfy
+   * allocation requests.
+   *
+   * @param upstream The resource used for allocating/deallocating device memory.
+   */
+  explicit thread_safe_resource_adaptor(device_async_resource_ref upstream);
+
+  ~thread_safe_resource_adaptor() = default;
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
    */
-  [[nodiscard]] rmm::device_async_resource_ref get_upstream_resource() const noexcept
-  {
-    return upstream_;
-  }
+  [[nodiscard]] device_async_resource_ref get_upstream_resource() const noexcept;
 
+  // Begin legacy device_memory_resource compatibility layer
  private:
-  /**
-   * @brief Allocates memory of size at least `bytes` using the upstream
-   * resource with thread safety.
-   *
-   * @throws rmm::bad_alloc if the requested allocation could not be fulfilled
-   * by the upstream resource.
-   *
-   * @param bytes The size, in bytes, of the allocation
-   * @param stream Stream on which to perform the allocation
-   * @return void* Pointer to the newly allocated memory
-   */
-  void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
-  {
-    lock_t lock(mtx);
-    return get_upstream_resource().allocate(stream, bytes);
-  }
+  void* do_allocate(std::size_t bytes, cuda_stream_view stream) override;
 
-  /**
-   * @brief Free allocation of size `bytes` pointed to by `ptr`.
-   *
-   * @param ptr Pointer to be deallocated
-   * @param bytes Size of the allocation
-   * @param stream Stream on which to perform the deallocation
-   */
-  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) noexcept override
-  {
-    lock_t lock(mtx);
-    get_upstream_resource().deallocate(stream, ptr, bytes);
-  }
+  void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) noexcept override;
 
-  /**
-   * @brief Compare the upstream resource to another.
-   *
-   * @param other The other resource to compare to
-   * @return true If the two resources are equivalent
-   * @return false If the two resources are not equivalent
-   */
-  bool do_is_equal(device_memory_resource const& other) const noexcept override
-  {
-    if (this == std::addressof(other)) { return true; }
-    auto cast = dynamic_cast<thread_safe_resource_adaptor<Upstream> const*>(&other);
-    if (cast == nullptr) { return false; }
-    return get_upstream_resource() == cast->get_upstream_resource();
-  }
-
-  std::mutex mutable mtx;  // mutex for thread safe access to upstream
-  device_async_resource_ref
-    upstream_;  ///< The upstream resource used for satisfying allocation requests
+  [[nodiscard]] bool do_is_equal(device_memory_resource const& other) const noexcept override;
+  // End legacy device_memory_resource compatibility layer
 };
+
+static_assert(cuda::mr::resource_with<thread_safe_resource_adaptor, cuda::mr::device_accessible>,
+              "thread_safe_resource_adaptor does not satisfy the cuda::mr::resource concept");
 
 /** @} */  // end of group
 }  // namespace mr

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+namespace detail {
+
+thread_safe_resource_adaptor_impl::thread_safe_resource_adaptor_impl(
+  device_async_resource_ref upstream)
+  : upstream_mr_{upstream}
+{
+}
+
+device_async_resource_ref thread_safe_resource_adaptor_impl::get_upstream_resource() const noexcept
+{
+  return device_async_resource_ref{
+    const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(upstream_mr_)};
+}
+
+void* thread_safe_resource_adaptor_impl::allocate(cuda::stream_ref stream,
+                                                  std::size_t bytes,
+                                                  std::size_t /*alignment*/)
+{
+  std::lock_guard<std::mutex> lock(mtx_);
+  return upstream_mr_.allocate(stream, bytes);
+}
+
+void thread_safe_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
+                                                   void* ptr,
+                                                   std::size_t bytes,
+                                                   std::size_t /*alignment*/) noexcept
+{
+  std::lock_guard<std::mutex> lock(mtx_);
+  upstream_mr_.deallocate(stream, ptr, bytes);
+}
+
+void* thread_safe_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return allocate(cuda_stream_view{}, bytes, alignment);
+}
+
+void thread_safe_resource_adaptor_impl::deallocate_sync(void* ptr,
+                                                        std::size_t bytes,
+                                                        std::size_t alignment) noexcept
+{
+  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+}
+
+}  // namespace detail
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/thread_safe_resource_adaptor.cpp
+++ b/cpp/src/mr/thread_safe_resource_adaptor.cpp
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/aligned.hpp>
+#include <rmm/mr/thread_safe_resource_adaptor.hpp>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+
+thread_safe_resource_adaptor::thread_safe_resource_adaptor(device_async_resource_ref upstream)
+  : shared_base(cuda::mr::make_shared_resource<detail::thread_safe_resource_adaptor_impl>(upstream))
+{
+}
+
+device_async_resource_ref thread_safe_resource_adaptor::get_upstream_resource() const noexcept
+{
+  return get().get_upstream_resource();
+}
+
+// Begin legacy device_memory_resource compatibility layer
+void* thread_safe_resource_adaptor::do_allocate(std::size_t bytes, cuda_stream_view stream)
+{
+  return shared_base::allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+}
+
+void thread_safe_resource_adaptor::do_deallocate(void* ptr,
+                                                 std::size_t bytes,
+                                                 cuda_stream_view stream) noexcept
+{
+  shared_base::deallocate(stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+}
+
+bool thread_safe_resource_adaptor::do_is_equal(device_memory_resource const& other) const noexcept
+{
+  if (this == std::addressof(other)) { return true; }
+  auto const* cast = dynamic_cast<thread_safe_resource_adaptor const*>(&other);
+  if (cast == nullptr) { return false; }
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(*cast);
+}
+// End legacy device_memory_resource compatibility layer
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -159,6 +159,7 @@ ConfigureTest(DEVICE_MEMORY_RESOURCE_VIEW_TEST mr/device_memory_resource_view_te
 # general adaptor tests
 ConfigureTest(ADAPTOR_TEST mr/adaptor_tests.cpp GPUS 1 PERCENT 5)
 ConfigureTest(CCCL_ADAPTOR_TEST mr/cccl_adaptor_tests.cpp GPUS 1 PERCENT 100)
+ConfigureTest(THREAD_SAFE_MR_REF_TEST mr/mr_ref_thread_safe_tests.cpp GPUS 1 PERCENT 5)
 
 # pool mr tests
 ConfigureTest(POOL_MR_TEST mr/pool_mr_tests.cpp GPUS 1 PERCENT 100)

--- a/cpp/tests/mr/adaptor_tests.cpp
+++ b/cpp/tests/mr/adaptor_tests.cpp
@@ -33,14 +33,13 @@ using owning_wrapper = rmm::mr::owning_wrapper<limiting_resource_adaptor<cuda_mr
 // explicit instantiations for test coverage purposes
 template class rmm::mr::failure_callback_resource_adaptor<cuda_mr>;
 template class rmm::mr::limiting_resource_adaptor<cuda_mr>;
-template class rmm::mr::thread_safe_resource_adaptor<cuda_mr>;
 
 namespace rmm::test {
 
 using adaptors = ::testing::Types<failure_callback_resource_adaptor<cuda_mr>,
                                   limiting_resource_adaptor<cuda_mr>,
                                   owning_wrapper,
-                                  thread_safe_resource_adaptor<cuda_mr>>;
+                                  thread_safe_resource_adaptor>;
 
 // static property checks
 static_assert(
@@ -50,7 +49,7 @@ static_assert(rmm::detail::polyfill::resource_with<rmm::mr::limiting_resource_ad
                                                    cuda::mr::device_accessible>);
 static_assert(rmm::detail::polyfill::resource_with<rmm::mr::owning_wrapper<cuda_mr>,
                                                    cuda::mr::device_accessible>);
-static_assert(rmm::detail::polyfill::resource_with<rmm::mr::thread_safe_resource_adaptor<cuda_mr>,
+static_assert(rmm::detail::polyfill::resource_with<rmm::mr::thread_safe_resource_adaptor,
                                                    cuda::mr::device_accessible>);
 
 template <typename MemoryResourceType>
@@ -73,6 +72,8 @@ struct AdaptorTest : public ::testing::Test {
     } else if constexpr (std::is_same_v<adaptor_type, owning_wrapper>) {
       return mr::make_owning_wrapper<limiting_resource_adaptor>(std::make_shared<cuda_mr>(),
                                                                 64_MiB);
+    } else if constexpr (std::is_same_v<adaptor_type, thread_safe_resource_adaptor>) {
+      return std::make_shared<adaptor_type>(*upstream);
     } else {
       return std::make_shared<adaptor_type>(upstream);
     }
@@ -83,7 +84,8 @@ TYPED_TEST_SUITE(AdaptorTest, adaptors);
 
 TYPED_TEST(AdaptorTest, NullUpstream)
 {
-  if constexpr (not std::is_same_v<TypeParam, owning_wrapper>) {
+  if constexpr (not std::is_same_v<TypeParam, owning_wrapper> and
+                not std::is_same_v<TypeParam, thread_safe_resource_adaptor>) {
     EXPECT_THROW(this->make_adaptor(nullptr), rmm::logic_error);
   }
 }
@@ -94,7 +96,12 @@ TYPED_TEST(AdaptorTest, Equality)
 
   {
     auto other_mr = this->make_adaptor(&this->cuda);
-    EXPECT_TRUE(this->mr->is_equal(*other_mr));
+    if constexpr (std::is_same_v<TypeParam, thread_safe_resource_adaptor>) {
+      // shared_resource equality: two distinct constructions are NOT equal
+      EXPECT_FALSE(this->mr->is_equal(*other_mr));
+    } else {
+      EXPECT_TRUE(this->mr->is_equal(*other_mr));
+    }
   }
 
   {

--- a/cpp/tests/mr/cccl_adaptor_tests.cpp
+++ b/cpp/tests/mr/cccl_adaptor_tests.cpp
@@ -14,6 +14,7 @@
 #include <rmm/mr/logging_resource_adaptor.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
+#include <rmm/mr/thread_safe_resource_adaptor.hpp>
 #include <rmm/mr/tracking_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
@@ -29,6 +30,7 @@ using rmm::mr::fixed_size_memory_resource;
 using rmm::mr::logging_resource_adaptor;
 using rmm::mr::pool_memory_resource;
 using rmm::mr::statistics_resource_adaptor;
+using rmm::mr::thread_safe_resource_adaptor;
 using rmm::mr::tracking_resource_adaptor;
 
 // static property checks
@@ -39,6 +41,7 @@ static_assert(cuda::mr::resource_with<fixed_size_memory_resource, cuda::mr::devi
 static_assert(cuda::mr::resource_with<logging_resource_adaptor, cuda::mr::device_accessible>);
 static_assert(cuda::mr::resource_with<pool_memory_resource, cuda::mr::device_accessible>);
 static_assert(cuda::mr::resource_with<statistics_resource_adaptor, cuda::mr::device_accessible>);
+static_assert(cuda::mr::resource_with<thread_safe_resource_adaptor, cuda::mr::device_accessible>);
 static_assert(cuda::mr::resource_with<tracking_resource_adaptor, cuda::mr::device_accessible>);
 
 namespace rmm::test {
@@ -74,6 +77,8 @@ struct CcclAdaptorTest : public ::testing::Test {
       return AdaptorType{cuda, 0};
     } else if constexpr (std::is_same_v<AdaptorType, statistics_resource_adaptor>) {
       return AdaptorType{cuda};
+    } else if constexpr (std::is_same_v<AdaptorType, thread_safe_resource_adaptor>) {
+      return AdaptorType{cuda};
     } else if constexpr (std::is_same_v<AdaptorType, tracking_resource_adaptor>) {
       return AdaptorType{cuda};
     }
@@ -86,6 +91,7 @@ using cccl_adaptors = ::testing::Types<aligned_resource_adaptor,
                                        logging_resource_adaptor,
                                        pool_memory_resource,
                                        statistics_resource_adaptor,
+                                       thread_safe_resource_adaptor,
                                        tracking_resource_adaptor>;
 
 TYPED_TEST_SUITE(CcclAdaptorTest, cccl_adaptors);

--- a/cpp/tests/mr/mr_ref_thread_safe_tests.cpp
+++ b/cpp/tests/mr/mr_ref_thread_safe_tests.cpp
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "cccl_mr_ref_test_allocation.hpp"
+#include "cccl_mr_ref_test_basic.hpp"
+#include "cccl_mr_ref_test_mt.hpp"
+
+#include <rmm/mr/per_device_resource.hpp>
+#include <rmm/mr/thread_safe_resource_adaptor.hpp>
+
+namespace rmm::test {
+
+struct ThreadSafeMRFixture : public ::testing::Test {
+  rmm::mr::thread_safe_resource_adaptor mr{rmm::mr::get_current_device_resource_ref()};
+  rmm::device_async_resource_ref ref{mr};
+  rmm::cuda_stream stream{};
+};
+
+INSTANTIATE_TYPED_TEST_SUITE_P(ThreadSafeMR, CcclMrRefTest, ThreadSafeMRFixture);
+INSTANTIATE_TYPED_TEST_SUITE_P(ThreadSafeMR, CcclMrRefAllocationTest, ThreadSafeMRFixture);
+INSTANTIATE_TYPED_TEST_SUITE_P(ThreadSafeMR, CcclMrRefTestMT, ThreadSafeMRFixture);
+
+}  // namespace rmm::test


### PR DESCRIPTION
## Summary
- Split `thread_safe_resource_adaptor` implementation into `detail/thread_safe_resource_adaptor_impl.hpp` + `src/mr/detail/thread_safe_resource_adaptor_impl.cpp`, using `cuda::mr::shared_resource` for shared ownership
- Accept `device_async_resource_ref` upstream; class is now non-template
- Add `mr_ref_thread_safe_tests.cpp` and integrate into `cccl_adaptor_tests.cpp` typed test suite
- Update `adaptor_tests.cpp` type aliases, `NullUpstream`, and `Equality` tests for non-template type