### PR TITLE
Migrate Python/Cython bindings from device_memory_resource to device_async_resource_ref

### DIFF
--- a/python/rmm/rmm/librmm/device_buffer.pxd
+++ b/python/rmm/rmm/librmm/device_buffer.pxd
@@ -1,8 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "rmm/mr/per_device_resource.hpp" namespace "rmm" nogil:
@@ -26,18 +26,18 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         device_buffer(
             size_t size,
             cuda_stream_view stream,
-            device_memory_resource *
+            device_async_resource_ref mr
         ) except +
         device_buffer(
             const void* source_data,
             size_t size,
             cuda_stream_view stream,
-            device_memory_resource *
+            device_async_resource_ref mr
         ) except +
         device_buffer(
             const device_buffer buf,
             cuda_stream_view stream,
-            device_memory_resource *
+            device_async_resource_ref mr
         ) except +
         void reserve(size_t new_capacity, cuda_stream_view stream) except +
         void resize(size_t new_size, cuda_stream_view stream) except +

--- a/python/rmm/rmm/librmm/device_uvector.pxd
+++ b/python/rmm/rmm/librmm/device_uvector.pxd
@@ -1,9 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport device_buffer
-from rmm.librmm.memory_resource cimport device_memory_resource
 
 
 cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
@@ -25,4 +24,3 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         size_t capacity()
         T* data()
         size_t size()
-        device_memory_resource* memory_resource()

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -14,34 +14,71 @@ from libcpp.pair cimport pair
 from libcpp.string cimport string
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_memory_resource
 
 
-cdef extern from "rmm/mr/device_memory_resource.hpp" \
-        namespace "rmm::mr" nogil:
-    cdef cppclass device_memory_resource:
-        # Legacy functions
-        void* allocate(size_t bytes) except +
-        void* allocate(size_t bytes, cuda_stream_view stream) except +
-        void deallocate(void* ptr, size_t bytes) noexcept
-        void deallocate(
-            void* ptr,
-            size_t bytes,
-            cuda_stream_view stream
-        ) noexcept
-        # End legacy functions
-
-        void* allocate_sync(size_t bytes) except +
-        void deallocate_sync(void* ptr, size_t bytes) noexcept
-        void* allocate(
-            cuda_stream_view stream,
-            size_t bytes
-        ) except +
+cdef extern from "rmm/resource_ref.hpp" namespace "rmm" nogil:
+    cdef cppclass device_async_resource_ref:
+        void* allocate(cuda_stream_view stream, size_t bytes) except +
         void deallocate(
             cuda_stream_view stream,
             void* ptr,
             size_t bytes
         ) noexcept
+
+
+# Inline C++ helper to construct optional[device_async_resource_ref] from any
+# concrete resource type. Returns optional so that Cython assignment
+# (self.c_ref = make_device_async_resource_ref(...)) uses optional's
+# default-constructible temporary instead of device_async_resource_ref's
+# non-default-constructible one.
+cdef extern from *:
+    """
+    #include <optional>
+    #include <rmm/resource_ref.hpp>
+    template <typename T>
+    std::optional<rmm::device_async_resource_ref>
+    make_device_async_resource_ref(T& r) {
+        return std::optional<rmm::device_async_resource_ref>(
+            rmm::device_async_resource_ref(r));
+    }
+    """
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        cuda_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        managed_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        system_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        pinned_host_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        sam_headroom_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        cuda_async_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        cuda_async_view_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        cuda_async_managed_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        pool_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        arena_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        fixed_size_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        binning_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        callback_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        limiting_resource_adaptor&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        logging_resource_adaptor&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        statistics_resource_adaptor&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        tracking_resource_adaptor&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        prefetch_resource_adaptor&) except +
+
 
 cdef extern from "rmm/cuda_device.hpp" namespace "rmm" nogil:
     size_t percent_of_free_device_memory(int percent) except +
@@ -87,33 +124,33 @@ cdef extern from *:
 
 cdef extern from "rmm/mr/cuda_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass cuda_memory_resource(device_memory_resource):
+    cdef cppclass cuda_memory_resource:
         cuda_memory_resource() except +
 
 cdef extern from "rmm/mr/managed_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass managed_memory_resource(device_memory_resource):
+    cdef cppclass managed_memory_resource:
         managed_memory_resource() except +
 
 cdef extern from "rmm/mr/system_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass system_memory_resource(device_memory_resource):
+    cdef cppclass system_memory_resource:
         system_memory_resource() except +
 
 cdef extern from "rmm/mr/pinned_host_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass pinned_host_memory_resource(device_memory_resource):
+    cdef cppclass pinned_host_memory_resource:
         pinned_host_memory_resource() except +
 
 cdef extern from "rmm/mr/sam_headroom_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass sam_headroom_memory_resource(device_memory_resource):
+    cdef cppclass sam_headroom_memory_resource:
         sam_headroom_memory_resource(size_t headroom) except +
 
 cdef extern from "rmm/mr/cuda_async_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
 
-    cdef cppclass cuda_async_memory_resource(device_memory_resource):
+    cdef cppclass cuda_async_memory_resource:
         cuda_async_memory_resource(
             optional[size_t] initial_pool_size,
             optional[size_t] release_threshold,
@@ -122,7 +159,7 @@ cdef extern from "rmm/mr/cuda_async_memory_resource.hpp" \
 cdef extern from "rmm/mr/cuda_async_view_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
 
-    cdef cppclass cuda_async_view_memory_resource(device_memory_resource):
+    cdef cppclass cuda_async_view_memory_resource:
         cuda_async_view_memory_resource(
             cudaMemPool_t pool_handle) except +
         cudaMemPool_t pool_handle() const
@@ -130,7 +167,7 @@ cdef extern from "rmm/mr/cuda_async_view_memory_resource.hpp" \
 cdef extern from "rmm/mr/cuda_async_managed_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
 
-    cdef cppclass cuda_async_managed_memory_resource(device_memory_resource):
+    cdef cppclass cuda_async_managed_memory_resource:
         cuda_async_managed_memory_resource() except +
         cudaMemPool_t pool_handle() const
 
@@ -148,27 +185,27 @@ cdef extern from "rmm/mr/cuda_async_memory_resource.hpp" \
 
 cdef extern from "rmm/mr/pool_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass pool_memory_resource(device_memory_resource):
+    cdef cppclass pool_memory_resource:
         pool_memory_resource(
-            device_memory_resource* upstream_mr,
+            device_async_resource_ref upstream_mr,
             size_t initial_pool_size,
             optional[size_t] maximum_pool_size) except +
         size_t pool_size()
 
 cdef extern from "rmm/mr/arena_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass arena_memory_resource(device_memory_resource):
+    cdef cppclass arena_memory_resource:
         arena_memory_resource(
-            device_memory_resource* upstream_mr,
+            device_async_resource_ref upstream_mr,
             optional[size_t] arena_size,
             bool dump_log_on_failure
         ) except +
 
 cdef extern from "rmm/mr/fixed_size_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass fixed_size_memory_resource(device_memory_resource):
+    cdef cppclass fixed_size_memory_resource:
         fixed_size_memory_resource(
-            device_memory_resource* upstream_mr,
+            device_async_resource_ref upstream_mr,
             size_t block_size,
             size_t block_to_preallocate) except +
 
@@ -177,7 +214,7 @@ cdef extern from "rmm/mr/callback_memory_resource.hpp" \
     ctypedef void* (*allocate_callback_t)(size_t, cuda_stream_view, void*)
     ctypedef void (*deallocate_callback_t)(void*, size_t, cuda_stream_view, void*)
 
-    cdef cppclass callback_memory_resource(device_memory_resource):
+    cdef cppclass callback_memory_resource:
         callback_memory_resource(
             allocate_callback_t allocate_callback,
             deallocate_callback_t deallocate_callback,
@@ -187,23 +224,24 @@ cdef extern from "rmm/mr/callback_memory_resource.hpp" \
 
 cdef extern from "rmm/mr/binning_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass binning_memory_resource(device_memory_resource):
-        binning_memory_resource(device_memory_resource* upstream_mr) except +
+    cdef cppclass binning_memory_resource:
         binning_memory_resource(
-            device_memory_resource* upstream_mr,
+            device_async_resource_ref upstream_mr) except +
+        binning_memory_resource(
+            device_async_resource_ref upstream_mr,
             int8_t min_size_exponent,
             int8_t max_size_exponent) except +
 
-        void add_bin(size_t allocation_size) except +
         void add_bin(
             size_t allocation_size,
-            device_memory_resource* bin_resource) except +
+            optional[device_async_resource_ref] bin_resource
+        ) except +
 
 cdef extern from "rmm/mr/limiting_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass limiting_resource_adaptor(device_memory_resource):
+    cdef cppclass limiting_resource_adaptor:
         limiting_resource_adaptor(
-            device_memory_resource* upstream_mr,
+            device_async_resource_ref upstream_mr,
             size_t allocation_limit) except +
 
         size_t get_allocated_bytes() except +
@@ -211,16 +249,16 @@ cdef extern from "rmm/mr/limiting_resource_adaptor.hpp" \
 
 cdef extern from "rmm/mr/logging_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass logging_resource_adaptor(device_memory_resource):
+    cdef cppclass logging_resource_adaptor:
         logging_resource_adaptor(
-            device_memory_resource* upstream_mr,
+            device_async_resource_ref upstream_mr,
             string filename) except +
 
         void flush() except +
 
 cdef extern from "rmm/mr/statistics_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass statistics_resource_adaptor(device_memory_resource):
+    cdef cppclass statistics_resource_adaptor:
         struct counter:
             counter()
 
@@ -228,7 +266,8 @@ cdef extern from "rmm/mr/statistics_resource_adaptor.hpp" \
             int64_t peak
             int64_t total
 
-        statistics_resource_adaptor(device_memory_resource* upstream_mr) except +
+        statistics_resource_adaptor(
+            device_async_resource_ref upstream_mr) except +
 
         counter get_bytes_counter() except +
         counter get_allocations_counter() except +
@@ -237,9 +276,9 @@ cdef extern from "rmm/mr/statistics_resource_adaptor.hpp" \
 
 cdef extern from "rmm/mr/tracking_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass tracking_resource_adaptor(device_memory_resource):
+    cdef cppclass tracking_resource_adaptor:
         tracking_resource_adaptor(
-            device_memory_resource* upstream_mr,
+            device_async_resource_ref upstream_mr,
             bool capture_stacks) except +
 
         size_t get_allocated_bytes() except +
@@ -253,16 +292,28 @@ cdef extern from "rmm/error.hpp" namespace "rmm" nogil:
 cdef extern from "rmm/mr/failure_callback_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
     ctypedef bool (*failure_callback_t)(size_t, void*)
-    cdef cppclass failure_callback_resource_adaptor[ExceptionType](
-        device_memory_resource
-    ):
+    cdef cppclass failure_callback_resource_adaptor[ExceptionType]:
         failure_callback_resource_adaptor(
-            device_memory_resource* upstream_mr,
+            device_async_resource_ref upstream_mr,
             failure_callback_t callback,
             void* callback_arg
         ) except +
 
+ctypedef failure_callback_resource_adaptor[out_of_memory] \
+    failure_callback_resource_adaptor_oom
+
+# The make_device_async_resource_ref template (declared above) also covers
+# failure_callback_resource_adaptor_oom; just declare the overload here
+# since the typedef is only available after the class is declared.
+cdef extern from *:
+    """
+    // already defined above via template
+    """
+    optional[device_async_resource_ref] make_device_async_resource_ref(
+        failure_callback_resource_adaptor_oom&) except +
+
 cdef extern from "rmm/mr/prefetch_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
-    cdef cppclass prefetch_resource_adaptor(device_memory_resource):
-        prefetch_resource_adaptor(device_memory_resource* upstream_mr) except +
+    cdef cppclass prefetch_resource_adaptor:
+        prefetch_resource_adaptor(
+            device_async_resource_ref upstream_mr) except +

--- a/python/rmm/rmm/librmm/per_device_resource.pxd
+++ b/python/rmm/rmm/librmm/per_device_resource.pxd
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport device_async_resource_ref
 
 
 cdef extern from "rmm/mr/per_device_resource.hpp" namespace "rmm" nogil:
@@ -13,13 +13,9 @@ cdef extern from "rmm/mr/per_device_resource.hpp" namespace "rmm" nogil:
 
 cdef extern from "rmm/mr/per_device_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef device_memory_resource* set_current_device_resource(
-        device_memory_resource* new_mr
+    cdef void set_current_device_resource_ref(
+        device_async_resource_ref new_mr
     )
-    cdef device_memory_resource* get_current_device_resource()
-    cdef device_memory_resource* set_per_device_resource(
-        cuda_device_id id, device_memory_resource* new_mr
-    )
-    cdef device_memory_resource* get_per_device_resource (
-        cuda_device_id id
+    cdef void set_per_device_resource_ref(
+        cuda_device_id id, device_async_resource_ref new_mr
     )

--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 import numpy as np
 
@@ -28,7 +28,6 @@ from rmm.librmm.device_buffer cimport (
     get_current_cuda_device,
     prefetch,
 )
-from rmm.librmm.memory_resource cimport device_memory_resource
 from rmm.pylibrmm.memory_resource cimport (
     DeviceMemoryResource,
     get_current_device_resource,
@@ -79,20 +78,22 @@ cdef class DeviceBuffer:
         >>> db = rmm.DeviceBuffer(size=5)
         """
         cdef const void* c_ptr
-        cdef device_memory_resource * mr_ptr
         stream = as_stream(stream)
         # Save a reference to the MR and stream used for allocation
         self.mr = get_current_device_resource() if mr is None else mr
         self.stream = stream
 
-        mr_ptr = self.mr.get_mr()
         with nogil:
             c_ptr = <const void*>(ptr)
 
             if c_ptr == NULL or size == 0:
-                self.c_obj.reset(new device_buffer(size, stream.view(), mr_ptr))
+                self.c_obj.reset(new device_buffer(
+                    size, stream.view(), self.mr.c_ref.value()
+                ))
             else:
-                self.c_obj.reset(new device_buffer(c_ptr, size, stream.view(), mr_ptr))
+                self.c_obj.reset(new device_buffer(
+                    c_ptr, size, stream.view(), self.mr.c_ref.value()
+                ))
 
                 if stream.c_is_default():
                     stream.c_synchronize()

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pxd
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pxd
@@ -1,51 +1,72 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
-from libcpp.memory cimport shared_ptr
+from libcpp.memory cimport unique_ptr
+from libcpp.optional cimport optional
 
-from rmm.librmm.memory_resource cimport device_memory_resource
+from rmm.librmm.memory_resource cimport (
+    arena_memory_resource,
+    binning_memory_resource,
+    callback_memory_resource,
+    cuda_async_memory_resource,
+    cuda_async_view_memory_resource,
+    cuda_memory_resource,
+    device_async_resource_ref,
+    failure_callback_resource_adaptor_oom,
+    fixed_size_memory_resource,
+    limiting_resource_adaptor,
+    logging_resource_adaptor,
+    managed_memory_resource,
+    pinned_host_memory_resource,
+    pool_memory_resource,
+    prefetch_resource_adaptor,
+    sam_headroom_memory_resource,
+    statistics_resource_adaptor,
+    system_memory_resource,
+    tracking_resource_adaptor,
+)
 
 
 cdef class DeviceMemoryResource:
-    cdef shared_ptr[device_memory_resource] c_obj
-    cdef device_memory_resource* get_mr(self) noexcept nogil
+    cdef optional[device_async_resource_ref] c_ref
 
 cdef class UpstreamResourceAdaptor(DeviceMemoryResource):
     cdef readonly DeviceMemoryResource upstream_mr
 
     cpdef DeviceMemoryResource get_upstream(self)
 
-cdef class ArenaMemoryResource(UpstreamResourceAdaptor):
-    pass
-
 cdef class CudaMemoryResource(DeviceMemoryResource):
-    pass
+    cdef unique_ptr[cuda_memory_resource] c_obj
 
 cdef class ManagedMemoryResource(DeviceMemoryResource):
-    pass
+    cdef unique_ptr[managed_memory_resource] c_obj
 
 cdef class SystemMemoryResource(DeviceMemoryResource):
-    pass
+    cdef unique_ptr[system_memory_resource] c_obj
 
 cdef class PinnedHostMemoryResource(DeviceMemoryResource):
-    pass
+    cdef unique_ptr[pinned_host_memory_resource] c_obj
 
 cdef class SamHeadroomMemoryResource(DeviceMemoryResource):
-    pass
+    cdef unique_ptr[sam_headroom_memory_resource] c_obj
 
 cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
-    pass
+    cdef unique_ptr[cuda_async_memory_resource] c_obj
 
 cdef class CudaAsyncViewMemoryResource(DeviceMemoryResource):
-    pass
+    cdef unique_ptr[cuda_async_view_memory_resource] c_obj
 
 cdef class PoolMemoryResource(UpstreamResourceAdaptor):
-    pass
+    cdef unique_ptr[pool_memory_resource] c_obj
+
+cdef class ArenaMemoryResource(UpstreamResourceAdaptor):
+    cdef unique_ptr[arena_memory_resource] c_obj
 
 cdef class FixedSizeMemoryResource(UpstreamResourceAdaptor):
-    pass
+    cdef unique_ptr[fixed_size_memory_resource] c_obj
 
 cdef class BinningMemoryResource(UpstreamResourceAdaptor):
+    cdef unique_ptr[binning_memory_resource] c_obj
 
     cdef readonly list _bin_mrs
 
@@ -55,27 +76,30 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
         DeviceMemoryResource bin_resource=*)
 
 cdef class CallbackMemoryResource(DeviceMemoryResource):
+    cdef unique_ptr[callback_memory_resource] c_obj
     cdef object _allocate_func
     cdef object _deallocate_func
 
 cdef class LimitingResourceAdaptor(UpstreamResourceAdaptor):
-    pass
+    cdef unique_ptr[limiting_resource_adaptor] c_obj
 
 cdef class LoggingResourceAdaptor(UpstreamResourceAdaptor):
+    cdef unique_ptr[logging_resource_adaptor] c_obj
     cdef object _log_file_name
     cpdef get_file_name(self)
     cpdef flush(self)
 
 cdef class StatisticsResourceAdaptor(UpstreamResourceAdaptor):
-    pass
+    cdef unique_ptr[statistics_resource_adaptor] c_obj
 
 cdef class TrackingResourceAdaptor(UpstreamResourceAdaptor):
-    pass
+    cdef unique_ptr[tracking_resource_adaptor] c_obj
 
 cdef class FailureCallbackResourceAdaptor(UpstreamResourceAdaptor):
+    cdef unique_ptr[failure_callback_resource_adaptor_oom] c_obj
     cdef object _callback
 
 cdef class PrefetchResourceAdaptor(UpstreamResourceAdaptor):
-    pass
+    cdef unique_ptr[prefetch_resource_adaptor] c_obj
 
 cpdef DeviceMemoryResource get_current_device_resource()

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -30,7 +30,7 @@ from rmm.pylibrmm.stream import DEFAULT_STREAM
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.per_device_resource cimport (
     cuda_device_id,
-    set_per_device_resource as cpp_set_per_device_resource,
+    set_per_device_resource_ref as cpp_set_per_device_resource_ref,
 )
 from rmm.pylibrmm.helper cimport parse_bytes
 
@@ -48,14 +48,14 @@ from rmm.librmm.memory_resource cimport (
     cuda_async_view_memory_resource,
     cuda_memory_resource,
     deallocate_callback_t,
-    device_memory_resource,
-    failure_callback_resource_adaptor,
+    device_async_resource_ref,
+    failure_callback_resource_adaptor_oom,
     failure_callback_t,
     fixed_size_memory_resource,
     limiting_resource_adaptor,
     logging_resource_adaptor,
+    make_device_async_resource_ref,
     managed_memory_resource,
-    out_of_memory,
     percent_of_free_device_memory as c_percent_of_free_device_memory,
     pinned_host_memory_resource,
     pool_memory_resource,
@@ -70,10 +70,6 @@ from rmm.librmm.memory_resource cimport (
 
 
 cdef class DeviceMemoryResource:
-
-    cdef device_memory_resource* get_mr(self) noexcept nogil:
-        """Get the underlying C++ memory resource object."""
-        return self.c_obj.get()
 
     def allocate(self, size_t nbytes, Stream stream=DEFAULT_STREAM):
         """Allocate ``nbytes`` bytes of memory.
@@ -99,7 +95,9 @@ cdef class DeviceMemoryResource:
         stream = as_stream(stream)
         cdef uintptr_t ptr
         with nogil:
-            ptr = <uintptr_t>(self.c_obj.get().allocate(stream.view(), nbytes))
+            ptr = <uintptr_t>(self.c_ref.value().allocate(
+                stream.view(), nbytes
+            ))
         return ptr
 
     def deallocate(self, uintptr_t ptr, size_t nbytes, Stream stream=DEFAULT_STREAM):
@@ -116,14 +114,13 @@ cdef class DeviceMemoryResource:
         """
         stream = as_stream(stream)
         with nogil:
-            self.c_obj.get().deallocate(stream.view(), <void*>(ptr), nbytes)
+            self.c_ref.value().deallocate(
+                stream.view(), <void*>(ptr), nbytes
+            )
 
     def __dealloc__(self):
-        # See the __dealloc__ method on DeviceBuffer for discussion of why we must
-        # explicitly call reset here instead of relying on the unique_ptr's
-        # destructor.
         with nogil:
-            self.c_obj.reset()
+            self.c_ref.reset()
 
 
 # See the note about `no_gc_clear` in `device_buffer.pyx`.
@@ -147,18 +144,17 @@ cdef class UpstreamResourceAdaptor(DeviceMemoryResource):
         return self.upstream_mr
 
     def __dealloc__(self):
-        # Need to override the parent method with an identical implementation
-        # to ensure that self.upstream_mr is still alive when the C++ mr's
-        # destructor is invoked since it will reference self.upstream_mr.c_obj.
+        # Need to override the parent method to ensure that self.upstream_mr
+        # is still alive when the C++ resource's destructor is invoked since
+        # it holds a device_async_resource_ref to the upstream.
         with nogil:
-            self.c_obj.reset()
+            self.c_ref.reset()
 
 
 cdef class CudaMemoryResource(DeviceMemoryResource):
     def __cinit__(self):
-        self.c_obj.reset(
-            new cuda_memory_resource()
-        )
+        self.c_obj.reset(new cuda_memory_resource())
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(self):
         """
@@ -228,13 +224,12 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
             else optional[allocation_handle_type]()
         )
 
-        self.c_obj.reset(
-            new cuda_async_memory_resource(
-                c_initial_pool_size,
-                c_release_threshold,
-                c_export_handle_type
-            )
-        )
+        self.c_obj.reset(new cuda_async_memory_resource(
+            c_initial_pool_size,
+            c_release_threshold,
+            c_export_handle_type
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
 
 cdef class CudaAsyncViewMemoryResource(DeviceMemoryResource):
@@ -267,21 +262,17 @@ cdef class CudaAsyncViewMemoryResource(DeviceMemoryResource):
         cdef cyruntime.cudaMemPool_t c_pool_handle
         c_pool_handle = <cyruntime.cudaMemPool_t>(<uintptr_t>(int(pool_handle)))
 
-        self.c_obj.reset(
-            new cuda_async_view_memory_resource(c_pool_handle)
-        )
+        self.c_obj.reset(new cuda_async_view_memory_resource(c_pool_handle))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def pool_handle(self):
-        cdef cuda_async_view_memory_resource* c_mr = \
-            <cuda_async_view_memory_resource*>(self.c_obj.get())
-        return <uintptr_t>(c_mr.pool_handle())
+        return <uintptr_t>(deref(self.c_obj).pool_handle())
 
 
 cdef class ManagedMemoryResource(DeviceMemoryResource):
     def __cinit__(self):
-        self.c_obj.reset(
-            new managed_memory_resource()
-        )
+        self.c_obj.reset(new managed_memory_resource())
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(self):
         """
@@ -293,9 +284,8 @@ cdef class ManagedMemoryResource(DeviceMemoryResource):
 
 cdef class SystemMemoryResource(DeviceMemoryResource):
     def __cinit__(self):
-        self.c_obj.reset(
-            new system_memory_resource()
-        )
+        self.c_obj.reset(new system_memory_resource())
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(self):
         """
@@ -307,9 +297,8 @@ cdef class SystemMemoryResource(DeviceMemoryResource):
 
 cdef class PinnedHostMemoryResource(DeviceMemoryResource):
     def __cinit__(self):
-        self.c_obj.reset(
-            new pinned_host_memory_resource()
-        )
+        self.c_obj.reset(new pinned_host_memory_resource())
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(self):
         """
@@ -328,6 +317,7 @@ cdef class SamHeadroomMemoryResource(DeviceMemoryResource):
         size_t headroom
     ):
         self.c_obj.reset(new sam_headroom_memory_resource(headroom))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -365,13 +355,12 @@ cdef class PoolMemoryResource(UpstreamResourceAdaptor):
             maximum_pool_size is None
             else optional[size_t](<size_t> parse_bytes(maximum_pool_size))
         )
-        self.c_obj.reset(
-            new pool_memory_resource(
-                upstream_mr.get_mr(),
-                c_initial_pool_size,
-                c_maximum_pool_size
-            )
-        )
+        self.c_obj.reset(new pool_memory_resource(
+            upstream_mr.c_ref.value(),
+            c_initial_pool_size,
+            c_maximum_pool_size
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
             self,
@@ -397,10 +386,7 @@ cdef class PoolMemoryResource(UpstreamResourceAdaptor):
         pass
 
     def pool_size(self):
-        cdef pool_memory_resource* c_mr = (
-            <pool_memory_resource*>(self.get_mr())
-        )
-        return c_mr.pool_size()
+        return deref(self.c_obj).pool_size()
 
 cdef class ArenaMemoryResource(UpstreamResourceAdaptor):
     def __cinit__(
@@ -413,13 +399,12 @@ cdef class ArenaMemoryResource(UpstreamResourceAdaptor):
             arena_size is None
             else optional[size_t](<size_t> parse_bytes(arena_size))
         )
-        self.c_obj.reset(
-            new arena_memory_resource(
-                upstream_mr.get_mr(),
-                c_arena_size,
-                dump_log_on_failure,
-            )
-        )
+        self.c_obj.reset(new arena_memory_resource(
+            upstream_mr.c_ref.value(),
+            c_arena_size,
+            dump_log_on_failure,
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -451,13 +436,12 @@ cdef class FixedSizeMemoryResource(UpstreamResourceAdaptor):
             size_t block_size=1<<20,
             size_t blocks_to_preallocate=128
     ):
-        self.c_obj.reset(
-            new fixed_size_memory_resource(
-                upstream_mr.get_mr(),
-                block_size,
-                blocks_to_preallocate
-            )
-        )
+        self.c_obj.reset(new fixed_size_memory_resource(
+            upstream_mr.c_ref.value(),
+            block_size,
+            blocks_to_preallocate
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
             self,
@@ -497,19 +481,16 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
         self._bin_mrs = []
 
         if (min_size_exponent == -1 or max_size_exponent == -1):
-            self.c_obj.reset(
-                new binning_memory_resource(
-                    upstream_mr.get_mr()
-                )
-            )
+            self.c_obj.reset(new binning_memory_resource(
+                upstream_mr.c_ref.value()
+            ))
         else:
-            self.c_obj.reset(
-                new binning_memory_resource(
-                    upstream_mr.get_mr(),
-                    min_size_exponent,
-                    max_size_exponent
-                )
-            )
+            self.c_obj.reset(new binning_memory_resource(
+                upstream_mr.c_ref.value(),
+                min_size_exponent,
+                max_size_exponent
+            ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -562,17 +543,20 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
         bin_resource : DeviceMemoryResource
             The resource to use for this bin (optional)
         """
-        if bin_resource is None:
-            (<binning_memory_resource*>(
-                self.c_obj.get()))[0].add_bin(allocation_size)
-        else:
+        if bin_resource is not None:
             # Save the ref to the new bin resource to ensure its lifetime
             self._bin_mrs.append(bin_resource)
-
-            (<binning_memory_resource*>(
-                self.c_obj.get()))[0].add_bin(
-                    allocation_size,
-                    bin_resource.get_mr())
+            deref(self.c_obj).add_bin(
+                allocation_size,
+                optional[device_async_resource_ref](
+                    bin_resource.c_ref.value()
+                )
+            )
+        else:
+            deref(self.c_obj).add_bin(
+                allocation_size,
+                optional[device_async_resource_ref]()
+            )
 
     @property
     def bin_mrs(self) -> list:
@@ -658,14 +642,13 @@ cdef class CallbackMemoryResource(DeviceMemoryResource):
     ):
         self._allocate_func = allocate_func
         self._deallocate_func = deallocate_func
-        self.c_obj.reset(
-            new callback_memory_resource(
-                <allocate_callback_t>(_allocate_callback_wrapper),
-                <deallocate_callback_t>(_deallocate_callback_wrapper),
-                <void*>(allocate_func),
-                <void*>(deallocate_func)
-            )
-        )
+        self.c_obj.reset(new callback_memory_resource(
+            <allocate_callback_t>(_allocate_callback_wrapper),
+            <deallocate_callback_t>(_deallocate_callback_wrapper),
+            <void*>(allocate_func),
+            <void*>(deallocate_func)
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
 
 def _append_id(filename, id):
@@ -692,12 +675,11 @@ cdef class LimitingResourceAdaptor(UpstreamResourceAdaptor):
         DeviceMemoryResource upstream_mr,
         size_t allocation_limit
     ):
-        self.c_obj.reset(
-            new limiting_resource_adaptor(
-                upstream_mr.get_mr(),
-                allocation_limit
-            )
-        )
+        self.c_obj.reset(new limiting_resource_adaptor(
+            upstream_mr.c_ref.value(),
+            allocation_limit
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -724,9 +706,7 @@ cdef class LimitingResourceAdaptor(UpstreamResourceAdaptor):
         possible fragmentation and also internal page sizes and alignment that
         is not tracked by this allocator.
         """
-        return (<limiting_resource_adaptor*>(
-            self.c_obj.get())
-        )[0].get_allocated_bytes()
+        return deref(self.c_obj).get_allocated_bytes()
 
     def get_allocation_limit(self) -> size_t:
         """
@@ -735,9 +715,7 @@ cdef class LimitingResourceAdaptor(UpstreamResourceAdaptor):
         of the underlying device. The device may not be able to support this
         limit.
         """
-        return (<limiting_resource_adaptor*>(
-            self.c_obj.get())
-        )[0].get_allocation_limit()
+        return deref(self.c_obj).get_allocation_limit()
 
 
 cdef class LoggingResourceAdaptor(UpstreamResourceAdaptor):
@@ -762,12 +740,11 @@ cdef class LoggingResourceAdaptor(UpstreamResourceAdaptor):
         log_file_name = os.path.abspath(log_file_name)
         self._log_file_name = log_file_name
 
-        self.c_obj.reset(
-            new logging_resource_adaptor(
-                upstream_mr.get_mr(),
-                log_file_name.encode()
-            )
-        )
+        self.c_obj.reset(new logging_resource_adaptor(
+            upstream_mr.c_ref.value(),
+            log_file_name.encode()
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -788,8 +765,7 @@ cdef class LoggingResourceAdaptor(UpstreamResourceAdaptor):
         pass
 
     cpdef flush(self):
-        (<logging_resource_adaptor*>(
-            self.get_mr()))[0].flush()
+        deref(self.c_obj).flush()
 
     cpdef get_file_name(self):
         return self._log_file_name
@@ -800,11 +776,10 @@ cdef class StatisticsResourceAdaptor(UpstreamResourceAdaptor):
         self,
         DeviceMemoryResource upstream_mr
     ):
-        self.c_obj.reset(
-            new statistics_resource_adaptor(
-                upstream_mr.get_mr()
-            )
-        )
+        self.c_obj.reset(new statistics_resource_adaptor(
+            upstream_mr.c_ref.value()
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -837,11 +812,8 @@ cdef class StatisticsResourceAdaptor(UpstreamResourceAdaptor):
         Returns:
             dict: Dictionary containing allocation counts and bytes.
         """
-        cdef statistics_resource_adaptor* mr = \
-            <statistics_resource_adaptor*> self.c_obj.get()
-
-        counts = deref(mr).get_allocations_counter()
-        byte_counts = deref(mr).get_bytes_counter()
+        counts = deref(self.c_obj).get_allocations_counter()
+        byte_counts = deref(self.c_obj).get_bytes_counter()
         return Statistics(
             current_bytes=byte_counts.value,
             current_count=counts.value,
@@ -859,10 +831,7 @@ cdef class StatisticsResourceAdaptor(UpstreamResourceAdaptor):
         -------
         The popped statistics
         """
-        cdef statistics_resource_adaptor* mr = \
-            <statistics_resource_adaptor*> self.c_obj.get()
-
-        bytes_and_allocs = deref(mr).pop_counters()
+        bytes_and_allocs = deref(self.c_obj).pop_counters()
         return Statistics(
             current_bytes=bytes_and_allocs.first.value,
             current_count=bytes_and_allocs.second.value,
@@ -881,10 +850,7 @@ cdef class StatisticsResourceAdaptor(UpstreamResourceAdaptor):
         The statistics _before_ the push
         """
 
-        cdef statistics_resource_adaptor* mr = \
-            <statistics_resource_adaptor*> self.c_obj.get()
-
-        bytes_and_allocs = deref(mr).push_counters()
+        bytes_and_allocs = deref(self.c_obj).push_counters()
         return Statistics(
             current_bytes=bytes_and_allocs.first.value,
             current_count=bytes_and_allocs.second.value,
@@ -901,12 +867,11 @@ cdef class TrackingResourceAdaptor(UpstreamResourceAdaptor):
         DeviceMemoryResource upstream_mr,
         bool capture_stacks=False
     ):
-        self.c_obj.reset(
-            new tracking_resource_adaptor(
-                upstream_mr.get_mr(),
-                capture_stacks
-            )
-        )
+        self.c_obj.reset(new tracking_resource_adaptor(
+            upstream_mr.c_ref.value(),
+            capture_stacks
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -934,9 +899,7 @@ cdef class TrackingResourceAdaptor(UpstreamResourceAdaptor):
         possible fragmentation and also internal page sizes and alignment that
         is not tracked by this allocator.
         """
-        return (<tracking_resource_adaptor*>(
-            self.c_obj.get())
-        )[0].get_allocated_bytes()
+        return deref(self.c_obj).get_allocated_bytes()
 
     def get_outstanding_allocations_str(self) -> str:
         """
@@ -944,19 +907,16 @@ cdef class TrackingResourceAdaptor(UpstreamResourceAdaptor):
         allocations. For each allocation, the address, size and optional
         stack trace are shown.
         """
-
-        return (<tracking_resource_adaptor*>(
-            self.c_obj.get())
-        )[0].get_outstanding_allocations_str().decode('UTF-8')
+        return deref(self.c_obj).get_outstanding_allocations_str().decode(
+            'UTF-8'
+        )
 
     def log_outstanding_allocations(self):
         """
         Logs the output of :meth:`get_outstanding_allocations_str` to the
         current RMM log file if enabled.
         """
-
-        (<tracking_resource_adaptor*>(
-            self.c_obj.get()))[0].log_outstanding_allocations()
+        deref(self.c_obj).log_outstanding_allocations()
 
 
 # Note that this function is specifically designed to rethrow Python exceptions
@@ -980,13 +940,12 @@ cdef class FailureCallbackResourceAdaptor(UpstreamResourceAdaptor):
         object callback,
     ):
         self._callback = callback
-        self.c_obj.reset(
-            new failure_callback_resource_adaptor[out_of_memory](
-                upstream_mr.get_mr(),
-                <failure_callback_t>(_oom_callback_function),
-                <void*>(callback)
-            )
-        )
+        self.c_obj.reset(new failure_callback_resource_adaptor_oom(
+            upstream_mr.c_ref.value(),
+            <failure_callback_t>(_oom_callback_function),
+            <void*>(callback)
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -1011,11 +970,10 @@ cdef class PrefetchResourceAdaptor(UpstreamResourceAdaptor):
         self,
         DeviceMemoryResource upstream_mr
     ):
-        self.c_obj.reset(
-            new prefetch_resource_adaptor(
-                upstream_mr.get_mr()
-            )
-        )
+        self.c_obj.reset(new prefetch_resource_adaptor(
+            upstream_mr.c_ref.value()
+        ))
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def __init__(
         self,
@@ -1142,7 +1100,7 @@ cpdef set_per_device_resource(int device, DeviceMemoryResource mr):
     cdef unique_ptr[cuda_device_id] device_id = \
         make_unique[cuda_device_id](device)
 
-    cpp_set_per_device_resource(deref(device_id), mr.get_mr())
+    cpp_set_per_device_resource_ref(deref(device_id), mr.c_ref.value())
 
 
 cpdef set_current_device_resource(DeviceMemoryResource mr):
@@ -1197,7 +1155,7 @@ cpdef is_initialized():
     global _per_device_mrs
     cdef DeviceMemoryResource each_mr
     return all(
-        [each_mr.get_mr() is not NULL
+        [each_mr.c_ref.has_value()
             for each_mr in _per_device_mrs.values()]
     )
 

--- a/python/rmm/rmm/pylibrmm/memory_resource/experimental.pxd
+++ b/python/rmm/rmm/pylibrmm/memory_resource/experimental.pxd
@@ -1,9 +1,12 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+from libcpp.memory cimport unique_ptr
+
+from rmm.librmm.memory_resource cimport cuda_async_managed_memory_resource
 # import from the private _memory_resource to avoid a circular import
 from rmm.pylibrmm.memory_resource._memory_resource cimport DeviceMemoryResource
 
 
 cdef class CudaAsyncManagedMemoryResource(DeviceMemoryResource):
-    pass
+    cdef unique_ptr[cuda_async_managed_memory_resource] c_obj

--- a/python/rmm/rmm/pylibrmm/memory_resource/experimental.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/experimental.pyx
@@ -1,11 +1,15 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Experimental memory resource features."""
 
+from cython.operator cimport dereference as deref
 from libc.stdint cimport uintptr_t
 
-from rmm.librmm.memory_resource cimport cuda_async_managed_memory_resource
+from rmm.librmm.memory_resource cimport (
+    cuda_async_managed_memory_resource,
+    make_device_async_resource_ref,
+)
 # import from the private _memory_resource to avoid a circular import
 from rmm.pylibrmm.memory_resource._memory_resource cimport DeviceMemoryResource
 
@@ -22,9 +26,8 @@ cdef class CudaAsyncManagedMemoryResource(DeviceMemoryResource):
     (not supported on WSL2).
     """
     def __cinit__(self):
-        self.c_obj.reset(
-            new cuda_async_managed_memory_resource()
-        )
+        self.c_obj.reset(new cuda_async_managed_memory_resource())
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def pool_handle(self):
         """
@@ -35,6 +38,4 @@ cdef class CudaAsyncManagedMemoryResource(DeviceMemoryResource):
         int
             Handle to the underlying CUDA memory pool
         """
-        cdef cuda_async_managed_memory_resource* c_mr = \
-            <cuda_async_managed_memory_resource*>(self.c_obj.get())
-        return <uintptr_t>(c_mr.pool_handle())
+        return <uintptr_t>(deref(self.c_obj).pool_handle())


### PR DESCRIPTION
## Summary

Replaces `shared_ptr[device_memory_resource]` with per-subclass `unique_ptr[ConcreteType]` (owning) and `optional[device_async_resource_ref]` (non-owning reference) across all Python/Cython bindings. This is a part of #2011.

There are **significant** opportunities to make this Cython code better over time but I have to get something that removes `device_memory_resource` from the Python/Cython side before I can finish migration on the C++ side (#2296). I welcome critique of this design, and ideas for how it can be improved, particularly from @vyasr @wence-. I would like to address any suggested improvements in follow-up PRs, because this changeset is necessary to unblock #2301.

The changes in `cdef class DeviceMemoryResource` are perhaps the most significant changes here from a design perspective.

The solution I'm going with for now is to keep the `DeviceMemoryResource` class around, as a base class for the Cython MRs, and let it handle allocate/deallocate. It owns a `optional[device_async_resource_ref]` which is used for allocation/deallocation. It's `optional` so that the class can be default-constructed (Cython requires nullary constructors), but it should never be `nullopt` except during initialization.

Then, each MR class owns a `c_obj` like `unique_ptr[cuda_memory_resource]`. This is `unique_ptr` so it can be default-constructed for Cython's requirements. I chose `unique_ptr` over `optional` here to emphasize that this member is the thing that actually owns the resource. As with the `c_ref`, this should never be `nullptr` except during initialization. When an MR class is created, it initializes its `c_obj` and then constructs a `c_ref` (a member inherited from the `DeviceMemoryResource` base class).

"Special" methods for an MR like getting the statistics counts go through `deref(self.c_obj)`, and "common" methods like allocate/deallocate go through `self.c_ref.value()`.

### Changes

- **`.pxd` declarations**: Remove `device_memory_resource` class. Declare `device_async_resource_ref` and a `make_device_async_resource_ref()` inline C++ template that returns `optional` to work around Cython generating default-constructed temporaries for non-default-constructible types. All adaptor constructors take `device_async_resource_ref` instead of `device_memory_resource*`.
- **`.pxd` class definitions**: `DeviceMemoryResource` base holds `optional[device_async_resource_ref] c_ref`; each concrete subclass holds `unique_ptr[ConcreteType] c_obj`.
- **`.pyx` implementations**: All `__cinit__` methods construct via `unique_ptr` then set `c_ref` via `make_device_async_resource_ref`. Typed accessors (`pool_size`, `flush`, etc.) use `deref(self.c_obj)`. Per-device functions use `set_per_device_resource_ref`.
- **`device_buffer.pyx`**: Passes `self.mr.c_ref.value()` instead of `self.mr.get_mr()`.

Closes #2294