### PR TITLE
Fix tracking and aligned adaptors for zero-sized allocations

### DIFF
--- a/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
@@ -132,7 +132,8 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   void* do_allocate(std::size_t bytes, cuda_stream_view stream) override
   {
-    if (alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
+    if (bytes == 0 || alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT ||
+        bytes < alignment_threshold_) {
       return get_upstream_resource().allocate(stream, bytes, 1);
     }
     auto const size = upstream_allocation_size(bytes);
@@ -159,7 +160,8 @@ class aligned_resource_adaptor final : public device_memory_resource {
    */
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) noexcept override
   {
-    if (alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
+    if (bytes == 0 || alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT ||
+        bytes < alignment_threshold_) {
       get_upstream_resource().deallocate(stream, ptr, bytes, 1);
     } else {
       {

--- a/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
@@ -198,9 +198,9 @@ class tracking_resource_adaptor final : public device_memory_resource {
   {
     void* ptr = get_upstream_resource().allocate(stream, bytes);
     // track it.
-    {
+    if (bytes != 0) {
       write_lock_t lock(mtx_);
-      auto [_, inserted] = allocations_.emplace(ptr, allocation_info{bytes, capture_stacks_});
+      auto [_, inserted] = allocations_.try_emplace(ptr, bytes, capture_stacks_);
       RMM_EXPECTS(inserted, "pointer is already tracked");
     }
     allocated_bytes_ += bytes;
@@ -217,7 +217,7 @@ class tracking_resource_adaptor final : public device_memory_resource {
    */
   void do_deallocate(void* ptr, std::size_t bytes, cuda_stream_view stream) noexcept override
   {
-    {
+    if (bytes != 0) {
       write_lock_t lock(mtx_);
 
       const auto found = allocations_.find(ptr);

--- a/cpp/tests/mr/aligned_mr_tests.cpp
+++ b/cpp/tests/mr/aligned_mr_tests.cpp
@@ -1,11 +1,13 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "../mock_resource.hpp"
+#include "delayed_memory_resource.hpp"
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/aligned_resource_adaptor.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
@@ -28,6 +30,51 @@ void* int_to_address(std::size_t val)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr)
   return reinterpret_cast<void*>(val);
+}
+
+struct allocation_size : public ::testing::TestWithParam<std::size_t> {};
+
+INSTANTIATE_TEST_SUITE_P(AlignedTest, allocation_size, ::testing::Values(0, 256));
+
+TEST_P(allocation_size, MultiThreaded)
+{
+  const std::size_t allocation_size = GetParam();
+  auto upstream                     = rmm::mr::cuda_memory_resource{};
+  auto delayed = delayed_memory_resource(upstream, std::chrono::milliseconds{300});
+  auto mr      = rmm::mr::aligned_resource_adaptor<delayed_memory_resource>(delayed);
+  auto stream  = rmm::cuda_stream{};
+  // Provoke interleaving to test that aligned allocations are updated with correct ordering
+  // relative to upstream deallocate. The delayed memory resource frees the pointer upstream
+  // immediately then sleeps, simulating the window where the address is available for reuse
+  // but the adaptor hasn't updated its counters yet.
+  //
+  // Thread-0             Thread-1
+  // alloc
+  //                      alloc
+  //                      dealloc-start
+  // dealloc-start
+  //                      dealloc-end
+  // dealloc-end
+  //
+  // After both threads complete, the counters must reflect zero outstanding allocations.
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 2; i++) {
+    threads.emplace_back([&, i = i]() {
+      void* ptr{nullptr};
+      if (i != 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      EXPECT_NO_THROW(ptr = mr.allocate(stream, allocation_size));
+      if (allocation_size != 0) {
+        EXPECT_NE(ptr, nullptr);
+      } else {
+        EXPECT_EQ(ptr, nullptr);
+      }
+      if (i == 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      mr.deallocate(stream, ptr, allocation_size);
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
 }
 
 TEST(AlignedTest, ThrowOnNullUpstream)

--- a/cpp/tests/mr/statistics_mr_tests.cpp
+++ b/cpp/tests/mr/statistics_mr_tests.cpp
@@ -31,12 +31,17 @@ constexpr auto num_allocations{10};
 constexpr auto num_more_allocations{5};
 constexpr auto ten_MiB{10_MiB};
 
-TEST(StatisticsTest, MultiThreaded)
+struct allocation_size : public ::testing::TestWithParam<std::size_t> {};
+
+INSTANTIATE_TEST_SUITE_P(StatisticsTest, allocation_size, ::testing::Values(0, 256));
+
+TEST_P(allocation_size, MultiThreaded)
 {
-  auto upstream = rmm::mr::cuda_memory_resource{};
-  auto delayed  = delayed_memory_resource(upstream, std::chrono::milliseconds{300});
-  auto mr       = rmm::mr::statistics_resource_adaptor<delayed_memory_resource>(delayed);
-  auto stream   = rmm::cuda_stream{};
+  const std::size_t allocation_size = GetParam();
+  auto upstream                     = rmm::mr::cuda_memory_resource{};
+  auto delayed = delayed_memory_resource(upstream, std::chrono::milliseconds{300});
+  auto mr      = rmm::mr::statistics_resource_adaptor<delayed_memory_resource>(delayed);
+  auto stream  = rmm::cuda_stream{};
   // Provoke interleaving to test that statistics counters are updated with correct ordering
   // relative to upstream deallocate. The delayed memory resource frees the pointer upstream
   // immediately then sleeps, simulating the window where the address is available for reuse
@@ -44,25 +49,26 @@ TEST(StatisticsTest, MultiThreaded)
   //
   // Thread-0             Thread-1
   // alloc
-  // dealloc-start
   //                      alloc
   //                      dealloc-start
-  //
-  // dealloc-end
+  // dealloc-start
   //                      dealloc-end
+  // dealloc-end
   //
   // After both threads complete, the counters must reflect zero outstanding allocations.
   std::vector<std::thread> threads;
   for (int i = 0; i < 2; i++) {
     threads.emplace_back([&, i = i]() {
-      if (i == 0) {
-        void* ptr = mr.allocate(stream, 256);
-        mr.deallocate(stream, ptr, 256);
+      void* ptr{nullptr};
+      if (i != 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      EXPECT_NO_THROW(ptr = mr.allocate(stream, allocation_size));
+      if (allocation_size != 0) {
+        EXPECT_NE(ptr, nullptr);
       } else {
-        std::this_thread::sleep_for(std::chrono::milliseconds{100});
-        void* ptr = mr.allocate(stream, 256);
-        mr.deallocate(stream, ptr, 256);
+        EXPECT_EQ(ptr, nullptr);
       }
+      if (i == 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      mr.deallocate(stream, ptr, allocation_size);
     });
   }
   for (auto& t : threads) {
@@ -71,7 +77,7 @@ TEST(StatisticsTest, MultiThreaded)
   EXPECT_EQ(mr.get_bytes_counter().value, 0);
   EXPECT_EQ(mr.get_allocations_counter().value, 0);
   EXPECT_EQ(mr.get_allocations_counter().total, 2);
-  EXPECT_EQ(mr.get_bytes_counter().total, 512);
+  EXPECT_EQ(mr.get_bytes_counter().total, 2 * allocation_size);
 }
 
 TEST(StatisticsTest, ThrowOnNullUpstream)

--- a/cpp/tests/mr/tracking_mr_tests.cpp
+++ b/cpp/tests/mr/tracking_mr_tests.cpp
@@ -33,9 +33,14 @@ constexpr auto num_allocations{10};
 constexpr auto num_more_allocations{5};
 constexpr auto ten_MiB{10_MiB};
 
-TEST(TrackingTest, MultiThreaded)
+struct allocation_size : public ::testing::TestWithParam<std::size_t> {};
+
+INSTANTIATE_TEST_SUITE_P(TrackingTest, allocation_size, ::testing::Values(0, 256));
+
+TEST_P(allocation_size, MultiThreaded)
 {
-  auto upstream = rmm::mr::cuda_memory_resource{};
+  const std::size_t allocation_size = GetParam();
+  auto upstream                     = rmm::mr::cuda_memory_resource{};
   std::vector<std::thread> threads;
   auto delayed = delayed_memory_resource(upstream, std::chrono::milliseconds{300});
   auto mr      = rmm::mr::tracking_resource_adaptor<delayed_memory_resource>(delayed);
@@ -43,40 +48,39 @@ TEST(TrackingTest, MultiThreaded)
   // Idea, we want to provoke address reuse to test ABA problems in the tracking resource
   // adaptor. To do so, the delayed memory resource frees (and hence returns to the
   // upstream) an address immediately and then makes that thread sleep. So thread 0
-  // allocates, deallocates, sleeps. Thread 1 sleeps, allocates, deallocates, sleeps. We
+  // allocates, sleeps, deallocates, sleeps. Thread 1 sleeps, allocates, deallocates, sleeps. We
   // therefore expect an interleaving:
   //
   // Thread-0             Thread-1
   // alloc
-  // dealloc-start
   //                      alloc
   //                      dealloc-start
-  //
-  // dealloc-end
+  // dealloc-start
   //                      dealloc-end
+  // dealloc-end
   //
   // In this scenario, if the tracking adaptor doesn't correctly handle ordering,
   // allocation tracking should be morally an acquire-release pair bounded by the upstream
   // allocate/deallocate, then we can get ABA reuse of the upstream's pointer.
   for (int i = 0; i < 2; i++) {
     threads.emplace_back([&, i = i]() {
-      if (i == 0) {
-        void* ptr{nullptr};
-        EXPECT_NO_THROW(ptr = mr.allocate(stream, 256));
+      void* ptr{nullptr};
+      if (i != 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      EXPECT_NO_THROW(ptr = mr.allocate(stream, allocation_size));
+      if (allocation_size != 0) {
         EXPECT_NE(ptr, nullptr);
-        mr.deallocate(stream, ptr, 256);
       } else {
-        std::this_thread::sleep_for(std::chrono::milliseconds{100});
-        void* ptr{nullptr};
-        EXPECT_NO_THROW(ptr = mr.allocate(stream, 256));
-        EXPECT_NE(ptr, nullptr);
-        mr.deallocate(stream, ptr, 256);
+        EXPECT_EQ(ptr, nullptr);
       }
+      if (i == 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      mr.deallocate(stream, ptr, allocation_size);
     });
   }
   for (auto& t : threads) {
     t.join();
   }
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), 0);
+  EXPECT_EQ(mr.get_allocated_bytes(), 0);
 }
 
 TEST(TrackingTest, ThrowOnNullUpstream)


### PR DESCRIPTION
## Description
In #2304 we fixed an ABA reuse problem in the tracking and aligned adaptors. However, the edge case of zero-sized allocations was not treated correctly. If requesting a zero-sized allocation, two concurrent calls are allowed to return the same (null) pointer. Attempting to track these simultaneously would result in emplacing the same pointer more than once. Fix this by just not tracking zero-sized allocations.

Also, fix a small typo bug from #2304: we meant to use try_emplace, not emplace, in the tracking adaptor.

- Closes #2312

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
