### PR TITLE
Fix PTDS test registration to run the correct binary

### DIFF
--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -119,10 +119,10 @@ function(ConfigureTest TEST_NAME)
     target_link_libraries(${PTDS_TEST_NAME} PRIVATE CUDA::cuda_driver)
   endif()
 
-  foreach(name ${TEST_NAME} ${PTDS_TEST_NAME} ${NS_TEST_NAME})
+  foreach(name ${TEST_NAME} ${PTDS_TEST_NAME})
     rapids_test_add(
       NAME ${name}
-      COMMAND ${TEST_NAME}
+      COMMAND ${name}
       GPUS ${_RMM_TEST_GPUS}
       PERCENT ${_RMM_TEST_PERCENT}
       INSTALL_COMPONENT_SET testing)


### PR DESCRIPTION
## Description

Fix ctest registration so PTDS tests run the PTDS-compiled binary instead of re-running the base binary.

`COMMAND ${TEST_NAME}` always pointed to the base (non-PTDS) executable regardless of which test name was being registered. The PTDS binaries were compiled but never executed by ctest. After this fix, `COMMAND ${name}` correctly maps each test to its own binary.

Also removes vestigial `${NS_TEST_NAME}` from the `foreach` loop (never set, always expands to empty).

Confirmed by inspecting the generated `CTestTestfile.cmake` before and after: previously both `DEVICE_UVECTOR_TEST` and `DEVICE_UVECTOR_PTDS_TEST` ran `gtests/DEVICE_UVECTOR_TEST`. After the fix, each runs its own binary (verified by differing md5sums).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.