### PR TITLE
Update to clang 20.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: cython-lint
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v20.1.4
+    rev: v20.1.8
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - breathe>=4.35.0
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-python>=12.9.2,<13.0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - breathe>=4.35.0
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-python>=12.9.2,<13.0

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - breathe>=4.35.0
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-python>=13.0.1,<14.0

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - breathe>=4.35.0
 - c-compiler
-- clang-tools==20.1.4
-- clang==20.1.4
+- clang-tools==20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-python>=13.0.1,<14.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -317,8 +317,8 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - clang==20.1.4
-          - clang-tools==20.1.4
+          - clang==20.1.8
+          - clang-tools==20.1.8
           - gcovr>=5.0
   docs:
     common:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/267

This PR updates the clang version to 20.1.8.
