### PR TITLE
Add implicit conversion from rmm::cuda_stream to cuda::stream_ref

### DIFF
--- a/cpp/include/rmm/cuda_stream.hpp
+++ b/cpp/include/rmm/cuda_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <functional>
@@ -97,6 +98,13 @@ class cuda_stream {
    * @return A view of the owned stream
    */
   operator cuda_stream_view() const;
+
+  /**
+   * @brief Implicit conversion to cuda::stream_ref
+   *
+   * @return A stream_ref for the owned stream
+   */
+  operator cuda::stream_ref() const noexcept;
 
   /**
    * @brief Synchronize the owned CUDA stream.

--- a/cpp/src/cuda_stream.cpp
+++ b/cpp/src/cuda_stream.cpp
@@ -42,6 +42,8 @@ cuda_stream_view cuda_stream::view() const { return cuda_stream_view{value()}; }
 
 cuda_stream::operator cuda_stream_view() const { return view(); }
 
+cuda_stream::operator cuda::stream_ref() const noexcept { return cuda::stream_ref{value()}; }
+
 void cuda_stream::synchronize() const { RMM_CUDA_TRY(cudaStreamSynchronize(value())); }
 
 void cuda_stream::synchronize_no_throw() const noexcept

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,6 +7,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest-death-test.h>
@@ -35,6 +36,21 @@ TEST_F(CudaStreamTest, Equality)
   EXPECT_EQ(buff.stream(), view_default);
 
   EXPECT_NE(static_cast<cudaStream_t>(stream_a), rmm::cuda_stream_default.value());
+}
+
+TEST_F(CudaStreamTest, ImplicitConversionToStreamRef)
+{
+  rmm::cuda_stream stream;
+  cuda::stream_ref ref = stream;
+  EXPECT_EQ(ref.get(), stream.value());
+}
+
+TEST_F(CudaStreamTest, StreamRefConsistentWithView)
+{
+  rmm::cuda_stream stream;
+  cuda::stream_ref ref_from_stream = stream;
+  cuda::stream_ref ref_from_view   = stream.view();
+  EXPECT_EQ(ref_from_stream, ref_from_view);
 }
 
 TEST_F(CudaStreamTest, MoveConstructor)


### PR DESCRIPTION
## Description
`rmm::cuda_stream` converts to `rmm::cuda_stream_view`, and `rmm::cuda_stream_view` converts to `cuda::stream_ref`, but C++ does not chain two user-defined implicit conversions.

This PR adds a direct operator `cuda::stream_ref()` to `rmm::cuda_stream` so it can be passed to CCCL APIs that accept `cuda::stream_ref`.

This simplifies the ongoing migration to CCCL memory resources. Part of #2011.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
