### PR TITLE
Add skill for pull requests

### DIFF
--- a/.agents/skills/pull-requests/SKILL.md
+++ b/.agents/skills/pull-requests/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: pull-requests
+description: Open pull requests against rapidsai/rmm. Use when creating or editing PRs.
+---
+
+## Rules for pull requests
+- Target `main` unless told otherwise.
+- Always push branches to a user's fork of rapidsai/rmm, not to the upstream repository.
+- PR descriptions should follow `.github/pull_request_template.md`.
+- The PR title appears in the CHANGELOG; keep it concise.
+- Every PR should reference an issue.
+  - Check for an issue first.
+  - If no issue exists, ask the user whether to create one. Suggest relevant context for the issue.
+  - If an issue exists or is created, mention it in the PR description like "Closes #1234."


### PR DESCRIPTION
## Description
I am experimenting with agent skills, and would like to solve a specific pain point: my agent-generated pull requests haven't been following the PR template and often don't have issues. I would like to help automate some of this and keep agents to a common standard.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
