### PR TITLE
Scope binning memory resource fixture to class in Python tests

### DIFF
--- a/python/rmm/rmm/tests/test_binning_memory_resource.py
+++ b/python/rmm/rmm/tests/test_binning_memory_resource.py
@@ -30,7 +30,7 @@ def _make_binning_mr(upstream_mr):
     return mr
 
 
-_upstream_mrs = [
+_UPSTREAM_MRS = [
     lambda: rmm.mr.CudaMemoryResource(),
     lambda: rmm.mr.ManagedMemoryResource(),
     lambda: rmm.mr.PoolMemoryResource(rmm.mr.CudaMemoryResource(), 1 << 20),
@@ -47,7 +47,7 @@ _upstream_mrs = [
 # Create the BinningMemoryResource once per upstream_mr (class-scoped),
 # avoiding the expensive ManagedMemoryResource/FixedSizeMemoryResource slab
 # allocation on every test invocation.
-@pytest.fixture(scope="class", params=_upstream_mrs)
+@pytest.fixture(scope="class", params=_UPSTREAM_MRS)
 def binning_mr(request):
     """Create the BinningMemoryResource once per upstream_mr."""
     return _make_binning_mr(request.param)


### PR DESCRIPTION
## Description

Follow-up to #2273. The binning memory resource test recreates a `BinningMemoryResource` (with `FixedSizeMemoryResource` bins backed by `ManagedMemoryResource`) for every `(dtype, nelem, alloc, upstream_mr)` combination. The managed memory slab allocations make each creation take ~0.5–0.9s, totaling ~40s for 147 tests.

Restructure the test into a class with a class-scoped fixture so that each `BinningMemoryResource` is built once per `upstream_mr` rather than once per test. A function-scoped autouse fixture sets the current device resource before each test.

Times measured on an RTX 2070 Super (8 GiB) under WSL2, where managed memory operations can be particularly expensive. Binning tests drop from ~39s to ~3s; full suite drops from ~49s to ~11s.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.