### PR TITLE
Add get_mr() method to DeviceMemoryResource for downstream Cython usage

### DIFF
--- a/cpp/include/rmm/mr/detail/logging_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/logging_resource_adaptor_impl.hpp
@@ -47,7 +47,7 @@ class logging_resource_adaptor_impl {
 
   bool operator==(logging_resource_adaptor_impl const& other) const noexcept
   {
-    return upstream_ == other.upstream_ && logger_ == other.logger_;
+    return upstream_mr_ == other.upstream_mr_ && logger_ == other.logger_;
   }
 
   bool operator!=(logging_resource_adaptor_impl const& other) const noexcept
@@ -68,7 +68,7 @@ class logging_resource_adaptor_impl {
 
  private:
   std::shared_ptr<rapids_logger::logger> logger_{};
-  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_;
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr_;
 };
 
 }  // namespace detail

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -16,7 +16,7 @@ logging_resource_adaptor_impl::logging_resource_adaptor_impl(
   std::shared_ptr<rapids_logger::logger> logger,
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
   bool auto_flush)
-  : logger_{std::move(logger)}, upstream_{std::move(upstream)}
+  : logger_{std::move(logger)}, upstream_mr_{std::move(upstream)}
 {
   if (auto_flush) { logger_->flush_on(rapids_logger::level_enum::info); }
   logger_->set_pattern("%v");
@@ -28,7 +28,7 @@ void* logging_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_
 {
   auto const stream = cuda_stream_view{};
   try {
-    auto const ptr = upstream_.allocate(stream, bytes, alignment);
+    auto const ptr = upstream_mr_.allocate(stream, bytes, alignment);
     logger_->info("allocate,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
     return ptr;
   } catch (...) {
@@ -43,7 +43,7 @@ void logging_resource_adaptor_impl::deallocate_sync(void* ptr,
 {
   auto const stream = cuda_stream_view{};
   logger_->info("free,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
-  upstream_.deallocate(stream, ptr, bytes, alignment);
+  upstream_mr_.deallocate(stream, ptr, bytes, alignment);
 }
 
 void* logging_resource_adaptor_impl::allocate(cuda::stream_ref stream,
@@ -51,7 +51,7 @@ void* logging_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                               std::size_t alignment)
 {
   try {
-    auto const ptr = upstream_.allocate(stream, bytes, alignment);
+    auto const ptr = upstream_mr_.allocate(stream, bytes, alignment);
     logger_->info("allocate,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
     return ptr;
   } catch (...) {
@@ -66,13 +66,13 @@ void logging_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
                                                std::size_t alignment) noexcept
 {
   logger_->info("free,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
-  upstream_.deallocate(stream, ptr, bytes, alignment);
+  upstream_mr_.deallocate(stream, ptr, bytes, alignment);
 }
 
 rmm::device_async_resource_ref logging_resource_adaptor_impl::get_upstream_resource() const noexcept
 {
   return rmm::device_async_resource_ref{
-    const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(upstream_)};
+    const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(upstream_mr_)};
 }
 
 void logging_resource_adaptor_impl::flush() { logger_->flush(); }

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -16,8 +16,56 @@ from libcpp.string cimport string
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 
 
-cdef extern from "rmm/resource_ref.hpp" namespace "rmm" nogil:
-    cdef cppclass device_async_resource_ref:
+cdef extern from * nogil:
+    """
+    #include <optional>
+    #include <rmm/aligned.hpp>
+    #include <rmm/resource_ref.hpp>
+
+    // Default-constructible wrapper around rmm::device_async_resource_ref.
+    //
+    // Cython requires every C++ type used as a local variable or return
+    // value to be default-constructible (it emits `T __pyx_r;` for the
+    // return slot).  rmm::device_async_resource_ref inherits a deleted
+    // default constructor from cuda::mr::basic_any_ref, so it cannot be
+    // used directly.
+    //
+    // This wrapper stores the ref inside std::optional (which IS
+    // default-constructible) and provides an implicit conversion
+    // operator back to rmm::device_async_resource_ref so that C++
+    // call sites that expect the real type work transparently.
+    //
+    // The Cython declaration below maps the Cython name
+    // "device_async_resource_ref" to this struct, so all existing
+    // Cython code continues to use the familiar name while the
+    // generated C++ uses the default-constructible wrapper.
+    struct cython_device_async_resource_ref {
+        std::optional<rmm::device_async_resource_ref> ref;
+
+        cython_device_async_resource_ref() noexcept = default;
+
+        cython_device_async_resource_ref(
+            rmm::device_async_resource_ref r) noexcept : ref(r) {}
+
+        operator rmm::device_async_resource_ref() const noexcept {
+            return ref.value();
+        }
+
+        void* allocate(rmm::cuda_stream_view stream, std::size_t bytes) {
+            return ref.value().allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        }
+
+        void deallocate(
+            rmm::cuda_stream_view stream,
+            void* ptr,
+            std::size_t bytes) noexcept {
+            ref.value().deallocate(stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        }
+    };
+    """
+    cdef cppclass device_async_resource_ref \
+            "cython_device_async_resource_ref":
+        device_async_resource_ref() noexcept
         void* allocate(cuda_stream_view stream, size_t bytes) except +
         void deallocate(
             cuda_stream_view stream,
@@ -63,9 +111,9 @@ cdef extern from *:
     #include <optional>
     #include <rmm/resource_ref.hpp>
     template <typename T>
-    std::optional<rmm::device_async_resource_ref>
+    std::optional<cython_device_async_resource_ref>
     make_device_async_resource_ref(T& r) {
-        return std::optional<rmm::device_async_resource_ref>(
+        return std::optional<cython_device_async_resource_ref>(
             rmm::device_async_resource_ref(r));
     }
     """

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -51,20 +51,6 @@ cdef extern from * nogil:
             return ref.value();
         }
 
-        // Equality is only needed to satisfy CCCL's any_resource SFINAE checks
-        // during Cython template instantiation. Avoid delegating to
-        // optional/resource_ref operator== which triggers recursive constraint
-        // satisfaction in CCCL (NVIDIA/cccl#8320).
-        friend bool operator==(cython_device_async_resource_ref const& lhs,
-                               cython_device_async_resource_ref const& rhs) noexcept {
-            return &lhs == &rhs;
-        }
-
-        friend bool operator!=(cython_device_async_resource_ref const& lhs,
-                               cython_device_async_resource_ref const& rhs) noexcept {
-            return !(lhs == rhs);
-        }
-
         void* allocate(rmm::cuda_stream_view stream, std::size_t bytes) {
             return ref.value().allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
         }

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -51,6 +51,20 @@ cdef extern from * nogil:
             return ref.value();
         }
 
+        // Equality is only needed to satisfy CCCL's any_resource SFINAE checks
+        // during Cython template instantiation. Avoid delegating to
+        // optional/resource_ref operator== which triggers recursive constraint
+        // satisfaction in CCCL (NVIDIA/cccl#8320).
+        friend bool operator==(cython_device_async_resource_ref const& lhs,
+                               cython_device_async_resource_ref const& rhs) noexcept {
+            return &lhs == &rhs;
+        }
+
+        friend bool operator!=(cython_device_async_resource_ref const& lhs,
+                               cython_device_async_resource_ref const& rhs) noexcept {
+            return !(lhs == rhs);
+        }
+
         void* allocate(rmm::cuda_stream_view stream, std::size_t bytes) {
             return ref.value().allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
         }

--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -90,12 +90,12 @@ cdef class DeviceBuffer:
             if c_ptr == NULL or size == 0:
                 self.c_obj.reset(new device_buffer(
                     size, stream.view(),
-                    make_any_device_resource(self.mr.c_ref.value())
+                    make_any_device_resource(self.mr.get_mr())
                 ))
             else:
                 self.c_obj.reset(new device_buffer(
                     c_ptr, size, stream.view(),
-                    make_any_device_resource(self.mr.c_ref.value())
+                    make_any_device_resource(self.mr.get_mr())
                 ))
 
                 if stream.c_is_default():

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pxd
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pxd
@@ -30,6 +30,8 @@ from rmm.librmm.memory_resource cimport (
 cdef class DeviceMemoryResource:
     cdef optional[device_async_resource_ref] c_ref
 
+    cdef device_async_resource_ref get_mr(self) noexcept nogil
+
 cdef class UpstreamResourceAdaptor(DeviceMemoryResource):
     cdef readonly DeviceMemoryResource upstream_mr
 

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -72,6 +72,9 @@ from rmm.librmm.memory_resource cimport (
 
 cdef class DeviceMemoryResource:
 
+    cdef device_async_resource_ref get_mr(self) noexcept nogil:
+        return deref(self.c_ref)
+
     def allocate(self, size_t nbytes, Stream stream=DEFAULT_STREAM):
         """Allocate ``nbytes`` bytes of memory.
 
@@ -96,7 +99,7 @@ cdef class DeviceMemoryResource:
         stream = as_stream(stream)
         cdef uintptr_t ptr
         with nogil:
-            ptr = <uintptr_t>(self.c_ref.value().allocate(
+            ptr = <uintptr_t>(self.get_mr().allocate(
                 stream.view(), nbytes
             ))
         return ptr
@@ -115,7 +118,7 @@ cdef class DeviceMemoryResource:
         """
         stream = as_stream(stream)
         with nogil:
-            self.c_ref.value().deallocate(
+            self.get_mr().deallocate(
                 stream.view(), <void*>(ptr), nbytes
             )
 
@@ -357,7 +360,7 @@ cdef class PoolMemoryResource(UpstreamResourceAdaptor):
             else optional[size_t](<size_t> parse_bytes(maximum_pool_size))
         )
         self.c_obj.reset(new pool_memory_resource(
-            make_any_device_resource(upstream_mr.c_ref.value()),
+            make_any_device_resource(upstream_mr.get_mr()),
             c_initial_pool_size,
             c_maximum_pool_size
         ))
@@ -401,7 +404,7 @@ cdef class ArenaMemoryResource(UpstreamResourceAdaptor):
             else optional[size_t](<size_t> parse_bytes(arena_size))
         )
         self.c_obj.reset(new arena_memory_resource(
-            make_any_device_resource(upstream_mr.c_ref.value()),
+            make_any_device_resource(upstream_mr.get_mr()),
             c_arena_size,
             dump_log_on_failure,
         ))
@@ -438,7 +441,7 @@ cdef class FixedSizeMemoryResource(UpstreamResourceAdaptor):
             size_t blocks_to_preallocate=128
     ):
         self.c_obj.reset(new fixed_size_memory_resource(
-            make_any_device_resource(upstream_mr.c_ref.value()),
+            make_any_device_resource(upstream_mr.get_mr()),
             block_size,
             blocks_to_preallocate
         ))
@@ -483,11 +486,11 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
 
         if (min_size_exponent == -1 or max_size_exponent == -1):
             self.c_obj.reset(new binning_memory_resource(
-                make_any_device_resource(upstream_mr.c_ref.value())
+                make_any_device_resource(upstream_mr.get_mr())
             ))
         else:
             self.c_obj.reset(new binning_memory_resource(
-                make_any_device_resource(upstream_mr.c_ref.value()),
+                make_any_device_resource(upstream_mr.get_mr()),
                 min_size_exponent,
                 max_size_exponent
             ))
@@ -550,7 +553,7 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
             deref(self.c_obj).add_bin(
                 allocation_size,
                 optional[device_async_resource_ref](
-                    bin_resource.c_ref.value()
+                    bin_resource.get_mr()
                 )
             )
         else:
@@ -677,7 +680,7 @@ cdef class LimitingResourceAdaptor(UpstreamResourceAdaptor):
         size_t allocation_limit
     ):
         self.c_obj.reset(new limiting_resource_adaptor(
-            make_any_device_resource(upstream_mr.c_ref.value()),
+            make_any_device_resource(upstream_mr.get_mr()),
             allocation_limit
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
@@ -742,7 +745,7 @@ cdef class LoggingResourceAdaptor(UpstreamResourceAdaptor):
         self._log_file_name = log_file_name
 
         self.c_obj.reset(new logging_resource_adaptor(
-            make_any_device_resource(upstream_mr.c_ref.value()),
+            make_any_device_resource(upstream_mr.get_mr()),
             log_file_name.encode()
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
@@ -778,7 +781,7 @@ cdef class StatisticsResourceAdaptor(UpstreamResourceAdaptor):
         DeviceMemoryResource upstream_mr
     ):
         self.c_obj.reset(new statistics_resource_adaptor(
-            make_any_device_resource(upstream_mr.c_ref.value())
+            make_any_device_resource(upstream_mr.get_mr())
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
@@ -869,7 +872,7 @@ cdef class TrackingResourceAdaptor(UpstreamResourceAdaptor):
         bool capture_stacks=False
     ):
         self.c_obj.reset(new tracking_resource_adaptor(
-            make_any_device_resource(upstream_mr.c_ref.value()),
+            make_any_device_resource(upstream_mr.get_mr()),
             capture_stacks
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
@@ -942,7 +945,7 @@ cdef class FailureCallbackResourceAdaptor(UpstreamResourceAdaptor):
     ):
         self._callback = callback
         self.c_obj.reset(new failure_callback_resource_adaptor_oom(
-            make_any_device_resource(upstream_mr.c_ref.value()),
+            make_any_device_resource(upstream_mr.get_mr()),
             <failure_callback_t>(_oom_callback_function),
             <void*>(callback)
         ))
@@ -972,7 +975,7 @@ cdef class PrefetchResourceAdaptor(UpstreamResourceAdaptor):
         DeviceMemoryResource upstream_mr
     ):
         self.c_obj.reset(new prefetch_resource_adaptor(
-            make_any_device_resource(upstream_mr.c_ref.value())
+            make_any_device_resource(upstream_mr.get_mr())
         ))
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
@@ -1103,7 +1106,7 @@ cpdef set_per_device_resource(int device, DeviceMemoryResource mr):
 
     cpp_set_per_device_resource(
         deref(device_id),
-        make_any_device_resource(mr.c_ref.value())
+        make_any_device_resource(mr.get_mr())
     )
 
 


### PR DESCRIPTION
## Description

Adds a `get_mr()` cdef method to `DeviceMemoryResource`, matching the same API already on `main`. Downstream Cython consumers can use `mr.get_mr()` on both branches without conditional logic.

Before (`main`):
```cython
cdef device_memory_resource* get_mr(self) nogil
# usage: mr.get_mr()
```

After (`staging` + this PR):
```cython
cdef device_async_resource_ref get_mr(self) noexcept nogil
# usage: mr.get_mr()
```

To work around Cython's requirement that return types be default-constructible, the `device_async_resource_ref` Cython declaration is mapped to an inline C++ shim that wraps the real type in `std::optional` and converts back implicitly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.