### PR TITLE
Cap numba-cuda upper bound at <0.29.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - myst-parser
 - nbsphinx
 - ninja
-- numba-cuda>=0.22.1
+- numba-cuda>=0.22.1,<0.29.0
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - myst-parser
 - nbsphinx
 - ninja
-- numba-cuda>=0.22.1
+- numba-cuda>=0.22.1,<0.29.0
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - myst-parser
 - nbsphinx
 - ninja
-- numba-cuda>=0.22.1
+- numba-cuda>=0.22.1,<0.29.0
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -25,7 +25,7 @@ dependencies:
 - myst-parser
 - nbsphinx
 - ninja
-- numba-cuda>=0.22.1
+- numba-cuda>=0.22.1,<0.29.0
 - numba>=0.60.0,<0.65.0
 - numpy>=1.23,<3.0
 - numpydoc

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -289,7 +289,7 @@ dependencies:
           - myst-parser
           - nbsphinx
           - &numba numba>=0.60.0,<0.65.0
-          - &numba_cuda numba-cuda>=0.22.1
+          - &numba_cuda numba-cuda>=0.22.1,<0.29.0
           - numpydoc
           - pydata-sphinx-theme>=0.15.4
           - sphinx
@@ -362,7 +362,7 @@ dependencies:
           - matrix:
               dependencies: "oldest"
             packages:
-              - numba-cuda==0.22.1
+              - numba-cuda==0.22.1,<0.29.0
           - matrix:
             packages:
               - *numba_cuda
@@ -371,17 +371,17 @@ dependencies:
           - matrix:
               dependencies: "oldest"
             packages:
-              - numba-cuda==0.22.1
+              - numba-cuda==0.22.1,<0.29.0
           - matrix:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - &numba_cuda_cu12 numba-cuda[cu12]>=0.22.1
+              - &numba_cuda_cu12 numba-cuda[cu12]>=0.22.1,<0.29.0
           - matrix:
               cuda: "13.*"
               cuda_suffixed: "true"
             packages:
-              - &numba_cuda_cu13 numba-cuda[cu13]>=0.22.1
+              - &numba_cuda_cu13 numba-cuda[cu13]>=0.22.1,<0.29.0
           # fallback to numba-cuda with no extra CUDA packages if 'cuda_suffixed' isn't true
           - matrix:
             packages:

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "numba-cuda>=0.22.1",
+    "numba-cuda>=0.22.1,<0.29.0",
     "numba>=0.60.0,<0.65.0",
     "packaging",
     "pytest",


### PR DESCRIPTION
This PR sets an upper bound on the `numba-cuda` dependency to `<0.29.0`
