### PR TITLE
Add set_per_device_resource and set_current_device_resource taking any_resource by value

### DIFF
--- a/cpp/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/cpp/benchmarks/device_uvector/device_uvector_bench.cu
@@ -28,7 +28,7 @@ void BM_UvectorSizeConstruction(benchmark::State& state)
 {
   rmm::mr::cuda_memory_resource cuda_mr{};
   rmm::mr::pool_memory_resource mr{cuda_mr, rmm::percent_of_free_device_memory(50)};
-  rmm::mr::set_current_device_resource_ref(mr);
+  rmm::mr::set_current_device_resource(mr);
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_uvector<std::int32_t> vec(static_cast<std::size_t>(state.range(0)),
@@ -38,7 +38,7 @@ void BM_UvectorSizeConstruction(benchmark::State& state)
 
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
 
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
 }
 
 BENCHMARK(BM_UvectorSizeConstruction)
@@ -50,7 +50,7 @@ void BM_ThrustVectorSizeConstruction(benchmark::State& state)
 {
   rmm::mr::cuda_memory_resource cuda_mr{};
   rmm::mr::pool_memory_resource mr{cuda_mr, rmm::percent_of_free_device_memory(50)};
-  rmm::mr::set_current_device_resource_ref(mr);
+  rmm::mr::set_current_device_resource(mr);
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_vector<std::int32_t> vec(static_cast<std::size_t>(state.range(0)));
@@ -59,7 +59,7 @@ void BM_ThrustVectorSizeConstruction(benchmark::State& state)
 
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
 
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
 }
 
 BENCHMARK(BM_ThrustVectorSizeConstruction)
@@ -128,7 +128,7 @@ template <typename Vector>
 void BM_VectorWorkflow(benchmark::State& state)
 {
   rmm::mr::cuda_async_memory_resource cuda_async_mr{};
-  rmm::mr::set_current_device_resource_ref(cuda_async_mr);
+  rmm::mr::set_current_device_resource(cuda_async_mr);
 
   rmm::cuda_stream input_stream;
   std::vector<rmm::cuda_stream> streams(4);
@@ -147,7 +147,7 @@ void BM_VectorWorkflow(benchmark::State& state)
   state.SetBytesProcessed(
     static_cast<std::int64_t>(static_cast<std::size_t>(state.iterations()) * bytes));
 
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
 }
 
 BENCHMARK_TEMPLATE(BM_VectorWorkflow, thrust_vector)  // NOLINT

--- a/cpp/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/cpp/benchmarks/device_uvector/device_uvector_bench.cu
@@ -26,9 +26,8 @@
 
 void BM_UvectorSizeConstruction(benchmark::State& state)
 {
-  rmm::mr::cuda_memory_resource cuda_mr{};
-  rmm::mr::pool_memory_resource mr{cuda_mr, rmm::percent_of_free_device_memory(50)};
-  rmm::mr::set_current_device_resource(mr);
+  rmm::mr::set_current_device_resource(rmm::mr::pool_memory_resource{
+    rmm::mr::cuda_memory_resource{}, rmm::percent_of_free_device_memory(50)});
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_uvector<std::int32_t> vec(static_cast<std::size_t>(state.range(0)),
@@ -48,9 +47,8 @@ BENCHMARK(BM_UvectorSizeConstruction)
 
 void BM_ThrustVectorSizeConstruction(benchmark::State& state)
 {
-  rmm::mr::cuda_memory_resource cuda_mr{};
-  rmm::mr::pool_memory_resource mr{cuda_mr, rmm::percent_of_free_device_memory(50)};
-  rmm::mr::set_current_device_resource(mr);
+  rmm::mr::set_current_device_resource(rmm::mr::pool_memory_resource{
+    rmm::mr::cuda_memory_resource{}, rmm::percent_of_free_device_memory(50)});
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_vector<std::int32_t> vec(static_cast<std::size_t>(state.range(0)));
@@ -127,8 +125,7 @@ void vector_workflow(std::size_t num_elements,
 template <typename Vector>
 void BM_VectorWorkflow(benchmark::State& state)
 {
-  rmm::mr::cuda_async_memory_resource cuda_async_mr{};
-  rmm::mr::set_current_device_resource(cuda_async_mr);
+  rmm::mr::set_current_device_resource(rmm::mr::cuda_async_memory_resource{});
 
   rmm::cuda_stream input_stream;
   std::vector<rmm::cuda_stream> streams(4);

--- a/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
+++ b/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
@@ -90,8 +90,8 @@ inline any_device_resource make_cuda_async() { return rmm::mr::cuda_async_memory
 
 inline any_device_resource make_pool()
 {
-  rmm::mr::cuda_memory_resource cuda{};
-  return rmm::mr::pool_memory_resource{cuda, rmm::percent_of_free_device_memory(50)};
+  return rmm::mr::pool_memory_resource{rmm::mr::cuda_memory_resource{},
+                                       rmm::percent_of_free_device_memory(50)};
 }
 
 inline any_device_resource make_arena()

--- a/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
+++ b/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
@@ -64,7 +64,7 @@ static void BM_MultiStreamAllocations(benchmark::State& state, MRFactoryFunc con
 {
   auto mr = factory();
 
-  rmm::mr::set_current_device_resource_ref(mr);
+  rmm::mr::set_current_device_resource(mr);
 
   auto num_streams = state.range(0);
   auto num_kernels = state.range(1);
@@ -81,7 +81,7 @@ static void BM_MultiStreamAllocations(benchmark::State& state, MRFactoryFunc con
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations() * num_kernels));
 
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
 }
 
 inline any_device_resource make_cuda() { return rmm::mr::cuda_memory_resource{}; }

--- a/cpp/benchmarks/random_allocations/random_allocations.cpp
+++ b/cpp/benchmarks/random_allocations/random_allocations.cpp
@@ -157,8 +157,8 @@ inline any_device_resource make_cuda_async() { return rmm::mr::cuda_async_memory
 
 inline any_device_resource make_pool()
 {
-  rmm::mr::cuda_memory_resource cuda{};
-  return rmm::mr::pool_memory_resource{cuda, rmm::percent_of_free_device_memory(50)};
+  return rmm::mr::pool_memory_resource{rmm::mr::cuda_memory_resource{},
+                                       rmm::percent_of_free_device_memory(50)};
 }
 
 inline any_device_resource make_arena()

--- a/cpp/benchmarks/replay/replay.cpp
+++ b/cpp/benchmarks/replay/replay.cpp
@@ -49,8 +49,7 @@ inline any_device_resource make_pool(std::size_t simulated_size)
     rmm::mr::simulated_memory_resource sim{simulated_size};
     return rmm::mr::pool_memory_resource{sim, simulated_size, simulated_size};
   }
-  rmm::mr::cuda_memory_resource cuda{};
-  return rmm::mr::pool_memory_resource{cuda, 0};
+  return rmm::mr::pool_memory_resource{rmm::mr::cuda_memory_resource{}, 0};
 }
 
 inline any_device_resource make_arena(std::size_t simulated_size)

--- a/cpp/include/rmm/mr/per_device_resource.hpp
+++ b/cpp/include/rmm/mr/per_device_resource.hpp
@@ -105,13 +105,12 @@ RMM_EXPORT inline auto& get_ref_map()
  */
 inline device_async_resource_ref get_per_device_resource_ref(cuda_device_id device_id)
 {
-  using any_device_resource = cuda::mr::any_resource<cuda::mr::device_accessible>;
   std::lock_guard<std::mutex> lock{detail::ref_map_lock()};
   auto& map = detail::get_ref_map();
   // If a resource was never set for `id`, set to the initial resource
   auto const found = map.find(device_id.value());
   if (found == map.end()) {
-    auto item = map.emplace(device_id.value(), any_device_resource{detail::initial_resource()});
+    auto item = map.emplace(device_id.value(), detail::initial_resource());
     return device_async_resource_ref{item.first->second};
   }
   return device_async_resource_ref{found->second};
@@ -144,13 +143,12 @@ inline device_async_resource_ref get_per_device_resource_ref(cuda_device_id devi
 inline cuda::mr::any_resource<cuda::mr::device_accessible> set_per_device_resource(
   cuda_device_id device_id, cuda::mr::any_resource<cuda::mr::device_accessible> new_resource)
 {
-  using any_device_resource = cuda::mr::any_resource<cuda::mr::device_accessible>;
   std::lock_guard<std::mutex> lock{detail::ref_map_lock()};
   auto& map          = detail::get_ref_map();
   auto const old_itr = map.find(device_id.value());
   if (old_itr == map.end()) {
     map.emplace(device_id.value(), std::move(new_resource));
-    return any_device_resource{detail::initial_resource()};
+    return {detail::initial_resource()};
   }
   return std::exchange(old_itr->second, std::move(new_resource));
 }
@@ -294,8 +292,7 @@ set_current_device_resource_ref(device_async_resource_ref new_resource_ref)
 inline cuda::mr::any_resource<cuda::mr::device_accessible> reset_per_device_resource(
   cuda_device_id device_id)
 {
-  return set_per_device_resource(
-    device_id, cuda::mr::any_resource<cuda::mr::device_accessible>{detail::initial_resource()});
+  return set_per_device_resource(device_id, {detail::initial_resource()});
 }
 
 /**

--- a/cpp/include/rmm/mr/per_device_resource.hpp
+++ b/cpp/include/rmm/mr/per_device_resource.hpp
@@ -118,6 +118,44 @@ inline device_async_resource_ref get_per_device_resource_ref(cuda_device_id devi
 }
 
 /**
+ * @brief Set the memory resource for the specified device.
+ *
+ * Takes ownership of the provided resource by value. The resource is moved into the per-device
+ * resource map.
+ *
+ * `device_id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is
+ * undefined.
+ *
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `set_per_device_resource_ref`, `get_per_device_resource_ref`,
+ * `get_current_device_resource_ref`, `set_current_device_resource`,
+ * `set_current_device_resource_ref` and `reset_current_device_resource_ref`. Concurrent calls to
+ * any of these functions will result in a valid state, but the order of execution is undefined.
+ *
+ * @note The resource passed in `new_resource` must have been created when device `device_id`
+ * was the current CUDA device (e.g. set using `cudaSetDevice()`). The behavior of a memory
+ * resource is undefined if used while the active CUDA device is a different device from the one
+ * that was active when the memory resource was created.
+ *
+ * @param device_id The id of the target device
+ * @param new_resource New resource to use for `device_id`
+ * @return An owning `any_resource` holding the previous resource for `device_id`
+ */
+inline cuda::mr::any_resource<cuda::mr::device_accessible> set_per_device_resource(
+  cuda_device_id device_id, cuda::mr::any_resource<cuda::mr::device_accessible> new_resource)
+{
+  using any_device_resource = cuda::mr::any_resource<cuda::mr::device_accessible>;
+  std::lock_guard<std::mutex> lock{detail::ref_map_lock()};
+  auto& map          = detail::get_ref_map();
+  auto const old_itr = map.find(device_id.value());
+  if (old_itr == map.end()) {
+    map.emplace(device_id.value(), std::move(new_resource));
+    return any_device_resource{detail::initial_resource()};
+  }
+  return std::exchange(old_itr->second, std::move(new_resource));
+}
+
+/**
  * @brief Set the `device_async_resource_ref` for the specified device to `new_resource_ref`
  *
  * `device_id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is
@@ -127,10 +165,11 @@ inline device_async_resource_ref get_per_device_resource_ref(cuda_device_id devi
  * behavior is undefined. It is the caller's responsibility to maintain the lifetime of the resource
  * object.
  *
- * This function is thread-safe with respect to concurrent calls to `set_per_device_resource_ref`,
- * `get_per_device_resource_ref`, `get_current_device_resource_ref`,
- * `set_current_device_resource_ref` and `reset_current_device_resource_ref. Concurrent calls to any
- * of these functions will result in a valid state, but the order of execution is undefined.
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `set_per_device_resource_ref`, `get_per_device_resource_ref`,
+ * `get_current_device_resource_ref`, `set_current_device_resource`,
+ * `set_current_device_resource_ref` and `reset_current_device_resource_ref`. Concurrent calls to
+ * any of these functions will result in a valid state, but the order of execution is undefined.
  *
  * @note The resource passed in `new_resource_ref` must have been created when device `device_id`
  * was the current CUDA device (e.g. set using `cudaSetDevice()`). The behavior of a
@@ -144,15 +183,8 @@ inline device_async_resource_ref get_per_device_resource_ref(cuda_device_id devi
 inline cuda::mr::any_resource<cuda::mr::device_accessible> set_per_device_resource_ref(
   cuda_device_id device_id, device_async_resource_ref new_resource_ref)
 {
-  using any_device_resource = cuda::mr::any_resource<cuda::mr::device_accessible>;
-  std::lock_guard<std::mutex> lock{detail::ref_map_lock()};
-  auto& map          = detail::get_ref_map();
-  auto const old_itr = map.find(device_id.value());
-  if (old_itr == map.end()) {
-    map.emplace(device_id.value(), any_device_resource{new_resource_ref});
-    return any_device_resource{detail::initial_resource()};
-  }
-  return std::exchange(old_itr->second, any_device_resource{new_resource_ref});
+  return set_per_device_resource(
+    device_id, cuda::mr::any_resource<cuda::mr::device_accessible>{new_resource_ref});
 }
 
 /**
@@ -183,6 +215,31 @@ inline device_async_resource_ref get_current_device_resource_ref()
 }
 
 /**
+ * @brief Set the memory resource for the current device.
+ *
+ * Takes ownership of the provided resource by value. The "current device" is the device returned
+ * by `cudaGetDevice`.
+ *
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `set_per_device_resource_ref`, `get_per_device_resource_ref`,
+ * `get_current_device_resource_ref`, `set_current_device_resource`,
+ * `set_current_device_resource_ref` and `reset_current_device_resource_ref`. Concurrent calls to
+ * any of these functions will result in a valid state, but the order of execution is undefined.
+ *
+ * @note The resource passed in `new_resource` must have been created for the current CUDA device.
+ * The behavior of a memory resource is undefined if used while the active CUDA device is a
+ * different device from the one that was active when the memory resource was created.
+ *
+ * @param new_resource New resource to use for the current device
+ * @return An owning `any_resource` holding the previous resource for the current device
+ */
+inline cuda::mr::any_resource<cuda::mr::device_accessible> set_current_device_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> new_resource)
+{
+  return set_per_device_resource(rmm::get_current_cuda_device(), std::move(new_resource));
+}
+
+/**
  * @brief Set the `device_async_resource_ref` for the current device.
  *
  * The "current device" is the device returned by `cudaGetDevice`.
@@ -191,14 +248,15 @@ inline device_async_resource_ref get_current_device_resource_ref()
  * behavior is undefined. It is the caller's responsibility to maintain the lifetime of the resource
  * object.
  *
- * This function is thread-safe with respect to concurrent calls to `set_per_device_resource_ref`,
- * `get_per_device_resource_ref`, `get_current_device_resource_ref`,
- * `set_current_device_resource_ref` and `reset_current_device_resource_ref. Concurrent calls to any
- * of these functions will result in a valid state, but the order of execution is undefined.
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `set_per_device_resource_ref`, `get_per_device_resource_ref`,
+ * `get_current_device_resource_ref`, `set_current_device_resource`,
+ * `set_current_device_resource_ref` and `reset_current_device_resource_ref`. Concurrent calls to
+ * any of these functions will result in a valid state, but the order of execution is undefined.
  *
- * @note The resource passed in `new_resource` must have been created for the current CUDA device.
- * The behavior of a `device_async_resource_ref` is undefined if used while the active CUDA device
- * is a different device from the one that was active when the memory resource was created.
+ * @note The resource passed in `new_resource_ref` must have been created for the current CUDA
+ * device. The behavior of a `device_async_resource_ref` is undefined if used while the active CUDA
+ * device is a different device from the one that was active when the memory resource was created.
  *
  * @param new_resource_ref New `device_async_resource_ref` to use for the current device
  * @return An owning `any_resource` holding the previous resource for the current device
@@ -206,7 +264,8 @@ inline device_async_resource_ref get_current_device_resource_ref()
 inline cuda::mr::any_resource<cuda::mr::device_accessible> set_current_device_resource_ref(
   device_async_resource_ref new_resource_ref)
 {
-  return set_per_device_resource_ref(rmm::get_current_cuda_device(), new_resource_ref);
+  return set_current_device_resource(
+    cuda::mr::any_resource<cuda::mr::device_accessible>{new_resource_ref});
 }
 
 /**

--- a/cpp/include/rmm/mr/per_device_resource.hpp
+++ b/cpp/include/rmm/mr/per_device_resource.hpp
@@ -158,6 +158,8 @@ inline cuda::mr::any_resource<cuda::mr::device_accessible> set_per_device_resour
 /**
  * @brief Set the `device_async_resource_ref` for the specified device to `new_resource_ref`
  *
+ * @deprecated Use `set_per_device_resource` instead.
+ *
  * `device_id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is
  * undefined.
  *
@@ -180,8 +182,9 @@ inline cuda::mr::any_resource<cuda::mr::device_accessible> set_per_device_resour
  * @param new_resource_ref new `device_async_resource_ref` to use as new resource for `device_id`
  * @return An owning `any_resource` holding the previous resource for `device_id`
  */
-inline cuda::mr::any_resource<cuda::mr::device_accessible> set_per_device_resource_ref(
-  cuda_device_id device_id, device_async_resource_ref new_resource_ref)
+[[deprecated("Use set_per_device_resource instead.")]]  //
+inline cuda::mr::any_resource<cuda::mr::device_accessible>
+set_per_device_resource_ref(cuda_device_id device_id, device_async_resource_ref new_resource_ref)
 {
   return set_per_device_resource(
     device_id, cuda::mr::any_resource<cuda::mr::device_accessible>{new_resource_ref});
@@ -242,6 +245,8 @@ inline cuda::mr::any_resource<cuda::mr::device_accessible> set_current_device_re
 /**
  * @brief Set the `device_async_resource_ref` for the current device.
  *
+ * @deprecated Use `set_current_device_resource` instead.
+ *
  * The "current device" is the device returned by `cudaGetDevice`.
  *
  * The object referenced by `new_resource_ref` must outlive the last use of the resource, otherwise
@@ -261,51 +266,104 @@ inline cuda::mr::any_resource<cuda::mr::device_accessible> set_current_device_re
  * @param new_resource_ref New `device_async_resource_ref` to use for the current device
  * @return An owning `any_resource` holding the previous resource for the current device
  */
-inline cuda::mr::any_resource<cuda::mr::device_accessible> set_current_device_resource_ref(
-  device_async_resource_ref new_resource_ref)
+[[deprecated("Use set_current_device_resource instead.")]]  //
+inline cuda::mr::any_resource<cuda::mr::device_accessible>
+set_current_device_resource_ref(device_async_resource_ref new_resource_ref)
 {
   return set_current_device_resource(
     cuda::mr::any_resource<cuda::mr::device_accessible>{new_resource_ref});
 }
 
 /**
+ * @brief Reset the memory resource for the specified device to the initial resource.
+ *
+ * Resets to the initial `cuda_memory_resource`.
+ *
+ * `device_id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is
+ * undefined.
+ *
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `set_per_device_resource_ref`, `get_per_device_resource_ref`,
+ * `get_current_device_resource_ref`, `set_current_device_resource`,
+ * `set_current_device_resource_ref` and `reset_current_device_resource_ref`. Concurrent calls to
+ * any of these functions will result in a valid state, but the order of execution is undefined.
+ *
+ * @param device_id The id of the target device
+ * @return An owning `any_resource` holding the previous resource for `device_id`
+ */
+inline cuda::mr::any_resource<cuda::mr::device_accessible> reset_per_device_resource(
+  cuda_device_id device_id)
+{
+  return set_per_device_resource(
+    device_id, cuda::mr::any_resource<cuda::mr::device_accessible>{detail::initial_resource()});
+}
+
+/**
+ * @brief Reset the memory resource for the current device to the initial resource.
+ *
+ * Resets to the initial `cuda_memory_resource`. The "current device" is the device returned by
+ * `cudaGetDevice`.
+ *
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `set_per_device_resource_ref`, `get_per_device_resource_ref`,
+ * `get_current_device_resource_ref`, `set_current_device_resource`,
+ * `set_current_device_resource_ref` and `reset_current_device_resource_ref`. Concurrent calls to
+ * any of these functions will result in a valid state, but the order of execution is undefined.
+ *
+ * @return An owning `any_resource` holding the previous resource for the current device
+ */
+inline cuda::mr::any_resource<cuda::mr::device_accessible> reset_current_device_resource()
+{
+  return reset_per_device_resource(rmm::get_current_cuda_device());
+}
+
+/**
  * @brief Reset the `device_async_resource_ref` for the specified device to the initial resource.
+ *
+ * @deprecated Use `reset_per_device_resource` instead.
  *
  * Resets to a reference to the initial `cuda_memory_resource`.
  *
  * `device_id.value()` must be in the range `[0, cudaGetDeviceCount())`, otherwise behavior is
  * undefined.
  *
- * This function is thread-safe with respect to concurrent calls to `set_per_device_resource_ref`,
- * `get_per_device_resource_ref`, `get_current_device_resource_ref`,
- * `set_current_device_resource_ref` and `reset_current_device_resource_ref. Concurrent calls to any
- * of these functions will result in a valid state, but the order of execution is undefined.
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `set_per_device_resource_ref`, `get_per_device_resource_ref`,
+ * `get_current_device_resource_ref`, `set_current_device_resource`,
+ * `set_current_device_resource_ref` and `reset_current_device_resource_ref`. Concurrent calls to
+ * any of these functions will result in a valid state, but the order of execution is undefined.
  *
  * @param device_id The id of the target device
  * @return An owning `any_resource` holding the previous resource for `device_id`
  */
-inline cuda::mr::any_resource<cuda::mr::device_accessible> reset_per_device_resource_ref(
-  cuda_device_id device_id)
+[[deprecated("Use reset_per_device_resource instead.")]]  //
+inline cuda::mr::any_resource<cuda::mr::device_accessible>
+reset_per_device_resource_ref(cuda_device_id device_id)
 {
-  return set_per_device_resource_ref(device_id, detail::initial_resource());
+  return reset_per_device_resource(device_id);
 }
 
 /**
  * @brief Reset the `device_async_resource_ref` for the current device to the initial resource.
  *
+ * @deprecated Use `reset_current_device_resource` instead.
+ *
  * Resets to a reference to the initial `cuda_memory_resource`. The "current device" is the device
  * returned by `cudaGetDevice`.
  *
- * This function is thread-safe with respect to concurrent calls to `set_per_device_resource_ref`,
- * `get_per_device_resource_ref`, `get_current_device_resource_ref`,
- * `set_current_device_resource_ref` and `reset_current_device_resource_ref. Concurrent calls to any
- * of these functions will result in a valid state, but the order of execution is undefined.
+ * This function is thread-safe with respect to concurrent calls to `set_per_device_resource`,
+ * `set_per_device_resource_ref`, `get_per_device_resource_ref`,
+ * `get_current_device_resource_ref`, `set_current_device_resource`,
+ * `set_current_device_resource_ref` and `reset_current_device_resource_ref`. Concurrent calls to
+ * any of these functions will result in a valid state, but the order of execution is undefined.
  *
  * @return An owning `any_resource` holding the previous resource for the current device
  */
-inline cuda::mr::any_resource<cuda::mr::device_accessible> reset_current_device_resource_ref()
+[[deprecated("Use reset_current_device_resource instead.")]]  //
+inline cuda::mr::any_resource<cuda::mr::device_accessible>
+reset_current_device_resource_ref()
 {
-  return reset_per_device_resource_ref(rmm::get_current_cuda_device());
+  return reset_current_device_resource();
 }
 /** @} */  // end of group
 }  // namespace mr

--- a/cpp/tests/container_multidevice_tests.cu
+++ b/cpp/tests/container_multidevice_tests.cu
@@ -34,9 +34,8 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateDestroyDifferentActiveDevice)
   // only run on multidevice systems
   if (num_devices >= 2) {
     rmm::cuda_set_device_raii dev{rmm::cuda_device_id{0}};
-    auto orig_mr  = rmm::mr::get_current_device_resource_ref();
-    auto check_mr = device_check_resource_adaptor{orig_mr};
-    rmm::mr::set_current_device_resource(check_mr);
+    auto orig_mr = rmm::mr::get_current_device_resource_ref();
+    rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     {
       if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
@@ -61,9 +60,8 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateMoveDestroyDifferentActiveDevice)
   // only run on multidevice systems
   if (num_devices >= 2) {
     rmm::cuda_set_device_raii dev{rmm::cuda_device_id{0}};
-    auto orig_mr  = rmm::mr::get_current_device_resource_ref();
-    auto check_mr = device_check_resource_adaptor{orig_mr};
-    rmm::mr::set_current_device_resource(check_mr);
+    auto orig_mr = rmm::mr::get_current_device_resource_ref();
+    rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     {
       auto buf_1 = []() {
@@ -101,9 +99,8 @@ TYPED_TEST(ContainerMultiDeviceTest, ResizeDifferentActiveDevice)
   // only run on multidevice systems
   if (num_devices >= 2) {
     rmm::cuda_set_device_raii dev{rmm::cuda_device_id{0}};
-    auto orig_mr  = rmm::mr::get_current_device_resource_ref();
-    auto check_mr = device_check_resource_adaptor{orig_mr};
-    rmm::mr::set_current_device_resource(check_mr);
+    auto orig_mr = rmm::mr::get_current_device_resource_ref();
+    rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
       auto buf = TypeParam(128, rmm::cuda_stream_view{});
@@ -124,9 +121,8 @@ TYPED_TEST(ContainerMultiDeviceTest, ShrinkDifferentActiveDevice)
   // only run on multidevice systems
   if (num_devices >= 2) {
     rmm::cuda_set_device_raii dev{rmm::cuda_device_id{0}};
-    auto orig_mr  = rmm::mr::get_current_device_resource_ref();
-    auto check_mr = device_check_resource_adaptor{orig_mr};
-    rmm::mr::set_current_device_resource(check_mr);
+    auto orig_mr = rmm::mr::get_current_device_resource_ref();
+    rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
       auto buf = TypeParam(128, rmm::cuda_stream_view{});

--- a/cpp/tests/container_multidevice_tests.cu
+++ b/cpp/tests/container_multidevice_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -36,7 +36,7 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateDestroyDifferentActiveDevice)
     rmm::cuda_set_device_raii dev{rmm::cuda_device_id{0}};
     auto orig_mr  = rmm::mr::get_current_device_resource_ref();
     auto check_mr = device_check_resource_adaptor{orig_mr};
-    rmm::mr::set_current_device_resource_ref(check_mr);
+    rmm::mr::set_current_device_resource(check_mr);
 
     {
       if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
@@ -49,7 +49,7 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateDestroyDifferentActiveDevice)
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));
-    rmm::mr::set_current_device_resource_ref(orig_mr);
+    rmm::mr::set_current_device_resource(orig_mr);
   }
 }
 
@@ -63,7 +63,7 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateMoveDestroyDifferentActiveDevice)
     rmm::cuda_set_device_raii dev{rmm::cuda_device_id{0}};
     auto orig_mr  = rmm::mr::get_current_device_resource_ref();
     auto check_mr = device_check_resource_adaptor{orig_mr};
-    rmm::mr::set_current_device_resource_ref(check_mr);
+    rmm::mr::set_current_device_resource(check_mr);
 
     {
       auto buf_1 = []() {
@@ -89,7 +89,7 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateMoveDestroyDifferentActiveDevice)
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));
-    rmm::mr::set_current_device_resource_ref(orig_mr);
+    rmm::mr::set_current_device_resource(orig_mr);
   }
 }
 
@@ -103,7 +103,7 @@ TYPED_TEST(ContainerMultiDeviceTest, ResizeDifferentActiveDevice)
     rmm::cuda_set_device_raii dev{rmm::cuda_device_id{0}};
     auto orig_mr  = rmm::mr::get_current_device_resource_ref();
     auto check_mr = device_check_resource_adaptor{orig_mr};
-    rmm::mr::set_current_device_resource_ref(check_mr);
+    rmm::mr::set_current_device_resource(check_mr);
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
       auto buf = TypeParam(128, rmm::cuda_stream_view{});
@@ -112,7 +112,7 @@ TYPED_TEST(ContainerMultiDeviceTest, ResizeDifferentActiveDevice)
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));
-    rmm::mr::set_current_device_resource_ref(orig_mr);
+    rmm::mr::set_current_device_resource(orig_mr);
   }
 }
 
@@ -126,7 +126,7 @@ TYPED_TEST(ContainerMultiDeviceTest, ShrinkDifferentActiveDevice)
     rmm::cuda_set_device_raii dev{rmm::cuda_device_id{0}};
     auto orig_mr  = rmm::mr::get_current_device_resource_ref();
     auto check_mr = device_check_resource_adaptor{orig_mr};
-    rmm::mr::set_current_device_resource_ref(check_mr);
+    rmm::mr::set_current_device_resource(check_mr);
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
       auto buf = TypeParam(128, rmm::cuda_stream_view{});
@@ -136,6 +136,6 @@ TYPED_TEST(ContainerMultiDeviceTest, ShrinkDifferentActiveDevice)
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));
-    rmm::mr::set_current_device_resource_ref(orig_mr);
+    rmm::mr::set_current_device_resource(orig_mr);
   }
 }

--- a/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
@@ -26,8 +26,8 @@ TYPED_TEST_P(CcclMrRefTest, SetCurrentDeviceResourceRef)
   rmm::mr::cuda_memory_resource cuda_mr{};
   auto cuda_ref = rmm::device_async_resource_ref{cuda_mr};
 
-  rmm::mr::set_current_device_resource_ref(cuda_ref);
-  auto old = rmm::mr::set_current_device_resource_ref(this->ref);
+  rmm::mr::set_current_device_resource(cuda_ref);
+  auto old = rmm::mr::set_current_device_resource(this->ref);
 
   constexpr std::size_t size{100};
   void* ptr = old.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -41,7 +41,7 @@ TYPED_TEST_P(CcclMrRefTest, SetCurrentDeviceResourceRef)
 
   test_get_current_device_resource_ref();
 
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
   current = rmm::mr::get_current_device_resource_ref();
   ptr     = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);

--- a/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
@@ -23,10 +23,7 @@ TYPED_TEST_SUITE_P(CcclMrRefTest);
 
 TYPED_TEST_P(CcclMrRefTest, SetCurrentDeviceResourceRef)
 {
-  rmm::mr::cuda_memory_resource cuda_mr{};
-  auto cuda_ref = rmm::device_async_resource_ref{cuda_mr};
-
-  rmm::mr::set_current_device_resource(cuda_ref);
+  rmm::mr::set_current_device_resource(rmm::mr::cuda_memory_resource{});
   auto old = rmm::mr::set_current_device_resource(this->ref);
 
   constexpr std::size_t size{100};

--- a/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
@@ -23,7 +23,7 @@ TYPED_TEST_SUITE_P(CcclMrRefTestMT);
 
 TYPED_TEST_P(CcclMrRefTestMT, SetCurrentDeviceResourceRef_mt)
 {
-  rmm::mr::set_current_device_resource_ref(this->ref);
+  rmm::mr::set_current_device_resource(this->ref);
   test_get_current_device_resource_ref();
 
   int device;
@@ -34,7 +34,7 @@ TYPED_TEST_P(CcclMrRefTestMT, SetCurrentDeviceResourceRef_mt)
     test_get_current_device_resource_ref();
   });
 
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
   test_get_current_device_resource_ref();
 }
 
@@ -54,10 +54,10 @@ TYPED_TEST_P(CcclMrRefTestMT, SetCurrentDeviceResourceRefPerThread_mt)
         RMM_CUDA_TRY(cudaSetDevice(dev_id));
         test_get_current_device_resource_ref();
 
-        rmm::mr::set_current_device_resource_ref(mr);
+        rmm::mr::set_current_device_resource(mr);
         test_get_current_device_resource_ref();
 
-        rmm::mr::reset_current_device_resource_ref();
+        rmm::mr::reset_current_device_resource();
         test_get_current_device_resource_ref();
       },
       i);

--- a/cpp/tests/mr/mr_ref_default_tests.cpp
+++ b/cpp/tests/mr/mr_ref_default_tests.cpp
@@ -50,9 +50,7 @@ TEST(DefaultTest, GetCurrentDeviceResourceRef)
 
 TEST(DefaultTest, SetCurrentDeviceResourceRef)
 {
-  rmm::mr::cuda_memory_resource cuda_mr{};
-
-  rmm::mr::set_current_device_resource(cuda_mr);
+  rmm::mr::set_current_device_resource(rmm::mr::cuda_memory_resource{});
 
   auto ref = rmm::mr::get_current_device_resource_ref();
 

--- a/cpp/tests/mr/mr_ref_default_tests.cpp
+++ b/cpp/tests/mr/mr_ref_default_tests.cpp
@@ -52,7 +52,7 @@ TEST(DefaultTest, SetCurrentDeviceResourceRef)
 {
   rmm::mr::cuda_memory_resource cuda_mr{};
 
-  rmm::mr::set_current_device_resource_ref(cuda_mr);
+  rmm::mr::set_current_device_resource(cuda_mr);
 
   auto ref = rmm::mr::get_current_device_resource_ref();
 
@@ -64,7 +64,7 @@ TEST(DefaultTest, SetCurrentDeviceResourceRef)
 
   ref.deallocate_sync(ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
 }
 
 // Multi-threaded default resource tests

--- a/cpp/tests/mr/mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/mr_ref_test_basic.hpp
@@ -16,8 +16,8 @@ TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
   rmm::mr::cuda_memory_resource cuda_mr{};
   auto cuda_ref = rmm::device_async_resource_ref{cuda_mr};
 
-  rmm::mr::set_current_device_resource_ref(cuda_ref);
-  auto old = rmm::mr::set_current_device_resource_ref(this->ref);
+  rmm::mr::set_current_device_resource(cuda_ref);
+  auto old = rmm::mr::set_current_device_resource(this->ref);
 
   // Old ref should be functional (verify by successful allocation)
   constexpr std::size_t size{100};
@@ -34,7 +34,7 @@ TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
   test_get_current_device_resource_ref();
 
   // Resetting should reset to initial cuda resource
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
   // Verify reset worked by checking allocation succeeds with initial resource
   current = rmm::mr::get_current_device_resource_ref();
   ptr     = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);

--- a/cpp/tests/mr/mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/mr_ref_test_basic.hpp
@@ -13,10 +13,7 @@ namespace rmm::test {
 
 TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
 {
-  rmm::mr::cuda_memory_resource cuda_mr{};
-  auto cuda_ref = rmm::device_async_resource_ref{cuda_mr};
-
-  rmm::mr::set_current_device_resource(cuda_ref);
+  rmm::mr::set_current_device_resource(rmm::mr::cuda_memory_resource{});
   auto old = rmm::mr::set_current_device_resource(this->ref);
 
   // Old ref should be functional (verify by successful allocation)

--- a/cpp/tests/mr/mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/mr_ref_test_mt.hpp
@@ -17,7 +17,7 @@ struct mr_ref_test_mt : public mr_ref_test {};
 TEST_P(mr_ref_test_mt, SetCurrentDeviceResourceRef_mt)
 {
   // Single thread changes default resource, then multiple threads use it
-  rmm::mr::set_current_device_resource_ref(this->ref);
+  rmm::mr::set_current_device_resource(this->ref);
   test_get_current_device_resource_ref();
 
   int device;
@@ -25,12 +25,11 @@ TEST_P(mr_ref_test_mt, SetCurrentDeviceResourceRef_mt)
 
   spawn([device]() {
     RMM_CUDA_TRY(cudaSetDevice(device));
-    // Verify the current resource is functional
     test_get_current_device_resource_ref();
   });
 
   // Resetting default resource should reset to initial
-  rmm::mr::reset_current_device_resource_ref();
+  rmm::mr::reset_current_device_resource();
   // Verify reset worked by testing allocation with initial resource
   test_get_current_device_resource_ref();
 }
@@ -52,12 +51,12 @@ TEST_P(mr_ref_test_mt, SetCurrentDeviceResourceRefPerThread_mt)
         // Verify initial resource is functional
         test_get_current_device_resource_ref();
 
-        rmm::mr::set_current_device_resource_ref(mr);
+        rmm::mr::set_current_device_resource(mr);
         // Verify newly set resource is functional
         test_get_current_device_resource_ref();
 
         // Resetting current dev resource ref should restore initial resource
-        rmm::mr::reset_current_device_resource_ref();
+        rmm::mr::reset_current_device_resource();
         // Verify reset resource is functional
         test_get_current_device_resource_ref();
       },

--- a/cpp/tests/mr/pinned_host_pool_mr_tests.cpp
+++ b/cpp/tests/mr/pinned_host_pool_mr_tests.cpp
@@ -18,7 +18,9 @@ TEST(PinnedPoolTest, ThrowMaxLessThanInitial)
   // Make sure first argument is enough larger than the second that alignment rounding doesn't
   // make them equal
   auto max_less_than_initial = []() {
-    pool_mr mr{rmm::mr::pinned_host_memory_resource{}, 1024, 256};
+    const auto initial{1024};
+    const auto maximum{256};
+    pool_mr mr{rmm::mr::pinned_host_memory_resource{}, initial, maximum};
   };
   EXPECT_THROW(max_less_than_initial(), rmm::logic_error);
 }
@@ -28,7 +30,9 @@ TEST(PinnedPoolTest, ReferenceThrowMaxLessThanInitial)
   // Make sure first argument is enough larger than the second that alignment rounding doesn't
   // make them equal
   auto max_less_than_initial = []() {
-    pool_mr mr{rmm::mr::pinned_host_memory_resource{}, 1024, 256};
+    const auto initial{1024};
+    const auto maximum{256};
+    pool_mr mr{rmm::mr::pinned_host_memory_resource{}, initial, maximum};
   };
   EXPECT_THROW(max_less_than_initial(), rmm::logic_error);
 }
@@ -61,7 +65,9 @@ TEST(PinnedPoolTest, NonAlignedPoolSize)
 
 TEST(PinnedPoolTest, ThrowOutOfMemory)
 {
-  pool_mr mr{rmm::mr::pinned_host_memory_resource{}, 0, 1024};
+  const auto initial{0};
+  const auto maximum{1024};
+  pool_mr mr{rmm::mr::pinned_host_memory_resource{}, initial, maximum};
   (void)mr.allocate_sync(1024);
 
   EXPECT_THROW((void)mr.allocate_sync(1024), rmm::out_of_memory);

--- a/cpp/tests/mr/pinned_host_pool_mr_tests.cpp
+++ b/cpp/tests/mr/pinned_host_pool_mr_tests.cpp
@@ -18,10 +18,7 @@ TEST(PinnedPoolTest, ThrowMaxLessThanInitial)
   // Make sure first argument is enough larger than the second that alignment rounding doesn't
   // make them equal
   auto max_less_than_initial = []() {
-    rmm::mr::pinned_host_memory_resource pinned_mr{};
-    const auto initial{1024};
-    const auto maximum{256};
-    pool_mr mr{pinned_mr, initial, maximum};
+    pool_mr mr{rmm::mr::pinned_host_memory_resource{}, 1024, 256};
   };
   EXPECT_THROW(max_less_than_initial(), rmm::logic_error);
 }
@@ -31,10 +28,7 @@ TEST(PinnedPoolTest, ReferenceThrowMaxLessThanInitial)
   // Make sure first argument is enough larger than the second that alignment rounding doesn't
   // make them equal
   auto max_less_than_initial = []() {
-    rmm::mr::pinned_host_memory_resource pinned_mr{};
-    const auto initial{1024};
-    const auto maximum{256};
-    pool_mr mr{pinned_mr, initial, maximum};
+    pool_mr mr{rmm::mr::pinned_host_memory_resource{}, 1024, 256};
   };
   EXPECT_THROW(max_less_than_initial(), rmm::logic_error);
 }
@@ -43,8 +37,7 @@ TEST(PinnedPoolTest, ReferenceThrowMaxLessThanInitial)
 TEST(PinnedPoolTest, InitialAndMaxPoolSizeEqual)
 {
   EXPECT_NO_THROW([]() {
-    rmm::mr::pinned_host_memory_resource pinned_mr{};
-    pool_mr mr(pinned_mr, 1000192, 1000192);
+    pool_mr mr(rmm::mr::pinned_host_memory_resource{}, 1000192, 1000192);
     (void)mr.allocate_sync(1000);
   }());
 }
@@ -53,16 +46,14 @@ TEST(PinnedPoolTest, NonAlignedPoolSize)
 {
   EXPECT_THROW(
     []() {
-      rmm::mr::pinned_host_memory_resource pinned_mr{};
-      pool_mr mr(pinned_mr, 1000031, 1000192);
+      pool_mr mr(rmm::mr::pinned_host_memory_resource{}, 1000031, 1000192);
       (void)mr.allocate_sync(1000);
     }(),
     rmm::logic_error);
 
   EXPECT_THROW(
     []() {
-      rmm::mr::pinned_host_memory_resource pinned_mr{};
-      pool_mr mr(pinned_mr, 1000192, 1000200);
+      pool_mr mr(rmm::mr::pinned_host_memory_resource{}, 1000192, 1000200);
       (void)mr.allocate_sync(1000);
     }(),
     rmm::logic_error);
@@ -70,10 +61,7 @@ TEST(PinnedPoolTest, NonAlignedPoolSize)
 
 TEST(PinnedPoolTest, ThrowOutOfMemory)
 {
-  rmm::mr::pinned_host_memory_resource pinned_mr{};
-  const auto initial{0};
-  const auto maximum{1024};
-  pool_mr mr{pinned_mr, initial, maximum};
+  pool_mr mr{rmm::mr::pinned_host_memory_resource{}, 0, 1024};
   (void)mr.allocate_sync(1024);
 
   EXPECT_THROW((void)mr.allocate_sync(1024), rmm::out_of_memory);

--- a/cpp/tests/mr/polymorphic_allocator_tests.cpp
+++ b/cpp/tests/mr/polymorphic_allocator_tests.cpp
@@ -37,8 +37,8 @@ void test_conversion(rmm::mr::polymorphic_allocator<int> /*unused*/) {}
 
 TEST_F(allocator_test, implicit_conversion)
 {
-  rmm::mr::cuda_memory_resource mr;
-  test_conversion(cuda::mr::any_resource<cuda::mr::device_accessible>{mr});
+  test_conversion(
+    cuda::mr::any_resource<cuda::mr::device_accessible>{rmm::mr::cuda_memory_resource{}});
 }
 
 TEST_F(allocator_test, self_equality)
@@ -50,22 +50,16 @@ TEST_F(allocator_test, self_equality)
 
 TEST_F(allocator_test, equal_resources)
 {
-  rmm::mr::cuda_memory_resource mr0;
-  rmm::mr::polymorphic_allocator<int> alloc0{mr0};
-
-  rmm::mr::cuda_memory_resource mr1;
-  rmm::mr::polymorphic_allocator<int> alloc1{mr1};
+  rmm::mr::polymorphic_allocator<int> alloc0{rmm::mr::cuda_memory_resource{}};
+  rmm::mr::polymorphic_allocator<int> alloc1{rmm::mr::cuda_memory_resource{}};
   EXPECT_EQ(alloc0, alloc1);
   EXPECT_FALSE(alloc0 != alloc1);
 }
 
 TEST_F(allocator_test, unequal_resources)
 {
-  rmm::mr::managed_memory_resource mr0;
-  rmm::mr::polymorphic_allocator<int> alloc0{mr0};
-
-  rmm::mr::cuda_memory_resource mr1;
-  rmm::mr::polymorphic_allocator<int> alloc1{mr1};
+  rmm::mr::polymorphic_allocator<int> alloc0{rmm::mr::managed_memory_resource{}};
+  rmm::mr::polymorphic_allocator<int> alloc1{rmm::mr::cuda_memory_resource{}};
   EXPECT_NE(alloc0, alloc1);
 }
 

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -122,8 +122,7 @@ TEST(PoolTest, NonAlignedPoolSize)
 
 TEST(PoolTest, UpstreamDoesntSupportMemInfo)
 {
-  cuda_mr cuda;
-  pool_mr mr1{cuda, 0};
+  pool_mr mr1{cuda_mr{}, 0};
   pool_mr mr2{mr1, 0};
   auto* ptr = mr2.allocate_sync(1024);
   mr2.deallocate_sync(ptr, 1024);

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -146,7 +146,7 @@ TEST(PoolTest, MultidevicePool)
     for (int i = 0; i < devices; ++i) {
       RMM_CUDA_TRY(cudaSetDevice(i));
       auto mr = pool_mr{general_mr, pool_size, pool_size};
-      rmm::mr::set_per_device_resource_ref(rmm::cuda_device_id{i}, mr);
+      rmm::mr::set_per_device_resource(rmm::cuda_device_id{i}, mr);
       mrs.emplace_back(mr);
     }
 

--- a/cpp/tests/mr/stream_allocator_adaptor_tests.cpp
+++ b/cpp/tests/mr/stream_allocator_adaptor_tests.cpp
@@ -50,12 +50,10 @@ TEST_F(allocator_test, equal_allocators)
 
 TEST_F(allocator_test, unequal_resources)
 {
-  rmm::mr::cuda_memory_resource mr0;
-  rmm::mr::polymorphic_allocator<int> alloc0{mr0};
+  rmm::mr::polymorphic_allocator<int> alloc0{rmm::mr::cuda_memory_resource{}};
   auto adapted0 = rmm::mr::stream_allocator_adaptor(alloc0, stream);
 
-  rmm::mr::managed_memory_resource mr1;
-  rmm::mr::polymorphic_allocator<int> alloc1{mr1};
+  rmm::mr::polymorphic_allocator<int> alloc1{rmm::mr::managed_memory_resource{}};
   auto adapted1 = rmm::mr::stream_allocator_adaptor(alloc1, stream);
 
   EXPECT_NE(adapted0, adapted1);

--- a/cpp/tests/mr/thrust_allocator_tests.cu
+++ b/cpp/tests/mr/thrust_allocator_tests.cu
@@ -27,7 +27,7 @@ struct allocator_test : public mr_ref_test {};
 
 TEST_P(allocator_test, first)
 {
-  rmm::mr::set_current_device_resource_ref(this->ref);
+  rmm::mr::set_current_device_resource(this->ref);
   auto const num_ints{100};
   rmm::device_vector<int> ints(num_ints, 1);
   EXPECT_EQ(num_ints, thrust::reduce(ints.begin(), ints.end()));
@@ -35,7 +35,7 @@ TEST_P(allocator_test, first)
 
 TEST_P(allocator_test, defaults)
 {
-  rmm::mr::set_current_device_resource_ref(this->ref);
+  rmm::mr::set_current_device_resource(this->ref);
   rmm::mr::thrust_allocator<int> allocator(rmm::cuda_stream_default);
   EXPECT_EQ(allocator.stream(), rmm::cuda_stream_default);
   EXPECT_EQ(allocator.get_upstream_resource(),

--- a/python/rmm/rmm/librmm/per_device_resource.pxd
+++ b/python/rmm/rmm/librmm/per_device_resource.pxd
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
-from rmm.librmm.memory_resource cimport device_async_resource_ref
+from rmm.librmm.memory_resource cimport any_resource, device_accessible
 
 
 cdef extern from "rmm/mr/per_device_resource.hpp" namespace "rmm" nogil:
@@ -13,9 +13,9 @@ cdef extern from "rmm/mr/per_device_resource.hpp" namespace "rmm" nogil:
 
 cdef extern from "rmm/mr/per_device_resource.hpp" \
         namespace "rmm::mr" nogil:
-    cdef void set_current_device_resource_ref(
-        device_async_resource_ref new_mr
+    cdef void set_per_device_resource(
+        cuda_device_id id, any_resource[device_accessible] new_resource
     )
-    cdef void set_per_device_resource_ref(
-        cuda_device_id id, device_async_resource_ref new_mr
+    cdef void set_current_device_resource(
+        any_resource[device_accessible] new_resource
     )

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -30,7 +30,7 @@ from rmm.pylibrmm.stream import DEFAULT_STREAM
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.per_device_resource cimport (
     cuda_device_id,
-    set_per_device_resource_ref as cpp_set_per_device_resource_ref,
+    set_per_device_resource as cpp_set_per_device_resource,
 )
 from rmm.pylibrmm.helper cimport parse_bytes
 
@@ -1101,7 +1101,10 @@ cpdef set_per_device_resource(int device, DeviceMemoryResource mr):
     cdef unique_ptr[cuda_device_id] device_id = \
         make_unique[cuda_device_id](device)
 
-    cpp_set_per_device_resource_ref(deref(device_id), mr.c_ref.value())
+    cpp_set_per_device_resource(
+        deref(device_id),
+        make_any_device_resource(mr.c_ref.value())
+    )
 
 
 cpdef set_current_device_resource(DeviceMemoryResource mr):


### PR DESCRIPTION
## Summary

- Add `set_per_device_resource` and `set_current_device_resource` functions that take `cuda::mr::any_resource<cuda::mr::device_accessible>` by value (ownership-transferring), following the same sink-parameter pattern established in #2354
- Refactor `set_per_device_resource_ref` and `set_current_device_resource_ref` to delegate to the new functions
- Update Cython bindings to call the new owning-resource setters via `make_any_device_resource` workaround

The `_ref` variants remain for callers that have a non-owning `device_async_resource_ref`, but the implementation now routes through the owning `any_resource` path.