### PR TITLE
Forward-merge release/26.04 into main

### DIFF
--- a/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyi
+++ b/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyi
@@ -1,10 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Optional
 
-from rmm.pylibrmm.cuda_stream import CudaStreamFlags
-from rmm.pylibrmm.stream import Stream
+from rmm.pylibrmm.stream import CudaStreamFlags, Stream
 
 class CudaStreamPool:
     def __init__(


### PR DESCRIPTION
## Description
Forward-merge from `release/26.04` to `main`. Do not squash.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
