### PR TITLE
Fix deprecations of CCCL allocations without specified alignment

### DIFF
--- a/cpp/include/rmm/aligned.hpp
+++ b/cpp/include/rmm/aligned.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -80,8 +80,8 @@ static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
  *
  * @return true if the pointer is aligned
  */
-[[nodiscard]] bool is_pointer_aligned(void* ptr,
-                                      std::size_t alignment = CUDA_ALLOCATION_ALIGNMENT) noexcept;
+[[nodiscard]] bool is_pointer_aligned(
+  void* ptr, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
 /** @} */  // end of group
 

--- a/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
@@ -55,7 +55,7 @@ class RMM_EXPORT limiting_resource_adaptor
    */
   limiting_resource_adaptor(device_async_resource_ref upstream,
                             std::size_t allocation_limit,
-                            std::size_t alignment = CUDA_ALLOCATION_ALIGNMENT);
+                            std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   ~limiting_resource_adaptor() = default;
 

--- a/cpp/include/rmm/mr/system_memory_resource.hpp
+++ b/cpp/include/rmm/mr/system_memory_resource.hpp
@@ -98,7 +98,9 @@ class system_memory_resource final {
   {
     try {
       return rmm::detail::aligned_host_allocate(
-        bytes, CUDA_ALLOCATION_ALIGNMENT, [](std::size_t size) { return ::operator new(size); });
+        bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, [](std::size_t size) {
+          return ::operator new(size);
+        });
     } catch (std::bad_alloc const& e) {
       auto const msg = std::string("Failed to allocate ") + rmm::detail::format_bytes(bytes) +
                        std::string("of memory: ") + e.what();
@@ -129,7 +131,7 @@ class system_memory_resource final {
     RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 
     rmm::detail::aligned_host_deallocate(
-      ptr, bytes, CUDA_ALLOCATION_ALIGNMENT, [](void* ptr) { ::operator delete(ptr); });
+      ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, [](void* ptr) { ::operator delete(ptr); });
   }
 
   /**

--- a/cpp/src/mr/detail/binning_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/binning_memory_resource_impl.cpp
@@ -42,7 +42,7 @@ device_async_resource_ref binning_memory_resource_impl::get_upstream_resource() 
 void binning_memory_resource_impl::add_bin(std::size_t allocation_size,
                                            std::optional<device_async_resource_ref> bin_resource)
 {
-  allocation_size = align_up(allocation_size, CUDA_ALLOCATION_ALIGNMENT);
+  allocation_size = align_up(allocation_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   if (bin_resource.has_value()) {
     resource_bins_.insert({allocation_size, bin_resource.value()});

--- a/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
@@ -29,7 +29,7 @@ fixed_size_memory_resource_impl::fixed_size_memory_resource_impl(device_async_re
                                                                  std::size_t block_size,
                                                                  std::size_t blocks_to_preallocate)
   : upstream_mr_{upstream},
-    block_size_{align_up(block_size, CUDA_ALLOCATION_ALIGNMENT)},
+    block_size_{align_up(block_size, rmm::CUDA_ALLOCATION_ALIGNMENT)},
     upstream_chunk_size_{block_size_ * blocks_to_preallocate}
 {
   this->insert_blocks(std::move(blocks_from_upstream(cuda_stream_legacy)), cuda_stream_legacy);
@@ -60,7 +60,7 @@ fixed_size_memory_resource_impl::block_type fixed_size_memory_resource_impl::exp
 fixed_size_memory_resource_impl::free_list fixed_size_memory_resource_impl::blocks_from_upstream(
   cuda_stream_view stream)
 {
-  void* ptr = upstream_mr_.allocate(stream, upstream_chunk_size_);
+  void* ptr = upstream_mr_.allocate(stream, upstream_chunk_size_, rmm::CUDA_ALLOCATION_ALIGNMENT);
   block_type block{ptr};
   upstream_blocks_.push_back(block);
 
@@ -84,7 +84,7 @@ fixed_size_memory_resource_impl::split_block fixed_size_memory_resource_impl::al
 fixed_size_memory_resource_impl::block_type fixed_size_memory_resource_impl::free_block(
   void* ptr, [[maybe_unused]] std::size_t size) noexcept
 {
-  RMM_LOGGING_ASSERT(align_up(size, CUDA_ALLOCATION_ALIGNMENT) <= block_size_);
+  RMM_LOGGING_ASSERT(align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT) <= block_size_);
   return block_type{ptr};
 }
 
@@ -93,7 +93,8 @@ void fixed_size_memory_resource_impl::release()
   lock_guard lock(this->get_mutex());
 
   for (auto block : upstream_blocks_) {
-    upstream_mr_.deallocate_sync(block.pointer(), upstream_chunk_size_);
+    upstream_mr_.deallocate_sync(
+      block.pointer(), upstream_chunk_size_, rmm::CUDA_ALLOCATION_ALIGNMENT);
   }
   upstream_blocks_.clear();
 }

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -37,13 +37,13 @@ std::size_t limiting_resource_adaptor_impl::get_allocation_limit() const
 
 void* limiting_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                                std::size_t bytes,
-                                               std::size_t /*alignment*/)
+                                               std::size_t alignment)
 {
   auto const proposed_size = rmm::align_up(bytes, alignment_);
   auto const old           = allocated_bytes_.fetch_add(proposed_size);
   if (old + proposed_size <= allocation_limit_) {
     try {
-      return upstream_mr_.allocate(stream, bytes);
+      return upstream_mr_.allocate(stream, bytes, alignment);
     } catch (...) {
       allocated_bytes_ -= proposed_size;
       throw;
@@ -59,10 +59,10 @@ void* limiting_resource_adaptor_impl::allocate(cuda::stream_ref stream,
 void limiting_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
                                                 void* ptr,
                                                 std::size_t bytes,
-                                                std::size_t /*alignment*/) noexcept
+                                                std::size_t alignment) noexcept
 {
   std::size_t const allocated_size = rmm::align_up(bytes, alignment_);
-  upstream_mr_.deallocate(stream, ptr, bytes);
+  upstream_mr_.deallocate(stream, ptr, bytes, alignment);
   allocated_bytes_ -= allocated_size;
 }
 

--- a/cpp/src/mr/detail/pool_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/pool_memory_resource_impl.cpp
@@ -127,7 +127,7 @@ pool_memory_resource_impl::block_type pool_memory_resource_impl::block_from_upst
 
   if (size == 0) { return {}; }
 
-  void* ptr = get_upstream_resource().allocate(stream, size);
+  void* ptr = get_upstream_resource().allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   return *upstream_blocks_.emplace(static_cast<char*>(ptr), size, true).first;
 }
 
@@ -170,7 +170,8 @@ void pool_memory_resource_impl::release()
   lock_guard lock(this->get_mutex());
 
   for (auto block : upstream_blocks_) {
-    get_upstream_resource().deallocate_sync(block.pointer(), block.size());
+    get_upstream_resource().deallocate_sync(
+      block.pointer(), block.size(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   }
   upstream_blocks_.clear();
 #ifdef RMM_POOL_TRACK_ALLOCATIONS

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -24,9 +24,9 @@ device_async_resource_ref prefetch_resource_adaptor_impl::get_upstream_resource(
 
 void* prefetch_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                                std::size_t bytes,
-                                               std::size_t /*alignment*/)
+                                               std::size_t alignment)
 {
-  void* ptr = upstream_mr_.allocate(stream, bytes);
+  void* ptr = upstream_mr_.allocate(stream, bytes, alignment);
   rmm::prefetch(ptr, bytes, rmm::get_current_cuda_device(), cuda_stream_view{stream.get()});
   return ptr;
 }
@@ -34,9 +34,9 @@ void* prefetch_resource_adaptor_impl::allocate(cuda::stream_ref stream,
 void prefetch_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
                                                 void* ptr,
                                                 std::size_t bytes,
-                                                std::size_t /*alignment*/) noexcept
+                                                std::size_t alignment) noexcept
 {
-  upstream_mr_.deallocate(stream, ptr, bytes);
+  upstream_mr_.deallocate(stream, ptr, bytes, alignment);
 }
 
 void* prefetch_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -23,19 +23,19 @@ device_async_resource_ref thread_safe_resource_adaptor_impl::get_upstream_resour
 
 void* thread_safe_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                                   std::size_t bytes,
-                                                  std::size_t /*alignment*/)
+                                                  std::size_t alignment)
 {
   std::lock_guard<std::mutex> lock(mtx_);
-  return upstream_mr_.allocate(stream, bytes);
+  return upstream_mr_.allocate(stream, bytes, alignment);
 }
 
 void thread_safe_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
                                                    void* ptr,
                                                    std::size_t bytes,
-                                                   std::size_t /*alignment*/) noexcept
+                                                   std::size_t alignment) noexcept
 {
   std::lock_guard<std::mutex> lock(mtx_);
-  upstream_mr_.deallocate(stream, ptr, bytes);
+  upstream_mr_.deallocate(stream, ptr, bytes, alignment);
 }
 
 void* thread_safe_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)


### PR DESCRIPTION
## Description
Fixes some missed places where alignment needed to be specified to avoid CCCL deprecations.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
