### PR TITLE
Use any_resource<device_accessible> for upstream constructor parameters

### DIFF
--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -103,17 +103,16 @@ class device_buffer {
     cuda_stream_view stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
-  /**
-   * @copydoc device_buffer(std::size_t, cuda_stream_view,
-   * cuda::mr::any_resource<cuda::mr::device_accessible>)
-   *
-   * @throws rmm::bad_alloc If the requested alignment cannot be satisfied by the provided
-   * memory resource.
-   * @throws rmm::invalid_argument If the requested alignment is not a power of two
-   *
-   * @param alignment Required alignment of the allocation. The actual alignment will be
-   * at least the requested alignment.
-   */
+  // clang-format off
+  /// @copydoc device_buffer(std::size_t, cuda_stream_view, cuda::mr::any_resource<cuda::mr::device_accessible>)
+  // clang-format on
+  ///
+  /// @throws rmm::bad_alloc If the requested alignment cannot be satisfied by the provided
+  /// memory resource.
+  /// @throws rmm::invalid_argument If the requested alignment is not a power of two
+  ///
+  /// @param alignment Required alignment of the allocation. The actual alignment will be
+  /// at least the requested alignment.
   explicit device_buffer(
     std::size_t size,
     std::size_t alignment,
@@ -149,17 +148,16 @@ class device_buffer {
     cuda_stream_view stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
-  /**
-   * @copydoc device_buffer(void const *, std::size_t, cuda_stream_view,
-   * cuda::mr::any_resource<cuda::mr::device_accessible>)
-   *
-   * @throws rmm::bad_alloc If the requested alignment cannot be satisfied by the provided
-   * memory resource.
-   * @throws rmm::invalid_argument If the requested alignment is not a power of two
-   *
-   * @param alignment Required alignment of the allocation. The actual alignment will be
-   * at least the requested alignment.
-   */
+  // clang-format off
+  /// @copydoc device_buffer(void const*, std::size_t, cuda_stream_view, cuda::mr::any_resource<cuda::mr::device_accessible>)
+  // clang-format on
+  ///
+  /// @throws rmm::bad_alloc If the requested alignment cannot be satisfied by the provided
+  /// memory resource.
+  /// @throws rmm::invalid_argument If the requested alignment is not a power of two
+  ///
+  /// @param alignment Required alignment of the allocation. The actual alignment will be
+  /// at least the requested alignment.
   explicit device_buffer(
     void const* source_data,
     std::size_t size,

--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -28,8 +28,8 @@ namespace RMM_NAMESPACE {
  * @brief RAII construct for device memory allocation
  *
  * This class allocates untyped and *uninitialized* device memory using a
- * `device_async_resource_ref`. If not explicitly specified, the memory resource
- * returned from `get_current_device_resource_ref()` is used.
+ * `cuda::mr::any_resource<cuda::mr::device_accessible>`. If not explicitly specified, the memory
+ * resource returned from `get_current_device_resource_ref()` is used.
  *
  * @note Unlike `std::vector` or `thrust::device_vector`, the device memory
  * allocated by a `device_buffer` is uninitialized. Therefore, it is undefined
@@ -98,12 +98,14 @@ class device_buffer {
    * resource supports streams.
    * @param mr Memory resource to use for the device memory allocation.
    */
-  explicit device_buffer(std::size_t size,
-                         cuda_stream_view stream,
-                         device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  explicit device_buffer(
+    std::size_t size,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
   /**
-   * @copydoc device_buffer(std::size_t, cuda_stream_view, device_async_resource_ref)
+   * @copydoc device_buffer(std::size_t, cuda_stream_view,
+   * cuda::mr::any_resource<cuda::mr::device_accessible>)
    *
    * @throws rmm::bad_alloc If the requested alignment cannot be satisfied by the provided
    * memory resource.
@@ -112,10 +114,11 @@ class device_buffer {
    * @param alignment Required alignment of the allocation. The actual alignment will be
    * at least the requested alignment.
    */
-  explicit device_buffer(std::size_t size,
-                         std::size_t alignment,
-                         cuda_stream_view stream,
-                         device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  explicit device_buffer(
+    std::size_t size,
+    std::size_t alignment,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
   /**
    * @brief Construct a new device buffer by copying from a raw pointer to an existing host or
@@ -140,13 +143,15 @@ class device_buffer {
    * resource supports streams.
    * @param mr Memory resource to use for the device memory allocation
    */
-  device_buffer(void const* source_data,
-                std::size_t size,
-                cuda_stream_view stream,
-                device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  device_buffer(
+    void const* source_data,
+    std::size_t size,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
   /**
-   * @copydoc device_buffer(void const *, std::size_t, cuda_stream_view, device_async_resource_ref)
+   * @copydoc device_buffer(void const *, std::size_t, cuda_stream_view,
+   * cuda::mr::any_resource<cuda::mr::device_accessible>)
    *
    * @throws rmm::bad_alloc If the requested alignment cannot be satisfied by the provided
    * memory resource.
@@ -155,11 +160,12 @@ class device_buffer {
    * @param alignment Required alignment of the allocation. The actual alignment will be
    * at least the requested alignment.
    */
-  explicit device_buffer(void const* source_data,
-                         std::size_t size,
-                         std::size_t alignment,
-                         cuda_stream_view stream,
-                         device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  explicit device_buffer(
+    void const* source_data,
+    std::size_t size,
+    std::size_t alignment,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
   /**
    * @brief Construct a new `device_buffer` by deep copying the contents of
    * another `device_buffer`, optionally using the specified stream and memory
@@ -171,7 +177,8 @@ class device_buffer {
    *
    * @note The new buffer has the same alignment guarantees as the copied-from buffer. If you need
    *to control the alignment of the new buffer explicitly, use `device_buffer(void const*,
-   * std::size_t, std::size_t, cuda_stream_view, device_async_resource_ref)`.
+   * std::size_t, std::size_t, cuda_stream_view,
+   *cuda::mr::any_resource<cuda::mr::device_accessible>)`.
    *
    * @note This function does not synchronize `stream`. `other` is copied on `stream`, so the
    * caller is responsible for correct synchronization to ensure that `other` is valid when
@@ -185,9 +192,10 @@ class device_buffer {
    * @param stream The stream to use for the allocation and copy
    * @param mr The resource to use for allocating the new `device_buffer`
    */
-  device_buffer(device_buffer const& other,
-                cuda_stream_view stream,
-                device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  device_buffer(
+    device_buffer const& other,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
   /**
    * @brief Constructs a new `device_buffer` by moving the contents of another

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -83,9 +83,10 @@ class device_scalar {
    * @param stream Stream on which to perform asynchronous allocation.
    * @param mr Optional, resource with which to allocate.
    */
-  explicit device_scalar(cuda_stream_view stream,
-                         device_async_resource_ref mr = mr::get_current_device_resource_ref())
-    : _storage{1, stream, mr}
+  explicit device_scalar(
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
+    : _storage{1, stream, std::move(mr)}
   {
   }
 
@@ -107,10 +108,11 @@ class device_scalar {
    * @param stream Optional, stream on which to perform allocation and copy.
    * @param mr Optional, resource with which to allocate.
    */
-  explicit device_scalar(value_type const& initial_value,
-                         cuda_stream_view stream,
-                         device_async_resource_ref mr = mr::get_current_device_resource_ref())
-    : _storage{1, stream, mr}
+  explicit device_scalar(
+    value_type const& initial_value,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
+    : _storage{1, stream, std::move(mr)}
   {
     set_value_async(initial_value, stream);
   }
@@ -127,10 +129,11 @@ class device_scalar {
    * @param stream The stream to use for the allocation and copy
    * @param mr The resource to use for allocating the new `device_scalar`
    */
-  device_scalar(device_scalar const& other,
-                cuda_stream_view stream,
-                device_async_resource_ref mr = mr::get_current_device_resource_ref())
-    : _storage{other._storage, stream, mr}
+  device_scalar(
+    device_scalar const& other,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
+    : _storage{other._storage, stream, std::move(mr)}
   {
   }
 

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -124,10 +124,11 @@ class device_uvector {
    * @param stream The stream on which to perform the allocation
    * @param mr The resource used to allocate the device storage
    */
-  explicit device_uvector(size_type size,
-                          cuda_stream_view stream,
-                          device_async_resource_ref mr = mr::get_current_device_resource_ref())
-    : _storage{elements_to_bytes(size), std::alignment_of_v<T>, stream, mr}
+  explicit device_uvector(
+    size_type size,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
+    : _storage{elements_to_bytes(size), std::alignment_of_v<T>, stream, std::move(mr)}
   {
   }
 
@@ -140,10 +141,11 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @param mr The resource used to allocate device memory for the new vector
    */
-  explicit device_uvector(device_uvector const& other,
-                          cuda_stream_view stream,
-                          device_async_resource_ref mr = mr::get_current_device_resource_ref())
-    : _storage{other._storage, stream, mr}
+  explicit device_uvector(
+    device_uvector const& other,
+    cuda_stream_view stream,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
+    : _storage{other._storage, stream, std::move(mr)}
   {
   }
 

--- a/cpp/include/rmm/exec_policy.hpp
+++ b/cpp/include/rmm/exec_policy.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -45,8 +45,9 @@ class exec_policy : public thrust_exec_policy_t {
    * @param stream The stream on which to allocate temporary memory
    * @param mr The resource to use for allocating temporary memory
    */
-  explicit exec_policy(cuda_stream_view stream      = cuda_stream_default,
-                       device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  explicit exec_policy(
+    cuda_stream_view stream                                = cuda_stream_default,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 };
 
 /**
@@ -70,8 +71,9 @@ class exec_policy_nosync : public thrust_exec_policy_nosync_t {
    * @param stream The stream on which to allocate temporary memory
    * @param mr The resource to use for allocating temporary memory
    */
-  explicit exec_policy_nosync(cuda_stream_view stream      = cuda_stream_default,
-                              device_async_resource_ref mr = mr::get_current_device_resource_ref());
+  explicit exec_policy_nosync(
+    cuda_stream_view stream                                = cuda_stream_default,
+    cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 };
 
 /** @} */  // end of group

--- a/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
@@ -59,7 +59,7 @@ class RMM_EXPORT aligned_resource_adaptor
    * if smaller).
    * @param alignment_threshold Only allocations >= this size are aligned to `alignment`.
    */
-  explicit aligned_resource_adaptor(device_async_resource_ref upstream,
+  explicit aligned_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
                                     std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT,
                                     std::size_t alignment_threshold = default_alignment_threshold);

--- a/cpp/include/rmm/mr/arena_memory_resource.hpp
+++ b/cpp/include/rmm/mr/arena_memory_resource.hpp
@@ -76,12 +76,12 @@ class RMM_EXPORT arena_memory_resource
   /**
    * @brief Construct an `arena_memory_resource`.
    *
-   * @param upstream_mr The memory resource from which to allocate blocks for the global arena.
+   * @param upstream The resource from which to allocate blocks for the global arena.
    * @param arena_size Size in bytes of the global arena. Defaults to half of the available
    * memory on the current device.
    * @param dump_log_on_failure If true, dump memory log when running out of memory.
    */
-  explicit arena_memory_resource(device_async_resource_ref upstream_mr,
+  explicit arena_memory_resource(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                  std::optional<std::size_t> arena_size = std::nullopt,
                                  bool dump_log_on_failure              = false);
 

--- a/cpp/include/rmm/mr/binning_memory_resource.hpp
+++ b/cpp/include/rmm/mr/binning_memory_resource.hpp
@@ -45,12 +45,12 @@ class RMM_EXPORT binning_memory_resource
   /**
    * @brief Construct a new binning memory resource object.
    *
-   * Initially has no bins, so simply uses the upstream_resource until bin resources are added
+   * Initially has no bins, so simply uses the upstream resource until bin resources are added
    * with `add_bin`.
    *
-   * @param upstream_resource The upstream memory resource used to allocate bin pools.
+   * @param upstream The resource used to allocate bin pools.
    */
-  explicit binning_memory_resource(device_async_resource_ref upstream_resource);
+  explicit binning_memory_resource(cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
   /**
    * @brief Construct a new binning memory resource object with a range of initial bins.
@@ -60,11 +60,11 @@ class RMM_EXPORT binning_memory_resource
    * and `max_size_exponent==22`, creates bins of sizes 256KiB, 512KiB, 1024KiB, 2048KiB and
    * 4096KiB.
    *
-   * @param upstream_resource The upstream memory resource used to allocate bin pools.
+   * @param upstream The resource used to allocate bin pools.
    * @param min_size_exponent The minimum base-2 exponent bin size.
    * @param max_size_exponent The maximum base-2 exponent bin size.
    */
-  binning_memory_resource(device_async_resource_ref upstream_resource,
+  binning_memory_resource(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                           int8_t min_size_exponent,  // NOLINT(bugprone-easily-swappable-parameters)
                           int8_t max_size_exponent);
 

--- a/cpp/include/rmm/mr/detail/aligned_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/aligned_resource_adaptor_impl.hpp
@@ -29,7 +29,7 @@ class aligned_resource_adaptor_impl {
  public:
   static constexpr std::size_t default_alignment_threshold = 0;
 
-  aligned_resource_adaptor_impl(device_async_resource_ref upstream,
+  aligned_resource_adaptor_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                 std::size_t alignment,
                                 std::size_t alignment_threshold);
 

--- a/cpp/include/rmm/mr/detail/arena.hpp
+++ b/cpp/include/rmm/mr/detail/arena.hpp
@@ -490,8 +490,9 @@ class global_arena final {
    * @param arena_size Size in bytes of the global arena. Defaults to half of the available memory
    * on the current device.
    */
-  global_arena(device_async_resource_ref upstream_mr, std::optional<std::size_t> arena_size)
-    : upstream_mr_{upstream_mr}
+  global_arena(cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr,
+               std::optional<std::size_t> arena_size)
+    : upstream_mr_{std::move(upstream_mr)}
   {
     auto const size =
       rmm::align_down(arena_size.value_or(default_size()), rmm::CUDA_ALLOCATION_ALIGNMENT);

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -32,7 +32,7 @@ namespace detail {
  */
 class arena_memory_resource_impl {
  public:
-  arena_memory_resource_impl(device_async_resource_ref upstream_mr,
+  arena_memory_resource_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr,
                              std::optional<std::size_t> arena_size,
                              bool dump_log_on_failure);
 

--- a/cpp/include/rmm/mr/detail/binning_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/binning_memory_resource_impl.hpp
@@ -31,9 +31,10 @@ namespace detail {
  */
 class binning_memory_resource_impl {
  public:
-  explicit binning_memory_resource_impl(device_async_resource_ref upstream);
+  explicit binning_memory_resource_impl(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
-  binning_memory_resource_impl(device_async_resource_ref upstream,
+  binning_memory_resource_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                int8_t min_size_exponent,
                                int8_t max_size_exponent);
 

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -27,10 +27,11 @@ namespace detail {
 template <typename ExceptionType>
 class failure_callback_resource_adaptor_impl {
  public:
-  failure_callback_resource_adaptor_impl(device_async_resource_ref upstream,
-                                         failure_callback_t callback,
-                                         void* callback_arg)
-    : upstream_mr_{upstream}, callback_{std::move(callback)}, callback_arg_{callback_arg}
+  failure_callback_resource_adaptor_impl(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+    failure_callback_t callback,
+    void* callback_arg)
+    : upstream_mr_{std::move(upstream)}, callback_{std::move(callback)}, callback_arg_{callback_arg}
   {
   }
 

--- a/cpp/include/rmm/mr/detail/fixed_size_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/fixed_size_memory_resource_impl.hpp
@@ -36,7 +36,7 @@ class fixed_size_memory_resource_impl final
   static constexpr std::size_t default_block_size            = 1 << 20;
   static constexpr std::size_t default_blocks_to_preallocate = 128;
 
-  fixed_size_memory_resource_impl(device_async_resource_ref upstream,
+  fixed_size_memory_resource_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                   std::size_t block_size,
                                   std::size_t blocks_to_preallocate);
 

--- a/cpp/include/rmm/mr/detail/limiting_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/limiting_resource_adaptor_impl.hpp
@@ -26,7 +26,7 @@ namespace detail {
  */
 class limiting_resource_adaptor_impl {
  public:
-  limiting_resource_adaptor_impl(device_async_resource_ref upstream,
+  limiting_resource_adaptor_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                  std::size_t allocation_limit,
                                  std::size_t alignment);
 

--- a/cpp/include/rmm/mr/detail/logging_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/logging_resource_adaptor_impl.hpp
@@ -27,7 +27,7 @@ namespace detail {
 class logging_resource_adaptor_impl {
  public:
   logging_resource_adaptor_impl(std::shared_ptr<rapids_logger::logger> logger,
-                                device_async_resource_ref upstream,
+                                cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                 bool auto_flush);
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t));

--- a/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
@@ -34,7 +34,7 @@ class pool_memory_resource_impl final
  public:
   friend class stream_ordered_memory_resource<pool_memory_resource_impl, coalescing_free_list>;
 
-  pool_memory_resource_impl(device_async_resource_ref upstream,
+  pool_memory_resource_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                             std::size_t initial_pool_size,
                             std::optional<std::size_t> maximum_pool_size);
 

--- a/cpp/include/rmm/mr/detail/prefetch_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/prefetch_resource_adaptor_impl.hpp
@@ -24,7 +24,8 @@ namespace detail {
  */
 class prefetch_resource_adaptor_impl {
  public:
-  explicit prefetch_resource_adaptor_impl(device_async_resource_ref upstream);
+  explicit prefetch_resource_adaptor_impl(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
   ~prefetch_resource_adaptor_impl() = default;
 

--- a/cpp/include/rmm/mr/detail/statistics_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/statistics_resource_adaptor_impl.hpp
@@ -58,7 +58,8 @@ class statistics_resource_adaptor_impl {
     }
   };
 
-  explicit statistics_resource_adaptor_impl(device_async_resource_ref upstream);
+  explicit statistics_resource_adaptor_impl(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
   ~statistics_resource_adaptor_impl() = default;
 

--- a/cpp/include/rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp
@@ -27,7 +27,8 @@ namespace detail {
  */
 class thread_safe_resource_adaptor_impl {
  public:
-  explicit thread_safe_resource_adaptor_impl(device_async_resource_ref upstream);
+  explicit thread_safe_resource_adaptor_impl(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
   ~thread_safe_resource_adaptor_impl() = default;
 

--- a/cpp/include/rmm/mr/detail/tracking_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/tracking_resource_adaptor_impl.hpp
@@ -45,7 +45,8 @@ class tracking_resource_adaptor_impl {
     }
   };
 
-  tracking_resource_adaptor_impl(device_async_resource_ref upstream, bool capture_stacks);
+  tracking_resource_adaptor_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+                                 bool capture_stacks);
 
   ~tracking_resource_adaptor_impl() = default;
 

--- a/cpp/include/rmm/mr/failure_callback_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/failure_callback_resource_adaptor.hpp
@@ -65,12 +65,12 @@ class failure_callback_resource_adaptor
    * @param callback Callback function @see failure_callback_t
    * @param callback_arg Extra argument passed to `callback`
    */
-  failure_callback_resource_adaptor(device_async_resource_ref upstream,
+  failure_callback_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                     failure_callback_t callback,
                                     void* callback_arg)
     : shared_base(cuda::mr::make_shared_resource<
                   detail::failure_callback_resource_adaptor_impl<ExceptionType>>(
-        upstream, std::move(callback), callback_arg))
+        std::move(upstream), std::move(callback), callback_arg))
   {
   }
 

--- a/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
+++ b/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
@@ -51,17 +51,17 @@ class RMM_EXPORT fixed_size_memory_resource
 
   /**
    * @brief Construct a new `fixed_size_memory_resource` that allocates memory from
-   * `upstream_mr`.
+   * `upstream`.
    *
    * When the pool of blocks is all allocated, grows the pool by allocating
-   * `blocks_to_preallocate` more blocks from `upstream_mr`.
+   * `blocks_to_preallocate` more blocks from `upstream`.
    *
-   * @param upstream_mr The device_async_resource_ref from which to allocate blocks for the pool.
+   * @param upstream The resource from which to allocate blocks for the pool.
    * @param block_size The size of blocks to allocate.
    * @param blocks_to_preallocate The number of blocks to allocate to initialize the pool.
    */
   explicit fixed_size_memory_resource(
-    device_async_resource_ref upstream_mr,
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
     // NOLINTNEXTLINE bugprone-easily-swappable-parameters
     std::size_t block_size            = default_block_size,
     std::size_t blocks_to_preallocate = default_blocks_to_preallocate);

--- a/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
@@ -53,7 +53,7 @@ class RMM_EXPORT limiting_resource_adaptor
    * @param allocation_limit Maximum memory allowed for this allocator
    * @param alignment Alignment in bytes for the start of each allocated buffer
    */
-  limiting_resource_adaptor(device_async_resource_ref upstream,
+  limiting_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                             std::size_t allocation_limit,
                             std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 

--- a/cpp/include/rmm/mr/logging_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/logging_resource_adaptor.hpp
@@ -69,7 +69,7 @@ class RMM_EXPORT logging_resource_adaptor
    * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade
    * performance.
    */
-  logging_resource_adaptor(device_async_resource_ref upstream,
+  logging_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                            std::string const& filename = get_default_filename(),
                            bool auto_flush             = false);
 
@@ -85,7 +85,7 @@ class RMM_EXPORT logging_resource_adaptor
    * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade
    * performance.
    */
-  logging_resource_adaptor(device_async_resource_ref upstream,
+  logging_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                            std::ostream& stream,
                            bool auto_flush = false);
 
@@ -101,7 +101,7 @@ class RMM_EXPORT logging_resource_adaptor
    * @param auto_flush If true, flushes the log for every (de)allocation. Warning, this will degrade
    * performance.
    */
-  logging_resource_adaptor(device_async_resource_ref upstream,
+  logging_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                            std::initializer_list<rapids_logger::sink_ptr> sinks,
                            bool auto_flush = false);
 

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -55,7 +55,9 @@ class polymorphic_allocator {
    *
    * @param mr The upstream memory resource to use for allocation.
    */
-  polymorphic_allocator(device_async_resource_ref mr) : mr_(mr) {}
+  polymorphic_allocator(cuda::mr::any_resource<cuda::mr::device_accessible> mr) : mr_(std::move(mr))
+  {
+  }
 
   /**
    * @brief Construct a `polymorphic_allocator` using the underlying memory resource of `other`.

--- a/cpp/include/rmm/mr/pool_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pool_memory_resource.hpp
@@ -48,18 +48,18 @@ class RMM_EXPORT pool_memory_resource
 
   /**
    * @brief Construct a `pool_memory_resource` and allocate the initial device memory pool using
-   * `upstream_mr`.
+   * `upstream`.
    *
    * @throws rmm::logic_error if `initial_pool_size` is not aligned to a multiple of 256 bytes.
    * @throws rmm::logic_error if `maximum_pool_size` is neither the default nor aligned to a
    * multiple of 256 bytes.
    *
-   * @param upstream_mr The memory_resource from which to allocate blocks for the pool.
+   * @param upstream The resource from which to allocate blocks for the pool.
    * @param initial_pool_size Minimum size, in bytes, of the initial pool.
    * @param maximum_pool_size Maximum size, in bytes, that the pool can grow to. Defaults to all
    * of the available memory from the upstream resource.
    */
-  explicit pool_memory_resource(device_async_resource_ref upstream_mr,
+  explicit pool_memory_resource(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                                 std::size_t initial_pool_size,
                                 std::optional<std::size_t> maximum_pool_size = std::nullopt);
 

--- a/cpp/include/rmm/mr/prefetch_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/prefetch_resource_adaptor.hpp
@@ -44,7 +44,7 @@ class RMM_EXPORT prefetch_resource_adaptor
    *
    * @param upstream The resource_ref used for allocating/deallocating device memory
    */
-  explicit prefetch_resource_adaptor(device_async_resource_ref upstream);
+  explicit prefetch_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
   ~prefetch_resource_adaptor() = default;
 

--- a/cpp/include/rmm/mr/statistics_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/statistics_resource_adaptor.hpp
@@ -54,7 +54,8 @@ class RMM_EXPORT statistics_resource_adaptor
    *
    * @param upstream The resource used for allocating/deallocating device memory.
    */
-  explicit statistics_resource_adaptor(device_async_resource_ref upstream);
+  explicit statistics_resource_adaptor(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
   ~statistics_resource_adaptor() = default;
 

--- a/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
@@ -51,7 +51,8 @@ class RMM_EXPORT thread_safe_resource_adaptor
    *
    * @param upstream The resource used for allocating/deallocating device memory.
    */
-  explicit thread_safe_resource_adaptor(device_async_resource_ref upstream);
+  explicit thread_safe_resource_adaptor(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
   ~thread_safe_resource_adaptor() = default;
 

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -80,8 +80,8 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @param stream The stream to be used for device memory (de)allocation
    */
   RMM_EXEC_CHECK_DISABLE
-  thrust_allocator(cuda_stream_view stream, rmm::device_async_resource_ref mr)
-    : _stream{stream}, _mr(mr)
+  thrust_allocator(cuda_stream_view stream, cuda::mr::any_resource<cuda::mr::device_accessible> mr)
+    : _stream{stream}, _mr(std::move(mr))
   {
   }
 

--- a/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
@@ -57,7 +57,8 @@ class RMM_EXPORT tracking_resource_adaptor
    * @param upstream The resource used for allocating/deallocating device memory.
    * @param capture_stacks If true, capture stacks for each allocation.
    */
-  tracking_resource_adaptor(device_async_resource_ref upstream, bool capture_stacks = false);
+  tracking_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+                            bool capture_stacks = false);
 
   ~tracking_resource_adaptor() = default;
 

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -18,16 +18,16 @@ device_buffer::device_buffer() : _mr{rmm::mr::get_current_device_resource_ref()}
 
 device_buffer::device_buffer(std::size_t size,
                              cuda_stream_view stream,
-                             device_async_resource_ref mr)
-  : device_buffer::device_buffer(size, rmm::CUDA_ALLOCATION_ALIGNMENT, stream, mr)
+                             cuda::mr::any_resource<cuda::mr::device_accessible> mr)
+  : device_buffer::device_buffer(size, rmm::CUDA_ALLOCATION_ALIGNMENT, stream, std::move(mr))
 {
 }
 
 device_buffer::device_buffer(std::size_t size,
                              std::size_t alignment,
                              cuda_stream_view stream,
-                             device_async_resource_ref mr)
-  : _alignment{alignment}, _stream{stream}, _mr{mr}
+                             cuda::mr::any_resource<cuda::mr::device_accessible> mr)
+  : _alignment{alignment}, _stream{stream}, _mr{std::move(mr)}
 {
   RMM_EXPECTS(rmm::is_supported_alignment(alignment),
               "Requested alignment is not a power of 2",
@@ -39,8 +39,9 @@ device_buffer::device_buffer(std::size_t size,
 device_buffer::device_buffer(void const* source_data,
                              std::size_t size,
                              cuda_stream_view stream,
-                             device_async_resource_ref mr)
-  : device_buffer::device_buffer(source_data, size, rmm::CUDA_ALLOCATION_ALIGNMENT, stream, mr)
+                             cuda::mr::any_resource<cuda::mr::device_accessible> mr)
+  : device_buffer::device_buffer(
+      source_data, size, rmm::CUDA_ALLOCATION_ALIGNMENT, stream, std::move(mr))
 {
 }
 
@@ -48,8 +49,8 @@ device_buffer::device_buffer(void const* source_data,
                              std::size_t size,
                              std::size_t alignment,
                              cuda_stream_view stream,
-                             device_async_resource_ref mr)
-  : _alignment{alignment}, _stream{stream}, _mr{mr}
+                             cuda::mr::any_resource<cuda::mr::device_accessible> mr)
+  : _alignment{alignment}, _stream{stream}, _mr{std::move(mr)}
 {
   RMM_EXPECTS(rmm::is_supported_alignment(alignment),
               "Requested alignment is not a power of 2",
@@ -61,8 +62,8 @@ device_buffer::device_buffer(void const* source_data,
 
 device_buffer::device_buffer(device_buffer const& other,
                              cuda_stream_view stream,
-                             device_async_resource_ref mr)
-  : device_buffer{other.data(), other.size(), other.alignment(), stream, mr}
+                             cuda::mr::any_resource<cuda::mr::device_accessible> mr)
+  : device_buffer{other.data(), other.size(), other.alignment(), stream, std::move(mr)}
 {
 }
 

--- a/cpp/src/exec_policy.cpp
+++ b/cpp/src/exec_policy.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,15 +7,18 @@
 
 namespace rmm {
 
-exec_policy::exec_policy(cuda_stream_view stream, device_async_resource_ref mr)
+exec_policy::exec_policy(cuda_stream_view stream,
+                         cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : thrust_exec_policy_t(
-      thrust::cuda::par(mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
+      thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr))).on(stream.value()))
 {
 }
 
-exec_policy_nosync::exec_policy_nosync(cuda_stream_view stream, device_async_resource_ref mr)
+exec_policy_nosync::exec_policy_nosync(cuda_stream_view stream,
+                                       cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : thrust_exec_policy_nosync_t(
-      thrust::cuda::par_nosync(mr::thrust_allocator<char>(stream, mr)).on(stream.value()))
+      thrust::cuda::par_nosync(mr::thrust_allocator<char>(stream, std::move(mr)))
+        .on(stream.value()))
 {
 }
 

--- a/cpp/src/mr/aligned_resource_adaptor.cpp
+++ b/cpp/src/mr/aligned_resource_adaptor.cpp
@@ -10,11 +10,12 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-aligned_resource_adaptor::aligned_resource_adaptor(device_async_resource_ref upstream,
-                                                   std::size_t alignment,
-                                                   std::size_t alignment_threshold)
+aligned_resource_adaptor::aligned_resource_adaptor(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::size_t alignment,
+  std::size_t alignment_threshold)
   : shared_base(cuda::mr::make_shared_resource<detail::aligned_resource_adaptor_impl>(
-      upstream, alignment, alignment_threshold))
+      std::move(upstream), alignment, alignment_threshold))
 {
 }
 

--- a/cpp/src/mr/arena_memory_resource.cpp
+++ b/cpp/src/mr/arena_memory_resource.cpp
@@ -8,11 +8,12 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-arena_memory_resource::arena_memory_resource(device_async_resource_ref upstream_mr,
-                                             std::optional<std::size_t> arena_size,
-                                             bool dump_log_on_failure)
+arena_memory_resource::arena_memory_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::optional<std::size_t> arena_size,
+  bool dump_log_on_failure)
   : shared_base(cuda::mr::make_shared_resource<detail::arena_memory_resource_impl>(
-      upstream_mr, arena_size, dump_log_on_failure))
+      std::move(upstream), arena_size, dump_log_on_failure))
 {
 }
 

--- a/cpp/src/mr/binning_memory_resource.cpp
+++ b/cpp/src/mr/binning_memory_resource.cpp
@@ -11,16 +11,19 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-binning_memory_resource::binning_memory_resource(device_async_resource_ref upstream)
-  : shared_base(cuda::mr::make_shared_resource<detail::binning_memory_resource_impl>(upstream))
+binning_memory_resource::binning_memory_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream)
+  : shared_base(
+      cuda::mr::make_shared_resource<detail::binning_memory_resource_impl>(std::move(upstream)))
 {
 }
 
-binning_memory_resource::binning_memory_resource(device_async_resource_ref upstream,
-                                                 int8_t min_size_exponent,
-                                                 int8_t max_size_exponent)
+binning_memory_resource::binning_memory_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  int8_t min_size_exponent,
+  int8_t max_size_exponent)
   : shared_base(cuda::mr::make_shared_resource<detail::binning_memory_resource_impl>(
-      upstream, min_size_exponent, max_size_exponent))
+      std::move(upstream), min_size_exponent, max_size_exponent))
 {
 }
 

--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -15,10 +15,11 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-aligned_resource_adaptor_impl::aligned_resource_adaptor_impl(device_async_resource_ref upstream,
-                                                             std::size_t alignment,
-                                                             std::size_t alignment_threshold)
-  : upstream_mr_{upstream},
+aligned_resource_adaptor_impl::aligned_resource_adaptor_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::size_t alignment,
+  std::size_t alignment_threshold)
+  : upstream_mr_{std::move(upstream)},
     alignment_{std::max(alignment, rmm::CUDA_ALLOCATION_ALIGNMENT)},
     alignment_threshold_{alignment_threshold}
 {

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -15,10 +15,11 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-arena_memory_resource_impl::arena_memory_resource_impl(device_async_resource_ref upstream_mr,
-                                                       std::optional<std::size_t> arena_size,
-                                                       bool dump_log_on_failure)
-  : global_arena_{upstream_mr, arena_size}, dump_log_on_failure_{dump_log_on_failure}
+arena_memory_resource_impl::arena_memory_resource_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr,
+  std::optional<std::size_t> arena_size,
+  bool dump_log_on_failure)
+  : global_arena_{std::move(upstream_mr), arena_size}, dump_log_on_failure_{dump_log_on_failure}
 {
   if (dump_log_on_failure_) {
     logger_ =

--- a/cpp/src/mr/detail/binning_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/binning_memory_resource_impl.cpp
@@ -18,15 +18,17 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-binning_memory_resource_impl::binning_memory_resource_impl(device_async_resource_ref upstream)
-  : upstream_mr_{upstream}
+binning_memory_resource_impl::binning_memory_resource_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream)
+  : upstream_mr_{std::move(upstream)}
 {
 }
 
-binning_memory_resource_impl::binning_memory_resource_impl(device_async_resource_ref upstream,
-                                                           int8_t min_size_exponent,
-                                                           int8_t max_size_exponent)
-  : upstream_mr_{upstream}
+binning_memory_resource_impl::binning_memory_resource_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  int8_t min_size_exponent,
+  int8_t max_size_exponent)
+  : upstream_mr_{std::move(upstream)}
 {
   for (auto i = min_size_exponent; i <= max_size_exponent; i++) {
     add_bin(1 << i);

--- a/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
@@ -25,10 +25,11 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-fixed_size_memory_resource_impl::fixed_size_memory_resource_impl(device_async_resource_ref upstream,
-                                                                 std::size_t block_size,
-                                                                 std::size_t blocks_to_preallocate)
-  : upstream_mr_{upstream},
+fixed_size_memory_resource_impl::fixed_size_memory_resource_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::size_t block_size,
+  std::size_t blocks_to_preallocate)
+  : upstream_mr_{std::move(upstream)},
     block_size_{align_up(block_size, rmm::CUDA_ALLOCATION_ALIGNMENT)},
     upstream_chunk_size_{block_size_ * blocks_to_preallocate}
 {

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -12,10 +12,11 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-limiting_resource_adaptor_impl::limiting_resource_adaptor_impl(device_async_resource_ref upstream,
-                                                               std::size_t allocation_limit,
-                                                               std::size_t alignment)
-  : upstream_mr_{upstream},
+limiting_resource_adaptor_impl::limiting_resource_adaptor_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::size_t allocation_limit,
+  std::size_t alignment)
+  : upstream_mr_{std::move(upstream)},
     allocation_limit_{allocation_limit},
     allocated_bytes_(0),
     alignment_(alignment)

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -14,9 +14,9 @@ namespace detail {
 
 logging_resource_adaptor_impl::logging_resource_adaptor_impl(
   std::shared_ptr<rapids_logger::logger> logger,
-  device_async_resource_ref upstream,
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
   bool auto_flush)
-  : logger_{std::move(logger)}, upstream_{upstream}
+  : logger_{std::move(logger)}, upstream_{std::move(upstream)}
 {
   if (auto_flush) { logger_->flush_on(rapids_logger::level_enum::info); }
   logger_->set_pattern("%v");

--- a/cpp/src/mr/detail/pool_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/pool_memory_resource_impl.cpp
@@ -28,10 +28,11 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-pool_memory_resource_impl::pool_memory_resource_impl(device_async_resource_ref upstream,
-                                                     std::size_t initial_pool_size,
-                                                     std::optional<std::size_t> maximum_pool_size)
-  : upstream_mr_{upstream}
+pool_memory_resource_impl::pool_memory_resource_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::size_t initial_pool_size,
+  std::optional<std::size_t> maximum_pool_size)
+  : upstream_mr_{std::move(upstream)}
 {
   RMM_EXPECTS(rmm::is_aligned(initial_pool_size, rmm::CUDA_ALLOCATION_ALIGNMENT),
               "Error, Initial pool size required to be a multiple of 256 bytes");

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -11,8 +11,9 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-prefetch_resource_adaptor_impl::prefetch_resource_adaptor_impl(device_async_resource_ref upstream)
-  : upstream_mr_{upstream}
+prefetch_resource_adaptor_impl::prefetch_resource_adaptor_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream)
+  : upstream_mr_{std::move(upstream)}
 {
 }
 

--- a/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
@@ -13,8 +13,8 @@ namespace mr {
 namespace detail {
 
 statistics_resource_adaptor_impl::statistics_resource_adaptor_impl(
-  device_async_resource_ref upstream)
-  : upstream_mr_{upstream}
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream)
+  : upstream_mr_{std::move(upstream)}
 {
 }
 

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -10,8 +10,8 @@ namespace mr {
 namespace detail {
 
 thread_safe_resource_adaptor_impl::thread_safe_resource_adaptor_impl(
-  device_async_resource_ref upstream)
-  : upstream_mr_{upstream}
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream)
+  : upstream_mr_{std::move(upstream)}
 {
 }
 

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -14,9 +14,9 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-tracking_resource_adaptor_impl::tracking_resource_adaptor_impl(device_async_resource_ref upstream,
-                                                               bool capture_stacks)
-  : capture_stacks_{capture_stacks}, upstream_mr_{upstream}
+tracking_resource_adaptor_impl::tracking_resource_adaptor_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream, bool capture_stacks)
+  : capture_stacks_{capture_stacks}, upstream_mr_{std::move(upstream)}
 {
 }
 

--- a/cpp/src/mr/fixed_size_memory_resource.cpp
+++ b/cpp/src/mr/fixed_size_memory_resource.cpp
@@ -10,11 +10,12 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-fixed_size_memory_resource::fixed_size_memory_resource(device_async_resource_ref upstream,
-                                                       std::size_t block_size,
-                                                       std::size_t blocks_to_preallocate)
+fixed_size_memory_resource::fixed_size_memory_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::size_t block_size,
+  std::size_t blocks_to_preallocate)
   : shared_base(cuda::mr::make_shared_resource<detail::fixed_size_memory_resource_impl>(
-      upstream, block_size, blocks_to_preallocate))
+      std::move(upstream), block_size, blocks_to_preallocate))
 {
 }
 

--- a/cpp/src/mr/limiting_resource_adaptor.cpp
+++ b/cpp/src/mr/limiting_resource_adaptor.cpp
@@ -8,11 +8,12 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-limiting_resource_adaptor::limiting_resource_adaptor(device_async_resource_ref upstream,
-                                                     std::size_t allocation_limit,
-                                                     std::size_t alignment)
+limiting_resource_adaptor::limiting_resource_adaptor(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::size_t allocation_limit,
+  std::size_t alignment)
   : shared_base(cuda::mr::make_shared_resource<detail::limiting_resource_adaptor_impl>(
-      upstream, allocation_limit, alignment))
+      std::move(upstream), allocation_limit, alignment))
 {
 }
 

--- a/cpp/src/mr/logging_resource_adaptor.cpp
+++ b/cpp/src/mr/logging_resource_adaptor.cpp
@@ -33,28 +33,30 @@ auto make_logger(std::initializer_list<rapids_logger::sink_ptr> sinks)
 
 }  // namespace
 
-logging_resource_adaptor::logging_resource_adaptor(device_async_resource_ref upstream,
-                                                   std::string const& filename,
-                                                   bool auto_flush)
+logging_resource_adaptor::logging_resource_adaptor(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::string const& filename,
+  bool auto_flush)
   : shared_base(cuda::mr::make_shared_resource<detail::logging_resource_adaptor_impl>(
-      make_logger(filename), upstream, auto_flush))
-{
-}
-
-logging_resource_adaptor::logging_resource_adaptor(device_async_resource_ref upstream,
-                                                   std::ostream& stream,
-                                                   bool auto_flush)
-  : shared_base(cuda::mr::make_shared_resource<detail::logging_resource_adaptor_impl>(
-      make_logger(stream), upstream, auto_flush))
+      make_logger(filename), std::move(upstream), auto_flush))
 {
 }
 
 logging_resource_adaptor::logging_resource_adaptor(
-  device_async_resource_ref upstream,
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::ostream& stream,
+  bool auto_flush)
+  : shared_base(cuda::mr::make_shared_resource<detail::logging_resource_adaptor_impl>(
+      make_logger(stream), std::move(upstream), auto_flush))
+{
+}
+
+logging_resource_adaptor::logging_resource_adaptor(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
   std::initializer_list<rapids_logger::sink_ptr> sinks,
   bool auto_flush)
   : shared_base(cuda::mr::make_shared_resource<detail::logging_resource_adaptor_impl>(
-      make_logger(sinks), upstream, auto_flush))
+      make_logger(sinks), std::move(upstream), auto_flush))
 {
 }
 

--- a/cpp/src/mr/pool_memory_resource.cpp
+++ b/cpp/src/mr/pool_memory_resource.cpp
@@ -12,11 +12,12 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-pool_memory_resource::pool_memory_resource(device_async_resource_ref upstream,
-                                           std::size_t initial_pool_size,
-                                           std::optional<std::size_t> maximum_pool_size)
+pool_memory_resource::pool_memory_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::size_t initial_pool_size,
+  std::optional<std::size_t> maximum_pool_size)
   : shared_base(cuda::mr::make_shared_resource<detail::pool_memory_resource_impl>(
-      upstream, initial_pool_size, maximum_pool_size))
+      std::move(upstream), initial_pool_size, maximum_pool_size))
 {
 }
 

--- a/cpp/src/mr/prefetch_resource_adaptor.cpp
+++ b/cpp/src/mr/prefetch_resource_adaptor.cpp
@@ -8,8 +8,10 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-prefetch_resource_adaptor::prefetch_resource_adaptor(device_async_resource_ref upstream)
-  : shared_base(cuda::mr::make_shared_resource<detail::prefetch_resource_adaptor_impl>(upstream))
+prefetch_resource_adaptor::prefetch_resource_adaptor(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream)
+  : shared_base(
+      cuda::mr::make_shared_resource<detail::prefetch_resource_adaptor_impl>(std::move(upstream)))
 {
 }
 

--- a/cpp/src/mr/statistics_resource_adaptor.cpp
+++ b/cpp/src/mr/statistics_resource_adaptor.cpp
@@ -11,8 +11,10 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-statistics_resource_adaptor::statistics_resource_adaptor(device_async_resource_ref upstream)
-  : shared_base(cuda::mr::make_shared_resource<detail::statistics_resource_adaptor_impl>(upstream))
+statistics_resource_adaptor::statistics_resource_adaptor(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream)
+  : shared_base(
+      cuda::mr::make_shared_resource<detail::statistics_resource_adaptor_impl>(std::move(upstream)))
 {
 }
 

--- a/cpp/src/mr/thread_safe_resource_adaptor.cpp
+++ b/cpp/src/mr/thread_safe_resource_adaptor.cpp
@@ -8,8 +8,10 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-thread_safe_resource_adaptor::thread_safe_resource_adaptor(device_async_resource_ref upstream)
-  : shared_base(cuda::mr::make_shared_resource<detail::thread_safe_resource_adaptor_impl>(upstream))
+thread_safe_resource_adaptor::thread_safe_resource_adaptor(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream)
+  : shared_base(cuda::mr::make_shared_resource<detail::thread_safe_resource_adaptor_impl>(
+      std::move(upstream)))
 {
 }
 

--- a/cpp/src/mr/tracking_resource_adaptor.cpp
+++ b/cpp/src/mr/tracking_resource_adaptor.cpp
@@ -12,10 +12,10 @@
 namespace RMM_NAMESPACE {
 namespace mr {
 
-tracking_resource_adaptor::tracking_resource_adaptor(device_async_resource_ref upstream,
-                                                     bool capture_stacks)
+tracking_resource_adaptor::tracking_resource_adaptor(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream, bool capture_stacks)
   : shared_base(cuda::mr::make_shared_resource<detail::tracking_resource_adaptor_impl>(
-      upstream, capture_stacks))
+      std::move(upstream), capture_stacks))
 {
 }
 

--- a/cpp/tests/mr/polymorphic_allocator_tests.cpp
+++ b/cpp/tests/mr/polymorphic_allocator_tests.cpp
@@ -38,7 +38,7 @@ void test_conversion(rmm::mr::polymorphic_allocator<int> /*unused*/) {}
 TEST_F(allocator_test, implicit_conversion)
 {
   rmm::mr::cuda_memory_resource mr;
-  test_conversion(rmm::device_async_resource_ref{mr});
+  test_conversion(cuda::mr::any_resource<cuda::mr::device_accessible>{mr});
 }
 
 TEST_F(allocator_test, self_equality)

--- a/python/rmm/rmm/librmm/device_buffer.pxd
+++ b/python/rmm/rmm/librmm/device_buffer.pxd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
-from rmm.librmm.memory_resource cimport device_async_resource_ref
+from rmm.librmm.memory_resource cimport any_resource, device_accessible
 
 
 cdef extern from "rmm/mr/per_device_resource.hpp" namespace "rmm" nogil:
@@ -26,18 +26,18 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         device_buffer(
             size_t size,
             cuda_stream_view stream,
-            device_async_resource_ref mr
+            any_resource[device_accessible] mr
         ) except +
         device_buffer(
             const void* source_data,
             size_t size,
             cuda_stream_view stream,
-            device_async_resource_ref mr
+            any_resource[device_accessible] mr
         ) except +
         device_buffer(
             const device_buffer buf,
             cuda_stream_view stream,
-            device_async_resource_ref mr
+            any_resource[device_accessible] mr
         ) except +
         void reserve(size_t new_capacity, cuda_stream_view stream) except +
         void resize(size_t new_size, cuda_stream_view stream) except +

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -26,6 +26,33 @@ cdef extern from "rmm/resource_ref.hpp" namespace "rmm" nogil:
         ) noexcept
 
 
+cdef extern from "<cuda/memory_resource>" namespace "cuda::mr" nogil:
+    cdef cppclass device_accessible:
+        pass
+    cdef cppclass any_resource[Properties]:
+        any_resource() except +
+
+
+# Inline C++ helper to convert device_async_resource_ref to
+# any_resource<device_accessible> for passing to constructor parameters.
+# Needed because Cython wraps intermediate values in __Pyx_FakeReference<T>,
+# a proxy with operator T&(). CCCL's any_resource only has a constrained
+# forwarding constructor that cannot see through this proxy. A free function
+# performs the conversion in pure C++ where it works directly.
+# TODO: Remove once CCCL merges NVIDIA/cccl#8320 and RMM upgrades.
+cdef extern from *:
+    """
+    #include <cuda/memory_resource>
+    #include <rmm/resource_ref.hpp>
+    inline cuda::mr::any_resource<cuda::mr::device_accessible>
+    make_any_device_resource(rmm::device_async_resource_ref ref) {
+        return cuda::mr::any_resource<cuda::mr::device_accessible>(ref);
+    }
+    """
+    any_resource[device_accessible] make_any_device_resource(
+        device_async_resource_ref) except +
+
+
 # Inline C++ helper to construct optional[device_async_resource_ref] from any
 # concrete resource type. Returns optional so that Cython assignment
 # (self.c_ref = make_device_async_resource_ref(...)) uses optional's
@@ -187,7 +214,7 @@ cdef extern from "rmm/mr/pool_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass pool_memory_resource:
         pool_memory_resource(
-            device_async_resource_ref upstream_mr,
+            any_resource[device_accessible] upstream_mr,
             size_t initial_pool_size,
             optional[size_t] maximum_pool_size) except +
         size_t pool_size()
@@ -196,7 +223,7 @@ cdef extern from "rmm/mr/arena_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass arena_memory_resource:
         arena_memory_resource(
-            device_async_resource_ref upstream_mr,
+            any_resource[device_accessible] upstream_mr,
             optional[size_t] arena_size,
             bool dump_log_on_failure
         ) except +
@@ -205,7 +232,7 @@ cdef extern from "rmm/mr/fixed_size_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass fixed_size_memory_resource:
         fixed_size_memory_resource(
-            device_async_resource_ref upstream_mr,
+            any_resource[device_accessible] upstream_mr,
             size_t block_size,
             size_t block_to_preallocate) except +
 
@@ -226,9 +253,9 @@ cdef extern from "rmm/mr/binning_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass binning_memory_resource:
         binning_memory_resource(
-            device_async_resource_ref upstream_mr) except +
+            any_resource[device_accessible] upstream_mr) except +
         binning_memory_resource(
-            device_async_resource_ref upstream_mr,
+            any_resource[device_accessible] upstream_mr,
             int8_t min_size_exponent,
             int8_t max_size_exponent) except +
 
@@ -241,7 +268,7 @@ cdef extern from "rmm/mr/limiting_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass limiting_resource_adaptor:
         limiting_resource_adaptor(
-            device_async_resource_ref upstream_mr,
+            any_resource[device_accessible] upstream_mr,
             size_t allocation_limit) except +
 
         size_t get_allocated_bytes() except +
@@ -251,7 +278,7 @@ cdef extern from "rmm/mr/logging_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass logging_resource_adaptor:
         logging_resource_adaptor(
-            device_async_resource_ref upstream_mr,
+            any_resource[device_accessible] upstream_mr,
             string filename) except +
 
         void flush() except +
@@ -267,7 +294,7 @@ cdef extern from "rmm/mr/statistics_resource_adaptor.hpp" \
             int64_t total
 
         statistics_resource_adaptor(
-            device_async_resource_ref upstream_mr) except +
+            any_resource[device_accessible] upstream_mr) except +
 
         counter get_bytes_counter() except +
         counter get_allocations_counter() except +
@@ -278,7 +305,7 @@ cdef extern from "rmm/mr/tracking_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass tracking_resource_adaptor:
         tracking_resource_adaptor(
-            device_async_resource_ref upstream_mr,
+            any_resource[device_accessible] upstream_mr,
             bool capture_stacks) except +
 
         size_t get_allocated_bytes() except +
@@ -294,7 +321,7 @@ cdef extern from "rmm/mr/failure_callback_resource_adaptor.hpp" \
     ctypedef bool (*failure_callback_t)(size_t, void*)
     cdef cppclass failure_callback_resource_adaptor[ExceptionType]:
         failure_callback_resource_adaptor(
-            device_async_resource_ref upstream_mr,
+            any_resource[device_accessible] upstream_mr,
             failure_callback_t callback,
             void* callback_arg
         ) except +
@@ -316,4 +343,4 @@ cdef extern from "rmm/mr/prefetch_resource_adaptor.hpp" \
         namespace "rmm::mr" nogil:
     cdef cppclass prefetch_resource_adaptor:
         prefetch_resource_adaptor(
-            device_async_resource_ref upstream_mr) except +
+            any_resource[device_accessible] upstream_mr) except +

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -50,7 +50,7 @@ cdef extern from *:
     }
     """
     any_resource[device_accessible] make_any_device_resource(
-        device_async_resource_ref) except +
+        device_async_resource_ref) nogil except +
 
 
 # Inline C++ helper to construct optional[device_async_resource_ref] from any

--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -28,6 +28,7 @@ from rmm.librmm.device_buffer cimport (
     get_current_cuda_device,
     prefetch,
 )
+from rmm.librmm.memory_resource cimport make_any_device_resource
 from rmm.pylibrmm.memory_resource cimport (
     DeviceMemoryResource,
     get_current_device_resource,
@@ -88,11 +89,13 @@ cdef class DeviceBuffer:
 
             if c_ptr == NULL or size == 0:
                 self.c_obj.reset(new device_buffer(
-                    size, stream.view(), self.mr.c_ref.value()
+                    size, stream.view(),
+                    make_any_device_resource(self.mr.c_ref.value())
                 ))
             else:
                 self.c_obj.reset(new device_buffer(
-                    c_ptr, size, stream.view(), self.mr.c_ref.value()
+                    c_ptr, size, stream.view(),
+                    make_any_device_resource(self.mr.c_ref.value())
                 ))
 
                 if stream.c_is_default():

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -54,6 +54,7 @@ from rmm.librmm.memory_resource cimport (
     fixed_size_memory_resource,
     limiting_resource_adaptor,
     logging_resource_adaptor,
+    make_any_device_resource,
     make_device_async_resource_ref,
     managed_memory_resource,
     percent_of_free_device_memory as c_percent_of_free_device_memory,
@@ -356,7 +357,7 @@ cdef class PoolMemoryResource(UpstreamResourceAdaptor):
             else optional[size_t](<size_t> parse_bytes(maximum_pool_size))
         )
         self.c_obj.reset(new pool_memory_resource(
-            upstream_mr.c_ref.value(),
+            make_any_device_resource(upstream_mr.c_ref.value()),
             c_initial_pool_size,
             c_maximum_pool_size
         ))
@@ -400,7 +401,7 @@ cdef class ArenaMemoryResource(UpstreamResourceAdaptor):
             else optional[size_t](<size_t> parse_bytes(arena_size))
         )
         self.c_obj.reset(new arena_memory_resource(
-            upstream_mr.c_ref.value(),
+            make_any_device_resource(upstream_mr.c_ref.value()),
             c_arena_size,
             dump_log_on_failure,
         ))
@@ -437,7 +438,7 @@ cdef class FixedSizeMemoryResource(UpstreamResourceAdaptor):
             size_t blocks_to_preallocate=128
     ):
         self.c_obj.reset(new fixed_size_memory_resource(
-            upstream_mr.c_ref.value(),
+            make_any_device_resource(upstream_mr.c_ref.value()),
             block_size,
             blocks_to_preallocate
         ))
@@ -482,11 +483,11 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
 
         if (min_size_exponent == -1 or max_size_exponent == -1):
             self.c_obj.reset(new binning_memory_resource(
-                upstream_mr.c_ref.value()
+                make_any_device_resource(upstream_mr.c_ref.value())
             ))
         else:
             self.c_obj.reset(new binning_memory_resource(
-                upstream_mr.c_ref.value(),
+                make_any_device_resource(upstream_mr.c_ref.value()),
                 min_size_exponent,
                 max_size_exponent
             ))
@@ -676,7 +677,7 @@ cdef class LimitingResourceAdaptor(UpstreamResourceAdaptor):
         size_t allocation_limit
     ):
         self.c_obj.reset(new limiting_resource_adaptor(
-            upstream_mr.c_ref.value(),
+            make_any_device_resource(upstream_mr.c_ref.value()),
             allocation_limit
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
@@ -741,7 +742,7 @@ cdef class LoggingResourceAdaptor(UpstreamResourceAdaptor):
         self._log_file_name = log_file_name
 
         self.c_obj.reset(new logging_resource_adaptor(
-            upstream_mr.c_ref.value(),
+            make_any_device_resource(upstream_mr.c_ref.value()),
             log_file_name.encode()
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
@@ -777,7 +778,7 @@ cdef class StatisticsResourceAdaptor(UpstreamResourceAdaptor):
         DeviceMemoryResource upstream_mr
     ):
         self.c_obj.reset(new statistics_resource_adaptor(
-            upstream_mr.c_ref.value()
+            make_any_device_resource(upstream_mr.c_ref.value())
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
@@ -868,7 +869,7 @@ cdef class TrackingResourceAdaptor(UpstreamResourceAdaptor):
         bool capture_stacks=False
     ):
         self.c_obj.reset(new tracking_resource_adaptor(
-            upstream_mr.c_ref.value(),
+            make_any_device_resource(upstream_mr.c_ref.value()),
             capture_stacks
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
@@ -941,7 +942,7 @@ cdef class FailureCallbackResourceAdaptor(UpstreamResourceAdaptor):
     ):
         self._callback = callback
         self.c_obj.reset(new failure_callback_resource_adaptor_oom(
-            upstream_mr.c_ref.value(),
+            make_any_device_resource(upstream_mr.c_ref.value()),
             <failure_callback_t>(_oom_callback_function),
             <void*>(callback)
         ))
@@ -971,7 +972,7 @@ cdef class PrefetchResourceAdaptor(UpstreamResourceAdaptor):
         DeviceMemoryResource upstream_mr
     ):
         self.c_obj.reset(new prefetch_resource_adaptor(
-            upstream_mr.c_ref.value()
+            make_any_device_resource(upstream_mr.c_ref.value())
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 


### PR DESCRIPTION
## Description

Change all resource/adaptor constructors from `device_async_resource_ref` to `cuda::mr::any_resource<cuda::mr::device_accessible>` taken **by value**, with `std::move` into member storage. This follows the sink-parameter idiom (like `std::shared_ptr`), enabling move semantics for rvalue arguments and making ownership transfer explicit.

The central motivation is that `device_async_resource_ref` is a non-owning reference that cannot bind to temporaries (rvalues/xvalues). Code like `pool_memory_resource(cuda_memory_resource(), size)` is impossible with `device_async_resource_ref` because the temporary `cuda_memory_resource` is destroyed before the adaptor can use it. `any_resource<device_accessible>` by value solves this: callers pass a resource that gets moved into type-erased owned storage, so the adaptor owns its upstream and no external lifetime management is needed.

Also renames `upstream_mr` / `upstream_resource` to `upstream` for consistency across all adaptors.

Cython bindings use a `make_any_device_resource` inline helper to work around a CCCL template deduction issue where `any_resource` cannot be constructed from Cython's `__Pyx_FakeReference` proxy type wrapping `resource_ref` ([NVIDIA/cccl#8320](https://github.com/NVIDIA/cccl/pull/8320)). This workaround should be removed once CCCL merges the upstream fix.

**Testing:**
- C++ build: 178/178 targets
- C++ tests: 103/103 passed
- Python tests: 1785 passed, 1 skipped
- All against stock (unpatched) CCCL

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.