### PR TITLE
Merge main into staging

### DIFF
--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -48,7 +48,7 @@ void* aligned_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                               std::size_t bytes,
                                               std::size_t /*alignment*/)
 {
-  if (alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
+  if (bytes == 0 || alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
     return upstream_mr_.allocate(stream, bytes, 1);
   }
   auto const size = upstream_allocation_size(bytes);
@@ -71,7 +71,7 @@ void aligned_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
                                                std::size_t bytes,
                                                std::size_t /*alignment*/) noexcept
 {
-  if (alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
+  if (bytes == 0 || alignment_ == rmm::CUDA_ALLOCATION_ALIGNMENT || bytes < alignment_threshold_) {
     upstream_mr_.deallocate(stream, ptr, bytes, 1);
   } else {
     {

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -63,9 +63,9 @@ void* tracking_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                                std::size_t alignment)
 {
   void* ptr = upstream_mr_.allocate(stream, bytes, alignment);
-  {
+  if (bytes != 0) {
     write_lock_t lock(mtx_);
-    auto [_, inserted] = allocations_.emplace(ptr, allocation_info{bytes, capture_stacks_});
+    auto [_, inserted] = allocations_.try_emplace(ptr, bytes, capture_stacks_);
     RMM_EXPECTS(inserted, "pointer is already tracked");
   }
   allocated_bytes_ += bytes;
@@ -77,7 +77,7 @@ void tracking_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
                                                 std::size_t bytes,
                                                 std::size_t alignment) noexcept
 {
-  {
+  if (bytes != 0) {
     write_lock_t lock(mtx_);
     auto const found = allocations_.find(ptr);
     if (found == allocations_.end()) {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -119,10 +119,10 @@ function(ConfigureTest TEST_NAME)
     target_link_libraries(${PTDS_TEST_NAME} PRIVATE CUDA::cuda_driver)
   endif()
 
-  foreach(name ${TEST_NAME} ${PTDS_TEST_NAME} ${NS_TEST_NAME})
+  foreach(name ${TEST_NAME} ${PTDS_TEST_NAME})
     rapids_test_add(
       NAME ${name}
-      COMMAND ${TEST_NAME}
+      COMMAND ${name}
       GPUS ${_RMM_TEST_GPUS}
       PERCENT ${_RMM_TEST_PERCENT}
       INSTALL_COMPONENT_SET testing)

--- a/cpp/tests/device_uvector_tests.cpp
+++ b/cpp/tests/device_uvector_tests.cpp
@@ -210,7 +210,7 @@ TYPED_TEST(TypedUVectorTest, OOBGetElement)
 
 TYPED_TEST(TypedUVectorTest, GetSetElement)
 {
-  auto const size{12345};
+  auto const size{100};
   rmm::device_uvector<TypeParam> vec(size, this->stream());
   for (std::size_t i = 0; i < vec.size(); ++i) {
     vec.set_element(i, i, this->stream());
@@ -220,7 +220,7 @@ TYPED_TEST(TypedUVectorTest, GetSetElement)
 
 TYPED_TEST(TypedUVectorTest, GetSetElementAsync)
 {
-  auto const size{12345};
+  auto const size{100};
   rmm::device_uvector<TypeParam> vec(size, this->stream());
   for (std::size_t i = 0; i < vec.size(); ++i) {
     auto init = static_cast<TypeParam>(i);
@@ -231,7 +231,7 @@ TYPED_TEST(TypedUVectorTest, GetSetElementAsync)
 
 TYPED_TEST(TypedUVectorTest, SetElementZeroAsync)
 {
-  auto const size{12345};
+  auto const size{100};
   rmm::device_uvector<TypeParam> vec(size, this->stream());
   for (std::size_t i = 0; i < vec.size(); ++i) {
     vec.set_element_to_zero_async(i, this->stream());

--- a/cpp/tests/mr/aligned_mr_tests.cpp
+++ b/cpp/tests/mr/aligned_mr_tests.cpp
@@ -4,8 +4,10 @@
  */
 
 #include "../mock_resource.hpp"
+#include "delayed_memory_resource.hpp"
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/aligned_resource_adaptor.hpp>
 #include <rmm/mr/device_memory_resource.hpp>
@@ -27,6 +29,51 @@ void* int_to_address(std::size_t val)
 {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr)
   return reinterpret_cast<void*>(val);
+}
+
+struct allocation_size : public ::testing::TestWithParam<std::size_t> {};
+
+INSTANTIATE_TEST_SUITE_P(AlignedTest, allocation_size, ::testing::Values(0, 256));
+
+TEST_P(allocation_size, MultiThreaded)
+{
+  const std::size_t allocation_size = GetParam();
+  auto upstream                     = rmm::mr::cuda_memory_resource{};
+  auto delayed = delayed_memory_resource(upstream, std::chrono::milliseconds{300});
+  auto mr      = rmm::mr::aligned_resource_adaptor(delayed);
+  auto stream  = rmm::cuda_stream{};
+  // Provoke interleaving to test that aligned allocations are updated with correct ordering
+  // relative to upstream deallocate. The delayed memory resource frees the pointer upstream
+  // immediately then sleeps, simulating the window where the address is available for reuse
+  // but the adaptor hasn't updated its counters yet.
+  //
+  // Thread-0             Thread-1
+  // alloc
+  //                      alloc
+  //                      dealloc-start
+  // dealloc-start
+  //                      dealloc-end
+  // dealloc-end
+  //
+  // After both threads complete, the counters must reflect zero outstanding allocations.
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 2; i++) {
+    threads.emplace_back([&, i = i]() {
+      void* ptr{nullptr};
+      if (i != 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      EXPECT_NO_THROW(ptr = mr.allocate(stream, allocation_size));
+      if (allocation_size != 0) {
+        EXPECT_NE(ptr, nullptr);
+      } else {
+        EXPECT_EQ(ptr, nullptr);
+      }
+      if (i == 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      mr.deallocate(stream, ptr, allocation_size);
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
 }
 
 TEST(AlignedTest, ThrowOnInvalidAllocationAlignment)

--- a/cpp/tests/mr/failure_callback_mr_tests.cpp
+++ b/cpp/tests/mr/failure_callback_mr_tests.cpp
@@ -32,16 +32,6 @@ bool failure_handler(std::size_t /*bytes*/, void* arg)
   return false;  // Second time we let the adaptor throw std::bad_alloc
 }
 
-TEST(FailureCallbackTest, RetryAllocationOnce)
-{
-  bool retried{false};
-  failure_callback_adaptor<> mr{
-    rmm::mr::get_current_device_resource_ref(), failure_handler, &retried};
-  EXPECT_EQ(retried, false);
-  EXPECT_THROW(mr.allocate_sync(512_GiB), std::bad_alloc);
-  EXPECT_EQ(retried, true);
-}
-
 template <typename ExceptionType>
 class always_throw_memory_resource final : public mr::device_memory_resource {
  private:
@@ -53,6 +43,16 @@ class always_throw_memory_resource final : public mr::device_memory_resource {
                      std::size_t /*bytes*/,
                      cuda_stream_view /*stream*/) noexcept override {};
 };
+
+TEST(FailureCallbackTest, RetryAllocationOnce)
+{
+  always_throw_memory_resource<rmm::bad_alloc> throwing_mr;
+  bool retried{false};
+  failure_callback_adaptor<> mr{&throwing_mr, failure_handler, &retried};
+  EXPECT_EQ(retried, false);
+  EXPECT_THROW(mr.allocate_sync(1_MiB), rmm::bad_alloc);
+  EXPECT_EQ(retried, true);
+}
 
 TEST(FailureCallbackTest, DifferentExceptionTypes)
 {

--- a/cpp/tests/mr/statistics_mr_tests.cpp
+++ b/cpp/tests/mr/statistics_mr_tests.cpp
@@ -31,10 +31,15 @@ constexpr auto num_allocations{10};
 constexpr auto num_more_allocations{5};
 constexpr auto ten_MiB{10_MiB};
 
-TEST(StatisticsTest, MultiThreaded)
+struct allocation_size : public ::testing::TestWithParam<std::size_t> {};
+
+INSTANTIATE_TEST_SUITE_P(StatisticsTest, allocation_size, ::testing::Values(0, 256));
+
+TEST_P(allocation_size, MultiThreaded)
 {
-  auto upstream = rmm::mr::cuda_memory_resource{};
-  auto delayed  = delayed_memory_resource(upstream, std::chrono::milliseconds{300});
+  const std::size_t allocation_size = GetParam();
+  auto upstream                     = rmm::mr::cuda_memory_resource{};
+  auto delayed = delayed_memory_resource(upstream, std::chrono::milliseconds{300});
   statistics_adaptor mr{rmm::device_async_resource_ref{delayed}};
   auto stream = rmm::cuda_stream{};
   // Provoke interleaving to test that statistics counters are updated with correct ordering
@@ -44,25 +49,26 @@ TEST(StatisticsTest, MultiThreaded)
   //
   // Thread-0             Thread-1
   // alloc
-  // dealloc-start
   //                      alloc
   //                      dealloc-start
-  //
-  // dealloc-end
+  // dealloc-start
   //                      dealloc-end
+  // dealloc-end
   //
   // After both threads complete, the counters must reflect zero outstanding allocations.
   std::vector<std::thread> threads;
   for (int i = 0; i < 2; i++) {
     threads.emplace_back([&, i = i]() {
-      if (i == 0) {
-        void* ptr = mr.allocate(stream, 256);
-        mr.deallocate(stream, ptr, 256);
+      void* ptr{nullptr};
+      if (i != 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      EXPECT_NO_THROW(ptr = mr.allocate(stream, allocation_size));
+      if (allocation_size != 0) {
+        EXPECT_NE(ptr, nullptr);
       } else {
-        std::this_thread::sleep_for(std::chrono::milliseconds{100});
-        void* ptr = mr.allocate(stream, 256);
-        mr.deallocate(stream, ptr, 256);
+        EXPECT_EQ(ptr, nullptr);
       }
+      if (i == 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      mr.deallocate(stream, ptr, allocation_size);
     });
   }
   for (auto& t : threads) {
@@ -71,7 +77,7 @@ TEST(StatisticsTest, MultiThreaded)
   EXPECT_EQ(mr.get_bytes_counter().value, 0);
   EXPECT_EQ(mr.get_allocations_counter().value, 0);
   EXPECT_EQ(mr.get_allocations_counter().total, 2);
-  EXPECT_EQ(mr.get_bytes_counter().total, 512);
+  EXPECT_EQ(mr.get_bytes_counter().total, 2 * allocation_size);
 }
 
 TEST(StatisticsTest, ThrowOnNullUpstream)

--- a/cpp/tests/mr/tracking_mr_tests.cpp
+++ b/cpp/tests/mr/tracking_mr_tests.cpp
@@ -33,9 +33,14 @@ constexpr auto num_allocations{10};
 constexpr auto num_more_allocations{5};
 constexpr auto ten_MiB{10_MiB};
 
-TEST(TrackingTest, MultiThreaded)
+struct allocation_size : public ::testing::TestWithParam<std::size_t> {};
+
+INSTANTIATE_TEST_SUITE_P(TrackingTest, allocation_size, ::testing::Values(0, 256));
+
+TEST_P(allocation_size, MultiThreaded)
 {
-  auto upstream = rmm::mr::cuda_memory_resource{};
+  const std::size_t allocation_size = GetParam();
+  auto upstream                     = rmm::mr::cuda_memory_resource{};
   std::vector<std::thread> threads;
   auto delayed = delayed_memory_resource(upstream, std::chrono::milliseconds{300});
   tracking_adaptor mr{rmm::device_async_resource_ref{delayed}};
@@ -43,40 +48,39 @@ TEST(TrackingTest, MultiThreaded)
   // Idea, we want to provoke address reuse to test ABA problems in the tracking resource
   // adaptor. To do so, the delayed memory resource frees (and hence returns to the
   // upstream) an address immediately and then makes that thread sleep. So thread 0
-  // allocates, deallocates, sleeps. Thread 1 sleeps, allocates, deallocates, sleeps. We
+  // allocates, sleeps, deallocates, sleeps. Thread 1 sleeps, allocates, deallocates, sleeps. We
   // therefore expect an interleaving:
   //
   // Thread-0             Thread-1
   // alloc
-  // dealloc-start
   //                      alloc
   //                      dealloc-start
-  //
-  // dealloc-end
+  // dealloc-start
   //                      dealloc-end
+  // dealloc-end
   //
   // In this scenario, if the tracking adaptor doesn't correctly handle ordering,
   // allocation tracking should be morally an acquire-release pair bounded by the upstream
   // allocate/deallocate, then we can get ABA reuse of the upstream's pointer.
   for (int i = 0; i < 2; i++) {
     threads.emplace_back([&, i = i]() {
-      if (i == 0) {
-        void* ptr{nullptr};
-        EXPECT_NO_THROW(ptr = mr.allocate(stream, 256));
+      void* ptr{nullptr};
+      if (i != 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      EXPECT_NO_THROW(ptr = mr.allocate(stream, allocation_size));
+      if (allocation_size != 0) {
         EXPECT_NE(ptr, nullptr);
-        mr.deallocate(stream, ptr, 256);
       } else {
-        std::this_thread::sleep_for(std::chrono::milliseconds{100});
-        void* ptr{nullptr};
-        EXPECT_NO_THROW(ptr = mr.allocate(stream, 256));
-        EXPECT_NE(ptr, nullptr);
-        mr.deallocate(stream, ptr, 256);
+        EXPECT_EQ(ptr, nullptr);
       }
+      if (i == 0) { std::this_thread::sleep_for(std::chrono::milliseconds{100}); }
+      mr.deallocate(stream, ptr, allocation_size);
     });
   }
   for (auto& t : threads) {
     t.join();
   }
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), 0);
+  EXPECT_EQ(mr.get_allocated_bytes(), 0);
 }
 
 TEST(TrackingTest, ThrowOnNullUpstream)


### PR DESCRIPTION
## Description

This merges the following changes into the `staging` branch:

- Fix PTDS test registration to run the correct binary ([#2314](https://github.com/rapidsai/rmm/pull/2314))
- Reduce C++ test runtime by avoiding expensive CUDA driver paths ([#2315](https://github.com/rapidsai/rmm/pull/2315))
- Fix tracking and aligned adaptors for zero-sized allocations ([#2316](https://github.com/rapidsai/rmm/pull/2316), closes [#2312](https://github.com/rapidsai/rmm/issues/2312))

### Conflict resolution notes

The zero-sized allocation fix (#2316) required special handling because `staging` refactored all memory resources to use the CCCL shared-resource design pattern. On `main`, the fix was applied to inline methods in headers. On `staging`, those implementations live in separate `_impl.cpp` files:

- `cpp/include/rmm/mr/aligned_resource_adaptor.hpp` — took staging's declarations-only version; ported the `bytes == 0` guard to `cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp`
- `cpp/include/rmm/mr/tracking_resource_adaptor.hpp` — took staging's declarations-only version; ported the `bytes != 0` guard and `emplace` → `try_emplace` fix to `cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp`
- `cpp/tests/mr/aligned_mr_tests.cpp` — merged the new parameterized `MultiThreaded` test from #2316, adapted constructor to staging's non-template API
- `cpp/tests/mr/statistics_mr_tests.cpp` — merged the parameterized `MultiThreaded` test from #2316, adapted constructor to staging's API

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.