### PR TITLE
Fix flags type annotation in CudaStreamPool

### DIFF
--- a/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyi
+++ b/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyi
@@ -1,10 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Optional
 
-from rmm.pylibrmm.cuda_stream import CudaStreamFlags
-from rmm.pylibrmm.stream import Stream
+from rmm.pylibrmm.stream import CudaStreamFlags, Stream
 
 class CudaStreamPool:
     def __init__(


### PR DESCRIPTION
## Description

Updates the type signature of CudaStreamFlags to use the non-deprecated stream.CudaStreamFlags rather than the deprecated cuda_stream.CudaStreamFlags.

This should only affect typing. The two implementations are identical.

xref https://github.com/rapidsai/cudf/pull/21925

