### PR TITLE
Deprecate get_per_device_resource_type and get_current_device_resource_type

### DIFF
--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -1162,11 +1162,20 @@ cpdef get_per_device_resource_type(int device):
     Get the memory resource type used for RMM device allocations on the
     specified device.
 
+    .. deprecated:: 26.06
+        Use ``type(get_per_device_resource(device))`` instead.
+
     Parameters
     ----------
     device : int
         The device ID
     """
+    warnings.warn(
+        "get_per_device_resource_type is deprecated. "
+        "Use type(get_per_device_resource(device)) instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     return type(get_per_device_resource(device))
 
 
@@ -1185,7 +1194,16 @@ cpdef get_current_device_resource_type():
     """
     Get the memory resource type used for RMM device allocations on the
     current device.
+
+    .. deprecated:: 26.06
+        Use ``type(get_current_device_resource())`` instead.
     """
+    warnings.warn(
+        "get_current_device_resource_type is deprecated. "
+        "Use type(get_current_device_resource()) instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     return type(get_current_device_resource())
 
 

--- a/python/rmm/rmm/tests/test_arena_memory_resource.py
+++ b/python/rmm/rmm/tests/test_arena_memory_resource.py
@@ -42,5 +42,5 @@ def test_arena_memory_resource(
     mr = rmm.mr.ArenaMemoryResource(upstream, arena_size=_TEST_POOL_SIZE)
 
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
     array_tester(dtype, nelem, alloc)

--- a/python/rmm/rmm/tests/test_binning_memory_resource.py
+++ b/python/rmm/rmm/tests/test_binning_memory_resource.py
@@ -74,7 +74,7 @@ class TestBinningMemoryResource:
     @pytest.mark.parametrize("alloc", _allocs)
     def test_binning_memory_resource(self, binning_mr, dtype, nelem, alloc):
         assert (
-            rmm.mr.get_current_device_resource_type()
+            type(rmm.mr.get_current_device_resource())
             is rmm.mr.BinningMemoryResource
         )
         array_tester(dtype, nelem, alloc)
@@ -83,7 +83,7 @@ class TestBinningMemoryResource:
     def test_binning_large_allocation(self, binning_mr, alloc):
         """Allocate 128 MiB to exercise the explicit CudaMemoryResource bin."""
         assert (
-            rmm.mr.get_current_device_resource_type()
+            type(rmm.mr.get_current_device_resource())
             is rmm.mr.BinningMemoryResource
         )
         array_tester(np.float64, _LARGE_NELEM, alloc)

--- a/python/rmm/rmm/tests/test_cuda_async_managed_memory_resource.py
+++ b/python/rmm/rmm/tests/test_cuda_async_managed_memory_resource.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for CudaAsyncManagedMemoryResource."""
@@ -27,7 +27,7 @@ from rmm.pylibrmm.stream import Stream
 def test_cuda_async_managed_memory_resource(dtype, nelem, alloc):
     mr = rmm.mr.experimental.CudaAsyncManagedMemoryResource()
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
     array_tester(dtype, nelem, alloc)
 
 

--- a/python/rmm/rmm/tests/test_cuda_async_memory_resource.py
+++ b/python/rmm/rmm/tests/test_cuda_async_memory_resource.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for CudaAsyncMemoryResource."""
@@ -24,7 +24,7 @@ from rmm.pylibrmm.stream import Stream
 def test_cuda_async_memory_resource(dtype, nelem, alloc):
     mr = rmm.mr.CudaAsyncMemoryResource()
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
     array_tester(dtype, nelem, alloc)
 
 
@@ -40,7 +40,7 @@ def test_cuda_async_memory_resource_ipc():
     # CUDA 11.3+ is required for IPC memory handle support
     mr = rmm.mr.CudaAsyncMemoryResource(enable_ipc=True)
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
 
 
 def test_cuda_async_memory_resource_fabric():
@@ -67,7 +67,7 @@ def test_cuda_async_memory_resource_fabric():
         )
     else:
         rmm.mr.set_current_device_resource(mr)
-        assert rmm.mr.get_current_device_resource_type() is type(mr)
+        assert type(rmm.mr.get_current_device_resource()) is type(mr)
 
 
 @pytest.mark.parametrize("nelems", _nelems)

--- a/python/rmm/rmm/tests/test_cuda_async_view_memory_resource.py
+++ b/python/rmm/rmm/tests/test_cuda_async_view_memory_resource.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for CudaAsyncViewMemoryResource."""
@@ -21,7 +21,7 @@ def test_cuda_async_view_memory_resource_default_pool(dtype, nelem, alloc):
 
     mr = rmm.mr.CudaAsyncViewMemoryResource(pool)
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
     array_tester(dtype, nelem, alloc)
 
 
@@ -39,7 +39,7 @@ def test_cuda_async_view_memory_resource_custom_pool(dtype, nelem, alloc):
 
     mr = rmm.mr.CudaAsyncViewMemoryResource(pool)
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
     array_tester(dtype, nelem, alloc)
 
     # After the pool is destroyed, new allocations should raise

--- a/python/rmm/rmm/tests/test_fixed_size_memory_resource.py
+++ b/python/rmm/rmm/tests/test_fixed_size_memory_resource.py
@@ -57,7 +57,7 @@ class TestFixedSizeMemoryResource:
         self, fixed_size_mr, dtype, nelem, alloc
     ):
         assert (
-            rmm.mr.get_current_device_resource_type()
+            type(rmm.mr.get_current_device_resource())
             is rmm.mr.FixedSizeMemoryResource
         )
         array_tester(dtype, nelem, alloc)

--- a/python/rmm/rmm/tests/test_pinned_host_memory_resource.py
+++ b/python/rmm/rmm/tests/test_pinned_host_memory_resource.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for PinnedHostMemoryResource."""
@@ -17,7 +17,7 @@ def test_pinned_host_memory_resource(dtype, nelem, alloc):
     """Test PinnedHostMemoryResource as a basic memory resource."""
     mr = rmm.mr.PinnedHostMemoryResource()
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
     array_tester(dtype, nelem, alloc)
 
 
@@ -33,7 +33,7 @@ def test_pinned_host_memory_resource_with_pool(dtype, nelem, alloc):
         maximum_pool_size="8MiB",
     )
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
     array_tester(dtype, nelem, alloc)
 
 

--- a/python/rmm/rmm/tests/test_pool_memory_resource.py
+++ b/python/rmm/rmm/tests/test_pool_memory_resource.py
@@ -32,7 +32,7 @@ def test_pool_memory_resource(
         maximum_pool_size="8MiB",
     )
     rmm.mr.set_current_device_resource(mr)
-    assert rmm.mr.get_current_device_resource_type() is type(mr)
+    assert type(rmm.mr.get_current_device_resource()) is type(mr)
     array_tester(dtype, nelem, alloc)
 
 


### PR DESCRIPTION
## Summary

- Deprecate `get_per_device_resource_type` and `get_current_device_resource_type` with `FutureWarning` — these are trivial wrappers around `type(get_per_device_resource(...))` / `type(get_current_device_resource())` that add API surface without adding capability
- Replace all test usages with the direct `type(...)` call
- https://github.com/rapidsai/dask-cuda/pull/1644 was the only place I could find in RAPIDS code that was using this