### PR TITLE
Fix concurrent 0-byte allocation crash in tracking and aligned adaptors

### DIFF
--- a/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
@@ -132,7 +132,8 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
-    if (alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
+    if (bytes == 0 || alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT ||
+        bytes < alignment_threshold_) {
       return get_upstream_resource().allocate(stream, bytes, 1);
     }
     auto const size = upstream_allocation_size(bytes);
@@ -159,7 +160,8 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) noexcept override
   {
-    if (alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
+    if (bytes == 0 || alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT ||
+        bytes < alignment_threshold_) {
       get_upstream_resource().deallocate(stream, ptr, bytes, 1);
     } else {
       {

--- a/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
@@ -197,8 +197,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
     void* ptr = get_upstream_resource().allocate(stream, bytes);
-    // track it.
-    {
+    if (bytes > 0) {
       write_lock_t lock(mtx_);
       auto [_, inserted] = allocations_.emplace(ptr, allocation_info{bytes, capture_stacks_});
       RMM_EXPECTS(inserted, "pointer is already tracked");
@@ -217,7 +216,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    */
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) noexcept override
   {
-    {
+    if (bytes > 0) {
       write_lock_t lock(mtx_);
 
       const auto found = allocations_.find(ptr);

--- a/cpp/tests/mr/tracking_mr_tests.cpp
+++ b/cpp/tests/mr/tracking_mr_tests.cpp
@@ -79,6 +79,23 @@ TEST(TrackingTest, MultiThreaded)
   }
 }
 
+TEST(TrackingTest, ConcurrentZeroByteAllocations)
+{
+  tracking_adaptor mr{rmm::mr::get_current_device_resource_ref()};
+  std::vector<std::thread> threads;
+  constexpr int num_threads{4};
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&mr]() {
+      void* ptr = mr.allocate_sync(0);
+      mr.deallocate_sync(ptr, 0);
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), 0);
+}
+
 TEST(TrackingTest, ThrowOnNullUpstream)
 {
   auto construct_nullptr = []() { tracking_adaptor mr{nullptr}; };


### PR DESCRIPTION
## Description

Closes #2312

`tracking_resource_adaptor` crashes when multiple threads perform concurrent 0-byte allocations. `cudaMalloc(0)` may return the same non-null pointer to concurrent callers, and the adaptor asserts uniqueness on map insertion, aborting the process. Fix: skip map insertion/lookup for 0-byte allocations since they represent no real memory.

`aligned_resource_adaptor` routes 0-byte requests through the alignment path when `alignment_threshold` is 0 (the default), since the guard `bytes < alignment_threshold` evaluates to `0 < 0 = false`. This causes `upstream_allocation_size(0)` to compute a nonzero value (`alignment_ - 256`), needlessly entering the pointer-tracking logic. Fix: add `bytes == 0` to the early-return condition so 0-byte requests bypass the alignment and pointer-tracking path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.