### PR TITLE
Store any_resource members in polymorphic_allocator, thrust_allocator, and device_check_resource_adaptor

### DIFF
--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -10,6 +10,8 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/memory_resource>
+
 #include <cstddef>
 #include <memory>
 
@@ -52,7 +54,7 @@ class polymorphic_allocator {
    *
    * @param mr The upstream memory resource to use for allocation.
    */
-  polymorphic_allocator(device_async_resource_ref mr) : mr_{mr} {}
+  polymorphic_allocator(device_async_resource_ref mr) : mr_(mr) {}
 
   /**
    * @brief Construct a `polymorphic_allocator` using the underlying memory resource of `other`.
@@ -62,7 +64,7 @@ class polymorphic_allocator {
    */
   template <typename U>
   polymorphic_allocator(polymorphic_allocator<U> const& other) noexcept
-    : mr_{other.get_upstream_resource()}
+    : mr_(other.get_upstream_resource())
   {
   }
 
@@ -75,7 +77,7 @@ class polymorphic_allocator {
    */
   value_type* allocate(std::size_t num, cuda_stream_view stream)
   {
-    return static_cast<value_type*>(get_upstream_resource().allocate(stream, num * sizeof(T)));
+    return static_cast<value_type*>(mr_.allocate(stream, num * sizeof(T)));
   }
 
   /**
@@ -90,7 +92,7 @@ class polymorphic_allocator {
    */
   void deallocate(value_type* ptr, std::size_t num, cuda_stream_view stream) noexcept
   {
-    get_upstream_resource().deallocate(stream, ptr, num * sizeof(T));
+    mr_.deallocate(stream, ptr, num * sizeof(T));
   }
 
   /**
@@ -98,11 +100,11 @@ class polymorphic_allocator {
    */
   [[nodiscard]] rmm::device_async_resource_ref get_upstream_resource() const noexcept
   {
-    return mr_;
+    return rmm::device_async_resource_ref{mr_};
   }
 
  private:
-  rmm::device_async_resource_ref mr_{
+  mutable cuda::mr::any_resource<cuda::mr::device_accessible> mr_{
     get_current_device_resource_ref()};  ///< Underlying resource used for (de)allocation
 };
 

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -11,6 +11,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/memory_resource>
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
@@ -120,7 +121,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    */
   [[nodiscard]] rmm::device_async_resource_ref get_upstream_resource() const noexcept
   {
-    return _mr;
+    return rmm::device_async_resource_ref{_mr};
   }
 
   /**
@@ -140,7 +141,8 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
 
  private:
   cuda_stream_view _stream{};
-  rmm::device_async_resource_ref _mr{rmm::mr::get_current_device_resource_ref()};
+  mutable cuda::mr::any_resource<cuda::mr::device_accessible> _mr{
+    rmm::mr::get_current_device_resource_ref()};
   cuda_device_id _device{get_current_cuda_device()};
 };
 /** @} */  // end of group

--- a/cpp/tests/device_check_resource_adaptor.hpp
+++ b/cpp/tests/device_check_resource_adaptor.hpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <utility>
 
 class device_check_resource_adaptor final {
  public:
@@ -31,7 +32,7 @@ class device_check_resource_adaptor final {
    */
   [[nodiscard]] rmm::device_async_resource_ref get_upstream_resource() const noexcept
   {
-    return upstream_;
+    return rmm::device_async_resource_ref{upstream_};
   }
 
   void* allocate(cuda::stream_ref stream,
@@ -88,7 +89,7 @@ class device_check_resource_adaptor final {
   [[nodiscard]] bool check_device_id() const { return device_id == rmm::get_current_cuda_device(); }
 
   rmm::cuda_device_id device_id;
-  rmm::device_async_resource_ref upstream_;
+  mutable cuda::mr::any_resource<cuda::mr::device_accessible> upstream_;
 };
 
 static_assert(cuda::mr::resource_with<device_check_resource_adaptor, cuda::mr::device_accessible>);


### PR DESCRIPTION
## Description

Replace `device_async_resource_ref` members with `cuda::mr::any_resource<device_accessible>` in `polymorphic_allocator`, `thrust_allocator`, and `device_check_resource_adaptor`. This eliminates the CCCL [#8037](https://github.com/NVIDIA/cccl/issues/8037) recursive constraint cycle for these classes.

Constructor signatures are unchanged; they still accept `device_async_resource_ref`, which implicitly converts to `any_resource`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.