### PR TITLE
Migrate stream APIs from rmm::cuda_stream_view to cuda::stream_ref

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
     rev: v0.21.1
     hooks:
       - id: cython-lint
+        args: ["--max-line-length=120"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.8
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ pre-commit run ruff-format --all-files   # Python formatting only
 Use `pre-commit run --all-files` to run linter and style checks. It will call clang-format, ruff, and other tools.
 
 ### Naming Conventions
-- **C++ classes**: `snake_case` (e.g., `device_buffer`, `cuda_stream_view`)
+- **C++ classes**: `snake_case` (e.g., `device_buffer`)
 - **C++ functions/methods**: `snake_case`
 - **C++ constants/macros**: `SCREAMING_SNAKE_CASE`
 - **C++ template params**: `PascalCase` with `T` suffix (e.g., `OffsetT`)
@@ -186,8 +186,8 @@ mr.deallocate_sync(ptr, bytes);
 
 ### Stream Usage (C++)
 ```cpp
-#include <rmm/cuda_stream_view.hpp>
-void func(rmm::cuda_stream_view stream) {
+#include <cuda/stream>
+void func(cuda::stream_ref stream) {
   // Use stream for async operations
 }
 ```
@@ -209,7 +209,7 @@ buf = rmm.DeviceBuffer(size=size)
 - Never use raw CUDA memory APIs for device memory - use memory resources (except in memory resource implementations)
 - Prefer `rmm::device_uvector<T>` for typed device memory
 - Prefer `rmm::device_buffer` for untyped device memory
-- All operations should be stream-ordered - accept `rmm::cuda_stream_view`
+- All operations should be stream-ordered - accept `cuda::stream_ref` from `<cuda/stream>`
 - Views (`*_view` suffix) are non-owning - don't manage their lifetime
 
 ## Key Files Reference

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ buf = rmm.DeviceBuffer(size=size)
 | C++ public headers | `cpp/include/rmm/` |
 | Memory resources | `cpp/include/rmm/mr/` |
 | Device containers | `cpp/include/rmm/device_uvector.hpp`, `device_buffer.hpp` |
-| Stream utilities | `cpp/include/rmm/cuda_stream.hpp`, `cuda_stream_view.hpp` |
+| Stream utilities | `<cuda/stream>`, `cpp/include/rmm/cuda_stream.hpp` (`cuda_stream_view.hpp` is deprecated) |
 | Error handling | `cpp/include/rmm/error.hpp` |
 | Python bindings | `python/rmm/rmm/` |
 | C++ tests | `cpp/tests/` |

--- a/README.md
+++ b/README.md
@@ -452,11 +452,11 @@ For example, recapitulating the previous example using `rmm::device_vector`:
 > initialize new elements: the user must arrange for this kernel launch to occur with the correct
 > device for the memory resource active.
 
-## `cuda_stream_view` and `cuda_stream`
+## `cuda::stream_ref`, `cuda_stream_view`, and `cuda_stream`
 
-`rmm::cuda_stream_view` is a simple non-owning wrapper around a CUDA `cudaStream_t`. New code should
-prefer `cuda::stream_ref` for compatibility with CCCL. `rmm::cuda_stream_view` can be converted
-to/from `cuda::stream_ref`.
+`cuda::stream_ref`, provided by `<cuda/stream>`, is the preferred non-owning CUDA stream wrapper.
+`rmm::cuda_stream_view` is deprecated; migrate existing code to `cuda::stream_ref`. The deprecated
+wrapper remains convertible to and from `cuda::stream_ref` for compatibility.
 
 `rmm::cuda_stream` is a simple owning wrapper around a CUDA `cudaStream_t`. This class provides
 RAII semantics (constructor creates the CUDA stream, destructor destroys it). An `rmm::cuda_stream`
@@ -468,8 +468,8 @@ a single non-default stream. `rmm::cuda_stream` cannot be copied, but can be mov
 `rmm::cuda_stream_pool` provides fast access to a pool of CUDA streams. This class can be used to
 create a set of `cuda_stream` objects whose lifetime is equal to the `cuda_stream_pool`. Using the
 stream pool can be faster than creating the streams on the fly. The size of the pool is configurable.
-Depending on this size, multiple calls to `cuda_stream_pool::get_stream()` may return instances of
-`rmm::cuda_stream_view` that represent identical CUDA streams.
+Depending on this size, multiple calls to `cuda_stream_pool::get_stream()` may return
+`cuda::stream_ref` instances that represent identical CUDA streams.
 
 ## Thread Safety
 
@@ -490,7 +490,8 @@ RMM provides several `Allocator` and `Allocator`-like classes.
 ### `polymorphic_allocator`
 
 A [stream-ordered](#stream-ordered-memory-allocation) allocator similar to [`std::pmr::polymorphic_allocator`](https://en.cppreference.com/w/cpp/memory/polymorphic_allocator).
-Unlike the standard C++ `Allocator` interface, the `allocate` and `deallocate` functions take a `cuda_stream_view` indicating the stream on which the (de)allocation occurs.
+Unlike the standard C++ `Allocator` interface, the `allocate` and `deallocate` functions take a
+`cuda::stream_ref` indicating the stream on which the (de)allocation occurs.
 
 ### `stream_allocator_adaptor`
 
@@ -527,12 +528,12 @@ An untyped, uninitialized RAII class for stream ordered device memory allocation
 #### Example
 
 ```c++
-cuda_stream_view s{...};
+cuda::stream_ref s{...};
 // Allocates at least 100 bytes on stream `s` using the *default* resource
 rmm::device_buffer b{100, s};
 void* p = b.data();                   // Raw, untyped pointer to underlying device memory
 
-kernel<<<..., s.value()>>>(b.data()); // `b` is only safe to use on `s`
+kernel<<<..., s.get()>>>(b.data());   // `b` is only safe to use on `s`
 
 rmm::mr::cuda_memory_resource mr;
 // Allocates at least 100 bytes on stream `s` using the resource `mr`
@@ -547,12 +548,12 @@ contained elements. This optimization restricts the types `T` to trivially copya
 #### Example
 
 ```c++
-cuda_stream_view s{...};
+cuda::stream_ref s{...};
 // Allocates uninitialized storage for 100 `int32_t` elements on stream `s` using the
 // default resource
 rmm::device_uvector<int32_t> v(100, s);
 // Initializes the elements to 0
-thrust::uninitialized_fill(thrust::cuda::par.on(s.value()), v.begin(), v.end(), int32_t{0});
+thrust::uninitialized_fill(thrust::cuda::par.on(s.get()), v.begin(), v.end(), int32_t{0});
 
 rmm::mr::cuda_memory_resource mr;
 // Allocates uninitialized storage for 100 `int32_t` elements on stream `s` using the resource `mr`
@@ -566,12 +567,12 @@ modifying the value in device memory from the host, or retrieving the value from
 
 #### Example
 ```c++
-cuda_stream_view s{...};
+cuda::stream_ref s{...};
 // Allocates uninitialized storage for a single `int32_t` in device memory
 rmm::device_scalar<int32_t> a{s};
 a.set_value(42, s); // Updates the value in device memory to `42` on stream `s`
 
-kernel<<<..., s.value()>>>(a.data()); // Pass raw pointer to underlying element in device memory
+kernel<<<..., s.get()>>>(a.data());   // Pass raw pointer to underlying element in device memory
 
 int32_t v = a.value(s); // Retrieves the value from device to host on stream `s`
 ```

--- a/cpp/REVIEW_GUIDELINES.md
+++ b/cpp/REVIEW_GUIDELINES.md
@@ -193,7 +193,7 @@ upstream_->deallocate(ptr, size, stream);
 - Respect stream-ordered memory semantics
 
 **Stream Management**:
-- Async allocations must accept a `cuda_stream_view`
+- Async allocations must accept a `cuda::stream_ref`
 - Synchronization must happen before memory is returned to pool
 - Document stream semantics in function documentation
 

--- a/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
+++ b/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@ static void BM_StreamPoolGetStream(benchmark::State& state)
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     auto stream = stream_pool.get_stream();
-    cudaStreamQuery(stream.value());
+    cudaStreamQuery(cuda::stream_ref{stream}.get());
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
@@ -29,7 +29,7 @@ static void BM_CudaStreamClass(benchmark::State& state)
 {
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     auto stream = rmm::cuda_stream{};
-    cudaStreamQuery(stream.view().value());
+    cudaStreamQuery(cuda::stream_ref{stream}.get());
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));

--- a/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
+++ b/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
+++ b/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
@@ -19,7 +19,7 @@ static void BM_StreamPoolGetStream(benchmark::State& state)
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     auto stream = stream_pool.get_stream();
-    RMM_CUDA_TRY(cudaStreamQuery(cuda::stream_ref{stream}.get()));
+    RMM_CUDA_TRY(cudaStreamQuery(stream.get()));
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
@@ -30,7 +30,7 @@ static void BM_CudaStreamClass(benchmark::State& state)
 {
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     auto stream = rmm::cuda_stream{};
-    RMM_CUDA_TRY(cudaStreamQuery(cuda::stream_ref{stream}.get()));
+    RMM_CUDA_TRY(cudaStreamQuery(stream.value()));
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));

--- a/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
+++ b/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
@@ -19,7 +19,7 @@ static void BM_StreamPoolGetStream(benchmark::State& state)
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     auto stream = stream_pool.get_stream();
-    RMM_CUDA_TRY(cudaStreamQuery(stream.value()));
+    RMM_CUDA_TRY(cudaStreamQuery(cuda::stream_ref{stream}.get()));
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
@@ -30,7 +30,7 @@ static void BM_CudaStreamClass(benchmark::State& state)
 {
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     auto stream = rmm::cuda_stream{};
-    RMM_CUDA_TRY(cudaStreamQuery(stream.view().value()));
+    RMM_CUDA_TRY(cudaStreamQuery(cuda::stream_ref{stream}.get()));
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));

--- a/cpp/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/cpp/benchmarks/device_uvector/device_uvector_bench.cu
@@ -15,6 +15,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 #include <thrust/device_vector.h>
 #include <thrust/memory.h>
@@ -31,7 +32,7 @@ void BM_UvectorSizeConstruction(benchmark::State& state)
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_uvector<std::int32_t> vec(static_cast<std::size_t>(state.range(0)),
-                                          rmm::cuda_stream_view{});
+                                          cuda::stream_ref{cudaStream_t{nullptr}});
     cudaDeviceSynchronize();
   }
 
@@ -78,7 +79,7 @@ using rmm_vector    = rmm::device_vector<int32_t>;
 using rmm_uvector   = rmm::device_uvector<int32_t>;
 
 template <typename Vector>
-Vector make_vector(std::size_t num_elements, rmm::cuda_stream_view stream, bool zero_init = false)
+Vector make_vector(std::size_t num_elements, cuda::stream_ref stream, bool zero_init = false)
 {
   static_assert(std::is_same_v<Vector, thrust_vector> or std::is_same_v<Vector, rmm_vector> or
                   std::is_same_v<Vector, rmm_uvector>,
@@ -90,7 +91,7 @@ Vector make_vector(std::size_t num_elements, rmm::cuda_stream_view stream, bool 
   } else if constexpr (std::is_same_v<Vector, rmm_uvector>) {
     auto vec = Vector(num_elements, stream);
     if (zero_init) {
-      cudaMemsetAsync(vec.data(), 0, num_elements * sizeof(std::int32_t), stream.value());
+      cudaMemsetAsync(vec.data(), 0, num_elements * sizeof(std::int32_t), stream.get());
     }
     return vec;
   }
@@ -111,14 +112,14 @@ void vector_workflow(std::size_t num_elements,
 {
   auto input = make_vector<Vector>(num_elements, input_stream, true);
   input_stream.synchronize();
-  for (rmm::cuda_stream_view stream : streams) {
+  for (cuda::stream_ref stream : streams) {
     auto output = make_vector<Vector>(num_elements, stream);
-    kernel<<<num_blocks, block_size, 0, stream.value()>>>(
+    kernel<<<num_blocks, block_size, 0, stream.get()>>>(
       vector_data(input), vector_data(output), num_elements);
   }
 
-  for (rmm::cuda_stream_view stream : streams) {
-    stream.synchronize();
+  for (cuda::stream_ref stream : streams) {
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   }
 }
 

--- a/cpp/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/cpp/benchmarks/device_uvector/device_uvector_bench.cu
@@ -7,6 +7,7 @@
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/device_vector.hpp>
@@ -32,7 +33,7 @@ void BM_UvectorSizeConstruction(benchmark::State& state)
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_uvector<std::int32_t> vec(static_cast<std::size_t>(state.range(0)),
-                                          cuda::stream_ref{cudaStream_t{nullptr}});
+                                          rmm::cuda_stream_default);
     cudaDeviceSynchronize();
   }
 

--- a/cpp/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/cpp/benchmarks/device_uvector/device_uvector_bench.cu
@@ -121,7 +121,7 @@ void vector_workflow(std::size_t num_elements,
   }
 
   for (cuda::stream_ref stream : streams) {
-    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+    stream.sync();
   }
 }
 

--- a/cpp/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/cpp/benchmarks/device_uvector/device_uvector_bench.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 #include <thrust/device_vector.h>
 #include <thrust/memory.h>
@@ -91,7 +91,8 @@ Vector make_vector(std::size_t num_elements, cuda::stream_ref stream, bool zero_
   } else if constexpr (std::is_same_v<Vector, rmm_uvector>) {
     auto vec = Vector(num_elements, stream);
     if (zero_init) {
-      cudaMemsetAsync(vec.data(), 0, num_elements * sizeof(std::int32_t), stream.get());
+      RMM_CUDA_TRY(
+        cudaMemsetAsync(vec.data(), 0, num_elements * sizeof(std::int32_t), stream.get()));
     }
     return vec;
   }

--- a/cpp/benchmarks/device_uvector/device_uvector_bench.cu
+++ b/cpp/benchmarks/device_uvector/device_uvector_bench.cu
@@ -7,7 +7,6 @@
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/device_vector.hpp>
@@ -33,7 +32,7 @@ void BM_UvectorSizeConstruction(benchmark::State& state)
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     rmm::device_uvector<std::int32_t> vec(static_cast<std::size_t>(state.range(0)),
-                                          rmm::cuda_stream_default);
+                                          cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
     cudaDeviceSynchronize();
   }
 

--- a/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
+++ b/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
@@ -15,6 +15,7 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <benchmark/benchmark.h>
@@ -54,9 +55,9 @@ static void run_test(std::size_t num_kernels,
                      rmm::device_async_resource_ref mr)
 {
   for (std::size_t i = 0; i < num_kernels; i++) {
-    auto stream = stream_pool.get_stream(i);
+    auto stream = cuda::stream_ref{stream_pool.get_stream(i)};
     auto buffer = rmm::device_uvector<int64_t>(1, stream, mr);
-    compute_bound_kernel<<<1, 1, 0, stream.value()>>>(buffer.data());
+    compute_bound_kernel<<<1, 1, 0, stream.get()>>>(buffer.data());
   }
 }
 

--- a/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
+++ b/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <benchmark/benchmark.h>

--- a/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
+++ b/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
@@ -55,7 +55,7 @@ static void run_test(std::size_t num_kernels,
                      rmm::device_async_resource_ref mr)
 {
   for (std::size_t i = 0; i < num_kernels; i++) {
-    auto stream = cuda::stream_ref{stream_pool.get_stream(i)};
+    auto stream = stream_pool.get_stream(i);
     auto buffer = rmm::device_uvector<int64_t>(1, stream, mr);
     compute_bound_kernel<<<1, 1, 0, stream.get()>>>(buffer.data());
   }

--- a/cpp/benchmarks/random_allocations/random_allocations.cpp
+++ b/cpp/benchmarks/random_allocations/random_allocations.cpp
@@ -13,6 +13,9 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
 #include <benchmark/benchmark.h>
 #include <benchmarks/utilities/cxxopts.hpp>
 
@@ -54,7 +57,7 @@ void random_allocation_free(rmm::device_async_resource_ref mr,
                             SizeDistribution size_distribution,
                             std::size_t num_allocations,
                             std::size_t max_usage,  // in MiB
-                            rmm::cuda_stream_view stream = {})
+                            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}})
 {
   std::default_random_engine generator;
 
@@ -132,7 +135,7 @@ void uniform_random_allocations(
   std::size_t num_allocations,      // NOLINT(bugprone-easily-swappable-parameters)
   std::size_t max_allocation_size,  // size in MiB
   std::size_t max_usage,
-  rmm::cuda_stream_view stream = {})
+  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}})
 {
   std::uniform_int_distribution<std::size_t> size_distribution(1, max_allocation_size * size_mb);
   random_allocation_free(mr, size_distribution, num_allocations, max_usage, stream);
@@ -144,7 +147,7 @@ void uniform_random_allocations(
                                 std::size_t mean_allocation_size = 500, // in MiB
                                 std::size_t stddev_allocation_size = 500, // in MiB
                                 std::size_t max_usage = 8 << 20,
-                                cuda_stream_view stream) {
+                                cuda::stream_ref stream) {
   std::normal_distribution<std::size_t> size_distribution(, max_allocation_size * size_mb);
 }*/
 

--- a/cpp/benchmarks/random_allocations/random_allocations.cpp
+++ b/cpp/benchmarks/random_allocations/random_allocations.cpp
@@ -5,6 +5,7 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/binning_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
@@ -57,7 +58,7 @@ void random_allocation_free(rmm::device_async_resource_ref mr,
                             SizeDistribution size_distribution,
                             std::size_t num_allocations,
                             std::size_t max_usage,  // in MiB
-                            cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}})
+                            cuda::stream_ref stream = rmm::cuda_stream_default)
 {
   std::default_random_engine generator;
 
@@ -135,7 +136,7 @@ void uniform_random_allocations(
   std::size_t num_allocations,      // NOLINT(bugprone-easily-swappable-parameters)
   std::size_t max_allocation_size,  // size in MiB
   std::size_t max_usage,
-  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}})
+  cuda::stream_ref stream = rmm::cuda_stream_default)
 {
   std::uniform_int_distribution<std::size_t> size_distribution(1, max_allocation_size * size_mb);
   random_allocation_free(mr, size_distribution, num_allocations, max_usage, stream);

--- a/cpp/benchmarks/random_allocations/random_allocations.cpp
+++ b/cpp/benchmarks/random_allocations/random_allocations.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <benchmark/benchmark.h>

--- a/cpp/benchmarks/random_allocations/random_allocations.cpp
+++ b/cpp/benchmarks/random_allocations/random_allocations.cpp
@@ -5,7 +5,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/binning_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
@@ -58,7 +57,8 @@ void random_allocation_free(rmm::device_async_resource_ref mr,
                             SizeDistribution size_distribution,
                             std::size_t num_allocations,
                             std::size_t max_usage,  // in MiB
-                            cuda::stream_ref stream = rmm::cuda_stream_default)
+                            cuda::stream_ref stream = cuda::stream_ref{
+                              cudaStream_t{cudaStreamDefault}})
 {
   std::default_random_engine generator;
 
@@ -136,7 +136,7 @@ void uniform_random_allocations(
   std::size_t num_allocations,      // NOLINT(bugprone-easily-swappable-parameters)
   std::size_t max_allocation_size,  // size in MiB
   std::size_t max_usage,
-  cuda::stream_ref stream = rmm::cuda_stream_default)
+  cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}})
 {
   std::uniform_int_distribution<std::size_t> size_distribution(1, max_allocation_size * size_mb);
   random_allocation_free(mr, size_distribution, num_allocations, max_usage, stream);

--- a/cpp/benchmarks/replay/replay.cpp
+++ b/cpp/benchmarks/replay/replay.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
@@ -16,6 +15,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
 #include <thrust/execution_policy.h>
 #include <thrust/reduce.h>
 
@@ -253,8 +253,14 @@ std::vector<std::vector<rmm::detail::event>> parse_per_thread_events(std::string
                           [](auto const& event) {
                             cudaStream_t custream;
                             memcpy(&custream, &event.stream, sizeof(cudaStream_t));
-                            auto stream = rmm::cuda_stream_view{custream};
-                            return stream.is_default() or stream.is_per_thread_default();
+                            auto stream = cuda::stream_ref{custream};
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+                            return stream.get() == cudaStreamLegacy or
+                                   stream.get() == cudaStreamPerThread or stream.get() == nullptr;
+#else
+                            return stream.get() == cudaStreamLegacy or stream.get() == nullptr or
+                                   stream.get() == cudaStreamPerThread;
+#endif
                           }),
               "Non-default streams not currently supported.");
 

--- a/cpp/benchmarks/replay/replay.cpp
+++ b/cpp/benchmarks/replay/replay.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/execution_policy.h>
 #include <thrust/reduce.h>
 

--- a/cpp/benchmarks/replay/replay.cpp
+++ b/cpp/benchmarks/replay/replay.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/cuda_stream.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/logger.hpp>
@@ -256,9 +255,7 @@ std::vector<std::vector<rmm::detail::event>> parse_per_thread_events(std::string
                             cudaStream_t custream;
                             memcpy(&custream, &event.stream, sizeof(cudaStream_t));
                             auto const stream = cuda::stream_ref{custream};
-                            return rmm::detail::is_default_stream(stream) or
-                                   stream == rmm::cuda_stream_per_thread or
-                                   stream == rmm::cuda_stream_default;
+                            return rmm::detail::is_default_stream(stream);
                           }),
               "Non-default streams not currently supported.");
 

--- a/cpp/benchmarks/replay/replay.cpp
+++ b/cpp/benchmarks/replay/replay.cpp
@@ -4,6 +4,8 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/detail/cuda_stream.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
@@ -253,14 +255,10 @@ std::vector<std::vector<rmm::detail::event>> parse_per_thread_events(std::string
                           [](auto const& event) {
                             cudaStream_t custream;
                             memcpy(&custream, &event.stream, sizeof(cudaStream_t));
-                            auto stream = cuda::stream_ref{custream};
-#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
-                            return stream.get() == cudaStreamLegacy or
-                                   stream.get() == cudaStreamPerThread or stream.get() == nullptr;
-#else
-                            return stream.get() == cudaStreamLegacy or stream.get() == nullptr or
-                                   stream.get() == cudaStreamPerThread;
-#endif
+                            auto const stream = cuda::stream_ref{custream};
+                            return rmm::detail::is_default_stream(stream) or
+                                   stream == rmm::cuda_stream_per_thread or
+                                   stream == rmm::cuda_stream_default;
                           }),
               "Non-default streams not currently supported.");
 

--- a/cpp/benchmarks/synchronization/synchronization.cpp
+++ b/cpp/benchmarks/synchronization/synchronization.cpp
@@ -19,7 +19,7 @@
 
 cuda_event_timer::cuda_event_timer(benchmark::State& state,
                                    bool flush_l2_cache,
-                                   rmm::cuda_stream_view stream)
+                                   cuda::stream_ref stream)
   : stream(stream), p_state(&state)
 {
   // flush all of L2$
@@ -36,18 +36,18 @@ cuda_event_timer::cuda_event_timer(benchmark::State& state,
       RMM_CUDA_TRY(cudaMemsetAsync(l2_cache_buffer.data(),
                                    memset_value,
                                    static_cast<std::size_t>(l2_cache_bytes),
-                                   stream.value()));
+                                   stream.get()));
     }
   }
 
   RMM_CUDA_TRY(cudaEventCreate(&start));
   RMM_CUDA_TRY(cudaEventCreate(&stop));
-  RMM_CUDA_TRY(cudaEventRecord(start, stream.value()));
+  RMM_CUDA_TRY(cudaEventRecord(start, stream.get()));
 }
 
 cuda_event_timer::~cuda_event_timer()
 {
-  RMM_CUDA_ASSERT_OK(cudaEventRecord(stop, stream.value()));
+  RMM_CUDA_ASSERT_OK(cudaEventRecord(stop, stream.get()));
   RMM_CUDA_ASSERT_OK(cudaEventSynchronize(stop));
 
   float milliseconds = 0.0F;

--- a/cpp/benchmarks/synchronization/synchronization.cpp
+++ b/cpp/benchmarks/synchronization/synchronization.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/cpp/benchmarks/synchronization/synchronization.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -47,9 +47,7 @@
 
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
-
-// Google Benchmark library
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <benchmark/benchmark.h>
@@ -68,7 +66,7 @@ class cuda_event_timer {
    */
   cuda_event_timer(benchmark::State& state,
                    bool flush_l2_cache,
-                   rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
 
   // The user will HAVE to provide a benchmark::State object to set
   // the timer so we disable the default c'tor.
@@ -88,6 +86,6 @@ class cuda_event_timer {
  private:
   cudaEvent_t start{};
   cudaEvent_t stop{};
-  rmm::cuda_stream_view stream{};
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   benchmark::State* p_state{};
 };

--- a/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/cpp/benchmarks/synchronization/synchronization.hpp
@@ -15,39 +15,39 @@
  *
  * It is built on top of the idea of Resource acquisition is initialization
  * (RAII). In the following we show a minimal example of how to use this class.
-
-    #include <rmm/cuda_stream_view.hpp>
-
-#include <benchmark/benchmark.h>
-
-    static void sample_cuda_benchmark(benchmark::State& state) {
-
-      for (auto _ : state){
-
-        cudaStream_t stream = 0;
-
-        // Create (Construct) an object of this class. You HAVE to pass in the
-        // benchmark::State object you are using. It measures the time from its
-        // creation to its destruction that is spent on the specified CUDA stream.
-        // It also clears the L2 cache by cudaMemset'ing a device buffer that is of
-        // the size of the L2 cache (if flush_l2_cache is set to true and there is
-        // an L2 cache on the current device).
-        cuda_event_timer raii(state, true, stream); // flush_l2_cache = true
-
-        // Now perform the operations that is to be benchmarked
-        sample_kernel<<<1, 256, 0, stream>>>(); // Possibly launching a CUDA kernel
-
-      }
-    }
-
-    // Register the function as a benchmark. You will need to set the `UseManualTime()`
-    // flag in order to use the timer embedded in this class.
-    BENCHMARK(sample_cuda_benchmark)->UseManualTime();
-
-
+ *
+ * @code{.cpp}
+ * #include <rmm/cuda_stream_view.hpp>
+ *
+ * #include <benchmark/benchmark.h>
+ *
+ * static void sample_cuda_benchmark(benchmark::State& state)
+ * {
+ *   for (auto _ : state) {
+ *     auto const stream = rmm::cuda_stream_default;
+ *
+ *     // Create (Construct) an object of this class. You HAVE to pass in the
+ *     // benchmark::State object you are using. It measures the time from its
+ *     // creation to its destruction that is spent on the specified CUDA stream.
+ *     // It also clears the L2 cache by cudaMemset'ing a device buffer that is of
+ *     // the size of the L2 cache (if flush_l2_cache is set to true and there is
+ *     // an L2 cache on the current device).
+ *     cuda_event_timer raii(state, true, stream);  // flush_l2_cache = true
+ *
+ *     // Now perform the operations that are to be benchmarked.
+ *     sample_kernel<<<1, 256, 0, stream.get()>>>();  // Possibly launch a CUDA kernel
+ *   }
+ * }
+ *
+ * // Register the function as a benchmark. You will need to set the `UseManualTime()`
+ * // flag in order to use the timer embedded in this class.
+ * BENCHMARK(sample_cuda_benchmark)->UseManualTime();
+ * @endcode
  */
 
 #pragma once
+
+#include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/stream>
 #include <cuda_runtime_api.h>
@@ -88,6 +88,6 @@ class cuda_event_timer {
  private:
   cudaEvent_t start{};
   cudaEvent_t stop{};
-  cuda::stream_ref stream{cudaStream_t{nullptr}};
+  cuda::stream_ref stream{rmm::cuda_stream_default};
   benchmark::State* p_state{};
 };

--- a/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/cpp/benchmarks/synchronization/synchronization.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -47,7 +47,7 @@
 
 #pragma once
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <benchmark/benchmark.h>

--- a/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/cpp/benchmarks/synchronization/synchronization.hpp
@@ -16,7 +16,9 @@
  * It is built on top of the idea of Resource acquisition is initialization
  * (RAII). In the following we show a minimal example of how to use this class.
 
-    #include <benchmark/benchmark.h>
+    #include <rmm/cuda_stream_view.hpp>
+
+#include <benchmark/benchmark.h>
 
     static void sample_cuda_benchmark(benchmark::State& state) {
 
@@ -66,7 +68,7 @@ class cuda_event_timer {
    */
   cuda_event_timer(benchmark::State& state,
                    bool flush_l2_cache,
-                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}});
+                   cuda::stream_ref stream = rmm::cuda_stream_default);
 
   // The user will HAVE to provide a benchmark::State object to set
   // the timer so we disable the default c'tor.

--- a/cpp/benchmarks/synchronization/synchronization.hpp
+++ b/cpp/benchmarks/synchronization/synchronization.hpp
@@ -17,14 +17,13 @@
  * (RAII). In the following we show a minimal example of how to use this class.
  *
  * @code{.cpp}
- * #include <rmm/cuda_stream_view.hpp>
- *
  * #include <benchmark/benchmark.h>
+ * #include <cuda/stream>
  *
  * static void sample_cuda_benchmark(benchmark::State& state)
  * {
  *   for (auto _ : state) {
- *     auto const stream = rmm::cuda_stream_default;
+ *     auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
  *
  *     // Create (Construct) an object of this class. You HAVE to pass in the
  *     // benchmark::State object you are using. It measures the time from its
@@ -47,8 +46,6 @@
 
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
-
 #include <cuda/stream>
 #include <cuda_runtime_api.h>
 
@@ -68,7 +65,7 @@ class cuda_event_timer {
    */
   cuda_event_timer(benchmark::State& state,
                    bool flush_l2_cache,
-                   cuda::stream_ref stream = rmm::cuda_stream_default);
+                   cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 
   // The user will HAVE to provide a benchmark::State object to set
   // the timer so we disable the default c'tor.
@@ -88,6 +85,6 @@ class cuda_event_timer {
  private:
   cudaEvent_t start{};
   cudaEvent_t stop{};
-  cuda::stream_ref stream{rmm::cuda_stream_default};
+  cuda::stream_ref stream{cuda::stream_ref{cudaStream_t{cudaStreamDefault}}};
   benchmark::State* p_state{};
 };

--- a/cpp/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/cpp/benchmarks/utilities/simulated_memory_resource.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 
@@ -96,7 +97,7 @@ class simulated_memory_resource final {
    */
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+    return allocate(rmm::cuda_stream_default, bytes, alignment);
   }
 
   /**
@@ -112,7 +113,7 @@ class simulated_memory_resource final {
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
   }
 
   bool operator==(simulated_memory_resource const&) const noexcept { return true; }

--- a/cpp/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/cpp/benchmarks/utilities/simulated_memory_resource.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 
@@ -97,7 +96,7 @@ class simulated_memory_resource final {
    */
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(rmm::cuda_stream_default, bytes, alignment);
+    return allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   }
 
   /**
@@ -113,7 +112,7 @@ class simulated_memory_resource final {
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, bytes, alignment);
   }
 
   bool operator==(simulated_memory_resource const&) const noexcept { return true; }

--- a/cpp/include/rmm/cuda_stream.hpp
+++ b/cpp/include/rmm/cuda_stream.hpp
@@ -85,6 +85,11 @@ class cuda_stream {
    */
   explicit operator cudaStream_t() const noexcept;
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
   /**
    * @brief Creates an immutable, non-owning view of the wrapped CUDA stream.
    *
@@ -98,6 +103,10 @@ class cuda_stream {
    * @return A view of the owned stream
    */
   operator cuda_stream_view() const;
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
   /**
    * @brief Implicit conversion to cuda::stream_ref

--- a/cpp/include/rmm/cuda_stream.hpp
+++ b/cpp/include/rmm/cuda_stream.hpp
@@ -93,12 +93,16 @@ class cuda_stream {
   /**
    * @brief Creates an immutable, non-owning view of the wrapped CUDA stream.
    *
+   * `rmm::cuda_stream_view` is deprecated. Convert this stream to `cuda::stream_ref` instead.
+   *
    * @return rmm::cuda_stream_view The view of the CUDA stream
    */
   [[nodiscard]] cuda_stream_view view() const;
 
   /**
    * @brief Implicit conversion to cuda_stream_view
+   *
+   * `rmm::cuda_stream_view` is deprecated. Use the conversion to `cuda::stream_ref` instead.
    *
    * @return A view of the owned stream
    */

--- a/cpp/include/rmm/cuda_stream_pool.hpp
+++ b/cpp/include/rmm/cuda_stream_pool.hpp
@@ -25,7 +25,7 @@ RMM_NAMESPACE_BEGIN
  *
  * Provides efficient access to collection of CUDA stream objects.
  *
- * Successive calls may return a `cuda_stream_view` of identical streams. For example, a possible
+ * Successive calls may return a `cuda::stream_ref` of identical streams. For example, a possible
  * implementation is to maintain a circular buffer of `cuda_stream` objects.
  */
 class cuda_stream_pool {
@@ -49,28 +49,28 @@ class cuda_stream_pool {
   cuda_stream_pool& operator=(cuda_stream_pool const&) = delete;
 
   /**
-   * @brief Get a `cuda_stream_view` of a stream in the pool.
+   * @brief Get a `cuda::stream_ref` of a stream in the pool.
    *
    * This function is thread safe with respect to other calls to the same function.
    *
-   * @return rmm::cuda_stream_view
+   * @return cuda::stream_ref
    */
-  rmm::cuda_stream_view get_stream() const noexcept;
+  cuda::stream_ref get_stream() const noexcept;
 
   /**
-   * @brief Get a `cuda_stream_view` of the stream associated with `stream_id`.
-   * Equivalent values of `stream_id` return a stream_view to the same underlying stream.
+   * @brief Get a `cuda::stream_ref` of the stream associated with `stream_id`.
+   * Equivalent values of `stream_id` return a stream_ref to the same underlying stream.
    *
    * This function is thread safe with respect to other calls to the same function.
    *
    * @param stream_id Unique identifier for the desired stream
    *
-   * @return rmm::cuda_stream_view
+   * @return cuda::stream_ref
    *
    * @note @p stream_id is wrapped around the pool size, therefore any size_t value is
    * allowed.
    */
-  rmm::cuda_stream_view get_stream(std::size_t stream_id) const;
+  cuda::stream_ref get_stream(std::size_t stream_id) const;
 
   /**
    * @brief Get the number of streams in the pool.

--- a/cpp/include/rmm/cuda_stream_pool.hpp
+++ b/cpp/include/rmm/cuda_stream_pool.hpp
@@ -6,8 +6,9 @@
 #pragma once
 
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
+
+#include <cuda/stream>
 
 #include <atomic>
 #include <cstddef>

--- a/cpp/include/rmm/cuda_stream_view.hpp
+++ b/cpp/include/rmm/cuda_stream_view.hpp
@@ -129,16 +129,12 @@ static constexpr cuda::stream_ref cuda_stream_default{cudaStream_t{nullptr}};
 /**
  * @brief Static cuda::stream_ref of cudaStreamLegacy, for convenience
  */
-static const cuda::stream_ref cuda_stream_legacy{
-  cudaStreamLegacy  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-};
+static const cuda::stream_ref cuda_stream_legacy{cudaStream_t{cudaStreamLegacy}};
 
 /**
  * @brief Static cuda::stream_ref of cudaStreamPerThread, for convenience
  */
-static const cuda::stream_ref cuda_stream_per_thread{
-  cudaStreamPerThread  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-};
+static const cuda::stream_ref cuda_stream_per_thread{cudaStream_t{cudaStreamPerThread}};
 
 /**
  * @brief Equality comparison operator for streams

--- a/cpp/include/rmm/cuda_stream_view.hpp
+++ b/cpp/include/rmm/cuda_stream_view.hpp
@@ -10,6 +10,7 @@
 #include <cuda/stream>
 #include <cuda_runtime_api.h>
 
+#include <concepts>
 #include <cstddef>
 #include <ostream>
 
@@ -139,20 +140,48 @@ static const cuda::stream_ref cuda_stream_per_thread{cudaStream_t{cudaStreamPerT
 /**
  * @brief Equality comparison operator for streams
  *
- * @param lhs The first stream view to compare
- * @param rhs The second stream view to compare
+ * @param lhs The first stream to compare
+ * @param rhs The second stream to compare
  * @return true if equal, false if unequal
  */
 bool operator==(cuda_stream_view lhs, cuda_stream_view rhs);
 
+/// @copydoc operator==(cuda_stream_view, cuda_stream_view)
+template <std::same_as<cuda::stream_ref> StreamRef>
+bool operator==(cuda_stream_view lhs, StreamRef const& rhs)
+{
+  return lhs.value() == rhs.get();
+}
+
+/// @copydoc operator==(cuda_stream_view, cuda_stream_view)
+template <std::same_as<cuda::stream_ref> StreamRef>
+bool operator==(StreamRef const& lhs, cuda_stream_view rhs)
+{
+  return lhs.get() == rhs.value();
+}
+
 /**
  * @brief Inequality comparison operator for streams
  *
- * @param lhs The first stream view to compare
- * @param rhs The second stream view to compare
+ * @param lhs The first stream to compare
+ * @param rhs The second stream to compare
  * @return true if unequal, false if equal
  */
 bool operator!=(cuda_stream_view lhs, cuda_stream_view rhs);
+
+/// @copydoc operator!=(cuda_stream_view, cuda_stream_view)
+template <std::same_as<cuda::stream_ref> StreamRef>
+bool operator!=(cuda_stream_view lhs, StreamRef const& rhs)
+{
+  return lhs.value() != rhs.get();
+}
+
+/// @copydoc operator!=(cuda_stream_view, cuda_stream_view)
+template <std::same_as<cuda::stream_ref> StreamRef>
+bool operator!=(StreamRef const& lhs, cuda_stream_view rhs)
+{
+  return lhs.get() != rhs.value();
+}
 
 /**
  * @brief Output stream operator for printing / logging streams

--- a/cpp/include/rmm/cuda_stream_view.hpp
+++ b/cpp/include/rmm/cuda_stream_view.hpp
@@ -122,21 +122,21 @@ class cuda_stream_view {
 };
 
 /**
- * @brief Static cuda_stream_view of the default stream (stream 0), for convenience
+ * @brief Static cuda::stream_ref of the default stream (stream 0), for convenience
  */
-static constexpr cuda_stream_view cuda_stream_default{};
+static constexpr cuda::stream_ref cuda_stream_default{cudaStream_t{nullptr}};
 
 /**
- * @brief Static cuda_stream_view of cudaStreamLegacy, for convenience
+ * @brief Static cuda::stream_ref of cudaStreamLegacy, for convenience
  */
-static const cuda_stream_view cuda_stream_legacy{
+static const cuda::stream_ref cuda_stream_legacy{
   cudaStreamLegacy  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
 };
 
 /**
- * @brief Static cuda_stream_view of cudaStreamPerThread, for convenience
+ * @brief Static cuda::stream_ref of cudaStreamPerThread, for convenience
  */
-static const cuda_stream_view cuda_stream_per_thread{
+static const cuda::stream_ref cuda_stream_per_thread{
   cudaStreamPerThread  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
 };
 

--- a/cpp/include/rmm/cuda_stream_view.hpp
+++ b/cpp/include/rmm/cuda_stream_view.hpp
@@ -25,8 +25,10 @@ RMM_NAMESPACE_BEGIN
  * @brief Strongly-typed non-owning wrapper for CUDA streams with default constructor.
  *
  * This wrapper is simply a "view": it does not own the lifetime of the stream it wraps.
+ *
+ * @deprecated Use cuda::stream_ref instead.
  */
-class cuda_stream_view {
+class [[deprecated("Use cuda::stream_ref instead.")]] cuda_stream_view {
  public:
   cuda_stream_view()                        = default;
   ~cuda_stream_view()                       = default;
@@ -137,6 +139,11 @@ static const cuda::stream_ref cuda_stream_legacy{cudaStream_t{cudaStreamLegacy}}
  */
 static const cuda::stream_ref cuda_stream_per_thread{cudaStream_t{cudaStreamPerThread}};
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 /**
  * @brief Equality comparison operator for streams
  *
@@ -191,6 +198,10 @@ bool operator!=(StreamRef const& lhs, cuda_stream_view rhs)
  * @return std::ostream& The output ostream
  */
 std::ostream& operator<<(std::ostream& os, cuda_stream_view stream);
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 /** @} */  // end of group
 RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/cuda_stream.hpp
+++ b/cpp/include/rmm/detail/cuda_stream.hpp
@@ -8,11 +8,28 @@
 #include <rmm/detail/export.hpp>
 
 #include <cuda/stream>
+#include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN
 namespace detail {
 
-[[nodiscard]] RMM_EXPORT bool is_default_stream(cuda::stream_ref stream) noexcept;
+/**
+ * @brief Indicates whether a stream is a default stream in the current compilation mode.
+ *
+ * In per-thread default stream mode, the null stream and `cudaStreamPerThread` are default
+ * streams. Otherwise, the null stream and `cudaStreamLegacy` are default streams.
+ *
+ * @param stream The stream to check.
+ * @return true if `stream` is a default stream in the current compilation mode.
+ */
+[[nodiscard, maybe_unused]] static bool is_default_stream(cuda::stream_ref stream) noexcept
+{
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  return stream == cudaStream_t{} || stream == cudaStream_t{cudaStreamPerThread};
+#else
+  return stream == cudaStream_t{} || stream == cudaStream_t{cudaStreamLegacy};
+#endif
+}
 
 }  // namespace detail
 RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/cuda_stream.hpp
+++ b/cpp/include/rmm/detail/cuda_stream.hpp
@@ -12,7 +12,7 @@
 RMM_NAMESPACE_BEGIN
 namespace detail {
 
-[[nodiscard]] bool is_default_stream(cuda::stream_ref stream) noexcept;
+[[nodiscard]] RMM_EXPORT bool is_default_stream(cuda::stream_ref stream) noexcept;
 
 }  // namespace detail
 RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/cuda_stream.hpp
+++ b/cpp/include/rmm/detail/cuda_stream.hpp
@@ -25,9 +25,9 @@ namespace detail {
 [[nodiscard, maybe_unused]] static bool is_default_stream(cuda::stream_ref stream) noexcept
 {
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
-  return stream == cudaStream_t{} || stream == cudaStream_t{cudaStreamPerThread};
+  return stream.get() == cudaStream_t{} || stream.get() == cudaStream_t{cudaStreamPerThread};
 #else
-  return stream == cudaStream_t{} || stream == cudaStream_t{cudaStreamLegacy};
+  return stream.get() == cudaStream_t{} || stream.get() == cudaStream_t{cudaStreamLegacy};
 #endif
 }
 

--- a/cpp/include/rmm/detail/format.hpp
+++ b/cpp/include/rmm/detail/format.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream_ref>
 
 #include <array>
 #include <cstdio>
@@ -31,10 +31,10 @@ inline std::string format_bytes(std::size_t value)
 }
 
 // Stringify a stream ID
-inline std::string format_stream(rmm::cuda_stream_view stream)
+inline std::string format_stream(cuda::stream_ref stream)
 {
   std::stringstream sstr{};
-  sstr << std::hex << stream.value();
+  sstr << std::hex << stream.get();
   return sstr.str();
 }
 

--- a/cpp/include/rmm/detail/format.hpp
+++ b/cpp/include/rmm/detail/format.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <array>
 #include <cstdio>

--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -13,6 +13,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <cassert>
@@ -379,8 +380,9 @@ class device_buffer {
   void* _data{nullptr};  ///< Pointer to device memory allocation
   std::size_t _size{};   ///< Requested size of the device memory allocation
   std::size_t _alignment{rmm::CUDA_ALLOCATION_ALIGNMENT};  ///< The alignment of the allocation
-  std::size_t _capacity{};     ///< The actual size of the device memory allocation
-  cuda_stream_view _stream{};  ///< Stream to use for device memory deallocation
+  std::size_t _capacity{};  ///< The actual size of the device memory allocation
+  cuda::stream_ref _stream{
+    cudaStream_t{nullptr}};  ///< Stream to use for device memory deallocation
 
   cuda::mr::any_resource<cuda::mr::device_accessible> _mr;  ///< The memory resource used to
                                                             ///< allocate/deallocate device memory

--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -382,7 +382,7 @@ class device_buffer {
   std::size_t _alignment{rmm::CUDA_ALLOCATION_ALIGNMENT};  ///< The alignment of the allocation
   std::size_t _capacity{};  ///< The actual size of the device memory allocation
   cuda::stream_ref _stream{
-    cudaStream_t{nullptr}};  ///< Stream to use for device memory deallocation
+    rmm::cuda_stream_default};  ///< Stream to use for device memory deallocation
 
   cuda::mr::any_resource<cuda::mr::device_accessible> _mr;  ///< The memory resource used to
                                                             ///< allocate/deallocate device memory

--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -13,7 +13,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cassert>

--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -45,7 +45,7 @@ RMM_NAMESPACE_BEGIN
  * // Allocates at least 100 bytes using the custom memory resource and
  * // specified stream
  * custom_memory_resource mr;
- * cuda_stream_view stream = cuda_stream_view{};
+ * auto stream = rmm::cuda_stream_default;
  * device_buffer custom_buff(100, stream, &mr);
  *
  * // Deep copies `buff` into a new device buffer using the specified stream
@@ -101,11 +101,11 @@ class device_buffer {
    */
   explicit device_buffer(
     std::size_t size,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
   // clang-format off
-  /// @copydoc device_buffer(std::size_t, cuda_stream_view, cuda::mr::any_resource<cuda::mr::device_accessible>)
+  /// @copydoc device_buffer(std::size_t, cuda::stream_ref, cuda::mr::any_resource<cuda::mr::device_accessible>)
   // clang-format on
   ///
   /// @throws rmm::bad_alloc If the requested alignment cannot be satisfied by the provided
@@ -117,7 +117,7 @@ class device_buffer {
   explicit device_buffer(
     std::size_t size,
     std::size_t alignment,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
   /**
@@ -146,11 +146,11 @@ class device_buffer {
   device_buffer(
     void const* source_data,
     std::size_t size,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
   // clang-format off
-  /// @copydoc device_buffer(void const*, std::size_t, cuda_stream_view, cuda::mr::any_resource<cuda::mr::device_accessible>)
+  /// @copydoc device_buffer(void const*, std::size_t, cuda::stream_ref, cuda::mr::any_resource<cuda::mr::device_accessible>)
   // clang-format on
   ///
   /// @throws rmm::bad_alloc If the requested alignment cannot be satisfied by the provided
@@ -163,7 +163,7 @@ class device_buffer {
     void const* source_data,
     std::size_t size,
     std::size_t alignment,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
   /**
    * @brief Construct a new `device_buffer` by deep copying the contents of
@@ -176,7 +176,7 @@ class device_buffer {
    *
    * @note The new buffer has the same alignment guarantees as the copied-from buffer. If you need
    *to control the alignment of the new buffer explicitly, use `device_buffer(void const*,
-   * std::size_t, std::size_t, cuda_stream_view,
+   * std::size_t, std::size_t, cuda::stream_ref,
    *cuda::mr::any_resource<cuda::mr::device_accessible>)`.
    *
    * @note This function does not synchronize `stream`. `other` is copied on `stream`, so the
@@ -193,7 +193,7 @@ class device_buffer {
    */
   device_buffer(
     device_buffer const& other,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 
   /**
@@ -256,7 +256,7 @@ class device_buffer {
    * @param new_capacity The requested new capacity, in bytes
    * @param stream The stream to use for allocation and copy
    */
-  void reserve(std::size_t new_capacity, cuda_stream_view stream);
+  void reserve(std::size_t new_capacity, cuda::stream_ref stream);
 
   /**
    * @brief Resize the device memory allocation
@@ -287,7 +287,7 @@ class device_buffer {
    * @param new_size The requested new size, in bytes
    * @param stream The stream to use for allocation and copy
    */
-  void resize(std::size_t new_size, cuda_stream_view stream);
+  void resize(std::size_t new_size, cuda::stream_ref stream);
 
   /**
    * @brief Forces the deallocation of unused memory.
@@ -306,7 +306,7 @@ class device_buffer {
    *
    * @param stream The stream on which the allocation and copy are performed
    */
-  void shrink_to_fit(cuda_stream_view stream);
+  void shrink_to_fit(cuda::stream_ref stream);
 
   /**
    * @briefreturn{Const pointer to the device memory allocation}
@@ -356,7 +356,7 @@ class device_buffer {
   /**
    * @briefreturn{The stream most recently specified for allocation/deallocation}
    */
-  [[nodiscard]] cuda_stream_view stream() const noexcept { return _stream; }
+  [[nodiscard]] cuda::stream_ref stream() const noexcept { return _stream; }
 
   /**
    * @brief Sets the stream to be used for deallocation
@@ -369,7 +369,7 @@ class device_buffer {
    *
    * @param stream The stream to use for deallocation
    */
-  void set_stream(cuda_stream_view stream) noexcept { _stream = stream; }
+  void set_stream(cuda::stream_ref stream) noexcept { _stream = stream; }
 
   /**
    * @briefreturn{The resource used to allocate and deallocate}

--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -6,7 +6,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -45,7 +44,7 @@ RMM_NAMESPACE_BEGIN
  * // Allocates at least 100 bytes using the custom memory resource and
  * // specified stream
  * custom_memory_resource mr;
- * auto stream = rmm::cuda_stream_default;
+ * auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
  * device_buffer custom_buff(100, stream, &mr);
  *
  * // Deep copies `buff` into a new device buffer using the specified stream
@@ -381,8 +380,8 @@ class device_buffer {
   std::size_t _size{};   ///< Requested size of the device memory allocation
   std::size_t _alignment{rmm::CUDA_ALLOCATION_ALIGNMENT};  ///< The alignment of the allocation
   std::size_t _capacity{};  ///< The actual size of the device memory allocation
-  cuda::stream_ref _stream{
-    rmm::cuda_stream_default};  ///< Stream to use for device memory deallocation
+  cuda::stream_ref _stream{cuda::stream_ref{
+    cudaStream_t{cudaStreamDefault}}};  ///< Stream to use for device memory deallocation
 
   cuda::mr::any_resource<cuda::mr::device_accessible> _mr;  ///< The memory resource used to
                                                             ///< allocate/deallocate device memory

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -11,6 +11,8 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
+
 #include <type_traits>
 
 namespace RMM_NAMESPACE {
@@ -84,7 +86,7 @@ class device_scalar {
    * @param mr Optional, resource with which to allocate.
    */
   explicit device_scalar(
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{1, stream, std::move(mr)}
   {
@@ -110,7 +112,7 @@ class device_scalar {
    */
   explicit device_scalar(
     value_type const& initial_value,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{1, stream, std::move(mr)}
   {
@@ -131,7 +133,7 @@ class device_scalar {
    */
   device_scalar(
     device_scalar const& other,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{other._storage, stream, std::move(mr)}
   {
@@ -153,7 +155,7 @@ class device_scalar {
    * @return T The value of the scalar.
    * @param stream CUDA stream on which to perform the copy and synchronize.
    */
-  [[nodiscard]] value_type value(cuda_stream_view stream) const
+  [[nodiscard]] value_type value(cuda::stream_ref stream) const
   {
     return _storage.front_element(stream);
   }
@@ -191,14 +193,14 @@ class device_scalar {
    * @param value The host value which will be copied to device
    * @param stream CUDA stream on which to perform the copy
    */
-  void set_value_async(value_type const& value, cuda_stream_view stream)
+  void set_value_async(value_type const& value, cuda::stream_ref stream)
   {
     _storage.set_element_async(0, value, stream);
   }
 
   // Disallow passing literals to set_value to avoid race conditions where the memory holding the
   // literal can be freed before the async memcpy / memset executes.
-  void set_value_async(value_type&&, cuda_stream_view) = delete;
+  void set_value_async(value_type&&, cuda::stream_ref) = delete;
 
   /**
    * @brief Sets the value of the `device_scalar` to zero on the specified stream.
@@ -214,7 +216,7 @@ class device_scalar {
    *
    * @param stream CUDA stream on which to perform the copy
    */
-  void set_value_to_zero_async(cuda_stream_view stream)
+  void set_value_to_zero_async(cuda::stream_ref stream)
   {
     _storage.set_element_to_zero_async(value_type{0}, stream);
   }
@@ -261,7 +263,7 @@ class device_scalar {
    *
    * @param stream Stream to be used for deallocation
    */
-  void set_stream(cuda_stream_view stream) noexcept { _storage.set_stream(stream); }
+  void set_stream(cuda::stream_ref stream) noexcept { _storage.set_stream(stream); }
 
  private:
   rmm::device_uvector<T> _storage;

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -11,7 +11,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <type_traits>
 
@@ -224,7 +224,7 @@ class device_scalar {
    */
   void set_value_to_zero_async(cuda::stream_ref stream)
   {
-    _storage.set_element_to_zero_async(value_type{0}, stream);
+    _storage.set_element_to_zero_async(size_type{0}, stream);
   }
 
   /**

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -262,7 +261,7 @@ class device_scalar {
   /**
    * @briefreturn{Stream associated with the device memory allocation}
    */
-  [[nodiscard]] cuda_stream_view stream() const noexcept { return _storage.stream(); }
+  [[nodiscard]] cuda::stream_ref stream() const noexcept { return _storage.stream(); }
 
   /**
    * @brief Sets the stream to be used for deallocation

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -11,6 +11,8 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
+
 #include <type_traits>
 
 RMM_NAMESPACE_BEGIN
@@ -84,7 +86,7 @@ class device_scalar {
    * @param mr Optional, resource with which to allocate.
    */
   explicit device_scalar(
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{1, stream, std::move(mr)}
   {
@@ -110,7 +112,7 @@ class device_scalar {
    */
   explicit device_scalar(
     value_type const& initial_value,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{1, stream, std::move(mr)}
   {
@@ -120,7 +122,7 @@ class device_scalar {
   // Disallow passing literals to the constructor to avoid race conditions where the
   // memory holding the literal can be freed before the async memcpy / memset executes.
   device_scalar(value_type const&&,
-                cuda_stream_view stream,
+                cuda::stream_ref stream,
                 cuda::mr::any_resource<cuda::mr::device_accessible> mr =
                   mr::get_current_device_resource_ref()) = delete;
   /**
@@ -137,7 +139,7 @@ class device_scalar {
    */
   device_scalar(
     device_scalar const& other,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{other._storage, stream, std::move(mr)}
   {
@@ -159,7 +161,7 @@ class device_scalar {
    * @return T The value of the scalar.
    * @param stream CUDA stream on which to perform the copy and synchronize.
    */
-  [[nodiscard]] value_type value(cuda_stream_view stream) const
+  [[nodiscard]] value_type value(cuda::stream_ref stream) const
   {
     return _storage.front_element(stream);
   }
@@ -197,14 +199,14 @@ class device_scalar {
    * @param value The host value which will be copied to device
    * @param stream CUDA stream on which to perform the copy
    */
-  void set_value_async(value_type const& value, cuda_stream_view stream)
+  void set_value_async(value_type const& value, cuda::stream_ref stream)
   {
     _storage.set_element_async(0, value, stream);
   }
 
   // Disallow passing literals to set_value to avoid race conditions where the memory holding the
   // literal can be freed before the async memcpy / memset executes.
-  void set_value_async(value_type const&&, cuda_stream_view) = delete;
+  void set_value_async(value_type const&&, cuda::stream_ref) = delete;
 
   /**
    * @brief Sets the value of the `device_scalar` to zero on the specified stream.
@@ -220,7 +222,7 @@ class device_scalar {
    *
    * @param stream CUDA stream on which to perform the copy
    */
-  void set_value_to_zero_async(cuda_stream_view stream)
+  void set_value_to_zero_async(cuda::stream_ref stream)
   {
     _storage.set_element_to_zero_async(value_type{0}, stream);
   }
@@ -267,35 +269,35 @@ class device_scalar {
    *
    * @param stream Stream to be used for deallocation
    */
-  void set_stream(cuda_stream_view stream) noexcept { _storage.set_stream(stream); }
+  void set_stream(cuda::stream_ref stream) noexcept { _storage.set_stream(stream); }
 
  private:
   rmm::device_uvector<T> _storage;
 };
 
-static_assert(std::is_constructible_v<device_scalar<int>, int const&, cuda_stream_view>);
+static_assert(std::is_constructible_v<device_scalar<int>, int const&, cuda::stream_ref>);
 static_assert(std::is_constructible_v<device_scalar<int>,
                                       int const&,
-                                      cuda_stream_view,
+                                      cuda::stream_ref,
                                       cuda::mr::any_resource<cuda::mr::device_accessible>>);
-static_assert(!std::is_constructible_v<device_scalar<int>, int, cuda_stream_view>);
-static_assert(!std::is_constructible_v<device_scalar<int>, int const, cuda_stream_view>);
+static_assert(!std::is_constructible_v<device_scalar<int>, int, cuda::stream_ref>);
+static_assert(!std::is_constructible_v<device_scalar<int>, int const, cuda::stream_ref>);
 static_assert(!std::is_constructible_v<device_scalar<int>,
                                        int,
-                                       cuda_stream_view,
+                                       cuda::stream_ref,
                                        cuda::mr::any_resource<cuda::mr::device_accessible>>);
 static_assert(!std::is_constructible_v<device_scalar<int>,
                                        int const,
-                                       cuda_stream_view,
+                                       cuda::stream_ref,
                                        cuda::mr::any_resource<cuda::mr::device_accessible>>);
 static_assert([]<typename Scalar>(Scalar*) {
-  return requires(Scalar& scalar, int value, cuda_stream_view stream) {
+  return requires(Scalar& scalar, int value, cuda::stream_ref stream) {
     scalar.set_value_async(value, stream);
-  } && requires(Scalar& scalar, int const value, cuda_stream_view stream) {
+  } && requires(Scalar& scalar, int const value, cuda::stream_ref stream) {
     scalar.set_value_async(value, stream);
-  } && !requires(Scalar& scalar, int value, cuda_stream_view stream) {
+  } && !requires(Scalar& scalar, int value, cuda::stream_ref stream) {
     scalar.set_value_async(std::move(value), stream);
-  } && !requires(Scalar& scalar, int const value, cuda_stream_view stream) {
+  } && !requires(Scalar& scalar, int const value, cuda::stream_ref stream) {
     scalar.set_value_async(std::move(value), stream);
   };
 }(static_cast<device_scalar<int>*>(nullptr)));

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -15,6 +15,7 @@
 
 #include <cuda/std/iterator>
 #include <cuda/std/span>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <type_traits>
@@ -126,7 +127,7 @@ class device_uvector {
    */
   explicit device_uvector(
     size_type size,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{elements_to_bytes(size), std::alignment_of_v<T>, stream, std::move(mr)}
   {
@@ -143,7 +144,7 @@ class device_uvector {
    */
   explicit device_uvector(
     device_uvector const& other,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{other._storage, stream, std::move(mr)}
   {
@@ -210,17 +211,17 @@ class device_uvector {
    * @param value The value to copy to the specified element
    * @param stream The stream on which to perform the copy
    */
-  void set_element_async(size_type element_index, value_type const& value, cuda_stream_view stream)
+  void set_element_async(size_type element_index, value_type const& value, cuda::stream_ref stream)
   {
     RMM_EXPECTS(
       element_index < size(), "Attempt to access out of bounds element.", rmm::out_of_range);
     RMM_CUDA_TRY(cudaMemcpyAsync(
-      element_ptr(element_index), &value, sizeof(value), cudaMemcpyDefault, stream.value()));
+      element_ptr(element_index), &value, sizeof(value), cudaMemcpyDefault, stream.get()));
   }
 
   // We delete the r-value reference overload to prevent asynchronously copying from a literal or
   // implicit temporary value after it is deleted or goes out of scope.
-  void set_element_async(size_type, value_type const&&, cuda_stream_view) = delete;
+  void set_element_async(size_type, value_type const&&, cuda::stream_ref) = delete;
 
   /**
    * @brief Asynchronously sets the specified element to zero in device memory.
@@ -244,12 +245,11 @@ class device_uvector {
    * @param element_index Index of the target element
    * @param stream The stream on which to perform the copy
    */
-  void set_element_to_zero_async(size_type element_index, cuda_stream_view stream)
+  void set_element_to_zero_async(size_type element_index, cuda::stream_ref stream)
   {
     RMM_EXPECTS(
       element_index < size(), "Attempt to access out of bounds element.", rmm::out_of_range);
-    RMM_CUDA_TRY(
-      cudaMemsetAsync(element_ptr(element_index), 0, sizeof(value_type), stream.value()));
+    RMM_CUDA_TRY(cudaMemsetAsync(element_ptr(element_index), 0, sizeof(value_type), stream.get()));
   }
 
   /**
@@ -281,10 +281,10 @@ class device_uvector {
    * @param value The value to copy to the specified element
    * @param stream The stream on which to perform the copy
    */
-  void set_element(size_type element_index, T const& value, cuda_stream_view stream)
+  void set_element(size_type element_index, T const& value, cuda::stream_ref stream)
   {
     set_element_async(element_index, value, stream);
-    stream.synchronize_no_throw();
+    RMM_ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream.get()));
   }
 
   /**
@@ -299,14 +299,14 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the specified element
    */
-  [[nodiscard]] value_type element(size_type element_index, cuda_stream_view stream) const
+  [[nodiscard]] value_type element(size_type element_index, cuda::stream_ref stream) const
   {
     RMM_EXPECTS(
       element_index < size(), "Attempt to access out of bounds element.", rmm::out_of_range);
     value_type value;
     RMM_CUDA_TRY(cudaMemcpyAsync(
-      &value, element_ptr(element_index), sizeof(value), cudaMemcpyDefault, stream.value()));
-    stream.synchronize();
+      &value, element_ptr(element_index), sizeof(value), cudaMemcpyDefault, stream.get()));
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return value;
   }
 
@@ -321,7 +321,7 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the first element
    */
-  [[nodiscard]] value_type front_element(cuda_stream_view stream) const
+  [[nodiscard]] value_type front_element(cuda::stream_ref stream) const
   {
     return element(0, stream);
   }
@@ -337,7 +337,7 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the last element
    */
-  [[nodiscard]] value_type back_element(cuda_stream_view stream) const
+  [[nodiscard]] value_type back_element(cuda::stream_ref stream) const
   {
     return element(size() - 1, stream);
   }
@@ -354,7 +354,7 @@ class device_uvector {
    * @param new_capacity The desired capacity (number of elements)
    * @param stream The stream on which to perform the allocation/copy (if any)
    */
-  void reserve(size_type new_capacity, cuda_stream_view stream)
+  void reserve(size_type new_capacity, cuda::stream_ref stream)
   {
     _storage.reserve(elements_to_bytes(new_capacity), stream);
   }
@@ -375,7 +375,7 @@ class device_uvector {
    * @param new_size The desired number of elements
    * @param stream The stream on which to perform the allocation/copy (if any)
    */
-  void resize(size_type new_size, cuda_stream_view stream)
+  void resize(size_type new_size, cuda::stream_ref stream)
   {
     _storage.resize(elements_to_bytes(new_size), stream);
   }
@@ -387,7 +387,7 @@ class device_uvector {
    *
    * @param stream Stream on which to perform allocation and copy
    */
-  void shrink_to_fit(cuda_stream_view stream) { _storage.shrink_to_fit(stream); }
+  void shrink_to_fit(cuda::stream_ref stream) { _storage.shrink_to_fit(stream); }
 
   /**
    * @brief Release ownership of device memory storage.
@@ -612,7 +612,7 @@ class device_uvector {
    *
    * @param stream The stream to use for deallocation
    */
-  void set_stream(cuda_stream_view stream) noexcept { _storage.set_stream(stream); }
+  void set_stream(cuda::stream_ref stream) noexcept { _storage.set_stream(stream); }
 
  private:
   device_buffer _storage{};  ///< Device memory storage for vector elements

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -16,7 +16,7 @@
 
 #include <cuda/std/iterator>
 #include <cuda/std/span>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <limits>

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -16,6 +16,7 @@
 
 #include <cuda/std/iterator>
 #include <cuda/std/span>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <limits>
@@ -129,7 +130,7 @@ class device_uvector {
    */
   explicit device_uvector(
     size_type size,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{elements_to_bytes(size), std::alignment_of_v<T>, stream, std::move(mr)}
   {
@@ -146,7 +147,7 @@ class device_uvector {
    */
   explicit device_uvector(
     device_uvector const& other,
-    cuda_stream_view stream,
+    cuda::stream_ref stream,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref())
     : _storage{other._storage, stream, std::move(mr)}
   {
@@ -213,7 +214,7 @@ class device_uvector {
    * @param value The value to copy to the specified element
    * @param stream The stream on which to perform the copy
    */
-  void set_element_async(size_type element_index, value_type const& value, cuda_stream_view stream)
+  void set_element_async(size_type element_index, value_type const& value, cuda::stream_ref stream)
   {
     RMM_EXPECTS(
       element_index < size(), "Attempt to access out of bounds element.", rmm::out_of_range);
@@ -223,7 +224,7 @@ class device_uvector {
 
   // We delete the r-value reference overload to prevent asynchronously copying from a literal or
   // implicit temporary value after it is deleted or goes out of scope.
-  void set_element_async(size_type, value_type const&&, cuda_stream_view) = delete;
+  void set_element_async(size_type, value_type const&&, cuda::stream_ref) = delete;
 
   /**
    * @brief Asynchronously sets the specified element to zero in device memory.
@@ -247,12 +248,11 @@ class device_uvector {
    * @param element_index Index of the target element
    * @param stream The stream on which to perform the copy
    */
-  void set_element_to_zero_async(size_type element_index, cuda_stream_view stream)
+  void set_element_to_zero_async(size_type element_index, cuda::stream_ref stream)
   {
     RMM_EXPECTS(
       element_index < size(), "Attempt to access out of bounds element.", rmm::out_of_range);
-    RMM_CUDA_TRY(
-      cudaMemsetAsync(element_ptr(element_index), 0, sizeof(value_type), stream.value()));
+    RMM_CUDA_TRY(cudaMemsetAsync(element_ptr(element_index), 0, sizeof(value_type), stream.get()));
   }
 
   /**
@@ -284,10 +284,10 @@ class device_uvector {
    * @param value The value to copy to the specified element
    * @param stream The stream on which to perform the copy
    */
-  void set_element(size_type element_index, T const& value, cuda_stream_view stream)
+  void set_element(size_type element_index, T const& value, cuda::stream_ref stream)
   {
     set_element_async(element_index, value, stream);
-    stream.synchronize_no_throw();
+    RMM_ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream.get()));
   }
 
   /**
@@ -302,7 +302,7 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the specified element
    */
-  [[nodiscard]] value_type element(size_type element_index, cuda_stream_view stream) const
+  [[nodiscard]] value_type element(size_type element_index, cuda::stream_ref stream) const
   {
     RMM_EXPECTS(
       element_index < size(), "Attempt to access out of bounds element.", rmm::out_of_range);
@@ -324,7 +324,7 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the first element
    */
-  [[nodiscard]] value_type front_element(cuda_stream_view stream) const
+  [[nodiscard]] value_type front_element(cuda::stream_ref stream) const
   {
     return element(0, stream);
   }
@@ -340,7 +340,7 @@ class device_uvector {
    * @param stream The stream on which to perform the copy
    * @return The value of the last element
    */
-  [[nodiscard]] value_type back_element(cuda_stream_view stream) const
+  [[nodiscard]] value_type back_element(cuda::stream_ref stream) const
   {
     return element(size() - 1, stream);
   }
@@ -359,7 +359,7 @@ class device_uvector {
    * @param new_capacity The desired capacity (number of elements)
    * @param stream The stream on which to perform the allocation/copy (if any)
    */
-  void reserve(size_type new_capacity, cuda_stream_view stream)
+  void reserve(size_type new_capacity, cuda::stream_ref stream)
   {
     _storage.reserve(elements_to_bytes(new_capacity), stream);
   }
@@ -382,7 +382,7 @@ class device_uvector {
    * @param new_size The desired number of elements
    * @param stream The stream on which to perform the allocation/copy (if any)
    */
-  void resize(size_type new_size, cuda_stream_view stream)
+  void resize(size_type new_size, cuda::stream_ref stream)
   {
     _storage.resize(elements_to_bytes(new_size), stream);
   }
@@ -394,7 +394,7 @@ class device_uvector {
    *
    * @param stream Stream on which to perform allocation and copy
    */
-  void shrink_to_fit(cuda_stream_view stream) { _storage.shrink_to_fit(stream); }
+  void shrink_to_fit(cuda::stream_ref stream) { _storage.shrink_to_fit(stream); }
 
   /**
    * @brief Release ownership of device memory storage.
@@ -619,7 +619,7 @@ class device_uvector {
    *
    * @param stream The stream to use for deallocation
    */
-  void set_stream(cuda_stream_view stream) noexcept { _storage.set_stream(stream); }
+  void set_stream(cuda::stream_ref stream) noexcept { _storage.set_stream(stream); }
 
  private:
   device_buffer _storage{};  ///< Device memory storage for vector elements

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/cuda_memcpy.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/exec_check_disable.hpp>
@@ -43,7 +42,7 @@ RMM_NAMESPACE_BEGIN
  * Example:
  * @code{.cpp}
  * auto mr = new my_custom_resource();
- * auto s = rmm::cuda_stream_default;
+ * auto s = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
  *
  * // Allocates *uninitialized* device memory on stream `s` sufficient for 100 ints using the
  * // supplied resource `mr`

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -309,7 +309,7 @@ class device_uvector {
     value_type value;
     RMM_CUDA_TRY(
       rmm::detail::memcpy_async(&value, element_ptr(element_index), sizeof(value), stream));
-    stream.synchronize();
+    stream.sync();
     return value;
   }
 

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -43,7 +43,7 @@ RMM_NAMESPACE_BEGIN
  * Example:
  * @code{.cpp}
  * auto mr = new my_custom_resource();
- * rmm::cuda_stream_view s{};
+ * auto s = rmm::cuda_stream_default;
  *
  * // Allocates *uninitialized* device memory on stream `s` sufficient for 100 ints using the
  * // supplied resource `mr`
@@ -606,7 +606,7 @@ class device_uvector {
   /**
    * @briefreturn{Stream most recently specified for allocation/deallocation}
    */
-  [[nodiscard]] cuda_stream_view stream() const noexcept { return _storage.stream(); }
+  [[nodiscard]] cuda::stream_ref stream() const noexcept { return _storage.stream(); }
 
   /**
    * @brief Sets the stream to be used for deallocation

--- a/cpp/include/rmm/exec_policy.hpp
+++ b/cpp/include/rmm/exec_policy.hpp
@@ -10,12 +10,12 @@
 
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/thrust_namespace.h>
 #include <rmm/mr/thrust_allocator_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream>
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
 
@@ -46,7 +46,7 @@ class exec_policy : public thrust_exec_policy_t {
    * @param mr The resource to use for allocating temporary memory
    */
   explicit exec_policy(
-    cuda::stream_ref stream                                = cuda_stream_default,
+    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 };
 
@@ -72,7 +72,7 @@ class exec_policy_nosync : public thrust_exec_policy_nosync_t {
    * @param mr The resource to use for allocating temporary memory
    */
   explicit exec_policy_nosync(
-    cuda::stream_ref stream                                = cuda_stream_default,
+    cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 };
 

--- a/cpp/include/rmm/exec_policy.hpp
+++ b/cpp/include/rmm/exec_policy.hpp
@@ -46,7 +46,7 @@ class exec_policy : public thrust_exec_policy_t {
    * @param mr The resource to use for allocating temporary memory
    */
   explicit exec_policy(
-    cuda_stream_view stream                                = cuda_stream_default,
+    cuda::stream_ref stream                                = cuda_stream_default,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 };
 
@@ -72,7 +72,7 @@ class exec_policy_nosync : public thrust_exec_policy_nosync_t {
    * @param mr The resource to use for allocating temporary memory
    */
   explicit exec_policy_nosync(
-    cuda_stream_view stream                                = cuda_stream_default,
+    cuda::stream_ref stream                                = cuda_stream_default,
     cuda::mr::any_resource<cuda::mr::device_accessible> mr = mr::get_current_device_resource_ref());
 };
 

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -9,6 +9,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <functional>
@@ -24,7 +25,7 @@ namespace mr {
  * @brief Callback function type used by callback memory resource for allocation.
  *
  * The signature of the callback function is:
- *   `void* allocate_callback_t(std::size_t bytes, cuda_stream_view stream, void* arg);`
+ *   `void* allocate_callback_t(std::size_t bytes, cuda::stream_ref stream, void* arg);`
  *
  * * Returns a pointer to an allocation of at least `bytes` usable immediately on
  *   `stream`. The stream-ordered behavior requirements are identical to
@@ -33,13 +34,13 @@ namespace mr {
  * * The `arg` is provided to the constructor of the `callback_memory_resource`
  *   and will be forwarded along to every invocation of the callback function.
  */
-using allocate_callback_t = std::function<void*(std::size_t, cuda_stream_view, void*)>;
+using allocate_callback_t = std::function<void*(std::size_t, cuda::stream_ref, void*)>;
 
 /**
  * @brief Callback function type used by callback_memory_resource for deallocation.
  *
  * The signature of the callback function is:
- *   `void deallocate_callback_t(void* ptr, std::size_t bytes, cuda_stream_view stream, void* arg);`
+ *   `void deallocate_callback_t(void* ptr, std::size_t bytes, cuda::stream_ref stream, void* arg);`
  *
  * * Deallocates memory pointed to by `ptr`. `bytes` specifies the size of the allocation
  *   in bytes, and must equal the value of `bytes` that was passed to the allocate callback
@@ -49,7 +50,7 @@ using allocate_callback_t = std::function<void*(std::size_t, cuda_stream_view, v
  * * The `arg` is provided to the constructor of the `callback_memory_resource`
  *   and will be forwarded along to every invocation of the callback function.
  */
-using deallocate_callback_t = std::function<void(void*, std::size_t, cuda_stream_view, void*)>;
+using deallocate_callback_t = std::function<void(void*, std::size_t, cuda::stream_ref, void*)>;
 
 namespace detail {
 class callback_memory_resource_impl;

--- a/cpp/include/rmm/mr/detail/arena.hpp
+++ b/cpp/include/rmm/mr/detail/arena.hpp
@@ -7,7 +7,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/format.hpp>
@@ -16,6 +15,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <algorithm>
@@ -595,10 +595,10 @@ class global_arena final {
    * that was passed to the `allocate` call that returned `ptr`.
    * @return bool true if the allocation is found, false otherwise.
    */
-  bool deallocate(cuda_stream_view stream, void* ptr, std::size_t size)
+  bool deallocate(cuda::stream_ref stream, void* ptr, std::size_t size)
   {
     RMM_LOGGING_ASSERT(handles(size));
-    stream.synchronize_no_throw();
+    RMM_ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream.get()));
     return deallocate_sync(ptr, size);
   }
 
@@ -818,7 +818,7 @@ class arena {
    * that was passed to the `allocate` call that returned `ptr`.
    * @return bool true if the allocation is found, false otherwise.
    */
-  bool deallocate(cuda_stream_view stream, void* ptr, std::size_t size)
+  bool deallocate(cuda::stream_ref stream, void* ptr, std::size_t size)
   {
     if (global_arena::handles(size) && global_arena_.deallocate(stream, ptr, size)) { return true; }
     return deallocate_sync(ptr, size);

--- a/cpp/include/rmm/mr/detail/arena.hpp
+++ b/cpp/include/rmm/mr/detail/arena.hpp
@@ -15,7 +15,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <algorithm>

--- a/cpp/include/rmm/mr/detail/arena.hpp
+++ b/cpp/include/rmm/mr/detail/arena.hpp
@@ -598,7 +598,7 @@ class global_arena final {
   bool deallocate(cuda::stream_ref stream, void* ptr, std::size_t size)
   {
     RMM_LOGGING_ASSERT(handles(size));
-    RMM_ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream.get()));
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
     return deallocate_sync(ptr, size);
   }
 

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -4,12 +4,12 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/arena.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <map>
@@ -79,15 +79,15 @@ class arena_memory_resource_impl {
 
   void defragment();
 
-  void deallocate_from_other_arena(cuda_stream_view stream, void* ptr, std::size_t bytes);
+  void deallocate_from_other_arena(cuda::stream_ref stream, void* ptr, std::size_t bytes);
 
-  arena& get_arena(cuda_stream_view stream);
+  arena& get_arena(cuda::stream_ref stream);
   arena& get_thread_arena();
-  arena& get_stream_arena(cuda_stream_view stream);
+  arena& get_stream_arena(cuda::stream_ref stream);
 
   void dump_memory_log(std::size_t bytes);
 
-  static bool use_per_thread_arena(cuda_stream_view stream);
+  static bool use_per_thread_arena(cuda::stream_ref stream);
 
   global_arena global_arena_;
   std::map<std::thread::id, std::shared_ptr<arena>> thread_arenas_;

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -9,7 +9,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <map>

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -4,12 +4,12 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/arena.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <map>
@@ -80,15 +80,15 @@ class arena_memory_resource_impl {
 
   void defragment();
 
-  void deallocate_from_other_arena(cuda_stream_view stream, void* ptr, std::size_t bytes);
+  void deallocate_from_other_arena(cuda::stream_ref stream, void* ptr, std::size_t bytes);
 
-  arena& get_arena(cuda_stream_view stream);
+  arena& get_arena(cuda::stream_ref stream);
   arena& get_thread_arena();
-  arena& get_stream_arena(cuda_stream_view stream);
+  arena& get_stream_arena(cuda::stream_ref stream);
 
   void dump_memory_log(std::size_t bytes);
 
-  static bool use_per_thread_arena(cuda_stream_view stream);
+  static bool use_per_thread_arena(cuda::stream_ref stream);
 
   global_arena global_arena_;
   std::map<std::thread::id, std::shared_ptr<arena>> thread_arenas_;

--- a/cpp/include/rmm/mr/detail/binning_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/binning_memory_resource_impl.hpp
@@ -4,12 +4,12 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/fixed_size_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <map>

--- a/cpp/include/rmm/mr/detail/callback_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/callback_memory_resource_impl.hpp
@@ -4,11 +4,11 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <functional>
@@ -28,8 +28,8 @@ namespace detail {
 class callback_memory_resource_impl {
  public:
   callback_memory_resource_impl(
-    std::function<void*(std::size_t, cuda_stream_view, void*)> allocate_callback,
-    std::function<void(void*, std::size_t, cuda_stream_view, void*)> deallocate_callback,
+    std::function<void*(std::size_t, cuda::stream_ref, void*)> allocate_callback,
+    std::function<void(void*, std::size_t, cuda::stream_ref, void*)> deallocate_callback,
     void* allocate_callback_arg,
     void* deallocate_callback_arg) noexcept;
 
@@ -72,8 +72,8 @@ class callback_memory_resource_impl {
   }
 
  private:
-  std::function<void*(std::size_t, cuda_stream_view, void*)> allocate_callback_;
-  std::function<void(void*, std::size_t, cuda_stream_view, void*)> deallocate_callback_;
+  std::function<void*(std::size_t, cuda::stream_ref, void*)> allocate_callback_;
+  std::function<void(void*, std::size_t, cuda::stream_ref, void*)> deallocate_callback_;
   void* allocate_callback_arg_;
   void* deallocate_callback_arg_;
 };

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -5,12 +5,13 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/failure_callback_t.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <cstddef>
 #include <utility>
@@ -86,14 +87,14 @@ class failure_callback_resource_adaptor_impl {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
   {
-    return allocate(cuda_stream_view{}, bytes, alignment);
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
   }
 
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = alignof(std::max_align_t)) noexcept
   {
-    deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
   }
 
   RMM_CONSTEXPR_FRIEND void get_property(failure_callback_resource_adaptor_impl const&,

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -5,14 +5,13 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/failure_callback_t.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -11,7 +11,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/failure_callback_t.hpp>
@@ -89,7 +90,7 @@ class failure_callback_resource_adaptor_impl {
   [[nodiscard]] void* allocate_sync(std::size_t bytes,
                                     std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto const stream = rmm::cuda_stream_default;
     auto* ptr         = allocate(stream, bytes, alignment);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return ptr;
@@ -99,7 +100,7 @@ class failure_callback_resource_adaptor_impl {
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto const stream = rmm::cuda_stream_default;
     deallocate(stream, ptr, bytes, alignment);
     RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
   }

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/failure_callback_t.hpp>
@@ -90,7 +89,7 @@ class failure_callback_resource_adaptor_impl {
   [[nodiscard]] void* allocate_sync(std::size_t bytes,
                                     std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto const stream = rmm::cuda_stream_default;
+    auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
     auto* ptr         = allocate(stream, bytes, alignment);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return ptr;
@@ -100,7 +99,7 @@ class failure_callback_resource_adaptor_impl {
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    auto const stream = rmm::cuda_stream_default;
+    auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
     deallocate(stream, ptr, bytes, alignment);
     RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
   }

--- a/cpp/include/rmm/mr/detail/fixed_size_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/fixed_size_memory_resource_impl.hpp
@@ -4,12 +4,12 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/detail/fixed_size_free_list.hpp>
 #include <rmm/mr/detail/stream_ordered_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <mutex>
@@ -70,7 +70,7 @@ class fixed_size_memory_resource_impl final
 
   [[nodiscard]] std::size_t get_maximum_allocation_size() const;
 
-  block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream);
+  block_type expand_pool(std::size_t size, free_list& blocks, cuda::stream_ref stream);
 
   split_block allocate_from_block(block_type const& block, std::size_t size);
 
@@ -79,7 +79,7 @@ class fixed_size_memory_resource_impl final
   std::pair<std::size_t, std::size_t> free_list_summary(free_list const& blocks);
 
  private:
-  free_list blocks_from_upstream(cuda_stream_view stream);
+  free_list blocks_from_upstream(cuda::stream_ref stream);
 
   void release();
 

--- a/cpp/include/rmm/mr/detail/fixed_size_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/fixed_size_memory_resource_impl.hpp
@@ -9,7 +9,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <mutex>

--- a/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
@@ -4,12 +4,12 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/detail/coalescing_free_list.hpp>
 #include <rmm/mr/detail/stream_ordered_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <memory>
@@ -67,11 +67,11 @@ class pool_memory_resource_impl final
   using lock_guard = std::lock_guard<std::mutex>;
 
   [[nodiscard]] std::size_t get_maximum_allocation_size() const;
-  block_type try_to_expand(std::size_t try_size, std::size_t min_size, cuda_stream_view stream);
+  block_type try_to_expand(std::size_t try_size, std::size_t min_size, cuda::stream_ref stream);
   void initialize_pool(std::size_t initial_size, std::optional<std::size_t> maximum_size);
-  block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream);
+  block_type expand_pool(std::size_t size, free_list& blocks, cuda::stream_ref stream);
   [[nodiscard]] std::size_t size_to_grow(std::size_t size) const;
-  block_type block_from_upstream(std::size_t size, cuda_stream_view stream);
+  block_type block_from_upstream(std::size_t size, cuda::stream_ref stream);
   split_block allocate_from_block(block_type const& block, std::size_t size);
   block_type free_block(void* ptr, std::size_t size) noexcept;
   void release();

--- a/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
@@ -4,12 +4,12 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/detail/coalescing_free_list.hpp>
 #include <rmm/mr/detail/stream_ordered_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <memory>
@@ -67,12 +67,12 @@ class pool_memory_resource_impl final
   using lock_guard = std::lock_guard<std::mutex>;
 
   [[nodiscard]] std::size_t get_maximum_allocation_size() const;
-  block_type try_to_expand(std::size_t try_size, std::size_t min_size, cuda_stream_view stream);
+  block_type try_to_expand(std::size_t try_size, std::size_t min_size, cuda::stream_ref stream);
   void initialize_pool(std::size_t initial_size, std::optional<std::size_t> maximum_size);
-  block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream);
-  void reclaim_free_blocks(std::size_t size, free_list& blocks, cuda_stream_view stream);
+  block_type expand_pool(std::size_t size, free_list& blocks, cuda::stream_ref stream);
+  void reclaim_free_blocks(std::size_t size, free_list& blocks, cuda::stream_ref stream);
   [[nodiscard]] std::size_t size_to_grow(std::size_t size) const;
-  block_type block_from_upstream(std::size_t size, cuda_stream_view stream);
+  block_type block_from_upstream(std::size_t size, cuda::stream_ref stream);
   split_block allocate_from_block(block_type const& block, std::size_t size);
   block_type free_block(void* ptr, std::size_t size) noexcept;
   void release();

--- a/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
@@ -9,7 +9,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -60,7 +60,7 @@ struct crtp {
  * documented separately:
  *
  * 1. `std::size_t get_maximum_allocation_size() const`
- * 2. `block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream)`
+ * 2. `block_type expand_pool(std::size_t size, free_list& blocks, cuda::stream_ref stream)`
  * 3. `split_block allocate_from_block(block_type const& b, std::size_t size)`
  * 4. `block_type free_block(void* ptr, std::size_t size) noexcept`
  */
@@ -89,15 +89,13 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
    */
   void* allocate(cuda::stream_ref stream, std::size_t bytes, std::size_t /*alignment*/)
   {
-    auto const strm = cuda_stream_view{stream};
-
-    RMM_LOG_TRACE("[A][stream %s][%zuB]", rmm::detail::format_stream(strm), bytes);
+    RMM_LOG_TRACE("[A][stream %s][%zuB]", rmm::detail::format_stream(stream), bytes);
 
     if (bytes == 0) { return nullptr; }
 
     lock_guard lock(mtx_);
 
-    auto stream_event = get_event(strm);
+    auto stream_event = get_event(stream);
 
     bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
     RMM_EXPECTS(bytes <= this->underlying().get_maximum_allocation_size(),
@@ -129,14 +127,12 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
                   std::size_t bytes,
                   std::size_t /*alignment*/) noexcept
   {
-    auto const strm = cuda_stream_view{stream};
-
-    RMM_LOG_TRACE("[D][stream %s][%zuB][%p]", rmm::detail::format_stream(strm), bytes, ptr);
+    RMM_LOG_TRACE("[D][stream %s][%zuB][%p]", rmm::detail::format_stream(stream), bytes, ptr);
 
     if (bytes == 0 || ptr == nullptr) { return; }
 
     lock_guard lock(mtx_);
-    auto stream_event = get_event(strm);
+    auto stream_event = get_event(stream);
 
     bytes            = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
     auto const block = this->underlying().free_block(ptr, bytes);
@@ -144,7 +140,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     // TODO: cudaEventRecord has significant overhead on deallocations. For the non-PTDS case
     // we may be able to delay recording the event in some situations. But using events rather
     // than streams allows stealing from deleted streams.
-    RMM_ASSERT_CUDA_SUCCESS(cudaEventRecord(stream_event.event, strm.value()));
+    RMM_ASSERT_CUDA_SUCCESS(cudaEventRecord(stream_event.event, stream.get()));
 
     stream_free_blocks_[stream_event].insert(block);
 
@@ -163,9 +159,9 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
   [[nodiscard]] void* allocate_sync(std::size_t bytes,
                                     std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto const stream = cuda_stream_view{};
+    auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
     void* ptr         = allocate(stream, bytes, alignment);
-    stream.synchronize();
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return ptr;
   }
 
@@ -181,7 +177,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     std::size_t bytes,
     [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
   }
 
  protected:
@@ -217,7 +213,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
    * @param stream The stream on which the memory is to be used.
    * @return block_type a block of at least `size` bytes
    */
-  // block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream)
+  // block_type expand_pool(std::size_t size, free_list& blocks, cuda::stream_ref stream)
 
   /// Pair representing a block that has been split for allocation
   using split_block = std::pair<block_type, block_type>;
@@ -252,12 +248,12 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
    * @param block The block to insert into the pool.
    * @param stream The stream on which the memory was last used.
    */
-  void insert_block(block_type const& block, cuda_stream_view stream)
+  void insert_block(block_type const& block, cuda::stream_ref stream)
   {
     stream_free_blocks_[get_event(stream)].insert(block);
   }
 
-  void insert_blocks(free_list&& blocks, cuda_stream_view stream)
+  void insert_blocks(free_list&& blocks, cuda::stream_ref stream)
   {
     stream_free_blocks_[get_event(stream)].insert(std::move(blocks));
   }
@@ -301,9 +297,27 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
    * @param stream The stream for which to get an event.
    * @return The stream_event for `stream`.
    */
-  stream_event_pair get_event(cuda_stream_view stream)
+  static bool is_per_thread_default(cuda::stream_ref stream) noexcept
   {
-    if (stream.is_per_thread_default()) {
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+    return stream.get() == cudaStreamPerThread || stream.get() == nullptr;
+#else
+    return stream.get() == cudaStreamPerThread;
+#endif
+  }
+
+  static bool is_default(cuda::stream_ref stream) noexcept
+  {
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+    return stream.get() == cudaStreamLegacy;
+#else
+    return stream.get() == cudaStreamLegacy || stream.get() == nullptr;
+#endif
+  }
+
+  stream_event_pair get_event(cuda::stream_ref stream)
+  {
+    if (is_per_thread_default(stream)) {
       // Create a thread-local event for each device. These events are
       // deliberately leaked since the destructor needs to call into
       // the CUDA runtime and thread_local destructors (can) run below
@@ -320,7 +334,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
         }
         return e;
       }();
-      return stream_event_pair{stream.value(), event};
+      return stream_event_pair{stream.get(), event};
     }
     // We use cudaStreamLegacy as the event map key for the default stream for consistency between
     // PTDS and non-PTDS mode. In PTDS mode, the cudaStreamLegacy map key will only exist if the
@@ -328,7 +342,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     // at construction. For consistency, the same key is used for null stream free lists in
     // non-PTDS mode.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    auto* const stream_to_store = stream.is_default() ? cudaStreamLegacy : stream.value();
+    auto* const stream_to_store = is_default(stream) ? cudaStreamLegacy : stream.get();
     stream_id_type stream_id{};
     RMM_ASSERT_CUDA_SUCCESS(cudaStreamGetId(stream_to_store, &stream_id));
     auto const iter = stream_events_.find(stream_id);
@@ -393,7 +407,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
 
     // no large enough blocks available after merging, so grow the pool
     block_type const block =
-      this->underlying().expand_pool(size, blocks, cuda_stream_view{stream_event.stream});
+      this->underlying().expand_pool(size, blocks, cuda::stream_ref{stream_event.stream});
 
     return allocate_and_insert_remainder(block, size, blocks);
   }

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -61,7 +61,7 @@ struct crtp {
  * documented separately:
  *
  * 1. `std::size_t get_maximum_allocation_size() const`
- * 2. `block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream)`
+ * 2. `block_type expand_pool(std::size_t size, free_list& blocks, cuda::stream_ref stream)`
  * 3. `split_block allocate_from_block(block_type const& b, std::size_t size)`
  * 4. `block_type free_block(void* ptr, std::size_t size) noexcept`
  */
@@ -92,15 +92,13 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
                                std::size_t bytes,
                                std::size_t /*alignment*/)
   {
-    auto const strm = cuda_stream_view{stream};
-
-    RMM_LOG_TRACE("[A][stream %s][%zuB]", rmm::detail::format_stream(strm), bytes);
+    RMM_LOG_TRACE("[A][stream %s][%zuB]", rmm::detail::format_stream(stream), bytes);
 
     if (bytes == 0) { return nullptr; }
 
     lock_guard lock(mtx_);
 
-    auto stream_event = get_event(strm);
+    auto stream_event = get_event(stream);
 
     bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
     RMM_EXPECTS(bytes <= this->underlying().get_maximum_allocation_size(),
@@ -132,14 +130,12 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
                   std::size_t bytes,
                   std::size_t /*alignment*/) noexcept
   {
-    auto const strm = cuda_stream_view{stream};
-
-    RMM_LOG_TRACE("[D][stream %s][%zuB][%p]", rmm::detail::format_stream(strm), bytes, ptr);
+    RMM_LOG_TRACE("[D][stream %s][%zuB][%p]", rmm::detail::format_stream(stream), bytes, ptr);
 
     if (bytes == 0 || ptr == nullptr) { return; }
 
     lock_guard lock(mtx_);
-    auto stream_event = get_event(strm);
+    auto stream_event = get_event(stream);
 
     bytes            = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
     auto const block = this->underlying().free_block(ptr, bytes);
@@ -147,7 +143,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     // TODO: cudaEventRecord has significant overhead on deallocations. For the non-PTDS case
     // we may be able to delay recording the event in some situations. But using events rather
     // than streams allows stealing from deleted streams.
-    RMM_ASSERT_CUDA_SUCCESS(cudaEventRecord(stream_event.event, strm.value()));
+    RMM_ASSERT_CUDA_SUCCESS(cudaEventRecord(stream_event.event, stream.get()));
 
     stream_free_blocks_[stream_event].insert(block);
 
@@ -222,7 +218,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
    * @param stream The stream on which the memory is to be used.
    * @return block_type a block of at least `size` bytes
    */
-  // block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream)
+  // block_type expand_pool(std::size_t size, free_list& blocks, cuda::stream_ref stream)
 
   /// Pair representing a block that has been split for allocation
   using split_block = std::pair<block_type, block_type>;
@@ -257,12 +253,12 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
    * @param block The block to insert into the pool.
    * @param stream The stream on which the memory was last used.
    */
-  void insert_block(block_type const& block, cuda_stream_view stream)
+  void insert_block(block_type const& block, cuda::stream_ref stream)
   {
     stream_free_blocks_[get_event(stream)].insert(block);
   }
 
-  void insert_blocks(free_list&& blocks, cuda_stream_view stream)
+  void insert_blocks(free_list&& blocks, cuda::stream_ref stream)
   {
     stream_free_blocks_[get_event(stream)].insert(std::move(blocks));
   }
@@ -306,9 +302,27 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
    * @param stream The stream for which to get an event.
    * @return The stream_event for `stream`.
    */
-  stream_event_pair get_event(cuda_stream_view stream)
+  static bool is_per_thread_default(cuda::stream_ref stream) noexcept
   {
-    if (stream.is_per_thread_default()) {
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+    return stream.get() == cudaStreamPerThread || stream.get() == nullptr;
+#else
+    return stream.get() == cudaStreamPerThread;
+#endif
+  }
+
+  static bool is_default(cuda::stream_ref stream) noexcept
+  {
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+    return stream.get() == cudaStreamLegacy;
+#else
+    return stream.get() == cudaStreamLegacy || stream.get() == nullptr;
+#endif
+  }
+
+  stream_event_pair get_event(cuda::stream_ref stream)
+  {
+    if (is_per_thread_default(stream)) {
       // Create a thread-local event for each device. These events are
       // deliberately leaked since the destructor needs to call into
       // the CUDA runtime and thread_local destructors (can) run below
@@ -325,7 +339,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
         }
         return e;
       }();
-      return stream_event_pair{stream.value(), event};
+      return stream_event_pair{stream.get(), event};
     }
     // We use cudaStreamLegacy as the event map key for the default stream for consistency between
     // PTDS and non-PTDS mode. In PTDS mode, the cudaStreamLegacy map key will only exist if the
@@ -333,7 +347,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     // at construction. For consistency, the same key is used for null stream free lists in
     // non-PTDS mode.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    auto* const stream_to_store = stream.is_default() ? cudaStreamLegacy : stream.value();
+    auto* const stream_to_store = is_default(stream) ? cudaStreamLegacy : stream.get();
     stream_id_type stream_id{};
     RMM_ASSERT_CUDA_SUCCESS(cudaStreamGetId(stream_to_store, &stream_id));
     auto const iter = stream_events_.find(stream_id);
@@ -398,7 +412,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
 
     // no large enough blocks available after merging, so grow the pool
     block_type const block =
-      this->underlying().expand_pool(size, blocks, cuda_stream_view{stream_event.stream});
+      this->underlying().expand_pool(size, blocks, cuda::stream_ref{stream_event.stream});
 
     return allocate_and_insert_remainder(block, size, blocks);
   }

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -6,6 +6,7 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/format.hpp>
@@ -162,7 +163,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
   [[nodiscard]] void* allocate_sync(std::size_t bytes,
                                     std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto const stream = rmm::cuda_stream_default;
     void* ptr         = allocate(stream, bytes, alignment);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return ptr;
@@ -180,7 +181,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     std::size_t bytes,
     [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto const stream = rmm::cuda_stream_default;
     deallocate(stream, ptr, bytes, alignment);
     RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
   }

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -412,8 +412,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     log_summary_trace();
 
     // no large enough blocks available after merging, so grow the pool
-    block_type const block =
-      this->underlying().expand_pool(size, blocks, cuda::stream_ref{stream_event.stream});
+    block_type const block = this->underlying().expand_pool(size, blocks, stream_event.stream);
 
     return allocate_and_insert_remainder(block, size, blocks);
   }

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -6,7 +6,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/detail/format.hpp>
@@ -163,7 +162,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
   [[nodiscard]] void* allocate_sync(std::size_t bytes,
                                     std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto const stream = rmm::cuda_stream_default;
+    auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
     void* ptr         = allocate(stream, bytes, alignment);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return ptr;
@@ -181,7 +180,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     std::size_t bytes,
     [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    auto const stream = rmm::cuda_stream_default;
+    auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
     deallocate(stream, ptr, bytes, alignment);
     RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
   }

--- a/cpp/include/rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp
@@ -4,11 +4,11 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <mutex>

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -12,6 +12,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <memory>
@@ -251,8 +252,9 @@ class stream_allocator_adaptor {
   [[nodiscard]] Allocator underlying_allocator() const noexcept { return alloc_; }
 
  private:
-  Allocator alloc_;          ///< Underlying allocator used for (de)allocation
-  cuda_stream_view stream_;  ///< Stream on which (de)allocations are performed
+  Allocator alloc_;  ///< Underlying allocator used for (de)allocation
+  cuda::stream_ref stream_{
+    cudaStream_t{nullptr}};  ///< Stream on which (de)allocations are performed
 };
 
 /**

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -254,7 +254,7 @@ class stream_allocator_adaptor {
  private:
   Allocator alloc_;  ///< Underlying allocator used for (de)allocation
   cuda::stream_ref stream_{
-    cudaStream_t{nullptr}};  ///< Stream on which (de)allocations are performed
+    rmm::cuda_stream_default};  ///< Stream on which (de)allocations are performed
 };
 
 /**

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -12,7 +12,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <memory>

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -79,7 +79,7 @@ class polymorphic_allocator {
    * @param stream The stream on which to perform the allocation
    * @return Pointer to the allocated storage
    */
-  value_type* allocate(std::size_t num, cuda_stream_view stream)
+  value_type* allocate(std::size_t num, cuda::stream_ref stream)
   {
     return static_cast<value_type*>(
       mr_.allocate(stream, num * sizeof(T), rmm::CUDA_ALLOCATION_ALIGNMENT));
@@ -95,7 +95,7 @@ class polymorphic_allocator {
    * @param num Number of objects originally allocated
    * @param stream Stream on which to perform the deallocation
    */
-  void deallocate(value_type* ptr, std::size_t num, cuda_stream_view stream) noexcept
+  void deallocate(value_type* ptr, std::size_t num, cuda::stream_ref stream) noexcept
   {
     mr_.deallocate(stream, ptr, num * sizeof(T), rmm::CUDA_ALLOCATION_ALIGNMENT);
   }
@@ -151,7 +151,7 @@ bool operator!=(polymorphic_allocator<T> const& lhs, polymorphic_allocator<U> co
 /**
  * @brief Adapts a stream ordered allocator to provide a standard `Allocator` interface
  *
- * A stream-ordered allocator (i.e., `allocate/deallocate` use a `cuda_stream_view`) cannot be used
+ * A stream-ordered allocator (i.e., `allocate/deallocate` use a `cuda::stream_ref`) cannot be used
  * in an interface that expects a standard C++ `Allocator` interface. `stream_allocator_adaptor`
  * wraps a stream-ordered allocator and a stream to provide a standard `Allocator` interface. The
  * adaptor uses the wrapped stream in calls to the underlying allocator's `allocate` and
@@ -160,7 +160,7 @@ bool operator!=(polymorphic_allocator<T> const& lhs, polymorphic_allocator<U> co
  * Example:
  *\code{.cpp}
  * my_stream_ordered_allocator<int> a{...};
- * cuda_stream_view s = // create stream;
+ * cuda::stream_ref s = // create stream;
  *
  * auto adapted = stream_allocator_adaptor(a, s);
  *
@@ -188,7 +188,7 @@ class stream_allocator_adaptor {
    * @param allocator The stream ordered allocator to use as the underlying allocator
    * @param stream The stream used with the underlying allocator
    */
-  stream_allocator_adaptor(Allocator const& allocator, cuda_stream_view stream)
+  stream_allocator_adaptor(Allocator const& allocator, cuda::stream_ref stream)
     : alloc_{allocator}, stream_{stream}
   {
   }
@@ -244,7 +244,7 @@ class stream_allocator_adaptor {
   /**
    * @briefreturn{The stream on which calls to the underlying allocator are made}
    */
-  [[nodiscard]] cuda_stream_view stream() const noexcept { return stream_; }
+  [[nodiscard]] cuda::stream_ref stream() const noexcept { return stream_; }
 
   /**
    * @briefreturn{The underlying allocator}

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -253,8 +252,8 @@ class stream_allocator_adaptor {
 
  private:
   Allocator alloc_;  ///< Underlying allocator used for (de)allocation
-  cuda::stream_ref stream_{
-    rmm::cuda_stream_default};  ///< Stream on which (de)allocations are performed
+  cuda::stream_ref stream_{cuda::stream_ref{
+    cudaStream_t{cudaStreamDefault}}};  ///< Stream on which (de)allocations are performed
 };
 
 /**

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -14,6 +14,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
@@ -179,7 +180,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   }
 
  private:
-  cuda_stream_view _stream{};
+  cuda::stream_ref _stream{cudaStream_t{nullptr}};
   mutable cuda::mr::any_resource<cuda::mr::device_accessible> _mr{
     rmm::mr::get_current_device_resource_ref()};
   cuda_device_id _device{get_current_cuda_device()};

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -14,7 +14,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <thrust/device_malloc_allocator.h>
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -180,7 +180,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   }
 
  private:
-  cuda::stream_ref _stream{cudaStream_t{nullptr}};
+  cuda::stream_ref _stream{rmm::cuda_stream_default};
   mutable cuda::mr::any_resource<cuda::mr::device_accessible> _mr{
     rmm::mr::get_current_device_resource_ref()};
   cuda_device_id _device{get_current_cuda_device()};

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -180,7 +180,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   }
 
  private:
-  cuda::stream_ref _stream{rmm::cuda_stream_default};
+  cuda::stream_ref _stream{cuda::stream_ref{cudaStream_t{cudaStreamDefault}}};
   mutable cuda::mr::any_resource<cuda::mr::device_accessible> _mr{
     rmm::mr::get_current_device_resource_ref()};
   cuda_device_id _device{get_current_cuda_device()};

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -71,7 +71,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @param stream The stream to be used for device memory (de)allocation
    */
   RMM_EXEC_CHECK_DISABLE
-  explicit thrust_allocator(cuda_stream_view stream) : _stream{stream} {}
+  explicit thrust_allocator(cuda::stream_ref stream) : _stream{stream} {}
 
   /**
    * @brief Constructs a `thrust_allocator` using a device memory resource and
@@ -81,7 +81,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
    * @param stream The stream to be used for device memory (de)allocation
    */
   RMM_EXEC_CHECK_DISABLE
-  thrust_allocator(cuda_stream_view stream, cuda::mr::any_resource<cuda::mr::device_accessible> mr)
+  thrust_allocator(cuda::stream_ref stream, cuda::mr::any_resource<cuda::mr::device_accessible> mr)
     : _stream{stream}, _mr(std::move(mr))
   {
   }
@@ -167,7 +167,7 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
   /**
    * @briefreturn{The stream used by this allocator}
    */
-  [[nodiscard]] cuda_stream_view stream() const noexcept { return _stream; }
+  [[nodiscard]] cuda::stream_ref stream() const noexcept { return _stream; }
 
   /**
    * @brief Enables the `cuda::mr::device_accessible` property

--- a/cpp/include/rmm/prefetch.hpp
+++ b/cpp/include/rmm/prefetch.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,6 +12,7 @@
 #include <rmm/error.hpp>
 
 #include <cuda/std/span>
+#include <cuda/stream_ref>
 
 namespace RMM_NAMESPACE {
 

--- a/cpp/include/rmm/prefetch.hpp
+++ b/cpp/include/rmm/prefetch.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/error.hpp>
@@ -38,7 +37,7 @@ RMM_NAMESPACE_BEGIN
 void prefetch(void const* ptr,
               std::size_t size,
               rmm::cuda_device_id device,
-              rmm::cuda_stream_view stream);
+              cuda::stream_ref stream);
 
 /**
  * @brief Prefetch a span of memory to the specified device on the specified stream.
@@ -52,9 +51,7 @@ void prefetch(void const* ptr,
  * @param stream The stream to use for the prefetch
  */
 template <typename T>
-void prefetch(cuda::std::span<T const> data,
-              rmm::cuda_device_id device,
-              rmm::cuda_stream_view stream)
+void prefetch(cuda::std::span<T const> data, rmm::cuda_device_id device, cuda::stream_ref stream)
 {
   prefetch(data.data(), data.size_bytes(), device, stream);
 }

--- a/cpp/include/rmm/prefetch.hpp
+++ b/cpp/include/rmm/prefetch.hpp
@@ -12,7 +12,7 @@
 #include <rmm/error.hpp>
 
 #include <cuda/std/span>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 RMM_NAMESPACE_BEGIN
 

--- a/cpp/include/rmm/prefetch.hpp
+++ b/cpp/include/rmm/prefetch.hpp
@@ -12,6 +12,7 @@
 #include <rmm/error.hpp>
 
 #include <cuda/std/span>
+#include <cuda/stream_ref>
 
 RMM_NAMESPACE_BEGIN
 

--- a/cpp/src/cuda_stream_pool.cpp
+++ b/cpp/src/cuda_stream_pool.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/cuda_stream_pool.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 
 #include <algorithm>
@@ -21,14 +20,14 @@ cuda_stream_pool::cuda_stream_pool(std::size_t pool_size, cuda_stream::flags fla
     std::back_inserter(streams_), pool_size, [flags]() { return cuda_stream(flags); });
 }
 
-rmm::cuda_stream_view cuda_stream_pool::get_stream() const noexcept
+cuda::stream_ref cuda_stream_pool::get_stream() const noexcept
 {
-  return streams_[(next_stream.fetch_add(1, std::memory_order_relaxed)) % streams_.size()].view();
+  return streams_[(next_stream.fetch_add(1, std::memory_order_relaxed)) % streams_.size()];
 }
 
-rmm::cuda_stream_view cuda_stream_pool::get_stream(std::size_t stream_id) const
+cuda::stream_ref cuda_stream_pool::get_stream(std::size_t stream_id) const
 {
-  return streams_[stream_id % streams_.size()].view();
+  return streams_[stream_id % streams_.size()];
 }
 
 std::size_t cuda_stream_pool::get_pool_size() const noexcept { return streams_.size(); }

--- a/cpp/src/cuda_stream_view.cpp
+++ b/cpp/src/cuda_stream_view.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/cuda_stream_view.hpp>
-#include <rmm/detail/cuda_stream.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 
@@ -38,21 +37,12 @@ bool cuda_stream_view::is_per_thread_default() const noexcept
 
 bool cuda_stream_view::is_default() const noexcept
 {
-  return detail::is_default_stream(static_cast<cuda::stream_ref>(*this));
-}
-
-namespace detail {
-
-bool is_default_stream(cuda::stream_ref stream) noexcept
-{
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
-  return stream == cudaStreamLegacy;
+  return value() == cuda_stream_legacy.get();
 #else
-  return stream == cudaStreamLegacy || stream == cudaStream_t{};
+  return value() == cuda_stream_legacy.get() || value() == nullptr;
 #endif
 }
-
-}  // namespace detail
 
 void cuda_stream_view::synchronize() const { RMM_CUDA_TRY(cudaStreamSynchronize(stream_)); }
 

--- a/cpp/src/cuda_stream_view.cpp
+++ b/cpp/src/cuda_stream_view.cpp
@@ -30,9 +30,9 @@ cuda_stream_view::operator cuda::stream_ref() const noexcept { return value(); }
 bool cuda_stream_view::is_per_thread_default() const noexcept
 {
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
-  return *this == cuda_stream_per_thread || value() == nullptr;
+  return value() == cuda_stream_per_thread.get() || value() == nullptr;
 #else
-  return *this == cuda_stream_per_thread;
+  return value() == cuda_stream_per_thread.get();
 #endif
 }
 

--- a/cpp/src/cuda_stream_view.cpp
+++ b/cpp/src/cuda_stream_view.cpp
@@ -29,18 +29,18 @@ cuda_stream_view::operator cuda::stream_ref() const noexcept { return value(); }
 bool cuda_stream_view::is_per_thread_default() const noexcept
 {
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
-  return value() == cuda_stream_per_thread.get() || value() == nullptr;
+  return value() == cudaStreamPerThread || value() == nullptr;
 #else
-  return value() == cuda_stream_per_thread.get();
+  return value() == cudaStreamPerThread;
 #endif
 }
 
 bool cuda_stream_view::is_default() const noexcept
 {
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
-  return value() == cuda_stream_legacy.get();
+  return value() == cudaStreamLegacy;
 #else
-  return value() == cuda_stream_legacy.get() || value() == nullptr;
+  return value() == cudaStreamLegacy || value() == nullptr;
 #endif
 }
 

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -8,6 +8,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/error.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <memory>
@@ -80,8 +81,8 @@ device_buffer::device_buffer(device_buffer&& other) noexcept
   other._size      = 0;
   other._alignment = 1;
   other._capacity  = 0;
-  other.set_stream(cuda_stream_view{});
-  other._device = cuda_device_id{-1};
+  other._stream    = cuda::stream_ref{cudaStream_t{nullptr}};
+  other._device    = cuda_device_id{-1};
 }
 
 device_buffer& device_buffer::operator=(device_buffer&& other) noexcept
@@ -102,8 +103,8 @@ device_buffer& device_buffer::operator=(device_buffer&& other) noexcept
     other._size      = 0;
     other._alignment = 1;
     other._capacity  = 0;
-    other.set_stream(cuda_stream_view{});
-    other._device = cuda_device_id{-1};
+    other._stream    = cuda::stream_ref{cudaStream_t{nullptr}};
+    other._device    = cuda_device_id{-1};
   }
   return *this;
 }
@@ -112,19 +113,19 @@ device_buffer::~device_buffer() noexcept
 {
   cuda_set_device_raii dev{_device};
   deallocate_async();
-  _stream = cuda_stream_view{};
+  _stream = cuda::stream_ref{cudaStream_t{nullptr}};
 }
 
 void device_buffer::allocate_async(std::size_t bytes)
 {
   _size     = bytes;
   _capacity = bytes;
-  _data     = (bytes > 0) ? _mr.allocate(stream(), bytes, alignment()) : nullptr;
+  _data     = (bytes > 0) ? _mr.allocate(_stream, bytes, alignment()) : nullptr;
 }
 
 void device_buffer::deallocate_async() noexcept
 {
-  if (capacity() > 0) { _mr.deallocate(stream(), data(), capacity(), alignment()); }
+  if (capacity() > 0) { _mr.deallocate(_stream, data(), capacity(), alignment()); }
   _size      = 0;
   _alignment = 1;
   _capacity  = 0;
@@ -137,7 +138,7 @@ void device_buffer::copy_async(void const* source, std::size_t bytes)
     RMM_EXPECTS(nullptr != source, "Invalid copy from nullptr.");
     RMM_EXPECTS(nullptr != _data, "Invalid copy to nullptr.");
 
-    RMM_CUDA_TRY(cudaMemcpyAsync(_data, source, bytes, cudaMemcpyDefault, stream().value()));
+    RMM_CUDA_TRY(cudaMemcpyAsync(_data, source, bytes, cudaMemcpyDefault, _stream.get()));
   }
 }
 
@@ -148,7 +149,7 @@ void device_buffer::reserve(std::size_t new_capacity, cuda_stream_view stream)
     cuda_set_device_raii dev{_device};
     auto tmp            = device_buffer{new_capacity, alignment(), stream, _mr};
     auto const old_size = size();
-    RMM_CUDA_TRY(cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, stream.value()));
+    RMM_CUDA_TRY(cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, _stream.get()));
     *this = std::move(tmp);
     _size = old_size;
   }
@@ -164,7 +165,7 @@ void device_buffer::resize(std::size_t new_size, cuda_stream_view stream)
   } else {
     cuda_set_device_raii dev{_device};
     auto tmp = device_buffer{new_size, alignment(), stream, _mr};
-    RMM_CUDA_TRY(cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, stream.value()));
+    RMM_CUDA_TRY(cudaMemcpyAsync(tmp.data(), data(), size(), cudaMemcpyDefault, _stream.get()));
     *this = std::move(tmp);
   }
 }

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/cuda_memcpy.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
@@ -84,7 +83,7 @@ device_buffer::device_buffer(device_buffer&& other) noexcept
   other._size      = 0;
   other._alignment = 1;
   other._capacity  = 0;
-  other._stream    = rmm::cuda_stream_default;
+  other._stream    = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   other._device    = cuda_device_id{-1};
 }
 
@@ -106,7 +105,7 @@ device_buffer& device_buffer::operator=(device_buffer&& other) noexcept
     other._size      = 0;
     other._alignment = 1;
     other._capacity  = 0;
-    other._stream    = rmm::cuda_stream_default;
+    other._stream    = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
     other._device    = cuda_device_id{-1};
   }
   return *this;
@@ -116,7 +115,7 @@ device_buffer::~device_buffer() noexcept
 {
   cuda_set_device_raii dev{_device};
   deallocate_async();
-  _stream = rmm::cuda_stream_default;
+  _stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 }
 
 void device_buffer::allocate_async(std::size_t bytes)

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/cuda_memcpy.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
@@ -83,7 +84,7 @@ device_buffer::device_buffer(device_buffer&& other) noexcept
   other._size      = 0;
   other._alignment = 1;
   other._capacity  = 0;
-  other._stream    = cuda::stream_ref{cudaStream_t{nullptr}};
+  other._stream    = rmm::cuda_stream_default;
   other._device    = cuda_device_id{-1};
 }
 
@@ -105,7 +106,7 @@ device_buffer& device_buffer::operator=(device_buffer&& other) noexcept
     other._size      = 0;
     other._alignment = 1;
     other._capacity  = 0;
-    other._stream    = cuda::stream_ref{cudaStream_t{nullptr}};
+    other._stream    = rmm::cuda_stream_default;
     other._device    = cuda_device_id{-1};
   }
   return *this;
@@ -115,7 +116,7 @@ device_buffer::~device_buffer() noexcept
 {
   cuda_set_device_raii dev{_device};
   deallocate_async();
-  _stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  _stream = rmm::cuda_stream_default;
 }
 
 void device_buffer::allocate_async(std::size_t bytes)

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -20,7 +20,7 @@ RMM_NAMESPACE_BEGIN
 device_buffer::device_buffer() : _mr{rmm::mr::get_current_device_resource_ref()} {}
 
 device_buffer::device_buffer(std::size_t size,
-                             cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : device_buffer::device_buffer(size, rmm::CUDA_ALLOCATION_ALIGNMENT, stream, std::move(mr))
 {
@@ -28,7 +28,7 @@ device_buffer::device_buffer(std::size_t size,
 
 device_buffer::device_buffer(std::size_t size,
                              std::size_t alignment,
-                             cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _alignment{alignment}, _stream{stream}, _mr{std::move(mr)}
 {
@@ -41,7 +41,7 @@ device_buffer::device_buffer(std::size_t size,
 
 device_buffer::device_buffer(void const* source_data,
                              std::size_t size,
-                             cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : device_buffer::device_buffer(
       source_data, size, rmm::CUDA_ALLOCATION_ALIGNMENT, stream, std::move(mr))
@@ -51,7 +51,7 @@ device_buffer::device_buffer(void const* source_data,
 device_buffer::device_buffer(void const* source_data,
                              std::size_t size,
                              std::size_t alignment,
-                             cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : _alignment{alignment}, _stream{stream}, _mr{std::move(mr)}
 {
@@ -65,7 +65,7 @@ device_buffer::device_buffer(void const* source_data,
 }
 
 device_buffer::device_buffer(device_buffer const& other,
-                             cuda_stream_view stream,
+                             cuda::stream_ref stream,
                              cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : device_buffer{other.data(), other.size(), other.alignment(), stream, std::move(mr)}
 {
@@ -145,7 +145,7 @@ void device_buffer::copy_async(void const* source, std::size_t bytes)
   }
 }
 
-void device_buffer::reserve(std::size_t new_capacity, cuda_stream_view stream)
+void device_buffer::reserve(std::size_t new_capacity, cuda::stream_ref stream)
 {
   set_stream(stream);
   if (new_capacity > capacity()) {
@@ -158,7 +158,7 @@ void device_buffer::reserve(std::size_t new_capacity, cuda_stream_view stream)
   }
 }
 
-void device_buffer::resize(std::size_t new_size, cuda_stream_view stream)
+void device_buffer::resize(std::size_t new_size, cuda::stream_ref stream)
 {
   set_stream(stream);
   // If the requested size is smaller than the current capacity, just update
@@ -173,7 +173,7 @@ void device_buffer::resize(std::size_t new_size, cuda_stream_view stream)
   }
 }
 
-void device_buffer::shrink_to_fit(cuda_stream_view stream)
+void device_buffer::shrink_to_fit(cuda::stream_ref stream)
 {
   set_stream(stream);
   if (size() != capacity()) {

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -9,6 +9,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/error.hpp>
 
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <memory>
@@ -82,8 +83,8 @@ device_buffer::device_buffer(device_buffer&& other) noexcept
   other._size      = 0;
   other._alignment = 1;
   other._capacity  = 0;
-  other.set_stream(cuda_stream_view{});
-  other._device = cuda_device_id{-1};
+  other._stream    = cuda::stream_ref{cudaStream_t{nullptr}};
+  other._device    = cuda_device_id{-1};
 }
 
 device_buffer& device_buffer::operator=(device_buffer&& other) noexcept
@@ -104,8 +105,8 @@ device_buffer& device_buffer::operator=(device_buffer&& other) noexcept
     other._size      = 0;
     other._alignment = 1;
     other._capacity  = 0;
-    other.set_stream(cuda_stream_view{});
-    other._device = cuda_device_id{-1};
+    other._stream    = cuda::stream_ref{cudaStream_t{nullptr}};
+    other._device    = cuda_device_id{-1};
   }
   return *this;
 }
@@ -114,19 +115,19 @@ device_buffer::~device_buffer() noexcept
 {
   cuda_set_device_raii dev{_device};
   deallocate_async();
-  _stream = cuda_stream_view{};
+  _stream = cuda::stream_ref{cudaStream_t{nullptr}};
 }
 
 void device_buffer::allocate_async(std::size_t bytes)
 {
   _size     = bytes;
   _capacity = bytes;
-  _data     = (bytes > 0) ? _mr.allocate(stream(), bytes, alignment()) : nullptr;
+  _data     = (bytes > 0) ? _mr.allocate(_stream, bytes, alignment()) : nullptr;
 }
 
 void device_buffer::deallocate_async() noexcept
 {
-  if (capacity() > 0) { _mr.deallocate(stream(), data(), capacity(), alignment()); }
+  if (capacity() > 0) { _mr.deallocate(_stream, data(), capacity(), alignment()); }
   _size      = 0;
   _alignment = 1;
   _capacity  = 0;

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -9,7 +9,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/error.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <memory>

--- a/cpp/src/exec_policy.cpp
+++ b/cpp/src/exec_policy.cpp
@@ -9,8 +9,8 @@ namespace rmm {
 
 exec_policy::exec_policy(cuda_stream_view stream,
                          cuda::mr::any_resource<cuda::mr::device_accessible> mr)
-  : thrust_exec_policy_t(
-      thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr))).on(stream.value()))
+  : thrust_exec_policy_t(thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr)))
+                           .on(cuda::stream_ref{stream}.get()))
 {
 }
 
@@ -18,7 +18,7 @@ exec_policy_nosync::exec_policy_nosync(cuda_stream_view stream,
                                        cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : thrust_exec_policy_nosync_t(
       thrust::cuda::par_nosync(mr::thrust_allocator<char>(stream, std::move(mr)))
-        .on(stream.value()))
+        .on(cuda::stream_ref{stream}.get()))
 {
 }
 

--- a/cpp/src/exec_policy.cpp
+++ b/cpp/src/exec_policy.cpp
@@ -9,8 +9,8 @@ RMM_NAMESPACE_BEGIN
 
 exec_policy::exec_policy(cuda_stream_view stream,
                          cuda::mr::any_resource<cuda::mr::device_accessible> mr)
-  : thrust_exec_policy_t(
-      thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr))).on(stream.value()))
+  : thrust_exec_policy_t(thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr)))
+                           .on(cuda::stream_ref{stream}.get()))
 {
 }
 
@@ -18,7 +18,7 @@ exec_policy_nosync::exec_policy_nosync(cuda_stream_view stream,
                                        cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : thrust_exec_policy_nosync_t(
       thrust::cuda::par_nosync(mr::thrust_allocator<char>(stream, std::move(mr)))
-        .on(stream.value()))
+        .on(cuda::stream_ref{stream}.get()))
 {
 }
 

--- a/cpp/src/exec_policy.cpp
+++ b/cpp/src/exec_policy.cpp
@@ -9,8 +9,8 @@ RMM_NAMESPACE_BEGIN
 
 exec_policy::exec_policy(cuda_stream_view stream,
                          cuda::mr::any_resource<cuda::mr::device_accessible> mr)
-  : thrust_exec_policy_t(thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr)))
-                           .on(cuda::stream_ref{stream}.get()))
+  : thrust_exec_policy_t(
+      thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr))).on(stream.value()))
 {
 }
 
@@ -18,7 +18,7 @@ exec_policy_nosync::exec_policy_nosync(cuda_stream_view stream,
                                        cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : thrust_exec_policy_nosync_t(
       thrust::cuda::par_nosync(mr::thrust_allocator<char>(stream, std::move(mr)))
-        .on(cuda::stream_ref{stream}.get()))
+        .on(stream.value()))
 {
 }
 

--- a/cpp/src/exec_policy.cpp
+++ b/cpp/src/exec_policy.cpp
@@ -7,18 +7,17 @@
 
 RMM_NAMESPACE_BEGIN
 
-exec_policy::exec_policy(cuda_stream_view stream,
+exec_policy::exec_policy(cuda::stream_ref stream,
                          cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : thrust_exec_policy_t(
-      thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr))).on(stream.value()))
+      thrust::cuda::par(mr::thrust_allocator<char>(stream, std::move(mr))).on(stream.get()))
 {
 }
 
-exec_policy_nosync::exec_policy_nosync(cuda_stream_view stream,
+exec_policy_nosync::exec_policy_nosync(cuda::stream_ref stream,
                                        cuda::mr::any_resource<cuda::mr::device_accessible> mr)
   : thrust_exec_policy_nosync_t(
-      thrust::cuda::par_nosync(mr::thrust_allocator<char>(stream, std::move(mr)))
-        .on(stream.value()))
+      thrust::cuda::par_nosync(mr::thrust_allocator<char>(stream, std::move(mr))).on(stream.get()))
 {
 }
 

--- a/cpp/src/mr/cuda_async_view_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_view_memory_resource.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/cuda_async_view_memory_resource.hpp>
@@ -54,7 +55,7 @@ void cuda_async_view_memory_resource::deallocate(cuda::stream_ref stream,
 
 void* cuda_async_view_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -63,7 +64,7 @@ void cuda_async_view_memory_resource::deallocate_sync(void* ptr,
                                                       std::size_t bytes,
                                                       std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/cuda_async_view_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_view_memory_resource.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/cuda_async_view_memory_resource.hpp>
@@ -55,7 +54,7 @@ void cuda_async_view_memory_resource::deallocate(cuda::stream_ref stream,
 
 void* cuda_async_view_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -64,7 +63,7 @@ void cuda_async_view_memory_resource::deallocate_sync(void* ptr,
                                                       std::size_t bytes,
                                                       std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/cuda_memory_resource.cpp
+++ b/cpp/src/mr/cuda_memory_resource.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 
@@ -37,7 +38,7 @@ void cuda_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref stream,
 
 void* cuda_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -46,7 +47,7 @@ void cuda_memory_resource::deallocate_sync(void* ptr,
                                            std::size_t bytes,
                                            std::size_t alignment) noexcept
 {
-  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
 }
 
 bool cuda_memory_resource::operator==(cuda_memory_resource const&) const noexcept { return true; }

--- a/cpp/src/mr/cuda_memory_resource.cpp
+++ b/cpp/src/mr/cuda_memory_resource.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 
@@ -38,7 +37,7 @@ void cuda_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref stream,
 
 void* cuda_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -47,7 +46,7 @@ void cuda_memory_resource::deallocate_sync(void* ptr,
                                            std::size_t bytes,
                                            std::size_t alignment) noexcept
 {
-  deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, bytes, alignment);
 }
 
 bool cuda_memory_resource::operator==(cuda_memory_resource const&) const noexcept { return true; }

--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -4,9 +4,11 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/aligned_resource_adaptor_impl.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -89,14 +91,14 @@ void aligned_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* aligned_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return allocate(cuda_stream_view{}, bytes, alignment);
+  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void aligned_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -7,7 +7,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/aligned_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <algorithm>

--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/aligned_resource_adaptor_impl.hpp>
 
@@ -91,7 +92,7 @@ void aligned_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* aligned_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -101,7 +102,7 @@ void aligned_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -4,11 +4,10 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/aligned_resource_adaptor_impl.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <algorithm>

--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/aligned_resource_adaptor_impl.hpp>
 
@@ -92,7 +91,7 @@ void aligned_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* aligned_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -102,7 +101,7 @@ void aligned_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
@@ -33,13 +34,12 @@ void* arena_memory_resource_impl::allocate(cuda::stream_ref stream,
                                            std::size_t /*alignment*/)
 {
   if (bytes == 0) { return nullptr; }
-  cuda_stream_view sv{stream.get()};
 #ifdef RMM_ARENA_USE_SIZE_CLASSES
   bytes = rmm::mr::detail::arena::align_to_size_class(bytes);
 #else
   bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
 #endif
-  auto& arena = get_arena(sv);
+  auto& arena = get_arena(stream);
 
   {
     std::shared_lock lock(mtx_);
@@ -67,36 +67,35 @@ void arena_memory_resource_impl::deallocate(cuda::stream_ref stream,
                                             std::size_t /*alignment*/) noexcept
 {
   if (ptr == nullptr || bytes == 0) { return; }
-  cuda_stream_view sv{stream.get()};
 #ifdef RMM_ARENA_USE_SIZE_CLASSES
   bytes = rmm::mr::detail::arena::align_to_size_class(bytes);
 #else
   bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
 #endif
-  auto& arena = get_arena(sv);
+  auto& arena = get_arena(stream);
 
   {
     std::shared_lock lock(mtx_);
-    if (arena.deallocate(sv, ptr, bytes)) { return; }
+    if (arena.deallocate(stream, ptr, bytes)) { return; }
   }
 
   {
-    sv.synchronize_no_throw();
+    RMM_ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream.get()));
     std::unique_lock lock(mtx_);
-    deallocate_from_other_arena(sv, ptr, bytes);
+    deallocate_from_other_arena(stream, ptr, bytes);
   }
 }
 
 void* arena_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return allocate(cuda_stream_view{}, bytes, alignment);
+  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void arena_memory_resource_impl::deallocate_sync(void* ptr,
                                                  std::size_t bytes,
                                                  std::size_t alignment) noexcept
 {
-  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 void arena_memory_resource_impl::defragment()
@@ -110,7 +109,7 @@ void arena_memory_resource_impl::defragment()
   }
 }
 
-void arena_memory_resource_impl::deallocate_from_other_arena(cuda_stream_view stream,
+void arena_memory_resource_impl::deallocate_from_other_arena(cuda::stream_ref stream,
                                                              void* ptr,
                                                              std::size_t bytes)
 {
@@ -138,7 +137,7 @@ void arena_memory_resource_impl::deallocate_from_other_arena(cuda_stream_view st
   }
 }
 
-arena_memory_resource_impl::arena& arena_memory_resource_impl::get_arena(cuda_stream_view stream)
+arena_memory_resource_impl::arena& arena_memory_resource_impl::get_arena(cuda::stream_ref stream)
 {
   if (use_per_thread_arena(stream)) { return get_thread_arena(); }
   return get_stream_arena(stream);
@@ -162,18 +161,18 @@ arena_memory_resource_impl::arena& arena_memory_resource_impl::get_thread_arena(
 }
 
 arena_memory_resource_impl::arena& arena_memory_resource_impl::get_stream_arena(
-  cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   RMM_LOGGING_ASSERT(!use_per_thread_arena(stream));
   {
     std::shared_lock lock(map_mtx_);
-    auto const iter = stream_arenas_.find(stream.value());
+    auto const iter = stream_arenas_.find(stream.get());
     if (iter != stream_arenas_.end()) { return iter->second; }
   }
   {
     std::unique_lock lock(map_mtx_);
-    stream_arenas_.emplace(stream.value(), global_arena_);
-    return stream_arenas_.at(stream.value());
+    stream_arenas_.emplace(stream.get(), global_arena_);
+    return stream_arenas_.at(stream.get());
   }
 }
 
@@ -187,9 +186,13 @@ void arena_memory_resource_impl::dump_memory_log(std::size_t bytes)
   logger_->flush();
 }
 
-bool arena_memory_resource_impl::use_per_thread_arena(cuda_stream_view stream)
+bool arena_memory_resource_impl::use_per_thread_arena(cuda::stream_ref stream)
 {
-  return stream.is_per_thread_default();
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  return stream.get() == cudaStreamPerThread || stream.get() == nullptr;
+#else
+  return stream.get() == cudaStreamPerThread;
+#endif
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
@@ -34,13 +35,12 @@ void* arena_memory_resource_impl::allocate(cuda::stream_ref stream,
                                            std::size_t /*alignment*/)
 {
   if (bytes == 0) { return nullptr; }
-  cuda_stream_view sv{stream.get()};
 #ifdef RMM_ARENA_USE_SIZE_CLASSES
   bytes = rmm::mr::detail::arena::align_to_size_class(bytes);
 #else
   bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
 #endif
-  auto& arena = get_arena(sv);
+  auto& arena = get_arena(stream);
 
   {
     std::shared_lock lock(mtx_);
@@ -68,23 +68,22 @@ void arena_memory_resource_impl::deallocate(cuda::stream_ref stream,
                                             std::size_t /*alignment*/) noexcept
 {
   if (ptr == nullptr || bytes == 0) { return; }
-  cuda_stream_view sv{stream.get()};
 #ifdef RMM_ARENA_USE_SIZE_CLASSES
   bytes = rmm::mr::detail::arena::align_to_size_class(bytes);
 #else
   bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
 #endif
-  auto& arena = get_arena(sv);
+  auto& arena = get_arena(stream);
 
   {
     std::shared_lock lock(mtx_);
-    if (arena.deallocate(sv, ptr, bytes)) { return; }
+    if (arena.deallocate(stream, ptr, bytes)) { return; }
   }
 
   {
-    sv.synchronize_no_throw();
+    RMM_ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream.get()));
     std::unique_lock lock(mtx_);
-    deallocate_from_other_arena(sv, ptr, bytes);
+    deallocate_from_other_arena(stream, ptr, bytes);
   }
 }
 
@@ -116,7 +115,7 @@ void arena_memory_resource_impl::defragment()
   }
 }
 
-void arena_memory_resource_impl::deallocate_from_other_arena(cuda_stream_view stream,
+void arena_memory_resource_impl::deallocate_from_other_arena(cuda::stream_ref stream,
                                                              void* ptr,
                                                              std::size_t bytes)
 {
@@ -144,7 +143,7 @@ void arena_memory_resource_impl::deallocate_from_other_arena(cuda_stream_view st
   }
 }
 
-arena_memory_resource_impl::arena& arena_memory_resource_impl::get_arena(cuda_stream_view stream)
+arena_memory_resource_impl::arena& arena_memory_resource_impl::get_arena(cuda::stream_ref stream)
 {
   if (use_per_thread_arena(stream)) { return get_thread_arena(); }
   return get_stream_arena(stream);
@@ -168,18 +167,18 @@ arena_memory_resource_impl::arena& arena_memory_resource_impl::get_thread_arena(
 }
 
 arena_memory_resource_impl::arena& arena_memory_resource_impl::get_stream_arena(
-  cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   RMM_LOGGING_ASSERT(!use_per_thread_arena(stream));
   {
     std::shared_lock lock(map_mtx_);
-    auto const iter = stream_arenas_.find(stream.value());
+    auto const iter = stream_arenas_.find(stream.get());
     if (iter != stream_arenas_.end()) { return iter->second; }
   }
   {
     std::unique_lock lock(map_mtx_);
-    stream_arenas_.emplace(stream.value(), global_arena_);
-    return stream_arenas_.at(stream.value());
+    stream_arenas_.emplace(stream.get(), global_arena_);
+    return stream_arenas_.at(stream.get());
   }
 }
 
@@ -193,9 +192,13 @@ void arena_memory_resource_impl::dump_memory_log(std::size_t bytes)
   logger_->flush();
 }
 
-bool arena_memory_resource_impl::use_per_thread_arena(cuda_stream_view stream)
+bool arena_memory_resource_impl::use_per_thread_arena(cuda::stream_ref stream)
 {
-  return stream.is_per_thread_default();
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  return stream.get() == cudaStreamPerThread || stream.get() == nullptr;
+#else
+  return stream.get() == cudaStreamPerThread;
+#endif
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/detail/logging_assert.hpp>
@@ -89,7 +90,7 @@ void arena_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* arena_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -99,7 +100,7 @@ void arena_memory_resource_impl::deallocate_sync(void* ptr,
                                                  std::size_t bytes,
                                                  std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/detail/logging_assert.hpp>
@@ -90,7 +89,7 @@ void arena_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* arena_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -100,7 +99,7 @@ void arena_memory_resource_impl::deallocate_sync(void* ptr,
                                                  std::size_t bytes,
                                                  std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/binning_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/binning_memory_resource_impl.cpp
@@ -80,14 +80,16 @@ void binning_memory_resource_impl::deallocate(cuda::stream_ref stream,
 void* binning_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
   if (bytes == 0) { return nullptr; }
-  return get_resource_ref(bytes).allocate(cuda_stream_view{}, bytes, alignment);
+  return get_resource_ref(bytes).allocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void binning_memory_resource_impl::deallocate_sync(void* ptr,
                                                    std::size_t bytes,
                                                    std::size_t alignment) noexcept
 {
-  get_resource_ref(bytes).deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  get_resource_ref(bytes).deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/binning_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/binning_memory_resource_impl.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/detail/binning_memory_resource_impl.hpp>
 
 #include <cuda_runtime_api.h>
@@ -79,7 +80,7 @@ void binning_memory_resource_impl::deallocate(cuda::stream_ref stream,
 void* binning_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
   if (bytes == 0) { return nullptr; }
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = get_resource_ref(bytes).allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -89,7 +90,7 @@ void binning_memory_resource_impl::deallocate_sync(void* ptr,
                                                    std::size_t bytes,
                                                    std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   get_resource_ref(bytes).deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/binning_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/binning_memory_resource_impl.cpp
@@ -78,14 +78,20 @@ void binning_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* binning_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return get_resource_ref(bytes).allocate_sync(bytes, alignment);
+  if (bytes == 0) { return nullptr; }
+  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto* ptr         = get_resource_ref(bytes).allocate(stream, bytes, alignment);
+  RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+  return ptr;
 }
 
 void binning_memory_resource_impl::deallocate_sync(void* ptr,
                                                    std::size_t bytes,
                                                    std::size_t alignment) noexcept
 {
-  get_resource_ref(bytes).deallocate_sync(ptr, bytes, alignment);
+  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  get_resource_ref(bytes).deallocate(stream, ptr, bytes, alignment);
+  RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/binning_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/binning_memory_resource_impl.cpp
@@ -82,7 +82,7 @@ void* binning_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t
   if (bytes == 0) { return nullptr; }
   auto const stream = rmm::cuda_stream_default;
   auto* ptr         = get_resource_ref(bytes).allocate(stream, bytes, alignment);
-  RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+  stream.sync();
   return ptr;
 }
 

--- a/cpp/src/mr/detail/binning_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/binning_memory_resource_impl.cpp
@@ -4,9 +4,9 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/detail/binning_memory_resource_impl.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cassert>
@@ -80,7 +80,7 @@ void binning_memory_resource_impl::deallocate(cuda::stream_ref stream,
 void* binning_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
   if (bytes == 0) { return nullptr; }
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = get_resource_ref(bytes).allocate(stream, bytes, alignment);
   stream.sync();
   return ptr;
@@ -90,7 +90,7 @@ void binning_memory_resource_impl::deallocate_sync(void* ptr,
                                                    std::size_t bytes,
                                                    std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   get_resource_ref(bytes).deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -5,6 +5,9 @@
 
 #include <rmm/mr/detail/callback_memory_resource_impl.hpp>
 
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
 #include <utility>
 
 namespace RMM_NAMESPACE {
@@ -40,14 +43,14 @@ void callback_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* callback_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return allocate(cuda_stream_view{}, bytes, alignment);
+  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void callback_memory_resource_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/callback_memory_resource_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <utility>

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/callback_memory_resource_impl.hpp>
 
@@ -44,7 +45,7 @@ void callback_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* callback_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -54,7 +55,7 @@ void callback_memory_resource_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/callback_memory_resource_impl.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <utility>

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/callback_memory_resource_impl.hpp>
 
@@ -45,7 +44,7 @@ void callback_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* callback_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -55,7 +54,7 @@ void callback_memory_resource_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -17,8 +17,8 @@ namespace mr {
 namespace detail {
 
 callback_memory_resource_impl::callback_memory_resource_impl(
-  std::function<void*(std::size_t, cuda_stream_view, void*)> allocate_callback,
-  std::function<void(void*, std::size_t, cuda_stream_view, void*)> deallocate_callback,
+  std::function<void*(std::size_t, cuda::stream_ref, void*)> allocate_callback,
+  std::function<void(void*, std::size_t, cuda::stream_ref, void*)> deallocate_callback,
   void* allocate_callback_arg,
   void* deallocate_callback_arg) noexcept
   : allocate_callback_(std::move(allocate_callback)),
@@ -32,7 +32,7 @@ void* callback_memory_resource_impl::allocate(cuda::stream_ref stream,
                                               std::size_t bytes,
                                               std::size_t /*alignment*/)
 {
-  return allocate_callback_(bytes, cuda_stream_view{stream.get()}, allocate_callback_arg_);
+  return allocate_callback_(bytes, stream, allocate_callback_arg_);
 }
 
 void callback_memory_resource_impl::deallocate(cuda::stream_ref stream,
@@ -40,7 +40,7 @@ void callback_memory_resource_impl::deallocate(cuda::stream_ref stream,
                                                std::size_t bytes,
                                                std::size_t /*alignment*/) noexcept
 {
-  deallocate_callback_(ptr, bytes, cuda_stream_view{stream.get()}, deallocate_callback_arg_);
+  deallocate_callback_(ptr, bytes, stream, deallocate_callback_arg_);
 }
 
 void* callback_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)

--- a/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
@@ -67,7 +67,7 @@ void cuda_async_managed_memory_resource_impl::deallocate(cuda::stream_ref stream
 void* cuda_async_managed_memory_resource_impl::allocate_sync(std::size_t bytes,
                                                              std::size_t alignment)
 {
-  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -76,7 +76,7 @@ void cuda_async_managed_memory_resource_impl::deallocate_sync(void* ptr,
                                                               std::size_t bytes,
                                                               std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
@@ -5,11 +5,11 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/detail/cuda_async_managed_memory_resource_impl.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
@@ -67,7 +67,7 @@ void cuda_async_managed_memory_resource_impl::deallocate(cuda::stream_ref stream
 void* cuda_async_managed_memory_resource_impl::allocate_sync(std::size_t bytes,
                                                              std::size_t alignment)
 {
-  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -76,7 +76,7 @@ void cuda_async_managed_memory_resource_impl::deallocate_sync(void* ptr,
                                                               std::size_t bytes,
                                                               std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -62,8 +62,8 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
   // specified size (only if initial_pool_size is provided)
   if (initial_pool_size.has_value()) {
     auto const pool_size = initial_pool_size.value();
-    auto* ptr            = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, pool_size);
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, pool_size);
+    auto* ptr            = allocate(rmm::cuda_stream_default, pool_size);
+    deallocate(rmm::cuda_stream_default, ptr, pool_size);
   }
 }
 
@@ -96,7 +96,7 @@ void cuda_async_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* cuda_async_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -105,7 +105,7 @@ void cuda_async_memory_resource_impl::deallocate_sync(void* ptr,
                                                       std::size_t bytes,
                                                       std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -4,12 +4,12 @@
  */
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/detail/cuda_async_memory_resource_impl.hpp>
 #include <rmm/process_is_exiting.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <driver_types.h>
@@ -62,8 +62,8 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
   // specified size (only if initial_pool_size is provided)
   if (initial_pool_size.has_value()) {
     auto const pool_size = initial_pool_size.value();
-    auto* ptr            = allocate(rmm::cuda_stream_default, pool_size);
-    deallocate(rmm::cuda_stream_default, ptr, pool_size);
+    auto* ptr            = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, pool_size);
+    deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, pool_size);
   }
 }
 
@@ -96,7 +96,7 @@ void cuda_async_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* cuda_async_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -105,7 +105,7 @@ void cuda_async_memory_resource_impl::deallocate_sync(void* ptr,
                                                       std::size_t bytes,
                                                       std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
@@ -4,11 +4,12 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/mr/detail/fixed_size_memory_resource_impl.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <cstddef>
 #include <mutex>
@@ -33,7 +34,8 @@ fixed_size_memory_resource_impl::fixed_size_memory_resource_impl(
     block_size_{align_up(block_size, rmm::CUDA_ALLOCATION_ALIGNMENT)},
     upstream_chunk_size_{block_size_ * blocks_to_preallocate}
 {
-  this->insert_blocks(std::move(blocks_from_upstream(cuda_stream_legacy)), cuda_stream_legacy);
+  this->insert_blocks(std::move(blocks_from_upstream(cuda::stream_ref{cudaStreamLegacy})),
+                      cuda::stream_ref{cudaStreamLegacy});
 }
 
 fixed_size_memory_resource_impl::~fixed_size_memory_resource_impl() { release(); }
@@ -52,14 +54,14 @@ std::size_t fixed_size_memory_resource_impl::get_maximum_allocation_size() const
 }
 
 fixed_size_memory_resource_impl::block_type fixed_size_memory_resource_impl::expand_pool(
-  std::size_t size, free_list& blocks, cuda_stream_view stream)
+  std::size_t size, free_list& blocks, cuda::stream_ref stream)
 {
   blocks.insert(std::move(blocks_from_upstream(stream)));
   return blocks.get_block(size);
 }
 
 fixed_size_memory_resource_impl::free_list fixed_size_memory_resource_impl::blocks_from_upstream(
-  cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   void* ptr = upstream_mr_.allocate(stream, upstream_chunk_size_, rmm::CUDA_ALLOCATION_ALIGNMENT);
   block_type block{ptr};

--- a/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
@@ -4,12 +4,13 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/mr/detail/fixed_size_memory_resource_impl.hpp>
 #include <rmm/process_is_exiting.hpp>
 
 #include <cuda/iterator>
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <cstddef>
 #include <mutex>
@@ -34,7 +35,8 @@ fixed_size_memory_resource_impl::fixed_size_memory_resource_impl(
     block_size_{align_up(block_size, rmm::CUDA_ALLOCATION_ALIGNMENT)},
     upstream_chunk_size_{block_size_ * blocks_to_preallocate}
 {
-  this->insert_blocks(std::move(blocks_from_upstream(cuda_stream_legacy)), cuda_stream_legacy);
+  this->insert_blocks(std::move(blocks_from_upstream(cuda::stream_ref{cudaStreamLegacy})),
+                      cuda::stream_ref{cudaStreamLegacy});
 }
 
 fixed_size_memory_resource_impl::~fixed_size_memory_resource_impl() { release(); }
@@ -53,14 +55,14 @@ std::size_t fixed_size_memory_resource_impl::get_maximum_allocation_size() const
 }
 
 fixed_size_memory_resource_impl::block_type fixed_size_memory_resource_impl::expand_pool(
-  std::size_t size, free_list& blocks, cuda_stream_view stream)
+  std::size_t size, free_list& blocks, cuda::stream_ref stream)
 {
   blocks.insert(std::move(blocks_from_upstream(stream)));
   return blocks.get_block(size);
 }
 
 fixed_size_memory_resource_impl::free_list fixed_size_memory_resource_impl::blocks_from_upstream(
-  cuda_stream_view stream)
+  cuda::stream_ref stream)
 {
   void* ptr = upstream_mr_.allocate(stream, upstream_chunk_size_, rmm::CUDA_ALLOCATION_ALIGNMENT);
   block_type block{ptr};

--- a/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
@@ -9,7 +9,7 @@
 #include <rmm/process_is_exiting.hpp>
 
 #include <cuda/iterator>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -8,6 +8,9 @@
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/limiting_resource_adaptor_impl.hpp>
 
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
 namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
@@ -69,14 +72,14 @@ void limiting_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* limiting_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return allocate(cuda_stream_view{}, bytes, alignment);
+  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void limiting_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/limiting_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/limiting_resource_adaptor_impl.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/limiting_resource_adaptor_impl.hpp>
@@ -73,7 +74,7 @@ void limiting_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* limiting_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -83,7 +84,7 @@ void limiting_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/limiting_resource_adaptor_impl.hpp>
@@ -74,7 +73,7 @@ void limiting_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* limiting_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -84,7 +83,7 @@ void limiting_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -4,9 +4,11 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/logging_resource_adaptor_impl.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 namespace RMM_NAMESPACE {
 namespace mr {
@@ -26,7 +28,7 @@ logging_resource_adaptor_impl::logging_resource_adaptor_impl(
 
 void* logging_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda_stream_view{};
+  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
   try {
     auto const ptr = upstream_mr_.allocate(stream, bytes, alignment);
     logger_->info("allocate,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
@@ -41,7 +43,7 @@ void logging_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  auto const stream = cuda_stream_view{};
+  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
   logger_->info("free,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
   upstream_mr_.deallocate(stream, ptr, bytes, alignment);
 }

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -4,12 +4,11 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/logging_resource_adaptor_impl.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN
@@ -31,9 +30,15 @@ logging_resource_adaptor_impl::logging_resource_adaptor_impl(
 void* logging_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
   auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
-  void* ptr         = allocate(stream, bytes, alignment);
-  RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
-  return ptr;
+  try {
+    auto const ptr = upstream_mr_.allocate(stream, bytes, alignment);
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
+    logger_->info("allocate,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
+    return ptr;
+  } catch (...) {
+    logger_->info("allocate failure,%p,%zu,%s", nullptr, bytes, rmm::detail::format_stream(stream));
+    throw;
+  }
 }
 
 void logging_resource_adaptor_impl::deallocate_sync(void* ptr,

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/logging_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/logging_resource_adaptor_impl.hpp>
@@ -29,7 +30,7 @@ logging_resource_adaptor_impl::logging_resource_adaptor_impl(
 
 void* logging_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   try {
     auto const ptr = upstream_mr_.allocate(stream, bytes, alignment);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
@@ -45,7 +46,7 @@ void logging_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/logging_resource_adaptor_impl.hpp>
@@ -30,7 +29,7 @@ logging_resource_adaptor_impl::logging_resource_adaptor_impl(
 
 void* logging_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   try {
     auto const ptr = upstream_mr_.allocate(stream, bytes, alignment);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
@@ -46,7 +45,7 @@ void logging_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/pool_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/pool_memory_resource_impl.cpp
@@ -4,12 +4,14 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/pool_memory_resource_impl.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -58,7 +60,7 @@ std::size_t pool_memory_resource_impl::get_maximum_allocation_size() const
 }
 
 pool_memory_resource_impl::block_type pool_memory_resource_impl::try_to_expand(
-  std::size_t try_size, std::size_t min_size, cuda_stream_view stream)
+  std::size_t try_size, std::size_t min_size, cuda::stream_ref stream)
 {
   auto report_error = [&](const char* reason) {
     RMM_LOG_ERROR("[A][Stream %s][Upstream %zuB][FAILURE maximum pool size exceeded: %s]",
@@ -99,13 +101,14 @@ void pool_memory_resource_impl::initialize_pool(std::size_t initial_size,
               "Initial pool size exceeds the maximum pool size!");
 
   if (initial_size > 0) {
-    auto const block = try_to_expand(initial_size, initial_size, cuda_stream_legacy);
-    this->insert_block(block, cuda_stream_legacy);
+    auto const stream = cuda::stream_ref{cudaStreamLegacy};
+    auto const block  = try_to_expand(initial_size, initial_size, stream);
+    this->insert_block(block, stream);
   }
 }
 
 pool_memory_resource_impl::block_type pool_memory_resource_impl::expand_pool(
-  std::size_t size, [[maybe_unused]] free_list& blocks, cuda_stream_view stream)
+  std::size_t size, [[maybe_unused]] free_list& blocks, cuda::stream_ref stream)
 {
   return try_to_expand(size_to_grow(size), size, stream);
 }
@@ -122,7 +125,7 @@ std::size_t pool_memory_resource_impl::size_to_grow(std::size_t size) const
 }
 
 pool_memory_resource_impl::block_type pool_memory_resource_impl::block_from_upstream(
-  std::size_t size, cuda_stream_view stream)
+  std::size_t size, cuda::stream_ref stream)
 {
   RMM_LOG_DEBUG("[A][Stream %s][Upstream %zuB]", rmm::detail::format_stream(stream), size);
 

--- a/cpp/src/mr/detail/pool_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/pool_memory_resource_impl.cpp
@@ -4,13 +4,15 @@
  */
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
 #include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/pool_memory_resource_impl.hpp>
 #include <rmm/process_is_exiting.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -59,7 +61,7 @@ std::size_t pool_memory_resource_impl::get_maximum_allocation_size() const
 }
 
 pool_memory_resource_impl::block_type pool_memory_resource_impl::try_to_expand(
-  std::size_t try_size, std::size_t min_size, cuda_stream_view stream)
+  std::size_t try_size, std::size_t min_size, cuda::stream_ref stream)
 {
   auto report_error = [&](const char* reason) {
     RMM_LOG_ERROR("[A][Stream %s][Upstream %zuB][FAILURE maximum pool size exceeded: %s]",
@@ -100,13 +102,14 @@ void pool_memory_resource_impl::initialize_pool(std::size_t initial_size,
               "Initial pool size exceeds the maximum pool size!");
 
   if (initial_size > 0) {
-    auto const block = try_to_expand(initial_size, initial_size, cuda_stream_legacy);
-    this->insert_block(block, cuda_stream_legacy);
+    auto const stream = cuda::stream_ref{cudaStreamLegacy};
+    auto const block  = try_to_expand(initial_size, initial_size, stream);
+    this->insert_block(block, stream);
   }
 }
 
 pool_memory_resource_impl::block_type pool_memory_resource_impl::expand_pool(
-  std::size_t size, free_list& blocks, cuda_stream_view stream)
+  std::size_t size, free_list& blocks, cuda::stream_ref stream)
 {
   auto grow_size = size_to_grow(size);
   // When the pool is capped and cannot grow enough to satisfy `size` in a single new upstream
@@ -121,7 +124,7 @@ pool_memory_resource_impl::block_type pool_memory_resource_impl::expand_pool(
 
 void pool_memory_resource_impl::reclaim_free_blocks(std::size_t size,
                                                     free_list& blocks,
-                                                    cuda_stream_view stream)
+                                                    cuda::stream_ref stream)
 {
   // Reclamation only frees headroom when the pool has a capped maximum size.
   if (!maximum_pool_size_.has_value()) { return; }
@@ -180,7 +183,7 @@ std::size_t pool_memory_resource_impl::size_to_grow(std::size_t size) const
 }
 
 pool_memory_resource_impl::block_type pool_memory_resource_impl::block_from_upstream(
-  std::size_t size, cuda_stream_view stream)
+  std::size_t size, cuda::stream_ref stream)
 {
   RMM_LOG_DEBUG("[A][Stream %s][Upstream %zuB]", rmm::detail::format_stream(stream), size);
 

--- a/cpp/src/mr/detail/pool_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/pool_memory_resource_impl.cpp
@@ -11,7 +11,7 @@
 #include <rmm/mr/detail/pool_memory_resource_impl.hpp>
 #include <rmm/process_is_exiting.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <algorithm>

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -28,7 +28,7 @@ void* prefetch_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                                std::size_t alignment)
 {
   void* ptr = upstream_mr_.allocate(stream, bytes, alignment);
-  rmm::prefetch(ptr, bytes, rmm::get_current_cuda_device(), cuda_stream_view{stream.get()});
+  rmm::prefetch(ptr, bytes, rmm::get_current_cuda_device(), cuda_stream_view{stream});
   return ptr;
 }
 
@@ -42,14 +42,14 @@ void prefetch_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* prefetch_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return allocate(cuda_stream_view{}, bytes, alignment);
+  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void prefetch_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/prefetch_resource_adaptor_impl.hpp>
 #include <rmm/prefetch.hpp>
@@ -46,7 +47,7 @@ void prefetch_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* prefetch_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -56,7 +57,7 @@ void prefetch_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -33,7 +33,7 @@ void* prefetch_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                                std::size_t alignment)
 {
   void* ptr = upstream_mr_.allocate(stream, bytes, alignment);
-  rmm::prefetch(ptr, bytes, rmm::get_current_cuda_device(), cuda_stream_view{stream});
+  rmm::prefetch(ptr, bytes, rmm::get_current_cuda_device(), stream);
   return ptr;
 }
 

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -32,7 +32,7 @@ void* prefetch_resource_adaptor_impl::allocate(cuda::stream_ref stream,
                                                std::size_t alignment)
 {
   void* ptr = upstream_mr_.allocate(stream, bytes, alignment);
-  rmm::prefetch(ptr, bytes, rmm::get_current_cuda_device(), cuda_stream_view{stream.get()});
+  rmm::prefetch(ptr, bytes, rmm::get_current_cuda_device(), cuda_stream_view{stream});
   return ptr;
 }
 

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/prefetch_resource_adaptor_impl.hpp>
 #include <rmm/prefetch.hpp>
@@ -47,7 +46,7 @@ void prefetch_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* prefetch_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -57,7 +56,7 @@ void prefetch_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/sam_headroom_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/sam_headroom_memory_resource_impl.cpp
@@ -75,7 +75,7 @@ void sam_headroom_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* sam_headroom_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -84,7 +84,7 @@ void sam_headroom_memory_resource_impl::deallocate_sync(void* ptr,
                                                         std::size_t bytes,
                                                         std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/sam_headroom_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/sam_headroom_memory_resource_impl.cpp
@@ -5,7 +5,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/sam_headroom_memory_resource_impl.hpp>
 
@@ -75,7 +74,7 @@ void sam_headroom_memory_resource_impl::deallocate(cuda::stream_ref stream,
 
 void* sam_headroom_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -84,7 +83,7 @@ void sam_headroom_memory_resource_impl::deallocate_sync(void* ptr,
                                                         std::size_t bytes,
                                                         std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/detail/statistics_resource_adaptor_impl.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <stdexcept>
 
@@ -87,14 +89,14 @@ void statistics_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* statistics_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return allocate(cuda_stream_view{}, bytes, alignment);
+  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void statistics_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                        std::size_t bytes,
                                                        std::size_t alignment) noexcept
 {
-  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/statistics_resource_adaptor_impl.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <stdexcept>

--- a/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/statistics_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <stdexcept>

--- a/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/statistics_resource_adaptor_impl.hpp>
 
@@ -90,7 +91,7 @@ void statistics_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* statistics_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -100,7 +101,7 @@ void statistics_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                        std::size_t bytes,
                                                        std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/statistics_resource_adaptor_impl.hpp>
 
@@ -91,7 +90,7 @@ void statistics_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* statistics_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -101,7 +100,7 @@ void statistics_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                        std::size_t bytes,
                                                        std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -5,6 +5,9 @@
 
 #include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
 
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
 namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
@@ -40,14 +43,14 @@ void thread_safe_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* thread_safe_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return allocate(cuda_stream_view{}, bytes, alignment);
+  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void thread_safe_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                         std::size_t bytes,
                                                         std::size_t alignment) noexcept
 {
-  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
 
@@ -44,7 +45,7 @@ void thread_safe_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* thread_safe_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -54,7 +55,7 @@ void thread_safe_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                         std::size_t bytes,
                                                         std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
 
@@ -45,7 +44,7 @@ void thread_safe_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* thread_safe_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -55,7 +54,7 @@ void thread_safe_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                         std::size_t bytes,
                                                         std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/tracking_resource_adaptor_impl.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <sstream>
 #include <stdexcept>
@@ -103,14 +105,14 @@ void tracking_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* tracking_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  return allocate(cuda_stream_view{}, bytes, alignment);
+  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
 }
 
 void tracking_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
 }  // namespace detail

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/tracking_resource_adaptor_impl.hpp>
 
-#include <cuda/stream>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <sstream>

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/tracking_resource_adaptor_impl.hpp>
@@ -106,7 +107,7 @@ void tracking_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* tracking_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -116,7 +117,7 @@ void tracking_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -7,7 +7,7 @@
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/tracking_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <sstream>

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/tracking_resource_adaptor_impl.hpp>
@@ -107,7 +106,7 @@ void tracking_resource_adaptor_impl::deallocate(cuda::stream_ref stream,
 
 void* tracking_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   auto* ptr         = allocate(stream, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   return ptr;
@@ -117,7 +116,7 @@ void tracking_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                      std::size_t bytes,
                                                      std::size_t alignment) noexcept
 {
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   deallocate(stream, ptr, bytes, alignment);
   RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
 }

--- a/cpp/src/mr/managed_memory_resource.cpp
+++ b/cpp/src/mr/managed_memory_resource.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
 
@@ -40,7 +41,7 @@ void managed_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref strea
 
 void* managed_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -49,7 +50,7 @@ void managed_memory_resource::deallocate_sync(void* ptr,
                                               std::size_t bytes,
                                               std::size_t alignment) noexcept
 {
-  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
 }
 
 bool managed_memory_resource::operator==(managed_memory_resource const&) const noexcept

--- a/cpp/src/mr/managed_memory_resource.cpp
+++ b/cpp/src/mr/managed_memory_resource.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
 
@@ -41,7 +40,7 @@ void managed_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref strea
 
 void* managed_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -50,7 +49,7 @@ void managed_memory_resource::deallocate_sync(void* ptr,
                                               std::size_t bytes,
                                               std::size_t alignment) noexcept
 {
-  deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, bytes, alignment);
 }
 
 bool managed_memory_resource::operator==(managed_memory_resource const&) const noexcept

--- a/cpp/src/mr/pinned_host_memory_resource.cpp
+++ b/cpp/src/mr/pinned_host_memory_resource.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
@@ -46,7 +47,7 @@ void pinned_host_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref s
 
 void* pinned_host_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -55,7 +56,7 @@ void pinned_host_memory_resource::deallocate_sync(void* ptr,
                                                   std::size_t bytes,
                                                   std::size_t alignment) noexcept
 {
-  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
 }
 
 bool pinned_host_memory_resource::operator==(pinned_host_memory_resource const&) const noexcept

--- a/cpp/src/mr/pinned_host_memory_resource.cpp
+++ b/cpp/src/mr/pinned_host_memory_resource.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
@@ -47,7 +46,7 @@ void pinned_host_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref s
 
 void* pinned_host_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -56,7 +55,7 @@ void pinned_host_memory_resource::deallocate_sync(void* ptr,
                                                   std::size_t bytes,
                                                   std::size_t alignment) noexcept
 {
-  deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, bytes, alignment);
 }
 
 bool pinned_host_memory_resource::operator==(pinned_host_memory_resource const&) const noexcept

--- a/cpp/src/mr/system_memory_resource.cpp
+++ b/cpp/src/mr/system_memory_resource.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
@@ -71,7 +72,7 @@ void system_memory_resource::deallocate(cuda::stream_ref stream,
 
 void* system_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -80,7 +81,7 @@ void system_memory_resource::deallocate_sync(void* ptr,
                                              std::size_t bytes,
                                              std::size_t alignment) noexcept
 {
-  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+  deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
 }
 
 bool system_memory_resource::operator==(system_memory_resource const&) const noexcept

--- a/cpp/src/mr/system_memory_resource.cpp
+++ b/cpp/src/mr/system_memory_resource.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/format.hpp>
@@ -72,7 +71,7 @@ void system_memory_resource::deallocate(cuda::stream_ref stream,
 
 void* system_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
   return ptr;
 }
@@ -81,7 +80,7 @@ void system_memory_resource::deallocate_sync(void* ptr,
                                              std::size_t bytes,
                                              std::size_t alignment) noexcept
 {
-  deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+  deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, bytes, alignment);
 }
 
 bool system_memory_resource::operator==(system_memory_resource const&) const noexcept

--- a/cpp/src/prefetch.cpp
+++ b/cpp/src/prefetch.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,10 +10,11 @@
 
 namespace rmm {
 
-void prefetch(void const* ptr,
-              std::size_t size,
-              rmm::cuda_device_id device,
-              rmm::cuda_stream_view stream)
+namespace {
+void prefetch_impl(void const* ptr,
+                   std::size_t size,
+                   rmm::cuda_device_id device,
+                   cuda::stream_ref stream)
 {
   if (!rmm::detail::concurrent_managed_access::is_supported()) { return; }
 
@@ -22,13 +23,22 @@ void prefetch(void const* ptr,
     (device.value() == cudaCpuDeviceId) ? cudaMemLocationTypeHost : cudaMemLocationTypeDevice,
     device.value()};
   constexpr int flags = 0;
-  cudaError_t result  = cudaMemPrefetchAsync(ptr, size, location, flags, stream.value());
+  cudaError_t result  = cudaMemPrefetchAsync(ptr, size, location, flags, stream.get());
 #else
-  cudaError_t result = cudaMemPrefetchAsync(ptr, size, device.value(), stream.value());
+  cudaError_t result = cudaMemPrefetchAsync(ptr, size, device.value(), stream.get());
 #endif
   // cudaErrorInvalidValue is returned when non-managed memory is passed to
   // cudaMemPrefetchAsync. We treat this as a no-op.
   if (result != cudaErrorInvalidValue && result != cudaSuccess) { RMM_CUDA_TRY(result); }
+}
+}  // namespace
+
+void prefetch(void const* ptr,
+              std::size_t size,
+              rmm::cuda_device_id device,
+              rmm::cuda_stream_view stream)
+{
+  prefetch_impl(ptr, size, device, cuda::stream_ref{stream});
 }
 
 }  // namespace rmm

--- a/cpp/src/prefetch.cpp
+++ b/cpp/src/prefetch.cpp
@@ -38,7 +38,7 @@ void prefetch(void const* ptr,
               rmm::cuda_device_id device,
               rmm::cuda_stream_view stream)
 {
-  prefetch_impl(ptr, size, device, cuda::stream_ref{stream});
+  prefetch_impl(ptr, size, device, stream);
 }
 
 RMM_NAMESPACE_END

--- a/cpp/src/prefetch.cpp
+++ b/cpp/src/prefetch.cpp
@@ -10,10 +10,11 @@
 
 RMM_NAMESPACE_BEGIN
 
-void prefetch(void const* ptr,
-              std::size_t size,
-              rmm::cuda_device_id device,
-              rmm::cuda_stream_view stream)
+namespace {
+void prefetch_impl(void const* ptr,
+                   std::size_t size,
+                   rmm::cuda_device_id device,
+                   cuda::stream_ref stream)
 {
   if (!rmm::detail::concurrent_managed_access::is_supported()) { return; }
 
@@ -22,13 +23,22 @@ void prefetch(void const* ptr,
     (device.value() == cudaCpuDeviceId) ? cudaMemLocationTypeHost : cudaMemLocationTypeDevice,
     device.value()};
   constexpr int flags = 0;
-  cudaError_t result  = cudaMemPrefetchAsync(ptr, size, location, flags, stream.value());
+  cudaError_t result  = cudaMemPrefetchAsync(ptr, size, location, flags, stream.get());
 #else
-  cudaError_t result = cudaMemPrefetchAsync(ptr, size, device.value(), stream.value());
+  cudaError_t result = cudaMemPrefetchAsync(ptr, size, device.value(), stream.get());
 #endif
   // cudaErrorInvalidValue is returned when non-managed memory is passed to
   // cudaMemPrefetchAsync. We treat this as a no-op.
   if (result != cudaErrorInvalidValue && result != cudaSuccess) { RMM_CUDA_TRY(result); }
+}
+}  // namespace
+
+void prefetch(void const* ptr,
+              std::size_t size,
+              rmm::cuda_device_id device,
+              rmm::cuda_stream_view stream)
+{
+  prefetch_impl(ptr, size, device, cuda::stream_ref{stream});
 }
 
 RMM_NAMESPACE_END

--- a/cpp/src/prefetch.cpp
+++ b/cpp/src/prefetch.cpp
@@ -36,7 +36,7 @@ void prefetch_impl(void const* ptr,
 void prefetch(void const* ptr,
               std::size_t size,
               rmm::cuda_device_id device,
-              rmm::cuda_stream_view stream)
+              cuda::stream_ref stream)
 {
   prefetch_impl(ptr, size, device, stream);
 }

--- a/cpp/tests/container_multidevice_tests.cu
+++ b/cpp/tests/container_multidevice_tests.cu
@@ -39,10 +39,10 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateDestroyDifferentActiveDevice)
 
     {
       if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-        auto buf = TypeParam(rmm::cuda_stream_view{});
+        auto buf = TypeParam(cuda::stream_ref{cudaStream_t{nullptr}});
         RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force dtor with different active device
       } else {
-        auto buf = TypeParam(128, rmm::cuda_stream_view{});
+        auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
         RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force dtor with different active device
       }
     }
@@ -66,19 +66,19 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateMoveDestroyDifferentActiveDevice)
     {
       auto buf_1 = []() {
         if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-          return TypeParam(rmm::cuda_stream_view{});
+          return TypeParam(cuda::stream_ref{cudaStream_t{nullptr}});
         } else {
-          return TypeParam(128, rmm::cuda_stream_view{});
+          return TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
         }
       }();
 
       {
         if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
           // device_vector does not have a constructor that takes a stream
-          auto buf_0 = TypeParam(rmm::cuda_stream_view{});
+          auto buf_0 = TypeParam(cuda::stream_ref{cudaStream_t{nullptr}});
           buf_1      = std::move(buf_0);
         } else {
-          auto buf_0 = TypeParam(128, rmm::cuda_stream_view{});
+          auto buf_0 = TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
           buf_1      = std::move(buf_0);
         }
       }
@@ -103,9 +103,9 @@ TYPED_TEST(ContainerMultiDeviceTest, ResizeDifferentActiveDevice)
     rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-      auto buf = TypeParam(128, rmm::cuda_stream_view{});
+      auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
       RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force resize with different active device
-      buf.resize(1024, rmm::cuda_stream_view{});
+      buf.resize(1024, cuda::stream_ref{cudaStream_t{nullptr}});
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));
@@ -125,10 +125,10 @@ TYPED_TEST(ContainerMultiDeviceTest, ShrinkDifferentActiveDevice)
     rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-      auto buf = TypeParam(128, rmm::cuda_stream_view{});
+      auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
       RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force resize with different active device
-      buf.resize(64, rmm::cuda_stream_view{});
-      buf.shrink_to_fit(rmm::cuda_stream_view{});
+      buf.resize(64, cuda::stream_ref{cudaStream_t{nullptr}});
+      buf.shrink_to_fit(cuda::stream_ref{cudaStream_t{nullptr}});
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));

--- a/cpp/tests/container_multidevice_tests.cu
+++ b/cpp/tests/container_multidevice_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/container_multidevice_tests.cu
+++ b/cpp/tests/container_multidevice_tests.cu
@@ -6,6 +6,7 @@
 #include "device_check_resource_adaptor.hpp"
 
 #include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
@@ -39,10 +40,10 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateDestroyDifferentActiveDevice)
 
     {
       if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-        auto buf = TypeParam(cuda::stream_ref{cudaStream_t{nullptr}});
+        auto buf = TypeParam(rmm::cuda_stream_default);
         RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force dtor with different active device
       } else {
-        auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
+        auto buf = TypeParam(128, rmm::cuda_stream_default);
         RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force dtor with different active device
       }
     }
@@ -66,19 +67,19 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateMoveDestroyDifferentActiveDevice)
     {
       auto buf_1 = []() {
         if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-          return TypeParam(cuda::stream_ref{cudaStream_t{nullptr}});
+          return TypeParam(rmm::cuda_stream_default);
         } else {
-          return TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
+          return TypeParam(128, rmm::cuda_stream_default);
         }
       }();
 
       {
         if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
           // device_vector does not have a constructor that takes a stream
-          auto buf_0 = TypeParam(cuda::stream_ref{cudaStream_t{nullptr}});
+          auto buf_0 = TypeParam(rmm::cuda_stream_default);
           buf_1      = std::move(buf_0);
         } else {
-          auto buf_0 = TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
+          auto buf_0 = TypeParam(128, rmm::cuda_stream_default);
           buf_1      = std::move(buf_0);
         }
       }
@@ -103,9 +104,9 @@ TYPED_TEST(ContainerMultiDeviceTest, ResizeDifferentActiveDevice)
     rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-      auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
+      auto buf = TypeParam(128, rmm::cuda_stream_default);
       RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force resize with different active device
-      buf.resize(1024, cuda::stream_ref{cudaStream_t{nullptr}});
+      buf.resize(1024, rmm::cuda_stream_default);
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));
@@ -125,10 +126,10 @@ TYPED_TEST(ContainerMultiDeviceTest, ShrinkDifferentActiveDevice)
     rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-      auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{nullptr}});
+      auto buf = TypeParam(128, rmm::cuda_stream_default);
       RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force resize with different active device
-      buf.resize(64, cuda::stream_ref{cudaStream_t{nullptr}});
-      buf.shrink_to_fit(cuda::stream_ref{cudaStream_t{nullptr}});
+      buf.resize(64, rmm::cuda_stream_default);
+      buf.shrink_to_fit(rmm::cuda_stream_default);
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));

--- a/cpp/tests/container_multidevice_tests.cu
+++ b/cpp/tests/container_multidevice_tests.cu
@@ -6,12 +6,12 @@
 #include "device_check_resource_adaptor.hpp"
 
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
@@ -40,10 +40,10 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateDestroyDifferentActiveDevice)
 
     {
       if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-        auto buf = TypeParam(rmm::cuda_stream_default);
+        auto buf = TypeParam(cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
         RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force dtor with different active device
       } else {
-        auto buf = TypeParam(128, rmm::cuda_stream_default);
+        auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
         RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force dtor with different active device
       }
     }
@@ -67,19 +67,19 @@ TYPED_TEST(ContainerMultiDeviceTest, CreateMoveDestroyDifferentActiveDevice)
     {
       auto buf_1 = []() {
         if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-          return TypeParam(rmm::cuda_stream_default);
+          return TypeParam(cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
         } else {
-          return TypeParam(128, rmm::cuda_stream_default);
+          return TypeParam(128, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
         }
       }();
 
       {
         if constexpr (std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
           // device_vector does not have a constructor that takes a stream
-          auto buf_0 = TypeParam(rmm::cuda_stream_default);
+          auto buf_0 = TypeParam(cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
           buf_1      = std::move(buf_0);
         } else {
-          auto buf_0 = TypeParam(128, rmm::cuda_stream_default);
+          auto buf_0 = TypeParam(128, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
           buf_1      = std::move(buf_0);
         }
       }
@@ -104,9 +104,9 @@ TYPED_TEST(ContainerMultiDeviceTest, ResizeDifferentActiveDevice)
     rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-      auto buf = TypeParam(128, rmm::cuda_stream_default);
+      auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
       RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force resize with different active device
-      buf.resize(1024, rmm::cuda_stream_default);
+      buf.resize(1024, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));
@@ -126,10 +126,10 @@ TYPED_TEST(ContainerMultiDeviceTest, ShrinkDifferentActiveDevice)
     rmm::mr::set_current_device_resource(device_check_resource_adaptor{orig_mr});
 
     if constexpr (not std::is_same_v<TypeParam, rmm::device_scalar<int>>) {
-      auto buf = TypeParam(128, rmm::cuda_stream_default);
+      auto buf = TypeParam(128, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
       RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(1));  // force resize with different active device
-      buf.resize(64, rmm::cuda_stream_default);
-      buf.shrink_to_fit(rmm::cuda_stream_default);
+      buf.resize(64, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
+      buf.shrink_to_fit(cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
     }
 
     RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(0));

--- a/cpp/tests/cuda_stream_pool_tests.cpp
+++ b/cpp/tests/cuda_stream_pool_tests.cpp
@@ -49,7 +49,7 @@ TEST_F(CudaStreamPoolTest, ValidStreams)
   auto constexpr vector_size{100};
   auto vec1 = rmm::device_uvector<std::uint8_t>{vector_size, stream_a};
   RMM_CUDA_TRY(cudaMemsetAsync(vec1.data(), 0xcc, 100, stream_a.get()));
-  RMM_CUDA_TRY(cudaStreamSynchronize(stream_a.get()));
+  stream_a.sync();
 
   auto vec2    = rmm::device_uvector<std::uint8_t>{vec1, stream_b};
   auto element = vec2.front_element(stream_b);

--- a/cpp/tests/cuda_stream_pool_tests.cpp
+++ b/cpp/tests/cuda_stream_pool_tests.cpp
@@ -1,9 +1,10 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/cuda_stream_pool.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -35,8 +36,8 @@ TEST_F(CudaStreamPoolTest, Nondefault)
   auto const stream_a = this->pool.get_stream();
 
   // pool streams are explicit, non-default streams
-  EXPECT_FALSE(stream_a.is_default());
-  EXPECT_FALSE(stream_a.is_per_thread_default());
+  EXPECT_NE(stream_a, rmm::cuda_stream_default);
+  EXPECT_NE(stream_a, rmm::cuda_stream_per_thread);
 }
 
 TEST_F(CudaStreamPoolTest, ValidStreams)
@@ -47,8 +48,8 @@ TEST_F(CudaStreamPoolTest, ValidStreams)
   // Operations on the streams should work correctly and without throwing exceptions
   auto constexpr vector_size{100};
   auto vec1 = rmm::device_uvector<std::uint8_t>{vector_size, stream_a};
-  RMM_CUDA_TRY(cudaMemsetAsync(vec1.data(), 0xcc, 100, stream_a.value()));
-  stream_a.synchronize();
+  RMM_CUDA_TRY(cudaMemsetAsync(vec1.data(), 0xcc, 100, stream_a.get()));
+  RMM_CUDA_TRY(cudaStreamSynchronize(stream_a.get()));
 
   auto vec2    = rmm::device_uvector<std::uint8_t>{vec1, stream_b};
   auto element = vec2.front_element(stream_b);
@@ -76,7 +77,7 @@ TEST_F(CudaStreamPoolTest, CreateDefault)
   for (std::size_t i = 0; i < this->pool.get_pool_size(); i++) {
     auto stream = this->pool.get_stream(i);
     unsigned int flags;
-    RMM_CUDA_TRY(cudaStreamGetFlags(stream.value(), &flags));
+    RMM_CUDA_TRY(cudaStreamGetFlags(stream.get(), &flags));
     EXPECT_EQ(flags, cudaStreamDefault);
   }
 }
@@ -87,7 +88,7 @@ TEST_F(CudaStreamPoolTest, CreateNonBlocking)
   for (std::size_t i = 0; i < pool.get_pool_size(); i++) {
     auto stream = pool.get_stream(i);
     unsigned int flags;
-    RMM_CUDA_TRY(cudaStreamGetFlags(stream.value(), &flags));
+    RMM_CUDA_TRY(cudaStreamGetFlags(stream.get(), &flags));
     EXPECT_EQ(flags, cudaStreamNonBlocking);
   }
 }

--- a/cpp/tests/cuda_stream_pool_tests.cpp
+++ b/cpp/tests/cuda_stream_pool_tests.cpp
@@ -4,10 +4,10 @@
  */
 
 #include <rmm/cuda_stream_pool.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
@@ -36,8 +36,8 @@ TEST_F(CudaStreamPoolTest, Nondefault)
   auto const stream_a = this->pool.get_stream();
 
   // pool streams are explicit, non-default streams
-  EXPECT_NE(stream_a, rmm::cuda_stream_default);
-  EXPECT_NE(stream_a, rmm::cuda_stream_per_thread);
+  EXPECT_NE(stream_a, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
+  EXPECT_NE(stream_a, cuda::stream_ref{cudaStreamPerThread});
 }
 
 TEST_F(CudaStreamPoolTest, ValidStreams)

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -82,7 +82,7 @@ TEST_F(CudaStreamTest, TestStreamViewOstream)
 // Without this we don't get test coverage of ~stream_view, presumably because it is elided
 TEST_F(CudaStreamTest, TestStreamViewDestructor)
 {
-  auto view = std::make_shared<rmm::cuda_stream_view>(rmm::cuda_stream_per_thread);
+  auto view = std::make_shared<rmm::cuda_stream_view>(cuda::stream_ref{cudaStreamPerThread});
   view->synchronize();
 }
 

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -29,14 +29,15 @@ TEST_F(CudaStreamTest, Equality)
   EXPECT_EQ(stream_a, view_a);
   EXPECT_NE(stream_a, view_default);
   EXPECT_EQ(view_default, rmm::cuda_stream_view{});
-  EXPECT_EQ(view_default.value(), rmm::cuda_stream_default.get());
+  EXPECT_EQ(view_default.value(), cuda::stream_ref{cudaStream_t{cudaStreamDefault}}.get());
   EXPECT_NE(view_a, rmm::cuda_stream());
   EXPECT_NE(stream_a, rmm::cuda_stream());
 
   rmm::device_buffer buff{};
   EXPECT_EQ(buff.stream(), view_default);
 
-  EXPECT_NE(static_cast<cudaStream_t>(stream_a), rmm::cuda_stream_default.get());
+  EXPECT_NE(static_cast<cudaStream_t>(stream_a),
+            cuda::stream_ref{cudaStream_t{cudaStreamDefault}}.get());
 }
 
 TEST_F(CudaStreamTest, StreamViewCompatibilityAliases)
@@ -56,11 +57,11 @@ TEST_F(CudaStreamTest, ImplicitConversionToStreamRef)
 
 TEST_F(CudaStreamTest, StreamRefEquality)
 {
-  auto const view = rmm::cuda_stream_view{rmm::cuda_stream_default};
-  EXPECT_EQ(view, rmm::cuda_stream_default);
-  EXPECT_EQ(rmm::cuda_stream_default, view);
-  EXPECT_NE(view, rmm::cuda_stream_per_thread);
-  EXPECT_NE(rmm::cuda_stream_per_thread, view);
+  auto const view = rmm::cuda_stream_view{cuda::stream_ref{cudaStream_t{cudaStreamDefault}}};
+  EXPECT_EQ(view, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, view);
+  EXPECT_NE(view, cuda::stream_ref{cudaStreamPerThread});
+  EXPECT_NE(cuda::stream_ref{cudaStreamPerThread}, view);
 }
 
 TEST_F(CudaStreamTest, StreamRefConsistentWithView)
@@ -76,13 +77,13 @@ TEST_F(CudaStreamTest, IsDefaultStream)
   rmm::cuda_stream stream;
 
   EXPECT_FALSE(rmm::detail::is_default_stream(stream));
-  EXPECT_TRUE(rmm::detail::is_default_stream(rmm::cuda_stream_default));
+  EXPECT_TRUE(rmm::detail::is_default_stream(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}));
 #ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
-  EXPECT_FALSE(rmm::detail::is_default_stream(rmm::cuda_stream_legacy));
-  EXPECT_TRUE(rmm::detail::is_default_stream(rmm::cuda_stream_per_thread));
+  EXPECT_FALSE(rmm::detail::is_default_stream(cuda::stream_ref{cudaStreamLegacy}));
+  EXPECT_TRUE(rmm::detail::is_default_stream(cuda::stream_ref{cudaStreamPerThread}));
 #else
-  EXPECT_TRUE(rmm::detail::is_default_stream(rmm::cuda_stream_legacy));
-  EXPECT_FALSE(rmm::detail::is_default_stream(rmm::cuda_stream_per_thread));
+  EXPECT_TRUE(rmm::detail::is_default_stream(cuda::stream_ref{cudaStreamLegacy}));
+  EXPECT_FALSE(rmm::detail::is_default_stream(cuda::stream_ref{cudaStreamPerThread}));
 #endif
 }
 
@@ -115,7 +116,7 @@ TEST_F(CudaStreamTest, TestStreamViewOstream)
 // Without this we don't get test coverage of ~stream_view, presumably because it is elided
 TEST_F(CudaStreamTest, TestStreamViewDestructor)
 {
-  auto view = std::make_shared<rmm::cuda_stream_view>(rmm::cuda_stream_per_thread);
+  auto view = std::make_shared<rmm::cuda_stream_view>(cuda::stream_ref{cudaStreamPerThread});
   view->synchronize();
 }
 

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -106,7 +106,7 @@ TEST_F(CudaStreamTest, TestStreamViewOstream)
 // Without this we don't get test coverage of ~stream_view, presumably because it is elided
 TEST_F(CudaStreamTest, TestStreamViewDestructor)
 {
-  auto view = std::make_shared<rmm::cuda_stream_view>(rmm::cuda_stream_per_thread);
+  auto view = std::make_shared<rmm::cuda_stream_view>(cuda::stream_ref{cudaStreamPerThread});
   view->synchronize();
 }
 

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -29,14 +29,14 @@ TEST_F(CudaStreamTest, Equality)
   EXPECT_EQ(stream_a, view_a);
   EXPECT_NE(stream_a, view_default);
   EXPECT_EQ(view_default, rmm::cuda_stream_view{});
-  EXPECT_EQ(view_default, rmm::cuda_stream_default);
+  EXPECT_EQ(view_default.value(), rmm::cuda_stream_default.get());
   EXPECT_NE(view_a, rmm::cuda_stream());
   EXPECT_NE(stream_a, rmm::cuda_stream());
 
   rmm::device_buffer buff{};
   EXPECT_EQ(buff.stream(), view_default);
 
-  EXPECT_NE(static_cast<cudaStream_t>(stream_a), rmm::cuda_stream_default.value());
+  EXPECT_NE(static_cast<cudaStream_t>(stream_a), rmm::cuda_stream_default.get());
 }
 
 TEST_F(CudaStreamTest, StreamViewCompatibilityAliases)
@@ -106,7 +106,7 @@ TEST_F(CudaStreamTest, TestStreamViewOstream)
 // Without this we don't get test coverage of ~stream_view, presumably because it is elided
 TEST_F(CudaStreamTest, TestStreamViewDestructor)
 {
-  auto view = std::make_shared<rmm::cuda_stream_view>(cuda::stream_ref{cudaStreamPerThread});
+  auto view = std::make_shared<rmm::cuda_stream_view>(rmm::cuda_stream_per_thread);
   view->synchronize();
 }
 

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -67,14 +67,14 @@ TEST_F(CudaStreamTest, IsDefaultStream)
   rmm::cuda_stream stream;
 
   EXPECT_FALSE(rmm::detail::is_default_stream(stream));
-
-  EXPECT_EQ(rmm::cuda_stream_default.is_default(),
-            rmm::detail::is_default_stream(rmm::cuda_stream_default));
-  EXPECT_EQ(rmm::cuda_stream_legacy.is_default(),
-            rmm::detail::is_default_stream(rmm::cuda_stream_legacy));
-  EXPECT_EQ(rmm::cuda_stream_per_thread.is_default(),
-            rmm::detail::is_default_stream(rmm::cuda_stream_per_thread));
-  EXPECT_EQ(stream.view().is_default(), rmm::detail::is_default_stream(stream));
+  EXPECT_TRUE(rmm::detail::is_default_stream(rmm::cuda_stream_default));
+#ifdef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  EXPECT_FALSE(rmm::detail::is_default_stream(rmm::cuda_stream_legacy));
+  EXPECT_TRUE(rmm::detail::is_default_stream(rmm::cuda_stream_per_thread));
+#else
+  EXPECT_TRUE(rmm::detail::is_default_stream(rmm::cuda_stream_legacy));
+  EXPECT_FALSE(rmm::detail::is_default_stream(rmm::cuda_stream_per_thread));
+#endif
 }
 
 TEST_F(CudaStreamTest, MoveConstructor)

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -54,6 +54,15 @@ TEST_F(CudaStreamTest, ImplicitConversionToStreamRef)
   EXPECT_EQ(ref.get(), stream.value());
 }
 
+TEST_F(CudaStreamTest, StreamRefEquality)
+{
+  auto const view = rmm::cuda_stream_view{rmm::cuda_stream_default};
+  EXPECT_EQ(view, rmm::cuda_stream_default);
+  EXPECT_EQ(rmm::cuda_stream_default, view);
+  EXPECT_NE(view, rmm::cuda_stream_per_thread);
+  EXPECT_NE(rmm::cuda_stream_per_thread, view);
+}
+
 TEST_F(CudaStreamTest, StreamRefConsistentWithView)
 {
   rmm::cuda_stream stream;

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Suppress deprecation warnings while testing the deprecated API.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/cuda_stream.hpp>
@@ -155,4 +161,8 @@ TEST_F(CudaStreamDeathTest, TestSyncNoThrow)
   };
   EXPECT_DEATH(test(), "");
 }
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
 #endif

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -57,26 +57,26 @@ TEST(DeviceBufferSimpleTest, ExplicitResourceRef)
 {
   auto mr = rmm::mr::cuda_memory_resource{};
   rmm::device_async_resource_ref ref{mr};
-  auto buf = rmm::device_buffer(10, rmm::cuda_stream_default, ref);
+  auto buf = rmm::device_buffer(10, cuda::stream_ref{cudaStream_t{nullptr}}, ref);
   EXPECT_EQ(buf.size(), 10);
 }
 
 TYPED_TEST(DeviceBufferTest, EmptyBuffer)
 {
-  rmm::device_buffer buff(0, rmm::cuda_stream_default);
+  rmm::device_buffer buff(0, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(buff.is_empty());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResource)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.ssize());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
@@ -93,12 +93,12 @@ TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResource)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{this->mr}, buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResourceStream)
@@ -116,19 +116,19 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawDevicePointer)
 {
   void* device_memory{nullptr};
   EXPECT_EQ(cudaSuccess, cudaMalloc(&device_memory, this->size));
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<char*>(device_memory),
                    static_cast<char*>(device_memory) + this->size,
                    0);
-  rmm::device_buffer buff(device_memory, this->size, rmm::cuda_stream_default);
+  rmm::device_buffer buff(device_memory, this->size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<char*>(device_memory),
                             static_cast<char*>(device_memory) + buff.size(),
                             static_cast<char*>(buff.data())));
@@ -141,13 +141,13 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
   std::vector<uint8_t> host_data(this->size);
   std::iota(host_data.begin(), host_data.end(), static_cast<uint8_t>(0));
   rmm::device_buffer buff(
-    static_cast<void*>(host_data.data()), this->size, rmm::cuda_stream_default);
+    static_cast<void*>(host_data.data()), this->size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
   buff.stream().synchronize();
   std::vector<uint8_t> host_copy(this->size);
   EXPECT_EQ(cudaSuccess,
@@ -158,42 +158,43 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
 TYPED_TEST(DeviceBufferTest, CopyFromNullptr)
 {
   // can  copy from a nullptr only if size == 0
-  rmm::device_buffer buff(nullptr, 0, rmm::cuda_stream_default);
+  rmm::device_buffer buff(nullptr, 0, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(nullptr, buff.data());
   EXPECT_EQ(0, buff.size());
   EXPECT_EQ(0, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZero)
 {
   // can  copy from a nullptr only if size == 0
-  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, rmm::cuda_stream_default), rmm::logic_error);
+  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, cuda::stream_ref{cudaStream_t{nullptr}}),
+               rmm::logic_error);
 }
 
 TYPED_TEST(DeviceBufferTest, CopyConstructor)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
   // Initialize buffer
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<char*>(buff.data()) + buff.size(),
                    0);
 
-  rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);  // uses default MR
+  rmm::device_buffer buff_copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});  // uses default MR
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
   EXPECT_EQ(buff.capacity(), buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_default);
+  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<char*>(buff.data()) + buff.size(),
@@ -205,7 +206,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_EQ(buff_copy2.memory_resource(), buff.memory_resource());
   EXPECT_EQ(buff_copy2.stream(), buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -214,18 +215,18 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
-  rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);
+  rmm::device_buffer buff_copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
@@ -234,9 +235,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   EXPECT_EQ(new_size, buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_default);
+  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -245,9 +246,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -269,13 +270,13 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -300,7 +301,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, MoveConstructor)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -321,7 +322,8 @@ TYPED_TEST(DeviceBufferTest, MoveConstructor)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());  // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}},
+            buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
@@ -349,12 +351,13 @@ TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());  // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}},
+            buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
 {
-  rmm::device_buffer src(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer src(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
@@ -376,19 +379,19 @@ TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(rmm::cuda_stream_default, src.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignment)
 {
-  rmm::device_buffer src(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer src(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
   auto mr       = src.memory_resource();
   auto stream   = src.stream();
 
-  rmm::device_buffer dest(this->size - 1, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer dest(this->size - 1, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   dest = std::move(src);
 
   // contents of `from` should be in `to`
@@ -403,12 +406,12 @@ TYPED_TEST(DeviceBufferTest, MoveAssignment)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(rmm::cuda_stream_default, src.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -429,9 +432,9 @@ TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 
 TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -439,23 +442,23 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
   auto* old_data = buff.data();
   rmm::device_buffer old_content(
-    old_data, buff.size(), rmm::cuda_stream_default, this->mr);  // for comparison
+    old_data, buff.size(), cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);  // for comparison
 
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());  // Capacity should be unchanged
   // Resizing smaller means the existing allocation should remain unchanged
   EXPECT_EQ(old_data, buff.data());
 
-  buff.shrink_to_fit(rmm::cuda_stream_default);
+  buff.shrink_to_fit(cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff.data());
   // A reallocation should have occurred
   EXPECT_NE(old_data, buff.data());
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(buff.capacity(), buff.size());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -464,10 +467,10 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
 TYPED_TEST(DeviceBufferTest, ResizeBigger)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* old_data = buff.data();
   auto new_size  = this->size + 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(new_size, buff.capacity());
   // Resizing bigger means the data should point to a new allocation
@@ -476,11 +479,11 @@ TYPED_TEST(DeviceBufferTest, ResizeBigger)
 
 TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* const old_data    = buff.data();
   auto const old_capacity = buff.capacity();
   auto const new_capacity = buff.capacity() - 1;
-  buff.reserve(new_capacity, rmm::cuda_stream_default);
+  buff.reserve(new_capacity, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(old_capacity, buff.capacity());
   // Reserving smaller means the allocation is unchanged
@@ -489,10 +492,10 @@ TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 
 TYPED_TEST(DeviceBufferTest, ReserveBigger)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* const old_data    = buff.data();
   auto const new_capacity = buff.capacity() + 1;
-  buff.reserve(new_capacity, rmm::cuda_stream_default);
+  buff.reserve(new_capacity, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(new_capacity, buff.capacity());
   // Reserving bigger means the data should point to a new allocation
@@ -501,26 +504,27 @@ TYPED_TEST(DeviceBufferTest, ReserveBigger)
 
 TYPED_TEST(DeviceBufferTest, SetGetStream)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
-  EXPECT_EQ(buff.stream(), rmm::cuda_stream_default);
+  EXPECT_EQ(buff.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
 
-  rmm::cuda_stream_view const otherstream{cudaStreamPerThread};
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   buff.set_stream(otherstream);
 
-  EXPECT_EQ(buff.stream(), otherstream);
+  EXPECT_EQ(buff.stream(), rmm::cuda_stream_view{otherstream});
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultAlignment)
 {
-  rmm::device_buffer buff(100, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
 }
 
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 {
-  rmm::device_buffer buff(100, rmm::CUDA_ALLOCATION_ALIGNMENT, rmm::cuda_stream_default);
+  rmm::device_buffer buff(
+    100, rmm::CUDA_ALLOCATION_ALIGNMENT, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
   EXPECT_EQ(buff.size(), 100);
@@ -529,7 +533,7 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 {
   constexpr std::size_t alignment{64};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), 100);
@@ -540,13 +544,15 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 TEST(DeviceBufferAlignmentTest, DISABLED_ExplicitAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(rmm::device_buffer(100, alignment, rmm::cuda_stream_default), rmm::bad_alloc);
+  EXPECT_THROW(rmm::device_buffer(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}}),
+               rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, InvalidAlignment)
 {
-  EXPECT_THROW(rmm::device_buffer(100, 0, rmm::cuda_stream_default), rmm::invalid_argument);
-  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, rmm::cuda_stream_default),
+  EXPECT_THROW(rmm::device_buffer(100, 0, cuda::stream_ref{cudaStream_t{nullptr}}),
+               rmm::invalid_argument);
+  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, cuda::stream_ref{cudaStream_t{nullptr}}),
                rmm::invalid_argument);
 }
 
@@ -554,7 +560,8 @@ TEST(DeviceBufferAlignmentTest, CopyFromSourceExplicitAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(host_data.data(), host_data.size(), alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(
+    host_data.data(), host_data.size(), alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), host_data.size());
@@ -566,24 +573,25 @@ TEST(DeviceBufferAlignmentTest, DISABLED_CopyFromSourceAlignmentTooLarge)
 {
   std::vector<uint8_t> host_data(100, 42);
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(std::ignore = rmm::device_buffer(
-                 host_data.data(), host_data.size(), alignment, rmm::cuda_stream_default),
-               rmm::bad_alloc);
+  EXPECT_THROW(
+    std::ignore = rmm::device_buffer(
+      host_data.data(), host_data.size(), alignment, cuda::stream_ref{cudaStream_t{nullptr}}),
+    rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyFromSourceInvalidAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
   EXPECT_THROW(std::ignore = rmm::device_buffer(
-                 host_data.data(), host_data.size(), 3, rmm::cuda_stream_default),
+                 host_data.data(), host_data.size(), 3, cuda::stream_ref{cudaStream_t{nullptr}}),
                rmm::invalid_argument);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
-  rmm::device_buffer copy(buff, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(copy.alignment(), buff.alignment());
   EXPECT_EQ(copy.alignment(), alignment);
 }
@@ -591,7 +599,7 @@ TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   rmm::device_buffer moved(std::move(buff));
   EXPECT_EQ(moved.alignment(), alignment);
   // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
@@ -601,7 +609,7 @@ TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer src(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer src(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   rmm::device_buffer dest;
   dest = std::move(src);
   EXPECT_EQ(dest.alignment(), alignment);
@@ -612,7 +620,7 @@ TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, EmptyBufferAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(std::size_t{0}, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_EQ(buff.size(), 0);
   EXPECT_TRUE(buff.is_empty());
@@ -622,7 +630,7 @@ TEST(DeviceBufferAlignmentTest, EmptyBufferAlignment)
 TEST(DeviceBufferAlignmentTest, EmptyBufferAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(std::size_t{0}, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(buff.is_empty());
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
@@ -637,26 +645,26 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedHasValidAlignment)
 TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.resize(100, rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.resize(100, cuda::stream_ref{cudaStream_t{nullptr}}));
   EXPECT_EQ(buff.size(), 100);
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultConstructedReserveLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.reserve(100, rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.reserve(100, cuda::stream_ref{cudaStream_t{nullptr}}));
   EXPECT_GE(buff.capacity(), 100);
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultConstructedShrinkToFit)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.shrink_to_fit(rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.shrink_to_fit(cuda::stream_ref{cudaStream_t{nullptr}}));
 }
 
 TEST(DeviceBufferAlignmentTest, EmptyBufferResizeLarger)
 {
-  rmm::device_buffer buff(0, rmm::cuda_stream_default);
-  EXPECT_NO_THROW(buff.resize(100, rmm::cuda_stream_default));
+  rmm::device_buffer buff(0, cuda::stream_ref{cudaStream_t{nullptr}});
+  EXPECT_NO_THROW(buff.resize(100, cuda::stream_ref{cudaStream_t{nullptr}}));
   EXPECT_EQ(buff.size(), 100);
 }

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -34,7 +34,7 @@ using namespace testing;
 
 namespace {
 auto const null_stream_ref  = rmm::cuda_stream_default;
-auto const null_stream_view = rmm::cuda_stream_view{cudaStream_t{nullptr}};
+auto const null_stream_view = rmm::cuda_stream_view{rmm::cuda_stream_default};
 }  // namespace
 
 template <typename MemoryResourceType>

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -33,7 +33,7 @@ using namespace testing;
 #include <random>
 
 namespace {
-auto const null_stream_ref  = cuda::stream_ref{cudaStream_t{nullptr}};
+auto const null_stream_ref  = rmm::cuda_stream_default;
 auto const null_stream_view = rmm::cuda_stream_view{cudaStream_t{nullptr}};
 }  // namespace
 
@@ -522,7 +522,7 @@ TYPED_TEST(DeviceBufferTest, SetGetStream)
 
   EXPECT_EQ(buff.stream(), null_stream_view);
 
-  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
+  auto const otherstream = rmm::cuda_stream_per_thread;
   buff.set_stream(otherstream);
 
   EXPECT_EQ(buff.stream(), rmm::cuda_stream_view{otherstream});

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -5,7 +5,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/error.hpp>
@@ -17,6 +16,7 @@
 #include <rmm/mr/tracking_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream>
 #include <thrust/equal.h>
 #include <thrust/sequence.h>
 
@@ -58,26 +58,26 @@ TEST(DeviceBufferSimpleTest, ExplicitResourceRef)
 {
   auto mr = rmm::mr::cuda_memory_resource{};
   rmm::device_async_resource_ref ref{mr};
-  auto buf = rmm::device_buffer(10, rmm::cuda_stream_default, ref);
+  auto buf = rmm::device_buffer(10, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ref);
   EXPECT_EQ(buf.size(), 10);
 }
 
 TYPED_TEST(DeviceBufferTest, EmptyBuffer)
 {
-  rmm::device_buffer buff(0, rmm::cuda_stream_default);
+  rmm::device_buffer buff(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_TRUE(buff.is_empty());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResource)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.ssize());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
@@ -94,12 +94,12 @@ TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResource)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{this->mr}, buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResourceStream)
@@ -117,19 +117,20 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawDevicePointer)
 {
   void* device_memory{nullptr};
   EXPECT_EQ(cudaSuccess, cudaMalloc(&device_memory, this->size));
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                    static_cast<char*>(device_memory),
                    static_cast<char*>(device_memory) + this->size,
                    0);
-  rmm::device_buffer buff(device_memory, this->size, rmm::cuda_stream_default);
+  rmm::device_buffer buff(
+    device_memory, this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                             static_cast<char*>(device_memory),
                             static_cast<char*>(device_memory) + buff.size(),
                             static_cast<char*>(buff.data())));
@@ -141,14 +142,15 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
 {
   std::vector<uint8_t> host_data(this->size);
   std::iota(host_data.begin(), host_data.end(), static_cast<uint8_t>(0));
-  rmm::device_buffer buff(
-    static_cast<void*>(host_data.data()), this->size, rmm::cuda_stream_default);
+  rmm::device_buffer buff(static_cast<void*>(host_data.data()),
+                          this->size,
+                          cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, buff.stream());
   buff.stream().sync();
   std::vector<uint8_t> host_copy(this->size);
   EXPECT_EQ(cudaSuccess,
@@ -159,26 +161,29 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
 TYPED_TEST(DeviceBufferTest, CopyFromNullptr)
 {
   // can  copy from a nullptr only if size == 0
-  rmm::device_buffer buff(nullptr, 0, rmm::cuda_stream_default);
+  rmm::device_buffer buff(nullptr, 0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(nullptr, buff.data());
   EXPECT_EQ(0, buff.size());
   EXPECT_EQ(0, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZero)
 {
   // can  copy from a nullptr only if size == 0
-  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, rmm::cuda_stream_default), rmm::logic_error);
+  EXPECT_THROW(
+    rmm::device_buffer buff(nullptr, 1, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
+    rmm::logic_error);
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
 {
   rmm::mr::tracking_resource_adaptor mr{rmm::device_async_resource_ref{this->mr}};
 
-  EXPECT_THROW(std::ignore = rmm::device_buffer(nullptr, 1, rmm::cuda_stream_default, mr),
+  EXPECT_THROW(std::ignore = rmm::device_buffer(
+                 nullptr, 1, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, mr),
                rmm::logic_error);
   EXPECT_EQ(mr.get_outstanding_allocations().size(), 0);
   EXPECT_EQ(mr.get_allocated_bytes(), 0);
@@ -186,25 +191,26 @@ TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructor)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
 
   // Initialize buffer
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                    static_cast<char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<char*>(buff.data()) + buff.size(),
                    0);
 
-  rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);  // uses default MR
+  rmm::device_buffer buff_copy(
+    buff, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});  // uses default MR
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
   EXPECT_EQ(buff.capacity(), buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(rmm::cuda_stream_default, buff_copy.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, buff_copy.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                             static_cast<char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<char*>(buff.data()) + buff.size(),
@@ -216,7 +222,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_EQ(buff_copy2.memory_resource(), buff.memory_resource());
   EXPECT_EQ(buff_copy2.stream(), buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -225,18 +231,18 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
-  rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);
+  rmm::device_buffer buff_copy(buff, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
@@ -245,9 +251,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   EXPECT_EQ(new_size, buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(rmm::cuda_stream_default, buff_copy.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, buff_copy.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -256,9 +262,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -280,13 +286,13 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -311,7 +317,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, MoveConstructor)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -332,7 +338,7 @@ TYPED_TEST(DeviceBufferTest, MoveConstructor)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(rmm::cuda_stream_default,
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
             buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
@@ -361,13 +367,13 @@ TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(rmm::cuda_stream_default,
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
             buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
 {
-  rmm::device_buffer src(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer src(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
@@ -389,19 +395,20 @@ TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(rmm::cuda_stream_default, src.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignment)
 {
-  rmm::device_buffer src(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer src(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
   auto mr       = src.memory_resource();
   auto stream   = src.stream();
 
-  rmm::device_buffer dest(this->size - 1, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer dest(
+    this->size - 1, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   dest = std::move(src);
 
   // contents of `from` should be in `to`
@@ -416,12 +423,12 @@ TYPED_TEST(DeviceBufferTest, MoveAssignment)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(rmm::cuda_stream_default, src.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -442,33 +449,35 @@ TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 
 TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
 
   auto* old_data = buff.data();
-  rmm::device_buffer old_content(
-    old_data, buff.size(), rmm::cuda_stream_default, this->mr);  // for comparison
+  rmm::device_buffer old_content(old_data,
+                                 buff.size(),
+                                 cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
+                                 this->mr);  // for comparison
 
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());  // Capacity should be unchanged
   // Resizing smaller means the existing allocation should remain unchanged
   EXPECT_EQ(old_data, buff.data());
 
-  buff.shrink_to_fit(rmm::cuda_stream_default);
+  buff.shrink_to_fit(cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_NE(nullptr, buff.data());
   // A reallocation should have occurred
   EXPECT_NE(old_data, buff.data());
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(buff.capacity(), buff.size());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -477,10 +486,10 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
 TYPED_TEST(DeviceBufferTest, ResizeBigger)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   auto* old_data = buff.data();
   auto new_size  = this->size + 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(new_size, buff.capacity());
   // Resizing bigger means the data should point to a new allocation
@@ -489,11 +498,11 @@ TYPED_TEST(DeviceBufferTest, ResizeBigger)
 
 TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   auto* const old_data    = buff.data();
   auto const old_capacity = buff.capacity();
   auto const new_capacity = buff.capacity() - 1;
-  buff.reserve(new_capacity, rmm::cuda_stream_default);
+  buff.reserve(new_capacity, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(old_capacity, buff.capacity());
   // Reserving smaller means the allocation is unchanged
@@ -502,10 +511,10 @@ TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 
 TYPED_TEST(DeviceBufferTest, ReserveBigger)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
   auto* const old_data    = buff.data();
   auto const new_capacity = buff.capacity() + 1;
-  buff.reserve(new_capacity, rmm::cuda_stream_default);
+  buff.reserve(new_capacity, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(new_capacity, buff.capacity());
   // Reserving bigger means the data should point to a new allocation
@@ -514,11 +523,11 @@ TYPED_TEST(DeviceBufferTest, ReserveBigger)
 
 TYPED_TEST(DeviceBufferTest, SetGetStream)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, this->mr);
 
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, buff.stream());
 
-  auto const otherstream = rmm::cuda_stream_per_thread;
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   buff.set_stream(otherstream);
 
   EXPECT_EQ(buff.stream(), otherstream);
@@ -526,14 +535,15 @@ TYPED_TEST(DeviceBufferTest, SetGetStream)
 
 TEST(DeviceBufferAlignmentTest, DefaultAlignment)
 {
-  rmm::device_buffer buff(100, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
 }
 
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 {
-  rmm::device_buffer buff(100, rmm::CUDA_ALLOCATION_ALIGNMENT, rmm::cuda_stream_default);
+  rmm::device_buffer buff(
+    100, rmm::CUDA_ALLOCATION_ALIGNMENT, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
   EXPECT_EQ(buff.size(), 100);
@@ -542,7 +552,7 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 {
   constexpr std::size_t alignment{64};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), 100);
@@ -551,21 +561,28 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(rmm::device_buffer(100, alignment, rmm::cuda_stream_default), rmm::bad_alloc);
+  EXPECT_THROW(
+    rmm::device_buffer(100, alignment, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
+    rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, InvalidAlignment)
 {
-  EXPECT_THROW(rmm::device_buffer(100, 0, rmm::cuda_stream_default), rmm::invalid_argument);
-  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, rmm::cuda_stream_default),
+  EXPECT_THROW(rmm::device_buffer(100, 0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                rmm::invalid_argument);
+  EXPECT_THROW(
+    std::ignore = rmm::device_buffer(100, 3, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
+    rmm::invalid_argument);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyFromSourceExplicitAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(host_data.data(), host_data.size(), alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(host_data.data(),
+                          host_data.size(),
+                          alignment,
+                          cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), host_data.size());
@@ -575,24 +592,27 @@ TEST(DeviceBufferAlignmentTest, CopyFromSourceAlignmentTooLarge)
 {
   std::vector<uint8_t> host_data(100, 42);
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(std::ignore = rmm::device_buffer(
-                 host_data.data(), host_data.size(), alignment, rmm::cuda_stream_default),
+  EXPECT_THROW(std::ignore = rmm::device_buffer(host_data.data(),
+                                                host_data.size(),
+                                                alignment,
+                                                cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyFromSourceInvalidAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
-  EXPECT_THROW(std::ignore = rmm::device_buffer(
-                 host_data.data(), host_data.size(), 3, rmm::cuda_stream_default),
-               rmm::invalid_argument);
+  EXPECT_THROW(
+    std::ignore = rmm::device_buffer(
+      host_data.data(), host_data.size(), 3, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
+    rmm::invalid_argument);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
-  rmm::device_buffer copy(buff, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
+  rmm::device_buffer copy(buff, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(copy.alignment(), buff.alignment());
   EXPECT_EQ(copy.alignment(), alignment);
 }
@@ -600,7 +620,7 @@ TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   rmm::device_buffer moved(std::move(buff));
   EXPECT_EQ(moved.alignment(), alignment);
   // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
@@ -610,7 +630,7 @@ TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer src(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer src(100, alignment, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   rmm::device_buffer dest;
   dest = std::move(src);
   EXPECT_EQ(dest.alignment(), alignment);
@@ -621,7 +641,8 @@ TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, EmptyBufferAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(
+    std::size_t{0}, alignment, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_EQ(buff.size(), 0);
   EXPECT_TRUE(buff.is_empty());
@@ -632,7 +653,8 @@ TEST(DeviceBufferAlignmentTest, EmptyBufferAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
   EXPECT_NO_THROW({
-    rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
+    rmm::device_buffer buff(
+      std::size_t{0}, alignment, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
     EXPECT_EQ(buff.alignment(), alignment);
     EXPECT_TRUE(buff.is_empty());
     EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
@@ -648,7 +670,7 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedHasValidAlignment)
 TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.resize(100, rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.resize(100, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}));
   EXPECT_EQ(buff.size(), 100);
 }
 
@@ -663,19 +685,19 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLargerOnNonDefaultStream
 TEST(DeviceBufferAlignmentTest, DefaultConstructedReserveLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.reserve(100, rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.reserve(100, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}));
   EXPECT_GE(buff.capacity(), 100);
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultConstructedShrinkToFit)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.shrink_to_fit(rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.shrink_to_fit(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}));
 }
 
 TEST(DeviceBufferAlignmentTest, EmptyBufferResizeLarger)
 {
-  rmm::device_buffer buff(0, rmm::cuda_stream_default);
-  EXPECT_NO_THROW(buff.resize(100, rmm::cuda_stream_default));
+  rmm::device_buffer buff(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
+  EXPECT_NO_THROW(buff.resize(100, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}));
   EXPECT_EQ(buff.size(), 100);
 }

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -32,11 +32,6 @@ using namespace testing;
 #include <cstddef>
 #include <random>
 
-namespace {
-auto const null_stream_ref  = rmm::cuda_stream_default;
-auto const null_stream_view = rmm::cuda_stream_view{rmm::cuda_stream_default};
-}  // namespace
-
 template <typename MemoryResourceType>
 struct DeviceBufferTest : public ::testing::Test {
   rmm::cuda_stream stream{};
@@ -63,26 +58,26 @@ TEST(DeviceBufferSimpleTest, ExplicitResourceRef)
 {
   auto mr = rmm::mr::cuda_memory_resource{};
   rmm::device_async_resource_ref ref{mr};
-  auto buf = rmm::device_buffer(10, null_stream_ref, ref);
+  auto buf = rmm::device_buffer(10, rmm::cuda_stream_default, ref);
   EXPECT_EQ(buf.size(), 10);
 }
 
 TYPED_TEST(DeviceBufferTest, EmptyBuffer)
 {
-  rmm::device_buffer buff(0, null_stream_ref);
+  rmm::device_buffer buff(0, rmm::cuda_stream_default);
   EXPECT_TRUE(buff.is_empty());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResource)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.ssize());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(null_stream_view, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
@@ -99,12 +94,12 @@ TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResource)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{this->mr}, buff.memory_resource());
-  EXPECT_EQ(null_stream_view, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResourceStream)
@@ -122,19 +117,19 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawDevicePointer)
 {
   void* device_memory{nullptr};
   EXPECT_EQ(cudaSuccess, cudaMalloc(&device_memory, this->size));
-  thrust::sequence(rmm::exec_policy(null_stream_ref),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<char*>(device_memory),
                    static_cast<char*>(device_memory) + this->size,
                    0);
-  rmm::device_buffer buff(device_memory, this->size, null_stream_ref);
+  rmm::device_buffer buff(device_memory, this->size, rmm::cuda_stream_default);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(null_stream_view, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<char*>(device_memory),
                             static_cast<char*>(device_memory) + buff.size(),
                             static_cast<char*>(buff.data())));
@@ -146,13 +141,14 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
 {
   std::vector<uint8_t> host_data(this->size);
   std::iota(host_data.begin(), host_data.end(), static_cast<uint8_t>(0));
-  rmm::device_buffer buff(static_cast<void*>(host_data.data()), this->size, null_stream_ref);
+  rmm::device_buffer buff(
+    static_cast<void*>(host_data.data()), this->size, rmm::cuda_stream_default);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(null_stream_view, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
   buff.stream().synchronize();
   std::vector<uint8_t> host_copy(this->size);
   EXPECT_EQ(cudaSuccess,
@@ -163,19 +159,19 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
 TYPED_TEST(DeviceBufferTest, CopyFromNullptr)
 {
   // can  copy from a nullptr only if size == 0
-  rmm::device_buffer buff(nullptr, 0, null_stream_ref);
+  rmm::device_buffer buff(nullptr, 0, rmm::cuda_stream_default);
   EXPECT_EQ(nullptr, buff.data());
   EXPECT_EQ(0, buff.size());
   EXPECT_EQ(0, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(null_stream_view, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZero)
 {
   // can  copy from a nullptr only if size == 0
-  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, null_stream_ref), rmm::logic_error);
+  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, rmm::cuda_stream_default), rmm::logic_error);
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
@@ -190,25 +186,25 @@ TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructor)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
 
   // Initialize buffer
-  thrust::sequence(rmm::exec_policy(null_stream_ref),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<char*>(buff.data()) + buff.size(),
                    0);
 
-  rmm::device_buffer buff_copy(buff, null_stream_ref);  // uses default MR
+  rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);  // uses default MR
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
   EXPECT_EQ(buff.capacity(), buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(buff_copy.stream(), null_stream_view);
+  EXPECT_EQ(rmm::cuda_stream_default, buff_copy.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<char*>(buff.data()) + buff.size(),
@@ -220,7 +216,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_EQ(buff_copy2.memory_resource(), buff.memory_resource());
   EXPECT_EQ(buff_copy2.stream(), buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -229,18 +225,18 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, null_stream_ref);
+  buff.resize(new_size, rmm::cuda_stream_default);
 
-  thrust::sequence(rmm::exec_policy(null_stream_ref),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
-  rmm::device_buffer buff_copy(buff, null_stream_ref);
+  rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
@@ -249,9 +245,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   EXPECT_EQ(new_size, buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(buff_copy.stream(), null_stream_view);
+  EXPECT_EQ(rmm::cuda_stream_default, buff_copy.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -260,9 +256,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
 
-  thrust::sequence(rmm::exec_policy(null_stream_ref),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -284,13 +280,13 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, null_stream_ref);
+  buff.resize(new_size, rmm::cuda_stream_default);
 
-  thrust::sequence(rmm::exec_policy(null_stream_ref),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -315,7 +311,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, MoveConstructor)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -336,7 +332,7 @@ TYPED_TEST(DeviceBufferTest, MoveConstructor)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(null_stream_view,
+  EXPECT_EQ(rmm::cuda_stream_default,
             buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
@@ -365,13 +361,13 @@ TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(null_stream_view,
+  EXPECT_EQ(rmm::cuda_stream_default,
             buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
 {
-  rmm::device_buffer src(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer src(this->size, rmm::cuda_stream_default, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
@@ -393,19 +389,19 @@ TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(null_stream_view, src.stream());
+  EXPECT_EQ(rmm::cuda_stream_default, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignment)
 {
-  rmm::device_buffer src(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer src(this->size, rmm::cuda_stream_default, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
   auto mr       = src.memory_resource();
   auto stream   = src.stream();
 
-  rmm::device_buffer dest(this->size - 1, null_stream_ref, this->mr);
+  rmm::device_buffer dest(this->size - 1, rmm::cuda_stream_default, this->mr);
   dest = std::move(src);
 
   // contents of `from` should be in `to`
@@ -420,12 +416,12 @@ TYPED_TEST(DeviceBufferTest, MoveAssignment)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(null_stream_view, src.stream());
+  EXPECT_EQ(rmm::cuda_stream_default, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -446,9 +442,9 @@ TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 
 TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
 
-  thrust::sequence(rmm::exec_policy(null_stream_ref),
+  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -456,23 +452,23 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
   auto* old_data = buff.data();
   rmm::device_buffer old_content(
-    old_data, buff.size(), null_stream_ref, this->mr);  // for comparison
+    old_data, buff.size(), rmm::cuda_stream_default, this->mr);  // for comparison
 
   auto new_size = this->size - 1;
-  buff.resize(new_size, null_stream_ref);
+  buff.resize(new_size, rmm::cuda_stream_default);
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());  // Capacity should be unchanged
   // Resizing smaller means the existing allocation should remain unchanged
   EXPECT_EQ(old_data, buff.data());
 
-  buff.shrink_to_fit(null_stream_ref);
+  buff.shrink_to_fit(rmm::cuda_stream_default);
   EXPECT_NE(nullptr, buff.data());
   // A reallocation should have occurred
   EXPECT_NE(old_data, buff.data());
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(buff.capacity(), buff.size());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -481,10 +477,10 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
 TYPED_TEST(DeviceBufferTest, ResizeBigger)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
   auto* old_data = buff.data();
   auto new_size  = this->size + 1;
-  buff.resize(new_size, null_stream_ref);
+  buff.resize(new_size, rmm::cuda_stream_default);
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(new_size, buff.capacity());
   // Resizing bigger means the data should point to a new allocation
@@ -493,11 +489,11 @@ TYPED_TEST(DeviceBufferTest, ResizeBigger)
 
 TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
   auto* const old_data    = buff.data();
   auto const old_capacity = buff.capacity();
   auto const new_capacity = buff.capacity() - 1;
-  buff.reserve(new_capacity, null_stream_ref);
+  buff.reserve(new_capacity, rmm::cuda_stream_default);
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(old_capacity, buff.capacity());
   // Reserving smaller means the allocation is unchanged
@@ -506,10 +502,10 @@ TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 
 TYPED_TEST(DeviceBufferTest, ReserveBigger)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
   auto* const old_data    = buff.data();
   auto const new_capacity = buff.capacity() + 1;
-  buff.reserve(new_capacity, null_stream_ref);
+  buff.reserve(new_capacity, rmm::cuda_stream_default);
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(new_capacity, buff.capacity());
   // Reserving bigger means the data should point to a new allocation
@@ -518,9 +514,9 @@ TYPED_TEST(DeviceBufferTest, ReserveBigger)
 
 TYPED_TEST(DeviceBufferTest, SetGetStream)
 {
-  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
+  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
 
-  EXPECT_EQ(buff.stream(), null_stream_view);
+  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
 
   auto const otherstream = rmm::cuda_stream_per_thread;
   buff.set_stream(otherstream);
@@ -530,14 +526,14 @@ TYPED_TEST(DeviceBufferTest, SetGetStream)
 
 TEST(DeviceBufferAlignmentTest, DefaultAlignment)
 {
-  rmm::device_buffer buff(100, null_stream_ref);
+  rmm::device_buffer buff(100, rmm::cuda_stream_default);
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
 }
 
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 {
-  rmm::device_buffer buff(100, rmm::CUDA_ALLOCATION_ALIGNMENT, null_stream_ref);
+  rmm::device_buffer buff(100, rmm::CUDA_ALLOCATION_ALIGNMENT, rmm::cuda_stream_default);
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
   EXPECT_EQ(buff.size(), 100);
@@ -546,7 +542,7 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 {
   constexpr std::size_t alignment{64};
-  rmm::device_buffer buff(100, alignment, null_stream_ref);
+  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), 100);
@@ -555,20 +551,21 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(rmm::device_buffer(100, alignment, null_stream_ref), rmm::bad_alloc);
+  EXPECT_THROW(rmm::device_buffer(100, alignment, rmm::cuda_stream_default), rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, InvalidAlignment)
 {
-  EXPECT_THROW(rmm::device_buffer(100, 0, null_stream_ref), rmm::invalid_argument);
-  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, null_stream_ref), rmm::invalid_argument);
+  EXPECT_THROW(rmm::device_buffer(100, 0, rmm::cuda_stream_default), rmm::invalid_argument);
+  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, rmm::cuda_stream_default),
+               rmm::invalid_argument);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyFromSourceExplicitAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(host_data.data(), host_data.size(), alignment, null_stream_ref);
+  rmm::device_buffer buff(host_data.data(), host_data.size(), alignment, rmm::cuda_stream_default);
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), host_data.size());
@@ -578,24 +575,24 @@ TEST(DeviceBufferAlignmentTest, CopyFromSourceAlignmentTooLarge)
 {
   std::vector<uint8_t> host_data(100, 42);
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(std::ignore =
-                 rmm::device_buffer(host_data.data(), host_data.size(), alignment, null_stream_ref),
+  EXPECT_THROW(std::ignore = rmm::device_buffer(
+                 host_data.data(), host_data.size(), alignment, rmm::cuda_stream_default),
                rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyFromSourceInvalidAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
-  EXPECT_THROW(
-    std::ignore = rmm::device_buffer(host_data.data(), host_data.size(), 3, null_stream_ref),
-    rmm::invalid_argument);
+  EXPECT_THROW(std::ignore = rmm::device_buffer(
+                 host_data.data(), host_data.size(), 3, rmm::cuda_stream_default),
+               rmm::invalid_argument);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, null_stream_ref);
-  rmm::device_buffer copy(buff, null_stream_ref);
+  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer copy(buff, rmm::cuda_stream_default);
   EXPECT_EQ(copy.alignment(), buff.alignment());
   EXPECT_EQ(copy.alignment(), alignment);
 }
@@ -603,7 +600,7 @@ TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, null_stream_ref);
+  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
   rmm::device_buffer moved(std::move(buff));
   EXPECT_EQ(moved.alignment(), alignment);
   // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
@@ -613,7 +610,7 @@ TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer src(100, alignment, null_stream_ref);
+  rmm::device_buffer src(100, alignment, rmm::cuda_stream_default);
   rmm::device_buffer dest;
   dest = std::move(src);
   EXPECT_EQ(dest.alignment(), alignment);
@@ -624,7 +621,7 @@ TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, EmptyBufferAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(std::size_t{0}, alignment, null_stream_ref);
+  rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_EQ(buff.size(), 0);
   EXPECT_TRUE(buff.is_empty());
@@ -635,7 +632,7 @@ TEST(DeviceBufferAlignmentTest, EmptyBufferAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
   EXPECT_NO_THROW({
-    rmm::device_buffer buff(std::size_t{0}, alignment, null_stream_ref);
+    rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
     EXPECT_EQ(buff.alignment(), alignment);
     EXPECT_TRUE(buff.is_empty());
     EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
@@ -651,7 +648,7 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedHasValidAlignment)
 TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.resize(100, null_stream_ref));
+  EXPECT_NO_THROW(buff.resize(100, rmm::cuda_stream_default));
   EXPECT_EQ(buff.size(), 100);
 }
 
@@ -666,19 +663,19 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLargerOnNonDefaultStream
 TEST(DeviceBufferAlignmentTest, DefaultConstructedReserveLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.reserve(100, null_stream_ref));
+  EXPECT_NO_THROW(buff.reserve(100, rmm::cuda_stream_default));
   EXPECT_GE(buff.capacity(), 100);
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultConstructedShrinkToFit)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.shrink_to_fit(null_stream_ref));
+  EXPECT_NO_THROW(buff.shrink_to_fit(rmm::cuda_stream_default));
 }
 
 TEST(DeviceBufferAlignmentTest, EmptyBufferResizeLarger)
 {
-  rmm::device_buffer buff(0, null_stream_ref);
-  EXPECT_NO_THROW(buff.resize(100, null_stream_ref));
+  rmm::device_buffer buff(0, rmm::cuda_stream_default);
+  EXPECT_NO_THROW(buff.resize(100, rmm::cuda_stream_default));
   EXPECT_EQ(buff.size(), 100);
 }

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -32,6 +32,11 @@ using namespace testing;
 #include <cstddef>
 #include <random>
 
+namespace {
+auto const null_stream_ref  = cuda::stream_ref{cudaStream_t{nullptr}};
+auto const null_stream_view = rmm::cuda_stream_view{cudaStream_t{nullptr}};
+}  // namespace
+
 template <typename MemoryResourceType>
 struct DeviceBufferTest : public ::testing::Test {
   rmm::cuda_stream stream{};
@@ -58,26 +63,26 @@ TEST(DeviceBufferSimpleTest, ExplicitResourceRef)
 {
   auto mr = rmm::mr::cuda_memory_resource{};
   rmm::device_async_resource_ref ref{mr};
-  auto buf = rmm::device_buffer(10, cuda::stream_ref{cudaStream_t{nullptr}}, ref);
+  auto buf = rmm::device_buffer(10, null_stream_ref, ref);
   EXPECT_EQ(buf.size(), 10);
 }
 
 TYPED_TEST(DeviceBufferTest, EmptyBuffer)
 {
-  rmm::device_buffer buff(0, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(0, null_stream_ref);
   EXPECT_TRUE(buff.is_empty());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResource)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(this->size, null_stream_ref);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.ssize());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
+  EXPECT_EQ(null_stream_view, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
@@ -94,12 +99,12 @@ TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResource)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{this->mr}, buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
+  EXPECT_EQ(null_stream_view, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResourceStream)
@@ -117,19 +122,19 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawDevicePointer)
 {
   void* device_memory{nullptr};
   EXPECT_EQ(cudaSuccess, cudaMalloc(&device_memory, this->size));
-  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  thrust::sequence(rmm::exec_policy(null_stream_ref),
                    static_cast<char*>(device_memory),
                    static_cast<char*>(device_memory) + this->size,
                    0);
-  rmm::device_buffer buff(device_memory, this->size, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(device_memory, this->size, null_stream_ref);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
+  EXPECT_EQ(null_stream_view, buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
                             static_cast<char*>(device_memory),
                             static_cast<char*>(device_memory) + buff.size(),
                             static_cast<char*>(buff.data())));
@@ -141,14 +146,13 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
 {
   std::vector<uint8_t> host_data(this->size);
   std::iota(host_data.begin(), host_data.end(), static_cast<uint8_t>(0));
-  rmm::device_buffer buff(
-    static_cast<void*>(host_data.data()), this->size, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(static_cast<void*>(host_data.data()), this->size, null_stream_ref);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
+  EXPECT_EQ(null_stream_view, buff.stream());
   buff.stream().synchronize();
   std::vector<uint8_t> host_copy(this->size);
   EXPECT_EQ(cudaSuccess,
@@ -159,20 +163,19 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
 TYPED_TEST(DeviceBufferTest, CopyFromNullptr)
 {
   // can  copy from a nullptr only if size == 0
-  rmm::device_buffer buff(nullptr, 0, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(nullptr, 0, null_stream_ref);
   EXPECT_EQ(nullptr, buff.data());
   EXPECT_EQ(0, buff.size());
   EXPECT_EQ(0, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
+  EXPECT_EQ(null_stream_view, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZero)
 {
   // can  copy from a nullptr only if size == 0
-  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, cuda::stream_ref{cudaStream_t{nullptr}}),
-               rmm::logic_error);
+  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, null_stream_ref), rmm::logic_error);
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
@@ -187,25 +190,25 @@ TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructor)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
 
   // Initialize buffer
-  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  thrust::sequence(rmm::exec_policy(null_stream_ref),
                    static_cast<char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<char*>(buff.data()) + buff.size(),
                    0);
 
-  rmm::device_buffer buff_copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});  // uses default MR
+  rmm::device_buffer buff_copy(buff, null_stream_ref);  // uses default MR
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
   EXPECT_EQ(buff.capacity(), buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
+  EXPECT_EQ(buff_copy.stream(), null_stream_view);
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
                             static_cast<char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<char*>(buff.data()) + buff.size(),
@@ -217,7 +220,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_EQ(buff_copy2.memory_resource(), buff.memory_resource());
   EXPECT_EQ(buff_copy2.stream(), buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -226,18 +229,18 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
+  buff.resize(new_size, null_stream_ref);
 
-  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  thrust::sequence(rmm::exec_policy(null_stream_ref),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
-  rmm::device_buffer buff_copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff_copy(buff, null_stream_ref);
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
@@ -246,9 +249,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   EXPECT_EQ(new_size, buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
+  EXPECT_EQ(buff_copy.stream(), null_stream_view);
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -257,9 +260,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
 
-  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  thrust::sequence(rmm::exec_policy(null_stream_ref),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -281,13 +284,13 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
+  buff.resize(new_size, null_stream_ref);
 
-  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  thrust::sequence(rmm::exec_policy(null_stream_ref),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -312,7 +315,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, MoveConstructor)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -333,7 +336,7 @@ TYPED_TEST(DeviceBufferTest, MoveConstructor)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}},
+  EXPECT_EQ(null_stream_view,
             buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
@@ -362,13 +365,13 @@ TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}},
+  EXPECT_EQ(null_stream_view,
             buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
 {
-  rmm::device_buffer src(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer src(this->size, null_stream_ref, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
@@ -390,19 +393,19 @@ TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, src.stream());
+  EXPECT_EQ(null_stream_view, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignment)
 {
-  rmm::device_buffer src(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer src(this->size, null_stream_ref, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
   auto mr       = src.memory_resource();
   auto stream   = src.stream();
 
-  rmm::device_buffer dest(this->size - 1, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer dest(this->size - 1, null_stream_ref, this->mr);
   dest = std::move(src);
 
   // contents of `from` should be in `to`
@@ -417,12 +420,12 @@ TYPED_TEST(DeviceBufferTest, MoveAssignment)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, src.stream());
+  EXPECT_EQ(null_stream_view, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -443,9 +446,9 @@ TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 
 TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
 
-  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  thrust::sequence(rmm::exec_policy(null_stream_ref),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -453,23 +456,23 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
   auto* old_data = buff.data();
   rmm::device_buffer old_content(
-    old_data, buff.size(), cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);  // for comparison
+    old_data, buff.size(), null_stream_ref, this->mr);  // for comparison
 
   auto new_size = this->size - 1;
-  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
+  buff.resize(new_size, null_stream_ref);
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());  // Capacity should be unchanged
   // Resizing smaller means the existing allocation should remain unchanged
   EXPECT_EQ(old_data, buff.data());
 
-  buff.shrink_to_fit(cuda::stream_ref{cudaStream_t{nullptr}});
+  buff.shrink_to_fit(null_stream_ref);
   EXPECT_NE(nullptr, buff.data());
   // A reallocation should have occurred
   EXPECT_NE(old_data, buff.data());
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(buff.capacity(), buff.size());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(null_stream_ref),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -478,10 +481,10 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
 TYPED_TEST(DeviceBufferTest, ResizeBigger)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
   auto* old_data = buff.data();
   auto new_size  = this->size + 1;
-  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
+  buff.resize(new_size, null_stream_ref);
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(new_size, buff.capacity());
   // Resizing bigger means the data should point to a new allocation
@@ -490,11 +493,11 @@ TYPED_TEST(DeviceBufferTest, ResizeBigger)
 
 TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
   auto* const old_data    = buff.data();
   auto const old_capacity = buff.capacity();
   auto const new_capacity = buff.capacity() - 1;
-  buff.reserve(new_capacity, cuda::stream_ref{cudaStream_t{nullptr}});
+  buff.reserve(new_capacity, null_stream_ref);
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(old_capacity, buff.capacity());
   // Reserving smaller means the allocation is unchanged
@@ -503,10 +506,10 @@ TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 
 TYPED_TEST(DeviceBufferTest, ReserveBigger)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
   auto* const old_data    = buff.data();
   auto const new_capacity = buff.capacity() + 1;
-  buff.reserve(new_capacity, cuda::stream_ref{cudaStream_t{nullptr}});
+  buff.reserve(new_capacity, null_stream_ref);
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(new_capacity, buff.capacity());
   // Reserving bigger means the data should point to a new allocation
@@ -515,9 +518,9 @@ TYPED_TEST(DeviceBufferTest, ReserveBigger)
 
 TYPED_TEST(DeviceBufferTest, SetGetStream)
 {
-  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
+  rmm::device_buffer buff(this->size, null_stream_ref, this->mr);
 
-  EXPECT_EQ(buff.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
+  EXPECT_EQ(buff.stream(), null_stream_view);
 
   auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   buff.set_stream(otherstream);
@@ -527,15 +530,14 @@ TYPED_TEST(DeviceBufferTest, SetGetStream)
 
 TEST(DeviceBufferAlignmentTest, DefaultAlignment)
 {
-  rmm::device_buffer buff(100, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(100, null_stream_ref);
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
 }
 
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 {
-  rmm::device_buffer buff(
-    100, rmm::CUDA_ALLOCATION_ALIGNMENT, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(100, rmm::CUDA_ALLOCATION_ALIGNMENT, null_stream_ref);
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
   EXPECT_EQ(buff.size(), 100);
@@ -544,7 +546,7 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 {
   constexpr std::size_t alignment{64};
-  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(100, alignment, null_stream_ref);
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), 100);
@@ -553,24 +555,20 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(rmm::device_buffer(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}}),
-               rmm::bad_alloc);
+  EXPECT_THROW(rmm::device_buffer(100, alignment, null_stream_ref), rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, InvalidAlignment)
 {
-  EXPECT_THROW(rmm::device_buffer(100, 0, cuda::stream_ref{cudaStream_t{nullptr}}),
-               rmm::invalid_argument);
-  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, cuda::stream_ref{cudaStream_t{nullptr}}),
-               rmm::invalid_argument);
+  EXPECT_THROW(rmm::device_buffer(100, 0, null_stream_ref), rmm::invalid_argument);
+  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, null_stream_ref), rmm::invalid_argument);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyFromSourceExplicitAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(
-    host_data.data(), host_data.size(), alignment, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(host_data.data(), host_data.size(), alignment, null_stream_ref);
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), host_data.size());
@@ -580,25 +578,24 @@ TEST(DeviceBufferAlignmentTest, CopyFromSourceAlignmentTooLarge)
 {
   std::vector<uint8_t> host_data(100, 42);
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(
-    std::ignore = rmm::device_buffer(
-      host_data.data(), host_data.size(), alignment, cuda::stream_ref{cudaStream_t{nullptr}}),
-    rmm::bad_alloc);
+  EXPECT_THROW(std::ignore =
+                 rmm::device_buffer(host_data.data(), host_data.size(), alignment, null_stream_ref),
+               rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyFromSourceInvalidAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
-  EXPECT_THROW(std::ignore = rmm::device_buffer(
-                 host_data.data(), host_data.size(), 3, cuda::stream_ref{cudaStream_t{nullptr}}),
-               rmm::invalid_argument);
+  EXPECT_THROW(
+    std::ignore = rmm::device_buffer(host_data.data(), host_data.size(), 3, null_stream_ref),
+    rmm::invalid_argument);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
-  rmm::device_buffer copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(100, alignment, null_stream_ref);
+  rmm::device_buffer copy(buff, null_stream_ref);
   EXPECT_EQ(copy.alignment(), buff.alignment());
   EXPECT_EQ(copy.alignment(), alignment);
 }
@@ -606,7 +603,7 @@ TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(100, alignment, null_stream_ref);
   rmm::device_buffer moved(std::move(buff));
   EXPECT_EQ(moved.alignment(), alignment);
   // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
@@ -616,7 +613,7 @@ TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer src(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer src(100, alignment, null_stream_ref);
   rmm::device_buffer dest;
   dest = std::move(src);
   EXPECT_EQ(dest.alignment(), alignment);
@@ -627,7 +624,7 @@ TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, EmptyBufferAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(std::size_t{0}, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer buff(std::size_t{0}, alignment, null_stream_ref);
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_EQ(buff.size(), 0);
   EXPECT_TRUE(buff.is_empty());
@@ -638,8 +635,7 @@ TEST(DeviceBufferAlignmentTest, EmptyBufferAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
   EXPECT_NO_THROW({
-    rmm::device_buffer buff(
-      std::size_t{0}, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
+    rmm::device_buffer buff(std::size_t{0}, alignment, null_stream_ref);
     EXPECT_EQ(buff.alignment(), alignment);
     EXPECT_TRUE(buff.is_empty());
     EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
@@ -655,7 +651,7 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedHasValidAlignment)
 TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.resize(100, cuda::stream_ref{cudaStream_t{nullptr}}));
+  EXPECT_NO_THROW(buff.resize(100, null_stream_ref));
   EXPECT_EQ(buff.size(), 100);
 }
 
@@ -670,19 +666,19 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLargerOnNonDefaultStream
 TEST(DeviceBufferAlignmentTest, DefaultConstructedReserveLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.reserve(100, cuda::stream_ref{cudaStream_t{nullptr}}));
+  EXPECT_NO_THROW(buff.reserve(100, null_stream_ref));
   EXPECT_GE(buff.capacity(), 100);
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultConstructedShrinkToFit)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.shrink_to_fit(cuda::stream_ref{cudaStream_t{nullptr}}));
+  EXPECT_NO_THROW(buff.shrink_to_fit(null_stream_ref));
 }
 
 TEST(DeviceBufferAlignmentTest, EmptyBufferResizeLarger)
 {
-  rmm::device_buffer buff(0, cuda::stream_ref{cudaStream_t{nullptr}});
-  EXPECT_NO_THROW(buff.resize(100, cuda::stream_ref{cudaStream_t{nullptr}}));
+  rmm::device_buffer buff(0, null_stream_ref);
+  EXPECT_NO_THROW(buff.resize(100, null_stream_ref));
   EXPECT_EQ(buff.size(), 100);
 }

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -133,7 +133,7 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawDevicePointer)
                             static_cast<char*>(device_memory),
                             static_cast<char*>(device_memory) + buff.size(),
                             static_cast<char*>(buff.data())));
-  buff.stream().synchronize();
+  buff.stream().sync();
   EXPECT_EQ(cudaSuccess, cudaFree(device_memory));
 }
 
@@ -149,7 +149,7 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
   EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
-  buff.stream().synchronize();
+  buff.stream().sync();
   std::vector<uint8_t> host_copy(this->size);
   EXPECT_EQ(cudaSuccess,
             cudaMemcpy(host_copy.data(), buff.data(), this->size, cudaMemcpyDeviceToHost));
@@ -521,7 +521,7 @@ TYPED_TEST(DeviceBufferTest, SetGetStream)
   auto const otherstream = rmm::cuda_stream_per_thread;
   buff.set_stream(otherstream);
 
-  EXPECT_EQ(buff.stream(), rmm::cuda_stream_view{otherstream});
+  EXPECT_EQ(buff.stream(), otherstream);
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultAlignment)

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -58,26 +58,26 @@ TEST(DeviceBufferSimpleTest, ExplicitResourceRef)
 {
   auto mr = rmm::mr::cuda_memory_resource{};
   rmm::device_async_resource_ref ref{mr};
-  auto buf = rmm::device_buffer(10, rmm::cuda_stream_default, ref);
+  auto buf = rmm::device_buffer(10, cuda::stream_ref{cudaStream_t{nullptr}}, ref);
   EXPECT_EQ(buf.size(), 10);
 }
 
 TYPED_TEST(DeviceBufferTest, EmptyBuffer)
 {
-  rmm::device_buffer buff(0, rmm::cuda_stream_default);
+  rmm::device_buffer buff(0, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(buff.is_empty());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResource)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.ssize());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
@@ -94,12 +94,12 @@ TYPED_TEST(DeviceBufferTest, DefaultMemoryResourceStream)
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResource)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{this->mr}, buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, ExplicitMemoryResourceStream)
@@ -117,19 +117,19 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawDevicePointer)
 {
   void* device_memory{nullptr};
   EXPECT_EQ(cudaSuccess, cudaMalloc(&device_memory, this->size));
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<char*>(device_memory),
                    static_cast<char*>(device_memory) + this->size,
                    0);
-  rmm::device_buffer buff(device_memory, this->size, rmm::cuda_stream_default);
+  rmm::device_buffer buff(device_memory, this->size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<char*>(device_memory),
                             static_cast<char*>(device_memory) + buff.size(),
                             static_cast<char*>(buff.data())));
@@ -142,13 +142,13 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
   std::vector<uint8_t> host_data(this->size);
   std::iota(host_data.begin(), host_data.end(), static_cast<uint8_t>(0));
   rmm::device_buffer buff(
-    static_cast<void*>(host_data.data()), this->size, rmm::cuda_stream_default);
+    static_cast<void*>(host_data.data()), this->size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff.data());
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
   buff.stream().synchronize();
   std::vector<uint8_t> host_copy(this->size);
   EXPECT_EQ(cudaSuccess,
@@ -159,19 +159,20 @@ TYPED_TEST(DeviceBufferTest, CopyFromRawHostPointer)
 TYPED_TEST(DeviceBufferTest, CopyFromNullptr)
 {
   // can  copy from a nullptr only if size == 0
-  rmm::device_buffer buff(nullptr, 0, rmm::cuda_stream_default);
+  rmm::device_buffer buff(nullptr, 0, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(nullptr, buff.data());
   EXPECT_EQ(0, buff.size());
   EXPECT_EQ(0, buff.capacity());
   EXPECT_EQ(rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()},
             buff.memory_resource());
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, buff.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZero)
 {
   // can  copy from a nullptr only if size == 0
-  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, rmm::cuda_stream_default), rmm::logic_error);
+  EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, cuda::stream_ref{cudaStream_t{nullptr}}),
+               rmm::logic_error);
 }
 
 TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
@@ -186,25 +187,25 @@ TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructor)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
   // Initialize buffer
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<char*>(buff.data()) + buff.size(),
                    0);
 
-  rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);  // uses default MR
+  rmm::device_buffer buff_copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});  // uses default MR
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
   EXPECT_EQ(buff.capacity(), buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_default);
+  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<char*>(buff.data()) + buff.size(),
@@ -216,7 +217,7 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
   EXPECT_EQ(buff_copy2.memory_resource(), buff.memory_resource());
   EXPECT_EQ(buff_copy2.stream(), buff.stream());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -225,18 +226,18 @@ TYPED_TEST(DeviceBufferTest, CopyConstructor)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
                    0);
-  rmm::device_buffer buff_copy(buff, rmm::cuda_stream_default);
+  rmm::device_buffer buff_copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff_copy.data());
   EXPECT_NE(buff.data(), buff_copy.data());
   EXPECT_EQ(buff.size(), buff_copy.size());
@@ -245,9 +246,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
   EXPECT_EQ(new_size, buff_copy.capacity());
   EXPECT_EQ(buff_copy.memory_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
-  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_default);
+  EXPECT_EQ(buff_copy.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -256,9 +257,9 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSize)
 
 TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -280,13 +281,13 @@ TYPED_TEST(DeviceBufferTest, CopyConstructorExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
   // Resizing smaller to make `size()` < `capacity()`
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -311,7 +312,7 @@ TYPED_TEST(DeviceBufferTest, CopyCapacityLargerThanSizeExplicitMr)
 
 TYPED_TEST(DeviceBufferTest, MoveConstructor)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -332,7 +333,8 @@ TYPED_TEST(DeviceBufferTest, MoveConstructor)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());  // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}},
+            buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
@@ -360,12 +362,13 @@ TYPED_TEST(DeviceBufferTest, MoveConstructorStream)
             buff.data());         // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, buff.size());      // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, buff.capacity());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(rmm::cuda_stream_default, buff.stream());  // NOLINT(bugprone-use-after-move)
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}},
+            buff.stream());  // NOLINT(bugprone-use-after-move)
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
 {
-  rmm::device_buffer src(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer src(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
@@ -387,19 +390,19 @@ TYPED_TEST(DeviceBufferTest, MoveAssignmentToDefault)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(rmm::cuda_stream_default, src.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, MoveAssignment)
 {
-  rmm::device_buffer src(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer src(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* ptr     = src.data();
   auto size     = src.size();
   auto capacity = src.capacity();
   auto mr       = src.memory_resource();
   auto stream   = src.stream();
 
-  rmm::device_buffer dest(this->size - 1, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer dest(this->size - 1, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   dest = std::move(src);
 
   // contents of `from` should be in `to`
@@ -414,12 +417,12 @@ TYPED_TEST(DeviceBufferTest, MoveAssignment)
   EXPECT_EQ(nullptr, src.data());  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(0, src.size());
   EXPECT_EQ(0, src.capacity());
-  EXPECT_EQ(rmm::cuda_stream_default, src.stream());
+  EXPECT_EQ(rmm::cuda_stream_view{cudaStream_t{nullptr}}, src.stream());
 }
 
 TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* ptr     = buff.data();
   auto size     = buff.size();
   auto capacity = buff.capacity();
@@ -440,9 +443,9 @@ TYPED_TEST(DeviceBufferTest, SelfMoveAssignment)
 
 TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
-  thrust::sequence(rmm::exec_policy(rmm::cuda_stream_default),
+  thrust::sequence(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                    static_cast<signed char*>(buff.data()),
                    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                    static_cast<signed char*>(buff.data()) + buff.size(),
@@ -450,23 +453,23 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
   auto* old_data = buff.data();
   rmm::device_buffer old_content(
-    old_data, buff.size(), rmm::cuda_stream_default, this->mr);  // for comparison
+    old_data, buff.size(), cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);  // for comparison
 
   auto new_size = this->size - 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(this->size, buff.capacity());  // Capacity should be unchanged
   // Resizing smaller means the existing allocation should remain unchanged
   EXPECT_EQ(old_data, buff.data());
 
-  buff.shrink_to_fit(rmm::cuda_stream_default);
+  buff.shrink_to_fit(cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_NE(nullptr, buff.data());
   // A reallocation should have occurred
   EXPECT_NE(old_data, buff.data());
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(buff.capacity(), buff.size());
 
-  EXPECT_TRUE(thrust::equal(rmm::exec_policy(rmm::cuda_stream_default),
+  EXPECT_TRUE(thrust::equal(rmm::exec_policy(cuda::stream_ref{cudaStream_t{nullptr}}),
                             static_cast<signed char*>(buff.data()),
                             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                             static_cast<signed char*>(buff.data()) + buff.size(),
@@ -475,10 +478,10 @@ TYPED_TEST(DeviceBufferTest, ResizeSmaller)
 
 TYPED_TEST(DeviceBufferTest, ResizeBigger)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* old_data = buff.data();
   auto new_size  = this->size + 1;
-  buff.resize(new_size, rmm::cuda_stream_default);
+  buff.resize(new_size, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(new_size, buff.size());
   EXPECT_EQ(new_size, buff.capacity());
   // Resizing bigger means the data should point to a new allocation
@@ -487,11 +490,11 @@ TYPED_TEST(DeviceBufferTest, ResizeBigger)
 
 TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* const old_data    = buff.data();
   auto const old_capacity = buff.capacity();
   auto const new_capacity = buff.capacity() - 1;
-  buff.reserve(new_capacity, rmm::cuda_stream_default);
+  buff.reserve(new_capacity, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(old_capacity, buff.capacity());
   // Reserving smaller means the allocation is unchanged
@@ -500,10 +503,10 @@ TYPED_TEST(DeviceBufferTest, ReserveSmaller)
 
 TYPED_TEST(DeviceBufferTest, ReserveBigger)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
   auto* const old_data    = buff.data();
   auto const new_capacity = buff.capacity() + 1;
-  buff.reserve(new_capacity, rmm::cuda_stream_default);
+  buff.reserve(new_capacity, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(this->size, buff.size());
   EXPECT_EQ(new_capacity, buff.capacity());
   // Reserving bigger means the data should point to a new allocation
@@ -512,26 +515,27 @@ TYPED_TEST(DeviceBufferTest, ReserveBigger)
 
 TYPED_TEST(DeviceBufferTest, SetGetStream)
 {
-  rmm::device_buffer buff(this->size, rmm::cuda_stream_default, this->mr);
+  rmm::device_buffer buff(this->size, cuda::stream_ref{cudaStream_t{nullptr}}, this->mr);
 
-  EXPECT_EQ(buff.stream(), rmm::cuda_stream_default);
+  EXPECT_EQ(buff.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
 
-  rmm::cuda_stream_view const otherstream{cudaStreamPerThread};
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   buff.set_stream(otherstream);
 
-  EXPECT_EQ(buff.stream(), otherstream);
+  EXPECT_EQ(buff.stream(), rmm::cuda_stream_view{otherstream});
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultAlignment)
 {
-  rmm::device_buffer buff(100, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
 }
 
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 {
-  rmm::device_buffer buff(100, rmm::CUDA_ALLOCATION_ALIGNMENT, rmm::cuda_stream_default);
+  rmm::device_buffer buff(
+    100, rmm::CUDA_ALLOCATION_ALIGNMENT, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), rmm::CUDA_ALLOCATION_ALIGNMENT));
   EXPECT_EQ(buff.size(), 100);
@@ -540,7 +544,7 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentDefault)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 {
   constexpr std::size_t alignment{64};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), 100);
@@ -549,13 +553,15 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
 TEST(DeviceBufferAlignmentTest, ExplicitAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(rmm::device_buffer(100, alignment, rmm::cuda_stream_default), rmm::bad_alloc);
+  EXPECT_THROW(rmm::device_buffer(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}}),
+               rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, InvalidAlignment)
 {
-  EXPECT_THROW(rmm::device_buffer(100, 0, rmm::cuda_stream_default), rmm::invalid_argument);
-  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, rmm::cuda_stream_default),
+  EXPECT_THROW(rmm::device_buffer(100, 0, cuda::stream_ref{cudaStream_t{nullptr}}),
+               rmm::invalid_argument);
+  EXPECT_THROW(std::ignore = rmm::device_buffer(100, 3, cuda::stream_ref{cudaStream_t{nullptr}}),
                rmm::invalid_argument);
 }
 
@@ -563,7 +569,8 @@ TEST(DeviceBufferAlignmentTest, CopyFromSourceExplicitAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(host_data.data(), host_data.size(), alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(
+    host_data.data(), host_data.size(), alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
   EXPECT_EQ(buff.size(), host_data.size());
@@ -573,24 +580,25 @@ TEST(DeviceBufferAlignmentTest, CopyFromSourceAlignmentTooLarge)
 {
   std::vector<uint8_t> host_data(100, 42);
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  EXPECT_THROW(std::ignore = rmm::device_buffer(
-                 host_data.data(), host_data.size(), alignment, rmm::cuda_stream_default),
-               rmm::bad_alloc);
+  EXPECT_THROW(
+    std::ignore = rmm::device_buffer(
+      host_data.data(), host_data.size(), alignment, cuda::stream_ref{cudaStream_t{nullptr}}),
+    rmm::bad_alloc);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyFromSourceInvalidAlignment)
 {
   std::vector<uint8_t> host_data(100, 42);
   EXPECT_THROW(std::ignore = rmm::device_buffer(
-                 host_data.data(), host_data.size(), 3, rmm::cuda_stream_default),
+                 host_data.data(), host_data.size(), 3, cuda::stream_ref{cudaStream_t{nullptr}}),
                rmm::invalid_argument);
 }
 
 TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
-  rmm::device_buffer copy(buff, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_buffer copy(buff, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(copy.alignment(), buff.alignment());
   EXPECT_EQ(copy.alignment(), alignment);
 }
@@ -598,7 +606,7 @@ TEST(DeviceBufferAlignmentTest, CopyConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   rmm::device_buffer moved(std::move(buff));
   EXPECT_EQ(moved.alignment(), alignment);
   // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
@@ -608,7 +616,7 @@ TEST(DeviceBufferAlignmentTest, MoveConstructorPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer src(100, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer src(100, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   rmm::device_buffer dest;
   dest = std::move(src);
   EXPECT_EQ(dest.alignment(), alignment);
@@ -619,7 +627,7 @@ TEST(DeviceBufferAlignmentTest, MoveAssignmentPreservesAlignment)
 TEST(DeviceBufferAlignmentTest, EmptyBufferAlignment)
 {
   std::size_t constexpr alignment{128};
-  rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
+  rmm::device_buffer buff(std::size_t{0}, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_EQ(buff.alignment(), alignment);
   EXPECT_EQ(buff.size(), 0);
   EXPECT_TRUE(buff.is_empty());
@@ -630,7 +638,8 @@ TEST(DeviceBufferAlignmentTest, EmptyBufferAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
   EXPECT_NO_THROW({
-    rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
+    rmm::device_buffer buff(
+      std::size_t{0}, alignment, cuda::stream_ref{cudaStream_t{nullptr}});
     EXPECT_EQ(buff.alignment(), alignment);
     EXPECT_TRUE(buff.is_empty());
     EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
@@ -646,7 +655,7 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedHasValidAlignment)
 TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.resize(100, rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.resize(100, cuda::stream_ref{cudaStream_t{nullptr}}));
   EXPECT_EQ(buff.size(), 100);
 }
 
@@ -661,19 +670,19 @@ TEST(DeviceBufferAlignmentTest, DefaultConstructedResizeLargerOnNonDefaultStream
 TEST(DeviceBufferAlignmentTest, DefaultConstructedReserveLarger)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.reserve(100, rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.reserve(100, cuda::stream_ref{cudaStream_t{nullptr}}));
   EXPECT_GE(buff.capacity(), 100);
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultConstructedShrinkToFit)
 {
   rmm::device_buffer buff;
-  EXPECT_NO_THROW(buff.shrink_to_fit(rmm::cuda_stream_default));
+  EXPECT_NO_THROW(buff.shrink_to_fit(cuda::stream_ref{cudaStream_t{nullptr}}));
 }
 
 TEST(DeviceBufferAlignmentTest, EmptyBufferResizeLarger)
 {
-  rmm::device_buffer buff(0, rmm::cuda_stream_default);
-  EXPECT_NO_THROW(buff.resize(100, rmm::cuda_stream_default));
+  rmm::device_buffer buff(0, cuda::stream_ref{cudaStream_t{nullptr}});
+  EXPECT_NO_THROW(buff.resize(100, cuda::stream_ref{cudaStream_t{nullptr}}));
   EXPECT_EQ(buff.size(), 100);
 }

--- a/cpp/tests/device_check_resource_adaptor.hpp
+++ b/cpp/tests/device_check_resource_adaptor.hpp
@@ -6,7 +6,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -57,9 +56,9 @@ class device_check_resource_adaptor final {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    rmm::cuda_stream_view stream{};
-    auto* ptr = allocate(stream, bytes, alignment);
-    stream.synchronize();
+    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto* ptr   = allocate(stream, bytes, alignment);
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return ptr;
   }
 
@@ -67,7 +66,7 @@ class device_check_resource_adaptor final {
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_view{}, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
   }
 
   bool operator==(device_check_resource_adaptor const& other) const noexcept

--- a/cpp/tests/device_check_resource_adaptor.hpp
+++ b/cpp/tests/device_check_resource_adaptor.hpp
@@ -6,6 +6,7 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -56,7 +57,7 @@ class device_check_resource_adaptor final {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto stream = rmm::cuda_stream_default;
     auto* ptr   = allocate(stream, bytes, alignment);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return ptr;
@@ -66,7 +67,7 @@ class device_check_resource_adaptor final {
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
   }
 
   bool operator==(device_check_resource_adaptor const& other) const noexcept

--- a/cpp/tests/device_check_resource_adaptor.hpp
+++ b/cpp/tests/device_check_resource_adaptor.hpp
@@ -6,7 +6,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -57,7 +56,7 @@ class device_check_resource_adaptor final {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    auto stream = rmm::cuda_stream_default;
+    auto stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
     auto* ptr   = allocate(stream, bytes, alignment);
     RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     return ptr;
@@ -67,7 +66,7 @@ class device_check_resource_adaptor final {
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, bytes, alignment);
   }
 
   bool operator==(device_check_resource_adaptor const& other) const noexcept

--- a/cpp/tests/device_scalar_tests.cpp
+++ b/cpp/tests/device_scalar_tests.cpp
@@ -137,15 +137,15 @@ TYPED_TEST(DeviceScalarTest, SetGetStream)
 
   EXPECT_EQ(scalar.stream(), this->stream);
 
-  rmm::cuda_stream_view const otherstream{cudaStreamPerThread};
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   scalar.set_stream(otherstream);
 
-  EXPECT_EQ(scalar.stream(), otherstream);
+  EXPECT_EQ(scalar.stream(), rmm::cuda_stream_view{otherstream});
 }
 
 TEST(DeviceScalarAlignmentTest, SmallAlignment)
 {
-  auto s = rmm::device_scalar<int>(rmm::cuda_stream_view{});
+  auto s = rmm::device_scalar<int>(cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(rmm::is_pointer_aligned(s.data(), std::alignment_of_v<decltype(s)::value_type>));
 }
 
@@ -157,6 +157,7 @@ TEST(DeviceScalarAlignmentTest, DISABLED_LargeAlignment)
     int value;
   };
 
-  EXPECT_THROW(std::ignore = rmm::device_scalar<OverAligned>(rmm::cuda_stream_view{}),
-               rmm::bad_alloc);
+  EXPECT_THROW(
+    std::ignore = rmm::device_scalar<OverAligned>(cuda::stream_ref{cudaStream_t{nullptr}}),
+    rmm::bad_alloc);
 }

--- a/cpp/tests/device_scalar_tests.cpp
+++ b/cpp/tests/device_scalar_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/device_scalar_tests.cpp
+++ b/cpp/tests/device_scalar_tests.cpp
@@ -5,6 +5,7 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -139,7 +140,7 @@ TYPED_TEST(DeviceScalarTest, SetGetStream)
 
   EXPECT_EQ(scalar.stream(), this->stream);
 
-  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
+  auto const otherstream = rmm::cuda_stream_per_thread;
   scalar.set_stream(otherstream);
 
   EXPECT_EQ(scalar.stream(), rmm::cuda_stream_view{otherstream});
@@ -147,7 +148,7 @@ TYPED_TEST(DeviceScalarTest, SetGetStream)
 
 TEST(DeviceScalarAlignmentTest, SmallAlignment)
 {
-  auto s = rmm::device_scalar<int>(cuda::stream_ref{cudaStream_t{nullptr}});
+  auto s = rmm::device_scalar<int>(rmm::cuda_stream_default);
   EXPECT_TRUE(rmm::is_pointer_aligned(s.data(), std::alignment_of_v<decltype(s)::value_type>));
 }
 
@@ -157,7 +158,6 @@ TEST(DeviceScalarAlignmentTest, LargeAlignment)
     int value;
   };
 
-  EXPECT_THROW(
-    std::ignore = rmm::device_scalar<OverAligned>(cuda::stream_ref{cudaStream_t{nullptr}}),
-    rmm::bad_alloc);
+  EXPECT_THROW(std::ignore = rmm::device_scalar<OverAligned>(rmm::cuda_stream_default),
+               rmm::bad_alloc);
 }

--- a/cpp/tests/device_scalar_tests.cpp
+++ b/cpp/tests/device_scalar_tests.cpp
@@ -139,15 +139,15 @@ TYPED_TEST(DeviceScalarTest, SetGetStream)
 
   EXPECT_EQ(scalar.stream(), this->stream);
 
-  rmm::cuda_stream_view const otherstream{cudaStreamPerThread};
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   scalar.set_stream(otherstream);
 
-  EXPECT_EQ(scalar.stream(), otherstream);
+  EXPECT_EQ(scalar.stream(), rmm::cuda_stream_view{otherstream});
 }
 
 TEST(DeviceScalarAlignmentTest, SmallAlignment)
 {
-  auto s = rmm::device_scalar<int>(rmm::cuda_stream_view{});
+  auto s = rmm::device_scalar<int>(cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(rmm::is_pointer_aligned(s.data(), std::alignment_of_v<decltype(s)::value_type>));
 }
 
@@ -157,6 +157,7 @@ TEST(DeviceScalarAlignmentTest, LargeAlignment)
     int value;
   };
 
-  EXPECT_THROW(std::ignore = rmm::device_scalar<OverAligned>(rmm::cuda_stream_view{}),
-               rmm::bad_alloc);
+  EXPECT_THROW(
+    std::ignore = rmm::device_scalar<OverAligned>(cuda::stream_ref{cudaStream_t{nullptr}}),
+    rmm::bad_alloc);
 }

--- a/cpp/tests/device_scalar_tests.cpp
+++ b/cpp/tests/device_scalar_tests.cpp
@@ -5,7 +5,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -19,9 +18,13 @@
 #include <cstddef>
 #include <random>
 #include <type_traits>
+#include <utility>
 
 // explicit instantiation for test coverage purposes
 template class rmm::device_scalar<int>;
+
+static_assert(
+  std::is_same_v<decltype(std::declval<rmm::device_scalar<int>>().stream()), cuda::stream_ref>);
 
 template <typename T>
 struct DeviceScalarTest : public ::testing::Test {
@@ -143,7 +146,7 @@ TYPED_TEST(DeviceScalarTest, SetGetStream)
   auto const otherstream = rmm::cuda_stream_per_thread;
   scalar.set_stream(otherstream);
 
-  EXPECT_EQ(scalar.stream(), rmm::cuda_stream_view{otherstream});
+  EXPECT_EQ(scalar.stream(), otherstream);
 }
 
 TEST(DeviceScalarAlignmentTest, SmallAlignment)

--- a/cpp/tests/device_scalar_tests.cpp
+++ b/cpp/tests/device_scalar_tests.cpp
@@ -10,6 +10,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
@@ -143,7 +144,7 @@ TYPED_TEST(DeviceScalarTest, SetGetStream)
 
   EXPECT_EQ(scalar.stream(), this->stream);
 
-  auto const otherstream = rmm::cuda_stream_per_thread;
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   scalar.set_stream(otherstream);
 
   EXPECT_EQ(scalar.stream(), otherstream);
@@ -151,7 +152,7 @@ TYPED_TEST(DeviceScalarTest, SetGetStream)
 
 TEST(DeviceScalarAlignmentTest, SmallAlignment)
 {
-  auto s = rmm::device_scalar<int>(rmm::cuda_stream_default);
+  auto s = rmm::device_scalar<int>(cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_TRUE(rmm::is_pointer_aligned(s.data(), std::alignment_of_v<decltype(s)::value_type>));
 }
 
@@ -161,6 +162,7 @@ TEST(DeviceScalarAlignmentTest, LargeAlignment)
     int value;
   };
 
-  EXPECT_THROW(std::ignore = rmm::device_scalar<OverAligned>(rmm::cuda_stream_default),
+  EXPECT_THROW(std::ignore =
+                 rmm::device_scalar<OverAligned>(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                rmm::bad_alloc);
 }

--- a/cpp/tests/device_uvector_tests.cpp
+++ b/cpp/tests/device_uvector_tests.cpp
@@ -27,7 +27,10 @@ template class rmm::device_uvector<int32_t>;
 
 template <typename T>
 struct TypedUVectorTest : ::testing::Test {
-  [[nodiscard]] rmm::cuda_stream_view stream() const noexcept { return rmm::cuda_stream_view{}; }
+  [[nodiscard]] rmm::cuda_stream_view stream() const noexcept
+  {
+    return cuda::stream_ref{cudaStream_t{nullptr}};
+  }
 };
 
 using TestTypes = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
@@ -244,20 +247,20 @@ TYPED_TEST(TypedUVectorTest, SetElementZeroAsync)
 
 TEST(NegativeZeroTest, PreservesFloatNegativeZero)
 {
-  rmm::device_uvector<float> vec(1, rmm::cuda_stream_view{});
+  rmm::device_uvector<float> vec(1, cuda::stream_ref{cudaStream_t{nullptr}});
   float const neg_zero = -0.0f;
-  vec.set_element_async(0, neg_zero, rmm::cuda_stream_view{});
-  float const result = vec.element(0, rmm::cuda_stream_view{});
+  vec.set_element_async(0, neg_zero, cuda::stream_ref{cudaStream_t{nullptr}});
+  float const result = vec.element(0, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(std::signbit(result)) << "sign bit of -0.0f was lost";
   EXPECT_EQ(result, 0.0f);
 }
 
 TEST(NegativeZeroTest, PreservesDoubleNegativeZero)
 {
-  rmm::device_uvector<double> vec(1, rmm::cuda_stream_view{});
+  rmm::device_uvector<double> vec(1, cuda::stream_ref{cudaStream_t{nullptr}});
   double const neg_zero = -0.0;
-  vec.set_element_async(0, neg_zero, rmm::cuda_stream_view{});
-  double const result = vec.element(0, rmm::cuda_stream_view{});
+  vec.set_element_async(0, neg_zero, cuda::stream_ref{cudaStream_t{nullptr}});
+  double const result = vec.element(0, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(std::signbit(result)) << "sign bit of -0.0 was lost";
   EXPECT_EQ(result, 0.0);
 }
@@ -283,10 +286,10 @@ TYPED_TEST(TypedUVectorTest, SetGetStream)
 
   EXPECT_EQ(vec.stream(), this->stream());
 
-  rmm::cuda_stream_view const otherstream{cudaStreamPerThread};
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   vec.set_stream(otherstream);
 
-  EXPECT_EQ(vec.stream(), otherstream);
+  EXPECT_EQ(vec.stream(), rmm::cuda_stream_view{otherstream});
 }
 
 TYPED_TEST(TypedUVectorTest, Iterators)
@@ -383,7 +386,7 @@ TYPED_TEST(TypedUVectorTest, SpanConversionImplicit)
 
 TEST(DeviceUVectorAlignmentTest, SmallAlignment)
 {
-  auto v = rmm::device_uvector<int>(10, rmm::cuda_stream_view{});
+  auto v = rmm::device_uvector<int>(10, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(rmm::is_pointer_aligned(v.data(), std::alignment_of_v<decltype(v)::value_type>));
 }
 
@@ -395,6 +398,7 @@ TEST(DeviceUVectorAlignmentTest, DISABLED_LargeAlignment)
     int value;
   };
 
-  EXPECT_THROW(std::ignore = rmm::device_uvector<OverAligned>(10, rmm::cuda_stream_view{}),
-               rmm::bad_alloc);
+  EXPECT_THROW(
+    std::ignore = rmm::device_uvector<OverAligned>(10, cuda::stream_ref{cudaStream_t{nullptr}}),
+    rmm::bad_alloc);
 }

--- a/cpp/tests/device_uvector_tests.cpp
+++ b/cpp/tests/device_uvector_tests.cpp
@@ -29,7 +29,10 @@ template class rmm::device_uvector<int32_t>;
 
 template <typename T>
 struct TypedUVectorTest : ::testing::Test {
-  [[nodiscard]] rmm::cuda_stream_view stream() const noexcept { return rmm::cuda_stream_view{}; }
+  [[nodiscard]] rmm::cuda_stream_view stream() const noexcept
+  {
+    return cuda::stream_ref{cudaStream_t{nullptr}};
+  }
 };
 
 using TestTypes = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
@@ -280,20 +283,20 @@ TYPED_TEST(TypedUVectorTest, SetElementZeroAsync)
 
 TEST(NegativeZeroTest, PreservesFloatNegativeZero)
 {
-  rmm::device_uvector<float> vec(1, rmm::cuda_stream_view{});
+  rmm::device_uvector<float> vec(1, cuda::stream_ref{cudaStream_t{nullptr}});
   float const neg_zero = -0.0f;
-  vec.set_element_async(0, neg_zero, rmm::cuda_stream_view{});
-  float const result = vec.element(0, rmm::cuda_stream_view{});
+  vec.set_element_async(0, neg_zero, cuda::stream_ref{cudaStream_t{nullptr}});
+  float const result = vec.element(0, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(std::signbit(result)) << "sign bit of -0.0f was lost";
   EXPECT_EQ(result, 0.0f);
 }
 
 TEST(NegativeZeroTest, PreservesDoubleNegativeZero)
 {
-  rmm::device_uvector<double> vec(1, rmm::cuda_stream_view{});
+  rmm::device_uvector<double> vec(1, cuda::stream_ref{cudaStream_t{nullptr}});
   double const neg_zero = -0.0;
-  vec.set_element_async(0, neg_zero, rmm::cuda_stream_view{});
-  double const result = vec.element(0, rmm::cuda_stream_view{});
+  vec.set_element_async(0, neg_zero, cuda::stream_ref{cudaStream_t{nullptr}});
+  double const result = vec.element(0, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(std::signbit(result)) << "sign bit of -0.0 was lost";
   EXPECT_EQ(result, 0.0);
 }
@@ -319,10 +322,10 @@ TYPED_TEST(TypedUVectorTest, SetGetStream)
 
   EXPECT_EQ(vec.stream(), this->stream());
 
-  rmm::cuda_stream_view const otherstream{cudaStreamPerThread};
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   vec.set_stream(otherstream);
 
-  EXPECT_EQ(vec.stream(), otherstream);
+  EXPECT_EQ(vec.stream(), rmm::cuda_stream_view{otherstream});
 }
 
 TYPED_TEST(TypedUVectorTest, Iterators)
@@ -419,7 +422,7 @@ TYPED_TEST(TypedUVectorTest, SpanConversionImplicit)
 
 TEST(DeviceUVectorAlignmentTest, SmallAlignment)
 {
-  auto v = rmm::device_uvector<int>(10, rmm::cuda_stream_view{});
+  auto v = rmm::device_uvector<int>(10, cuda::stream_ref{cudaStream_t{nullptr}});
   EXPECT_TRUE(rmm::is_pointer_aligned(v.data(), std::alignment_of_v<decltype(v)::value_type>));
 }
 
@@ -429,6 +432,7 @@ TEST(DeviceUVectorAlignmentTest, LargeAlignment)
     int value;
   };
 
-  EXPECT_THROW(std::ignore = rmm::device_uvector<OverAligned>(10, rmm::cuda_stream_view{}),
-               rmm::bad_alloc);
+  EXPECT_THROW(
+    std::ignore = rmm::device_uvector<OverAligned>(10, cuda::stream_ref{cudaStream_t{nullptr}}),
+    rmm::bad_alloc);
 }

--- a/cpp/tests/device_uvector_tests.cpp
+++ b/cpp/tests/device_uvector_tests.cpp
@@ -29,7 +29,7 @@ template class rmm::device_uvector<int32_t>;
 
 template <typename T>
 struct TypedUVectorTest : ::testing::Test {
-  [[nodiscard]] rmm::cuda_stream_view stream() const noexcept { return rmm::cuda_stream_default; }
+  [[nodiscard]] cuda::stream_ref stream() const noexcept { return rmm::cuda_stream_default; }
 };
 
 using TestTypes = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
@@ -68,7 +68,7 @@ TEST(DeviceUVectorOverflowTest, Constructor)
   auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
 
   EXPECT_THROW(
-    std::ignore = rmm::device_uvector<uint64_t>(overflowing_size, rmm::cuda_stream_view{}),
+    std::ignore = rmm::device_uvector<uint64_t>(overflowing_size, rmm::cuda_stream_default),
     rmm::invalid_argument);
 }
 
@@ -170,9 +170,9 @@ TYPED_TEST(TypedUVectorTest, ReserveLarger)
 TEST(DeviceUVectorOverflowTest, Reserve)
 {
   auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
-  rmm::device_uvector<uint64_t> vec(0, rmm::cuda_stream_view{});
+  rmm::device_uvector<uint64_t> vec(0, rmm::cuda_stream_default);
 
-  EXPECT_THROW(vec.reserve(overflowing_size, rmm::cuda_stream_view{}), rmm::invalid_argument);
+  EXPECT_THROW(vec.reserve(overflowing_size, rmm::cuda_stream_default), rmm::invalid_argument);
 }
 
 TYPED_TEST(TypedUVectorTest, ResizeToZero)
@@ -192,9 +192,9 @@ TYPED_TEST(TypedUVectorTest, ResizeToZero)
 TEST(DeviceUVectorOverflowTest, Resize)
 {
   auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
-  rmm::device_uvector<uint64_t> vec(0, rmm::cuda_stream_view{});
+  rmm::device_uvector<uint64_t> vec(0, rmm::cuda_stream_default);
 
-  EXPECT_THROW(vec.resize(overflowing_size, rmm::cuda_stream_view{}), rmm::invalid_argument);
+  EXPECT_THROW(vec.resize(overflowing_size, rmm::cuda_stream_default), rmm::invalid_argument);
 }
 
 TYPED_TEST(TypedUVectorTest, Release)
@@ -322,7 +322,7 @@ TYPED_TEST(TypedUVectorTest, SetGetStream)
   auto const otherstream = rmm::cuda_stream_per_thread;
   vec.set_stream(otherstream);
 
-  EXPECT_EQ(vec.stream(), rmm::cuda_stream_view{otherstream});
+  EXPECT_EQ(vec.stream(), otherstream);
 }
 
 TYPED_TEST(TypedUVectorTest, Iterators)

--- a/cpp/tests/device_uvector_tests.cpp
+++ b/cpp/tests/device_uvector_tests.cpp
@@ -6,13 +6,13 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/std/span>
+#include <cuda/stream>
 
 #include <gtest/gtest.h>
 #include <gtest/internal/gtest-type-util.h>
@@ -29,7 +29,10 @@ template class rmm::device_uvector<int32_t>;
 
 template <typename T>
 struct TypedUVectorTest : ::testing::Test {
-  [[nodiscard]] cuda::stream_ref stream() const noexcept { return rmm::cuda_stream_default; }
+  [[nodiscard]] cuda::stream_ref stream() const noexcept
+  {
+    return cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
+  }
 };
 
 using TestTypes = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
@@ -67,9 +70,9 @@ TEST(DeviceUVectorOverflowTest, Constructor)
 {
   auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
 
-  EXPECT_THROW(
-    std::ignore = rmm::device_uvector<uint64_t>(overflowing_size, rmm::cuda_stream_default),
-    rmm::invalid_argument);
+  EXPECT_THROW(std::ignore = rmm::device_uvector<uint64_t>(
+                 overflowing_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
+               rmm::invalid_argument);
 }
 
 TYPED_TEST(TypedUVectorTest, CopyConstructor)
@@ -170,9 +173,10 @@ TYPED_TEST(TypedUVectorTest, ReserveLarger)
 TEST(DeviceUVectorOverflowTest, Reserve)
 {
   auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
-  rmm::device_uvector<uint64_t> vec(0, rmm::cuda_stream_default);
+  rmm::device_uvector<uint64_t> vec(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 
-  EXPECT_THROW(vec.reserve(overflowing_size, rmm::cuda_stream_default), rmm::invalid_argument);
+  EXPECT_THROW(vec.reserve(overflowing_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
+               rmm::invalid_argument);
 }
 
 TYPED_TEST(TypedUVectorTest, ResizeToZero)
@@ -192,9 +196,10 @@ TYPED_TEST(TypedUVectorTest, ResizeToZero)
 TEST(DeviceUVectorOverflowTest, Resize)
 {
   auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
-  rmm::device_uvector<uint64_t> vec(0, rmm::cuda_stream_default);
+  rmm::device_uvector<uint64_t> vec(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 
-  EXPECT_THROW(vec.resize(overflowing_size, rmm::cuda_stream_default), rmm::invalid_argument);
+  EXPECT_THROW(vec.resize(overflowing_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
+               rmm::invalid_argument);
 }
 
 TYPED_TEST(TypedUVectorTest, Release)
@@ -280,20 +285,20 @@ TYPED_TEST(TypedUVectorTest, SetElementZeroAsync)
 
 TEST(NegativeZeroTest, PreservesFloatNegativeZero)
 {
-  rmm::device_uvector<float> vec(1, rmm::cuda_stream_default);
+  rmm::device_uvector<float> vec(1, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   float const neg_zero = -0.0f;
-  vec.set_element_async(0, neg_zero, rmm::cuda_stream_default);
-  float const result = vec.element(0, rmm::cuda_stream_default);
+  vec.set_element_async(0, neg_zero, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
+  float const result = vec.element(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_TRUE(std::signbit(result)) << "sign bit of -0.0f was lost";
   EXPECT_EQ(result, 0.0f);
 }
 
 TEST(NegativeZeroTest, PreservesDoubleNegativeZero)
 {
-  rmm::device_uvector<double> vec(1, rmm::cuda_stream_default);
+  rmm::device_uvector<double> vec(1, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   double const neg_zero = -0.0;
-  vec.set_element_async(0, neg_zero, rmm::cuda_stream_default);
-  double const result = vec.element(0, rmm::cuda_stream_default);
+  vec.set_element_async(0, neg_zero, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
+  double const result = vec.element(0, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_TRUE(std::signbit(result)) << "sign bit of -0.0 was lost";
   EXPECT_EQ(result, 0.0);
 }
@@ -319,7 +324,7 @@ TYPED_TEST(TypedUVectorTest, SetGetStream)
 
   EXPECT_EQ(vec.stream(), this->stream());
 
-  auto const otherstream = rmm::cuda_stream_per_thread;
+  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
   vec.set_stream(otherstream);
 
   EXPECT_EQ(vec.stream(), otherstream);
@@ -419,7 +424,7 @@ TYPED_TEST(TypedUVectorTest, SpanConversionImplicit)
 
 TEST(DeviceUVectorAlignmentTest, SmallAlignment)
 {
-  auto v = rmm::device_uvector<int>(10, rmm::cuda_stream_default);
+  auto v = rmm::device_uvector<int>(10, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_TRUE(rmm::is_pointer_aligned(v.data(), std::alignment_of_v<decltype(v)::value_type>));
 }
 
@@ -429,6 +434,7 @@ TEST(DeviceUVectorAlignmentTest, LargeAlignment)
     int value;
   };
 
-  EXPECT_THROW(std::ignore = rmm::device_uvector<OverAligned>(10, rmm::cuda_stream_default),
+  EXPECT_THROW(std::ignore = rmm::device_uvector<OverAligned>(
+                 10, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}),
                rmm::bad_alloc);
 }

--- a/cpp/tests/device_uvector_tests.cpp
+++ b/cpp/tests/device_uvector_tests.cpp
@@ -29,10 +29,7 @@ template class rmm::device_uvector<int32_t>;
 
 template <typename T>
 struct TypedUVectorTest : ::testing::Test {
-  [[nodiscard]] rmm::cuda_stream_view stream() const noexcept
-  {
-    return cuda::stream_ref{cudaStream_t{nullptr}};
-  }
+  [[nodiscard]] rmm::cuda_stream_view stream() const noexcept { return rmm::cuda_stream_default; }
 };
 
 using TestTypes = ::testing::Types<int8_t, int32_t, uint64_t, float, double>;
@@ -283,20 +280,20 @@ TYPED_TEST(TypedUVectorTest, SetElementZeroAsync)
 
 TEST(NegativeZeroTest, PreservesFloatNegativeZero)
 {
-  rmm::device_uvector<float> vec(1, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_uvector<float> vec(1, rmm::cuda_stream_default);
   float const neg_zero = -0.0f;
-  vec.set_element_async(0, neg_zero, cuda::stream_ref{cudaStream_t{nullptr}});
-  float const result = vec.element(0, cuda::stream_ref{cudaStream_t{nullptr}});
+  vec.set_element_async(0, neg_zero, rmm::cuda_stream_default);
+  float const result = vec.element(0, rmm::cuda_stream_default);
   EXPECT_TRUE(std::signbit(result)) << "sign bit of -0.0f was lost";
   EXPECT_EQ(result, 0.0f);
 }
 
 TEST(NegativeZeroTest, PreservesDoubleNegativeZero)
 {
-  rmm::device_uvector<double> vec(1, cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::device_uvector<double> vec(1, rmm::cuda_stream_default);
   double const neg_zero = -0.0;
-  vec.set_element_async(0, neg_zero, cuda::stream_ref{cudaStream_t{nullptr}});
-  double const result = vec.element(0, cuda::stream_ref{cudaStream_t{nullptr}});
+  vec.set_element_async(0, neg_zero, rmm::cuda_stream_default);
+  double const result = vec.element(0, rmm::cuda_stream_default);
   EXPECT_TRUE(std::signbit(result)) << "sign bit of -0.0 was lost";
   EXPECT_EQ(result, 0.0);
 }
@@ -322,7 +319,7 @@ TYPED_TEST(TypedUVectorTest, SetGetStream)
 
   EXPECT_EQ(vec.stream(), this->stream());
 
-  auto const otherstream = cuda::stream_ref{cudaStreamPerThread};
+  auto const otherstream = rmm::cuda_stream_per_thread;
   vec.set_stream(otherstream);
 
   EXPECT_EQ(vec.stream(), rmm::cuda_stream_view{otherstream});
@@ -422,7 +419,7 @@ TYPED_TEST(TypedUVectorTest, SpanConversionImplicit)
 
 TEST(DeviceUVectorAlignmentTest, SmallAlignment)
 {
-  auto v = rmm::device_uvector<int>(10, cuda::stream_ref{cudaStream_t{nullptr}});
+  auto v = rmm::device_uvector<int>(10, rmm::cuda_stream_default);
   EXPECT_TRUE(rmm::is_pointer_aligned(v.data(), std::alignment_of_v<decltype(v)::value_type>));
 }
 
@@ -432,7 +429,6 @@ TEST(DeviceUVectorAlignmentTest, LargeAlignment)
     int value;
   };
 
-  EXPECT_THROW(
-    std::ignore = rmm::device_uvector<OverAligned>(10, cuda::stream_ref{cudaStream_t{nullptr}}),
-    rmm::bad_alloc);
+  EXPECT_THROW(std::ignore = rmm::device_uvector<OverAligned>(10, rmm::cuda_stream_default),
+               rmm::bad_alloc);
 }

--- a/cpp/tests/mock_resource.hpp
+++ b/cpp/tests/mock_resource.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/memory_resource>
 #include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <gmock/gmock.h>
 
@@ -23,14 +23,14 @@ class mock_resource {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(rmm::cuda_stream_view{}, bytes, alignment);
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
   }
 
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_view{}, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
   }
 
   bool operator==(mock_resource const&) const noexcept { return true; }

--- a/cpp/tests/mock_resource.hpp
+++ b/cpp/tests/mock_resource.hpp
@@ -7,7 +7,7 @@
 #include <rmm/aligned.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <gmock/gmock.h>

--- a/cpp/tests/mock_resource.hpp
+++ b/cpp/tests/mock_resource.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/memory_resource>
 #include <cuda/stream>
@@ -23,14 +24,14 @@ class mock_resource {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+    return allocate(rmm::cuda_stream_default, bytes, alignment);
   }
 
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
   }
 
   bool operator==(mock_resource const&) const noexcept { return true; }

--- a/cpp/tests/mock_resource.hpp
+++ b/cpp/tests/mock_resource.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream>
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <gmock/gmock.h>
 
@@ -23,14 +23,14 @@ class mock_resource {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(rmm::cuda_stream_view{}, bytes, alignment);
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
   }
 
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_view{}, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
   }
 
   bool operator==(mock_resource const&) const noexcept { return true; }

--- a/cpp/tests/mock_resource.hpp
+++ b/cpp/tests/mock_resource.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/memory_resource>
 #include <cuda/stream>
@@ -24,14 +23,14 @@ class mock_resource {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(rmm::cuda_stream_default, bytes, alignment);
+    return allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   }
 
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, bytes, alignment);
   }
 
   bool operator==(mock_resource const&) const noexcept { return true; }

--- a/cpp/tests/mr/aligned_mr_tests.cpp
+++ b/cpp/tests/mr/aligned_mr_tests.cpp
@@ -101,7 +101,7 @@ TEST(AlignedTest, DefaultAllocationAlignmentPassthrough)
   mock_resource_wrapper wrapper{&mock};
   aligned_adaptor mr{device_async_resource_ref{wrapper}};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   void* const pointer = int_to_address(123);
 
   {
@@ -125,7 +125,7 @@ TEST(AlignedTest, BelowAlignmentThresholdPassthrough)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   void* const pointer = int_to_address(123);
   {
     auto const size{3};
@@ -157,7 +157,7 @@ TEST(AlignedTest, UpstreamAddressAlreadyAligned)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   void* const pointer = int_to_address(4096);
 
   {
@@ -181,7 +181,7 @@ TEST(AlignedTest, AlignUpstreamAddress)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   {
     void* const pointer = int_to_address(256);
     auto const size{69376};
@@ -205,7 +205,7 @@ TEST(AlignedTest, AlignMultiple)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
 
   {
     void* const pointer1 = int_to_address(256);

--- a/cpp/tests/mr/aligned_mr_tests.cpp
+++ b/cpp/tests/mr/aligned_mr_tests.cpp
@@ -102,7 +102,7 @@ TEST(AlignedTest, DefaultAllocationAlignmentPassthrough)
   mock_resource_wrapper wrapper{&mock};
   aligned_adaptor mr{device_async_resource_ref{wrapper}};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   void* const pointer = int_to_address(123);
 
   {
@@ -126,7 +126,7 @@ TEST(AlignedTest, BelowAlignmentThresholdPassthrough)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   void* const pointer = int_to_address(123);
   {
     auto const size{3};
@@ -158,7 +158,7 @@ TEST(AlignedTest, UpstreamAddressAlreadyAligned)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   void* const pointer = int_to_address(4096);
 
   {
@@ -182,7 +182,7 @@ TEST(AlignedTest, AlignUpstreamAddress)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
   {
     void* const pointer = int_to_address(256);
     auto const size{69376};
@@ -206,7 +206,7 @@ TEST(AlignedTest, AlignMultiple)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda_stream_view stream;
+  cuda::stream_ref stream{cudaStream_t{nullptr}};
 
   {
     void* const pointer1 = int_to_address(256);

--- a/cpp/tests/mr/aligned_mr_tests.cpp
+++ b/cpp/tests/mr/aligned_mr_tests.cpp
@@ -102,7 +102,7 @@ TEST(AlignedTest, DefaultAllocationAlignmentPassthrough)
   mock_resource_wrapper wrapper{&mock};
   aligned_adaptor mr{device_async_resource_ref{wrapper}};
 
-  cuda::stream_ref stream{cudaStream_t{nullptr}};
+  auto const stream   = rmm::cuda_stream_default;
   void* const pointer = int_to_address(123);
 
   {
@@ -126,7 +126,7 @@ TEST(AlignedTest, BelowAlignmentThresholdPassthrough)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda::stream_ref stream{cudaStream_t{nullptr}};
+  auto const stream   = rmm::cuda_stream_default;
   void* const pointer = int_to_address(123);
   {
     auto const size{3};
@@ -158,7 +158,7 @@ TEST(AlignedTest, UpstreamAddressAlreadyAligned)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda::stream_ref stream{cudaStream_t{nullptr}};
+  auto const stream   = rmm::cuda_stream_default;
   void* const pointer = int_to_address(4096);
 
   {
@@ -182,7 +182,7 @@ TEST(AlignedTest, AlignUpstreamAddress)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda::stream_ref stream{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
   {
     void* const pointer = int_to_address(256);
     auto const size{69376};
@@ -206,7 +206,7 @@ TEST(AlignedTest, AlignMultiple)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  cuda::stream_ref stream{cudaStream_t{nullptr}};
+  auto const stream = rmm::cuda_stream_default;
 
   {
     void* const pointer1 = int_to_address(256);

--- a/cpp/tests/mr/aligned_mr_tests.cpp
+++ b/cpp/tests/mr/aligned_mr_tests.cpp
@@ -12,6 +12,8 @@
 #include <rmm/mr/aligned_resource_adaptor.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 
+#include <cuda/stream>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -102,7 +104,7 @@ TEST(AlignedTest, DefaultAllocationAlignmentPassthrough)
   mock_resource_wrapper wrapper{&mock};
   aligned_adaptor mr{device_async_resource_ref{wrapper}};
 
-  auto const stream   = rmm::cuda_stream_default;
+  auto const stream   = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   void* const pointer = int_to_address(123);
 
   {
@@ -126,7 +128,7 @@ TEST(AlignedTest, BelowAlignmentThresholdPassthrough)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  auto const stream   = rmm::cuda_stream_default;
+  auto const stream   = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   void* const pointer = int_to_address(123);
   {
     auto const size{3};
@@ -158,7 +160,7 @@ TEST(AlignedTest, UpstreamAddressAlreadyAligned)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  auto const stream   = rmm::cuda_stream_default;
+  auto const stream   = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   void* const pointer = int_to_address(4096);
 
   {
@@ -182,7 +184,7 @@ TEST(AlignedTest, AlignUpstreamAddress)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   {
     void* const pointer = int_to_address(256);
     auto const size{69376};
@@ -206,7 +208,7 @@ TEST(AlignedTest, AlignMultiple)
   auto const threshold{65536};
   aligned_adaptor mr{device_async_resource_ref{wrapper}, alignment, threshold};
 
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
 
   {
     void* const pointer1 = int_to_address(256);

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -563,8 +563,8 @@ TEST_F(ArenaTest, Defragment)  // NOLINT
     for (std::size_t i = 0; i < num_threads; ++i) {
       threads.emplace_back(std::thread([&] {
         cuda_stream stream{};
-        void* ptr = mr.allocate(cuda_stream_view{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
-        mr.deallocate(cuda_stream_view{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        void* ptr = mr.allocate(cuda::stream_ref{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        mr.deallocate(cuda::stream_ref{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
       }));
     }
     for (auto& thread : threads) {
@@ -585,28 +585,35 @@ TEST_F(ArenaTest, PerThreadToStreamDealloc)  // NOLINT
   auto const arena_size = superblock::minimum_size * 2;
   arena_mr mr(rmm::mr::get_current_device_resource_ref(), arena_size);
   // Create an allocation from a per thread arena
-  void* thread_ptr = mr.allocate(rmm::cuda_stream_per_thread, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* thread_ptr =
+    mr.allocate(cuda::stream_ref{cudaStreamPerThread}, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // Create an allocation in a stream arena to force global arena
   // to be empty
   cuda_stream stream{};
-  void* ptr = mr.allocate(cuda_stream_view{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  mr.deallocate(cuda_stream_view{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr = mr.allocate(cuda::stream_ref{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(cuda::stream_ref{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // at this point the global arena doesn't have any superblocks so
   // the next allocation causes defrag. Defrag causes all superblocks
   // from the thread and stream arena allocated above to go back to
   // global arena and it allocates one superblock to the stream arena.
-  auto* ptr1 =
-    mr.allocate(rmm::cuda_stream_view{}, superblock::minimum_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr1 = mr.allocate(cuda::stream_ref{cudaStream_t{nullptr}},
+                           superblock::minimum_size,
+                           rmm::CUDA_ALLOCATION_ALIGNMENT);
   // Allocate again to make sure all superblocks from
   // global arena are owned by a stream arena instead of a thread arena
   // or the global arena.
-  auto* ptr2 = mr.allocate(rmm::cuda_stream_view{}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr2 =
+    mr.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // The original thread ptr is now owned by a stream arena so make
   // sure deallocation works.
-  mr.deallocate(rmm::cuda_stream_per_thread, thread_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   mr.deallocate(
-    rmm::cuda_stream_view{}, ptr1, superblock::minimum_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  mr.deallocate(rmm::cuda_stream_view{}, ptr2, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    cuda::stream_ref{cudaStreamPerThread}, thread_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(cuda::stream_ref{cudaStream_t{nullptr}},
+                ptr1,
+                superblock::minimum_size,
+                rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr2, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TEST_F(ArenaTest, DumpLogOnFailure)  // NOLINT

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -564,8 +564,8 @@ TEST_F(ArenaTest, Defragment)  // NOLINT
     for (std::size_t i = 0; i < num_threads; ++i) {
       threads.emplace_back(std::thread([&] {
         cuda_stream stream{};
-        void* ptr = mr.allocate(cuda_stream_view{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
-        mr.deallocate(cuda_stream_view{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        void* ptr = mr.allocate(cuda::stream_ref{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        mr.deallocate(cuda::stream_ref{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
       }));
     }
     for (auto& thread : threads) {
@@ -586,28 +586,35 @@ TEST_F(ArenaTest, PerThreadToStreamDealloc)  // NOLINT
   auto const arena_size = superblock::minimum_size * 2;
   arena_mr mr(rmm::mr::get_current_device_resource_ref(), arena_size);
   // Create an allocation from a per thread arena
-  void* thread_ptr = mr.allocate(rmm::cuda_stream_per_thread, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* thread_ptr =
+    mr.allocate(cuda::stream_ref{cudaStreamPerThread}, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // Create an allocation in a stream arena to force global arena
   // to be empty
   cuda_stream stream{};
-  void* ptr = mr.allocate(cuda_stream_view{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  mr.deallocate(cuda_stream_view{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr = mr.allocate(cuda::stream_ref{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(cuda::stream_ref{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // at this point the global arena doesn't have any superblocks so
   // the next allocation causes defrag. Defrag causes all superblocks
   // from the thread and stream arena allocated above to go back to
   // global arena and it allocates one superblock to the stream arena.
-  auto* ptr1 =
-    mr.allocate(rmm::cuda_stream_view{}, superblock::minimum_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr1 = mr.allocate(cuda::stream_ref{cudaStream_t{nullptr}},
+                           superblock::minimum_size,
+                           rmm::CUDA_ALLOCATION_ALIGNMENT);
   // Allocate again to make sure all superblocks from
   // global arena are owned by a stream arena instead of a thread arena
   // or the global arena.
-  auto* ptr2 = mr.allocate(rmm::cuda_stream_view{}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr2 =
+    mr.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // The original thread ptr is now owned by a stream arena so make
   // sure deallocation works.
-  mr.deallocate(rmm::cuda_stream_per_thread, thread_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   mr.deallocate(
-    rmm::cuda_stream_view{}, ptr1, superblock::minimum_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  mr.deallocate(rmm::cuda_stream_view{}, ptr2, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    cuda::stream_ref{cudaStreamPerThread}, thread_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(cuda::stream_ref{cudaStream_t{nullptr}},
+                ptr1,
+                superblock::minimum_size,
+                rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr2, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TEST_F(ArenaTest, DumpLogOnFailure)  // NOLINT

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -565,8 +565,8 @@ TEST_F(ArenaTest, Defragment)  // NOLINT
     for (std::size_t i = 0; i < num_threads; ++i) {
       threads.emplace_back(std::thread([&] {
         cuda_stream stream{};
-        void* ptr = mr.allocate(cuda::stream_ref{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
-        mr.deallocate(cuda::stream_ref{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        void* ptr = mr.allocate(stream, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+        mr.deallocate(stream, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
       }));
     }
     for (auto& thread : threads) {
@@ -591,8 +591,8 @@ TEST_F(ArenaTest, PerThreadToStreamDealloc)  // NOLINT
   // Create an allocation in a stream arena to force global arena
   // to be empty
   cuda_stream stream{};
-  void* ptr = mr.allocate(cuda::stream_ref{stream}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  mr.deallocate(cuda::stream_ref{stream}, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr = mr.allocate(stream, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(stream, ptr, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // at this point the global arena doesn't have any superblocks so
   // the next allocation causes defrag. Defrag causes all superblocks
   // from the thread and stream arena allocated above to go back to

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -8,6 +8,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -586,8 +587,7 @@ TEST_F(ArenaTest, PerThreadToStreamDealloc)  // NOLINT
   auto const arena_size = superblock::minimum_size * 2;
   arena_mr mr(rmm::mr::get_current_device_resource_ref(), arena_size);
   // Create an allocation from a per thread arena
-  void* thread_ptr =
-    mr.allocate(cuda::stream_ref{cudaStreamPerThread}, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* thread_ptr = mr.allocate(rmm::cuda_stream_per_thread, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // Create an allocation in a stream arena to force global arena
   // to be empty
   cuda_stream stream{};
@@ -597,24 +597,18 @@ TEST_F(ArenaTest, PerThreadToStreamDealloc)  // NOLINT
   // the next allocation causes defrag. Defrag causes all superblocks
   // from the thread and stream arena allocated above to go back to
   // global arena and it allocates one superblock to the stream arena.
-  auto* ptr1 = mr.allocate(cuda::stream_ref{cudaStream_t{nullptr}},
-                           superblock::minimum_size,
-                           rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr1 =
+    mr.allocate(rmm::cuda_stream_default, superblock::minimum_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // Allocate again to make sure all superblocks from
   // global arena are owned by a stream arena instead of a thread arena
   // or the global arena.
-  auto* ptr2 =
-    mr.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr2 = mr.allocate(rmm::cuda_stream_default, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // The original thread ptr is now owned by a stream arena so make
   // sure deallocation works.
+  mr.deallocate(rmm::cuda_stream_per_thread, thread_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   mr.deallocate(
-    cuda::stream_ref{cudaStreamPerThread}, thread_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  mr.deallocate(cuda::stream_ref{cudaStream_t{nullptr}},
-                ptr1,
-                superblock::minimum_size,
-                rmm::CUDA_ALLOCATION_ALIGNMENT);
-  mr.deallocate(
-    cuda::stream_ref{cudaStream_t{nullptr}}, ptr2, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    rmm::cuda_stream_default, ptr1, superblock::minimum_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(rmm::cuda_stream_default, ptr2, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TEST_F(ArenaTest, DumpLogOnFailure)  // NOLINT

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -8,7 +8,6 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -587,7 +586,8 @@ TEST_F(ArenaTest, PerThreadToStreamDealloc)  // NOLINT
   auto const arena_size = superblock::minimum_size * 2;
   arena_mr mr(rmm::mr::get_current_device_resource_ref(), arena_size);
   // Create an allocation from a per thread arena
-  void* thread_ptr = mr.allocate(rmm::cuda_stream_per_thread, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* thread_ptr =
+    mr.allocate(cuda::stream_ref{cudaStreamPerThread}, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // Create an allocation in a stream arena to force global arena
   // to be empty
   cuda_stream stream{};
@@ -597,18 +597,26 @@ TEST_F(ArenaTest, PerThreadToStreamDealloc)  // NOLINT
   // the next allocation causes defrag. Defrag causes all superblocks
   // from the thread and stream arena allocated above to go back to
   // global arena and it allocates one superblock to the stream arena.
-  auto* ptr1 =
-    mr.allocate(rmm::cuda_stream_default, superblock::minimum_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr1 = mr.allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
+                           superblock::minimum_size,
+                           rmm::CUDA_ALLOCATION_ALIGNMENT);
   // Allocate again to make sure all superblocks from
   // global arena are owned by a stream arena instead of a thread arena
   // or the global arena.
-  auto* ptr2 = mr.allocate(rmm::cuda_stream_default, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr2 = mr.allocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
   // The original thread ptr is now owned by a stream arena so make
   // sure deallocation works.
-  mr.deallocate(rmm::cuda_stream_per_thread, thread_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   mr.deallocate(
-    rmm::cuda_stream_default, ptr1, superblock::minimum_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  mr.deallocate(rmm::cuda_stream_default, ptr2, 32_KiB, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    cuda::stream_ref{cudaStreamPerThread}, thread_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
+                ptr1,
+                superblock::minimum_size,
+                rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
+                ptr2,
+                32_KiB,
+                rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TEST_F(ArenaTest, DumpLogOnFailure)  // NOLINT

--- a/cpp/tests/mr/binning_mr_tests.cpp
+++ b/cpp/tests/mr/binning_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -37,7 +37,7 @@ TEST(BinningTest, ZeroByteAllocationsUseBinResource)
   mr.add_bin(1024, device_async_resource_ref{wrapper});
 
   EXPECT_CALL(mock, allocate(::testing::_, 0, rmm::CUDA_ALLOCATION_ALIGNMENT))
-    .Times(2)
+    .Times(1)
     .WillRepeatedly(::testing::Return(nullptr));
   EXPECT_CALL(mock, deallocate(::testing::_, nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT)).Times(2);
 

--- a/cpp/tests/mr/binning_mr_tests.cpp
+++ b/cpp/tests/mr/binning_mr_tests.cpp
@@ -9,6 +9,8 @@
 #include <rmm/mr/binning_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 
+#include <cuda/stream>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -41,8 +43,11 @@ TEST(BinningTest, ZeroByteAllocationsUseBinResource)
     .WillRepeatedly(::testing::Return(nullptr));
   EXPECT_CALL(mock, deallocate(::testing::_, nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT)).Times(2);
 
-  EXPECT_EQ(mr.allocate(rmm::cuda_stream_default, 0, rmm::CUDA_ALLOCATION_ALIGNMENT), nullptr);
-  mr.deallocate(rmm::cuda_stream_default, nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  EXPECT_EQ(mr.allocate(
+              cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, 0, rmm::CUDA_ALLOCATION_ALIGNMENT),
+            nullptr);
+  mr.deallocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_EQ(mr.allocate_sync(0, rmm::CUDA_ALLOCATION_ALIGNMENT), nullptr);
   mr.deallocate_sync(nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }

--- a/cpp/tests/mr/binning_mr_tests.cpp
+++ b/cpp/tests/mr/binning_mr_tests.cpp
@@ -41,8 +41,8 @@ TEST(BinningTest, ZeroByteAllocationsUseBinResource)
     .WillRepeatedly(::testing::Return(nullptr));
   EXPECT_CALL(mock, deallocate(::testing::_, nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT)).Times(2);
 
-  EXPECT_EQ(mr.allocate(cuda_stream_view{}, 0, rmm::CUDA_ALLOCATION_ALIGNMENT), nullptr);
-  mr.deallocate(cuda_stream_view{}, nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  EXPECT_EQ(mr.allocate(rmm::cuda_stream_default, 0, rmm::CUDA_ALLOCATION_ALIGNMENT), nullptr);
+  mr.deallocate(rmm::cuda_stream_default, nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_EQ(mr.allocate_sync(0, rmm::CUDA_ALLOCATION_ALIGNMENT), nullptr);
   mr.deallocate_sync(nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }

--- a/cpp/tests/mr/callback_mr_tests.cpp
+++ b/cpp/tests/mr/callback_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,6 @@
 #include "../mock_resource.hpp"
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/callback_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -32,11 +31,11 @@ TEST(CallbackTest, TestCallbacksAreInvoked)
   EXPECT_CALL(base_mr, allocate(_, 10_MiB, _)).Times(1);
   EXPECT_CALL(base_mr, deallocate(_, _, 10_MiB, _)).Times(1);
 
-  auto allocate_callback = [](std::size_t size, cuda_stream_view stream, void* arg) {
+  auto allocate_callback = [](std::size_t size, cuda::stream_ref stream, void* arg) {
     auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
     return base_mr.allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   };
-  auto deallocate_callback = [](void* ptr, std::size_t size, cuda_stream_view stream, void* arg) {
+  auto deallocate_callback = [](void* ptr, std::size_t size, cuda::stream_ref stream, void* arg) {
     auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
     base_mr.deallocate(stream, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   };
@@ -52,13 +51,13 @@ TEST(CallbackTest, LoggingTest)
   testing::internal::CaptureStdout();
 
   auto base_mr           = rmm::mr::get_current_device_resource_ref();
-  auto allocate_callback = [](std::size_t size, cuda_stream_view stream, void* arg) {
+  auto allocate_callback = [](std::size_t size, cuda::stream_ref stream, void* arg) {
     std::cout << "Allocating " << size << " bytes" << std::endl;
     auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
     return base_mr.allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   };
 
-  auto deallocate_callback = [](void* ptr, std::size_t size, cuda_stream_view stream, void* arg) {
+  auto deallocate_callback = [](void* ptr, std::size_t size, cuda::stream_ref stream, void* arg) {
     std::cout << "Deallocating " << size << " bytes" << std::endl;
     auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
     base_mr.deallocate(stream, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);

--- a/cpp/tests/mr/cccl_adaptor_tests.cpp
+++ b/cpp/tests/mr/cccl_adaptor_tests.cpp
@@ -182,11 +182,11 @@ TEST(CallbackMRAdaptorTest, EqualityAndSharedOwnership)
   cuda_mr cuda{};
   rmm::device_async_resource_ref upstream{cuda};
 
-  auto alloc_cb = [](std::size_t bytes, rmm::cuda_stream_view stream, void* arg) {
+  auto alloc_cb = [](std::size_t bytes, cuda::stream_ref stream, void* arg) {
     return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(
       stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
   };
-  auto dealloc_cb = [](void* ptr, std::size_t bytes, rmm::cuda_stream_view stream, void* arg) {
+  auto dealloc_cb = [](void* ptr, std::size_t bytes, cuda::stream_ref stream, void* arg) {
     static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(
       stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
   };

--- a/cpp/tests/mr/cccl_mr_ref_test_allocation.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_allocation.hpp
@@ -25,7 +25,7 @@ TYPED_TEST_P(CcclMrRefAllocationTest, AllocateDefault) { test_various_allocation
 
 TYPED_TEST_P(CcclMrRefAllocationTest, AllocateDefaultStream)
 {
-  test_various_async_allocations(this->ref, cuda_stream_view{});
+  test_various_async_allocations(this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, AllocateOnStream)
@@ -38,7 +38,7 @@ TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocations) { test_random_allocatio
 TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocationsDefaultStream)
 {
   test_random_async_allocations(
-    this->ref, default_num_allocations, default_max_size, cuda_stream_view{});
+    this->ref, default_num_allocations, default_max_size, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocationsStream)
@@ -53,7 +53,8 @@ TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFree)
 
 TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFreeDefaultStream)
 {
-  test_mixed_random_async_allocation_free(this->ref, default_max_size, cuda_stream_view{});
+  test_mixed_random_async_allocation_free(
+    this->ref, default_max_size, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFreeStream)

--- a/cpp/tests/mr/cccl_mr_ref_test_allocation.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_allocation.hpp
@@ -7,6 +7,8 @@
 
 #include "mr_ref_test.hpp"
 
+#include <rmm/cuda_stream_view.hpp>
+
 namespace rmm::test {
 
 /**
@@ -25,7 +27,7 @@ TYPED_TEST_P(CcclMrRefAllocationTest, AllocateDefault) { test_various_allocation
 
 TYPED_TEST_P(CcclMrRefAllocationTest, AllocateDefaultStream)
 {
-  test_various_async_allocations(this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
+  test_various_async_allocations(this->ref, rmm::cuda_stream_default);
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, AllocateOnStream)
@@ -38,7 +40,7 @@ TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocations) { test_random_allocatio
 TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocationsDefaultStream)
 {
   test_random_async_allocations(
-    this->ref, default_num_allocations, default_max_size, cuda::stream_ref{cudaStream_t{nullptr}});
+    this->ref, default_num_allocations, default_max_size, rmm::cuda_stream_default);
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocationsStream)
@@ -53,8 +55,7 @@ TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFree)
 
 TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFreeDefaultStream)
 {
-  test_mixed_random_async_allocation_free(
-    this->ref, default_max_size, cuda::stream_ref{cudaStream_t{nullptr}});
+  test_mixed_random_async_allocation_free(this->ref, default_max_size, rmm::cuda_stream_default);
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFreeStream)

--- a/cpp/tests/mr/cccl_mr_ref_test_allocation.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_allocation.hpp
@@ -7,7 +7,7 @@
 
 #include "mr_ref_test.hpp"
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace rmm::test {
 
@@ -27,7 +27,7 @@ TYPED_TEST_P(CcclMrRefAllocationTest, AllocateDefault) { test_various_allocation
 
 TYPED_TEST_P(CcclMrRefAllocationTest, AllocateDefaultStream)
 {
-  test_various_async_allocations(this->ref, rmm::cuda_stream_default);
+  test_various_async_allocations(this->ref, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, AllocateOnStream)
@@ -39,8 +39,10 @@ TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocations) { test_random_allocatio
 
 TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocationsDefaultStream)
 {
-  test_random_async_allocations(
-    this->ref, default_num_allocations, default_max_size, rmm::cuda_stream_default);
+  test_random_async_allocations(this->ref,
+                                default_num_allocations,
+                                default_max_size,
+                                cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, RandomAllocationsStream)
@@ -55,7 +57,8 @@ TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFree)
 
 TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFreeDefaultStream)
 {
-  test_mixed_random_async_allocation_free(this->ref, default_max_size, rmm::cuda_stream_default);
+  test_mixed_random_async_allocation_free(
+    this->ref, default_max_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TYPED_TEST_P(CcclMrRefAllocationTest, MixedRandomAllocationFreeStream)

--- a/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
@@ -27,22 +27,28 @@ TYPED_TEST_P(CcclMrRefTest, SetCurrentDeviceResourceRef)
   auto old = rmm::mr::set_current_device_resource(this->ref);
 
   constexpr std::size_t size{100};
-  void* ptr = old.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr =
+    old.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  old.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  old.deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   auto current = rmm::mr::get_current_device_resource_ref();
-  ptr          = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr =
+    current.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   test_get_current_device_resource_ref();
 
   rmm::mr::reset_current_device_resource();
   current = rmm::mr::get_current_device_resource_ref();
-  ptr     = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr =
+    current.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TYPED_TEST_P(CcclMrRefTest, SelfEquality) { EXPECT_TRUE(this->ref == this->ref); }
@@ -55,7 +61,7 @@ TYPED_TEST_P(CcclMrRefTest, AllocationsAreDifferent)
 
 TYPED_TEST_P(CcclMrRefTest, AsyncAllocationsAreDifferentDefaultStream)
 {
-  concurrent_async_allocations_are_different(this->ref, cuda_stream_view{});
+  concurrent_async_allocations_are_different(this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TYPED_TEST_P(CcclMrRefTest, AsyncAllocationsAreDifferent)

--- a/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
@@ -7,6 +7,8 @@
 
 #include "mr_ref_test.hpp"
 
+#include <rmm/cuda_stream_view.hpp>
+
 namespace rmm::test {
 
 /**
@@ -27,28 +29,22 @@ TYPED_TEST_P(CcclMrRefTest, SetCurrentDeviceResourceRef)
   auto old = rmm::mr::set_current_device_resource(this->ref);
 
   constexpr std::size_t size{100};
-  void* ptr =
-    old.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr = old.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  old.deallocate(
-    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  old.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   auto current = rmm::mr::get_current_device_resource_ref();
-  ptr =
-    current.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr          = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(
-    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   test_get_current_device_resource_ref();
 
   rmm::mr::reset_current_device_resource();
   current = rmm::mr::get_current_device_resource_ref();
-  ptr =
-    current.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr     = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(
-    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TYPED_TEST_P(CcclMrRefTest, SelfEquality) { EXPECT_TRUE(this->ref == this->ref); }
@@ -61,7 +57,7 @@ TYPED_TEST_P(CcclMrRefTest, AllocationsAreDifferent)
 
 TYPED_TEST_P(CcclMrRefTest, AsyncAllocationsAreDifferentDefaultStream)
 {
-  concurrent_async_allocations_are_different(this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
+  concurrent_async_allocations_are_different(this->ref, rmm::cuda_stream_default);
 }
 
 TYPED_TEST_P(CcclMrRefTest, AsyncAllocationsAreDifferent)

--- a/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_basic.hpp
@@ -7,7 +7,7 @@
 
 #include "mr_ref_test.hpp"
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace rmm::test {
 
@@ -29,22 +29,28 @@ TYPED_TEST_P(CcclMrRefTest, SetCurrentDeviceResourceRef)
   auto old = rmm::mr::set_current_device_resource(this->ref);
 
   constexpr std::size_t size{100};
-  void* ptr = old.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr = old.allocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  old.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  old.deallocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   auto current = rmm::mr::get_current_device_resource_ref();
-  ptr          = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr          = current.allocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   test_get_current_device_resource_ref();
 
   rmm::mr::reset_current_device_resource();
   current = rmm::mr::get_current_device_resource_ref();
-  ptr     = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr     = current.allocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TYPED_TEST_P(CcclMrRefTest, SelfEquality) { EXPECT_TRUE(this->ref == this->ref); }
@@ -57,7 +63,8 @@ TYPED_TEST_P(CcclMrRefTest, AllocationsAreDifferent)
 
 TYPED_TEST_P(CcclMrRefTest, AsyncAllocationsAreDifferentDefaultStream)
 {
-  concurrent_async_allocations_are_different(this->ref, rmm::cuda_stream_default);
+  concurrent_async_allocations_are_different(this->ref,
+                                             cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TYPED_TEST_P(CcclMrRefTest, AsyncAllocationsAreDifferent)

--- a/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
@@ -82,12 +82,12 @@ TYPED_TEST_P(CcclMrRefTestMT, Allocate)
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocateDefaultStream)
 {
-  spawn(test_various_async_allocations, this->ref, rmm::cuda_stream_view{});
+  spawn(test_various_async_allocations, this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocateOnStream)
 {
-  spawn(test_various_async_allocations, this->ref, this->stream.view());
+  spawn(test_various_async_allocations, this->ref, cuda::stream_ref{this->stream});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, RandomAllocations)
@@ -101,7 +101,7 @@ TYPED_TEST_P(CcclMrRefTestMT, RandomAllocationsDefaultStream)
         this->ref,
         default_num_allocations,
         default_max_size,
-        rmm::cuda_stream_view{});
+        cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, RandomAllocationsStream)
@@ -110,7 +110,7 @@ TYPED_TEST_P(CcclMrRefTestMT, RandomAllocationsStream)
         this->ref,
         default_num_allocations,
         default_max_size,
-        this->stream.view());
+        cuda::stream_ref{this->stream});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFree)
@@ -120,36 +120,43 @@ TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFree)
 
 TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFreeDefaultStream)
 {
-  spawn(
-    test_mixed_random_async_allocation_free, this->ref, default_max_size, rmm::cuda_stream_view{});
+  spawn(test_mixed_random_async_allocation_free,
+        this->ref,
+        default_max_size,
+        cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFreeStream)
 {
-  spawn(test_mixed_random_async_allocation_free, this->ref, default_max_size, this->stream.view());
+  spawn(test_mixed_random_async_allocation_free,
+        this->ref,
+        default_max_size,
+        cuda::stream_ref{this->stream});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, rmm::cuda_stream_default, rmm::cuda_stream_default);
+    this->ref, cuda::stream_ref{cudaStream_t{nullptr}}, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsPerThreadDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, rmm::cuda_stream_per_thread, rmm::cuda_stream_per_thread);
+    this->ref, cuda::stream_ref{cudaStreamPerThread}, cuda::stream_ref{cudaStreamPerThread});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsSameStream)
 {
-  test_async_allocate_free_different_threads(this->ref, this->stream, this->stream);
+  test_async_allocate_free_different_threads(
+    this->ref, cuda::stream_ref{this->stream}, cuda::stream_ref{this->stream});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsDifferentStream)
 {
   rmm::cuda_stream stream_b;
-  test_async_allocate_free_different_threads(this->ref, this->stream, stream_b);
+  test_async_allocate_free_different_threads(
+    this->ref, cuda::stream_ref{this->stream}, cuda::stream_ref{stream_b});
   stream_b.synchronize();
 }
 

--- a/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
@@ -148,15 +148,13 @@ TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsPerThreadDefaultStream)
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsSameStream)
 {
-  test_async_allocate_free_different_threads(
-    this->ref, cuda::stream_ref{this->stream}, cuda::stream_ref{this->stream});
+  test_async_allocate_free_different_threads(this->ref, this->stream, this->stream);
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsDifferentStream)
 {
   rmm::cuda_stream stream_b;
-  test_async_allocate_free_different_threads(
-    this->ref, cuda::stream_ref{this->stream}, cuda::stream_ref{stream_b});
+  test_async_allocate_free_different_threads(this->ref, this->stream, stream_b);
   stream_b.synchronize();
 }
 

--- a/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
@@ -7,6 +7,8 @@
 
 #include "mr_ref_test_mt_helpers.hpp"
 
+#include <rmm/cuda_stream_view.hpp>
+
 namespace rmm::test {
 
 /**
@@ -82,7 +84,7 @@ TYPED_TEST_P(CcclMrRefTestMT, Allocate)
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocateDefaultStream)
 {
-  spawn(test_various_async_allocations, this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
+  spawn(test_various_async_allocations, this->ref, rmm::cuda_stream_default);
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocateOnStream)
@@ -101,7 +103,7 @@ TYPED_TEST_P(CcclMrRefTestMT, RandomAllocationsDefaultStream)
         this->ref,
         default_num_allocations,
         default_max_size,
-        cuda::stream_ref{cudaStream_t{nullptr}});
+        rmm::cuda_stream_default);
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, RandomAllocationsStream)
@@ -120,10 +122,8 @@ TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFree)
 
 TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFreeDefaultStream)
 {
-  spawn(test_mixed_random_async_allocation_free,
-        this->ref,
-        default_max_size,
-        cuda::stream_ref{cudaStream_t{nullptr}});
+  spawn(
+    test_mixed_random_async_allocation_free, this->ref, default_max_size, rmm::cuda_stream_default);
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFreeStream)
@@ -137,13 +137,13 @@ TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFreeStream)
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, cuda::stream_ref{cudaStream_t{nullptr}}, cuda::stream_ref{cudaStream_t{nullptr}});
+    this->ref, rmm::cuda_stream_default, rmm::cuda_stream_default);
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsPerThreadDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, cuda::stream_ref{cudaStreamPerThread}, cuda::stream_ref{cudaStreamPerThread});
+    this->ref, rmm::cuda_stream_per_thread, rmm::cuda_stream_per_thread);
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsSameStream)

--- a/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/cccl_mr_ref_test_mt.hpp
@@ -7,7 +7,7 @@
 
 #include "mr_ref_test_mt_helpers.hpp"
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace rmm::test {
 
@@ -84,7 +84,8 @@ TYPED_TEST_P(CcclMrRefTestMT, Allocate)
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocateDefaultStream)
 {
-  spawn(test_various_async_allocations, this->ref, rmm::cuda_stream_default);
+  spawn(
+    test_various_async_allocations, this->ref, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocateOnStream)
@@ -103,7 +104,7 @@ TYPED_TEST_P(CcclMrRefTestMT, RandomAllocationsDefaultStream)
         this->ref,
         default_num_allocations,
         default_max_size,
-        rmm::cuda_stream_default);
+        cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, RandomAllocationsStream)
@@ -122,8 +123,10 @@ TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFree)
 
 TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFreeDefaultStream)
 {
-  spawn(
-    test_mixed_random_async_allocation_free, this->ref, default_max_size, rmm::cuda_stream_default);
+  spawn(test_mixed_random_async_allocation_free,
+        this->ref,
+        default_max_size,
+        cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFreeStream)
@@ -136,14 +139,15 @@ TYPED_TEST_P(CcclMrRefTestMT, MixedRandomAllocationFreeStream)
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsDefaultStream)
 {
-  test_async_allocate_free_different_threads(
-    this->ref, rmm::cuda_stream_default, rmm::cuda_stream_default);
+  test_async_allocate_free_different_threads(this->ref,
+                                             cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
+                                             cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsPerThreadDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, rmm::cuda_stream_per_thread, rmm::cuda_stream_per_thread);
+    this->ref, cuda::stream_ref{cudaStreamPerThread}, cuda::stream_ref{cudaStreamPerThread});
 }
 
 TYPED_TEST_P(CcclMrRefTestMT, AllocFreeDifferentThreadsSameStream)

--- a/cpp/tests/mr/delayed_memory_resource.hpp
+++ b/cpp/tests/mr/delayed_memory_resource.hpp
@@ -1,14 +1,14 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream>
 
 #include <chrono>
 #include <cstddef>
@@ -39,11 +39,11 @@ class delayed_memory_resource {
     upstream_.deallocate_sync(ptr, bytes, alignment);
     std::this_thread::sleep_for(delay_);
   }
-  void* allocate(rmm::cuda_stream_view stream, std::size_t bytes, std::size_t alignment)
+  void* allocate(cuda::stream_ref stream, std::size_t bytes, std::size_t alignment)
   {
     return upstream_.allocate(stream, bytes, alignment);
   }
-  void deallocate(rmm::cuda_stream_view stream, void* ptr, std::size_t bytes, std::size_t alignment)
+  void deallocate(cuda::stream_ref stream, void* ptr, std::size_t bytes, std::size_t alignment)
   {
     upstream_.deallocate(stream, ptr, bytes, alignment);
     std::this_thread::sleep_for(delay_);

--- a/cpp/tests/mr/failure_callback_mr_tests.cpp
+++ b/cpp/tests/mr/failure_callback_mr_tests.cpp
@@ -51,13 +51,13 @@ class always_throw_memory_resource final {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(rmm::cuda_stream_view{}, bytes, alignment);
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
   }
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_view{}, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
   }
 
   bool operator==(always_throw_memory_resource const&) const noexcept { return true; }

--- a/cpp/tests/mr/failure_callback_mr_tests.cpp
+++ b/cpp/tests/mr/failure_callback_mr_tests.cpp
@@ -55,13 +55,13 @@ class always_throw_memory_resource final {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+    return allocate(rmm::cuda_stream_default, bytes, alignment);
   }
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
   }
 
   bool operator==(always_throw_memory_resource const&) const noexcept { return true; }

--- a/cpp/tests/mr/failure_callback_mr_tests.cpp
+++ b/cpp/tests/mr/failure_callback_mr_tests.cpp
@@ -55,13 +55,13 @@ class always_throw_memory_resource final {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(rmm::cuda_stream_view{}, bytes, alignment);
+    return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
   }
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_view{}, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
   }
 
   bool operator==(always_throw_memory_resource const&) const noexcept { return true; }

--- a/cpp/tests/mr/failure_callback_mr_tests.cpp
+++ b/cpp/tests/mr/failure_callback_mr_tests.cpp
@@ -7,7 +7,6 @@
 #include "../mock_resource.hpp"
 
 #include <rmm/aligned.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/failure_callback_resource_adaptor.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -55,13 +54,13 @@ class always_throw_memory_resource final {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
-    return allocate(rmm::cuda_stream_default, bytes, alignment);
+    return allocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, bytes, alignment);
   }
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
                        std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
   {
-    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, bytes, alignment);
   }
 
   bool operator==(always_throw_memory_resource const&) const noexcept { return true; }
@@ -89,7 +88,7 @@ TEST(FailureCallbackTest, ForwardsAlignment)
   bool retried{false};
   failure_callback_adaptor<> mr{device_async_resource_ref{wrapper}, failure_handler, &retried};
 
-  auto const stream = rmm::cuda_stream_default;
+  auto const stream = cuda::stream_ref{cudaStream_t{cudaStreamDefault}};
   std::byte pointer_value{};
   void* const pointer = &pointer_value;
   auto const size{1024};

--- a/cpp/tests/mr/failure_callback_mr_tests.cpp
+++ b/cpp/tests/mr/failure_callback_mr_tests.cpp
@@ -89,7 +89,7 @@ TEST(FailureCallbackTest, ForwardsAlignment)
   bool retried{false};
   failure_callback_adaptor<> mr{device_async_resource_ref{wrapper}, failure_handler, &retried};
 
-  cuda_stream_view stream;
+  auto const stream = rmm::cuda_stream_default;
   std::byte pointer_value{};
   void* const pointer = &pointer_value;
   auto const size{1024};

--- a/cpp/tests/mr/mr_ref_callback_tests.cpp
+++ b/cpp/tests/mr/mr_ref_callback_tests.cpp
@@ -18,11 +18,11 @@ struct CallbackMRFixture : public ::testing::Test {
   rmm::device_async_resource_ref upstream{cuda};
 
   rmm::mr::callback_memory_resource mr{
-    [](std::size_t bytes, rmm::cuda_stream_view stream, void* arg) {
+    [](std::size_t bytes, cuda::stream_ref stream, void* arg) {
       return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(
         stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
     },
-    [](void* ptr, std::size_t bytes, rmm::cuda_stream_view stream, void* arg) {
+    [](void* ptr, std::size_t bytes, cuda::stream_ref stream, void* arg) {
       static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(
         stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
     },

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -11,7 +11,6 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/binning_memory_resource.hpp>
@@ -24,6 +23,8 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/system_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <gtest/gtest.h>
 
@@ -116,16 +117,16 @@ inline void test_allocate(resource_ref ref, std::size_t bytes)
 
 inline void test_async_allocate(rmm::device_async_resource_ref ref,
                                 std::size_t bytes,
-                                cuda_stream_view stream = {})
+                                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}})
 {
   try {
     void* ptr = ref.allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    if (not stream.is_default()) { stream.synchronize(); }
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     EXPECT_NE(nullptr, ptr);
     EXPECT_TRUE(is_properly_aligned(ptr));
     EXPECT_TRUE(is_device_accessible_memory(ptr));
     ref.deallocate(stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    if (not stream.is_default()) { stream.synchronize(); }
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   } catch (rmm::out_of_memory const& e) {
     EXPECT_NE(std::string{e.what()}.find("out_of_memory"), std::string::npos);
   }
@@ -145,7 +146,7 @@ inline void concurrent_allocations_are_different(resource_ref ref)
 }
 
 inline void concurrent_async_allocations_are_different(rmm::device_async_resource_ref ref,
-                                                       cuda_stream_view stream)
+                                                       cuda::stream_ref stream)
 {
   const auto size{8_B};
   void* ptr1 = ref.allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -187,14 +188,14 @@ inline void test_various_allocations(resource_ref ref)
 }
 
 inline void test_various_async_allocations(rmm::device_async_resource_ref ref,
-                                           cuda_stream_view stream)
+                                           cuda::stream_ref stream)
 {
   // test allocating zero bytes on non-default stream
   {
     void* ptr = ref.allocate(stream, 0, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    stream.synchronize();
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     EXPECT_NO_THROW(ref.deallocate(stream, ptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT));
-    stream.synchronize();
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   }
 
   test_async_allocate(ref, 4_B, stream);
@@ -244,7 +245,8 @@ inline void test_random_allocations(resource_ref ref,
 inline void test_random_async_allocations(rmm::device_async_resource_ref ref,
                                           std::size_t num_allocations = default_num_allocations,
                                           size_in_bytes max_size      = default_max_size,
-                                          cuda_stream_view stream     = {})
+                                          cuda::stream_ref stream     = cuda::stream_ref{
+                                            cudaStream_t{nullptr}})
 {
   std::vector<allocation> allocations(num_allocations);
 
@@ -258,14 +260,14 @@ inline void test_random_async_allocations(rmm::device_async_resource_ref ref,
     [&generator, &distribution, &ref, stream](allocation& alloc) {
       alloc.size = distribution(generator);
       EXPECT_NO_THROW(alloc.ptr = ref.allocate_sync(alloc.size, rmm::CUDA_ALLOCATION_ALIGNMENT));
-      if (not stream.is_default()) { stream.synchronize(); }
+      RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
       EXPECT_NE(nullptr, alloc.ptr);
       EXPECT_TRUE(is_properly_aligned(alloc.ptr));
     });
 
   std::for_each(allocations.begin(), allocations.end(), [stream, &ref](allocation& alloc) {
     EXPECT_NO_THROW(ref.deallocate_sync(alloc.ptr, alloc.size, rmm::CUDA_ALLOCATION_ALIGNMENT));
-    if (not stream.is_default()) { stream.synchronize(); }
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   });
 }
 
@@ -320,7 +322,8 @@ inline void test_mixed_random_allocation_free(resource_ref ref,
 
 inline void test_mixed_random_async_allocation_free(rmm::device_async_resource_ref ref,
                                                     size_in_bytes max_size  = default_max_size,
-                                                    cuda_stream_view stream = {})
+                                                    cuda::stream_ref stream = cuda::stream_ref{
+                                                      cudaStream_t{nullptr}})
 {
   std::default_random_engine generator;
   constexpr std::size_t num_allocations{100};

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -247,8 +247,7 @@ inline void test_random_allocations(resource_ref ref,
 inline void test_random_async_allocations(rmm::device_async_resource_ref ref,
                                           std::size_t num_allocations = default_num_allocations,
                                           size_in_bytes max_size      = default_max_size,
-                                          cuda::stream_ref stream     = cuda::stream_ref{
-                                            cudaStream_t{nullptr}})
+                                          cuda::stream_ref stream     = rmm::cuda_stream_default)
 {
   std::vector<allocation> allocations(num_allocations);
 
@@ -322,10 +321,10 @@ inline void test_mixed_random_allocation_free(resource_ref ref,
   EXPECT_EQ(allocations.size(), active_allocations);
 }
 
-inline void test_mixed_random_async_allocation_free(rmm::device_async_resource_ref ref,
-                                                    size_in_bytes max_size  = default_max_size,
-                                                    cuda::stream_ref stream = cuda::stream_ref{
-                                                      cudaStream_t{nullptr}})
+inline void test_mixed_random_async_allocation_free(
+  rmm::device_async_resource_ref ref,
+  size_in_bytes max_size  = default_max_size,
+  cuda::stream_ref stream = rmm::cuda_stream_default)
 {
   std::default_random_engine generator;
   constexpr std::size_t num_allocations{100};

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -11,7 +11,6 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
@@ -25,6 +24,8 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/system_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <gtest/gtest.h>
 
@@ -117,16 +118,16 @@ inline void test_allocate(resource_ref ref, std::size_t bytes)
 
 inline void test_async_allocate(rmm::device_async_resource_ref ref,
                                 std::size_t bytes,
-                                cuda_stream_view stream = {})
+                                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}})
 {
   try {
     void* ptr = ref.allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    if (not stream.is_default()) { stream.synchronize(); }
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     EXPECT_NE(nullptr, ptr);
     EXPECT_TRUE(is_properly_aligned(ptr));
     EXPECT_TRUE(is_device_accessible_memory(ptr));
     ref.deallocate(stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    if (not stream.is_default()) { stream.synchronize(); }
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   } catch (rmm::out_of_memory const& e) {
     EXPECT_NE(std::string{e.what()}.find("out_of_memory"), std::string::npos);
   }
@@ -146,7 +147,7 @@ inline void concurrent_allocations_are_different(resource_ref ref)
 }
 
 inline void concurrent_async_allocations_are_different(rmm::device_async_resource_ref ref,
-                                                       cuda_stream_view stream)
+                                                       cuda::stream_ref stream)
 {
   const auto size{8_B};
   void* ptr1 = ref.allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -188,14 +189,14 @@ inline void test_various_allocations(resource_ref ref)
 }
 
 inline void test_various_async_allocations(rmm::device_async_resource_ref ref,
-                                           cuda_stream_view stream)
+                                           cuda::stream_ref stream)
 {
   // test allocating zero bytes on non-default stream
   {
     void* ptr = ref.allocate(stream, 0, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    stream.synchronize();
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
     EXPECT_NO_THROW(ref.deallocate(stream, ptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT));
-    stream.synchronize();
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   }
 
   test_async_allocate(ref, 4_B, stream);
@@ -245,7 +246,8 @@ inline void test_random_allocations(resource_ref ref,
 inline void test_random_async_allocations(rmm::device_async_resource_ref ref,
                                           std::size_t num_allocations = default_num_allocations,
                                           size_in_bytes max_size      = default_max_size,
-                                          cuda_stream_view stream     = {})
+                                          cuda::stream_ref stream     = cuda::stream_ref{
+                                            cudaStream_t{nullptr}})
 {
   std::vector<allocation> allocations(num_allocations);
 
@@ -259,14 +261,14 @@ inline void test_random_async_allocations(rmm::device_async_resource_ref ref,
     [&generator, &distribution, &ref, stream](allocation& alloc) {
       alloc.size = distribution(generator);
       EXPECT_NO_THROW(alloc.ptr = ref.allocate(stream, alloc.size, rmm::CUDA_ALLOCATION_ALIGNMENT));
-      if (not stream.is_default()) { stream.synchronize(); }
+      RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
       EXPECT_NE(nullptr, alloc.ptr);
       EXPECT_TRUE(is_properly_aligned(alloc.ptr));
     });
 
   std::for_each(allocations.begin(), allocations.end(), [stream, &ref](allocation& alloc) {
     EXPECT_NO_THROW(ref.deallocate(stream, alloc.ptr, alloc.size, rmm::CUDA_ALLOCATION_ALIGNMENT));
-    if (not stream.is_default()) { stream.synchronize(); }
+    RMM_CUDA_TRY(cudaStreamSynchronize(stream.get()));
   });
 }
 
@@ -321,7 +323,8 @@ inline void test_mixed_random_allocation_free(resource_ref ref,
 
 inline void test_mixed_random_async_allocation_free(rmm::device_async_resource_ref ref,
                                                     size_in_bytes max_size  = default_max_size,
-                                                    cuda_stream_view stream = {})
+                                                    cuda::stream_ref stream = cuda::stream_ref{
+                                                      cudaStream_t{nullptr}})
 {
   std::default_random_engine generator;
   constexpr std::size_t num_allocations{100};

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -11,6 +11,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
@@ -118,7 +119,7 @@ inline void test_allocate(resource_ref ref, std::size_t bytes)
 
 inline void test_async_allocate(rmm::device_async_resource_ref ref,
                                 std::size_t bytes,
-                                cuda::stream_ref stream = cuda::stream_ref{cudaStream_t{nullptr}})
+                                cuda::stream_ref stream = rmm::cuda_stream_default)
 {
   try {
     void* ptr = ref.allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -25,7 +25,7 @@
 #include <rmm/mr/system_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -11,7 +11,6 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
@@ -119,7 +118,8 @@ inline void test_allocate(resource_ref ref, std::size_t bytes)
 
 inline void test_async_allocate(rmm::device_async_resource_ref ref,
                                 std::size_t bytes,
-                                cuda::stream_ref stream = rmm::cuda_stream_default)
+                                cuda::stream_ref stream = cuda::stream_ref{
+                                  cudaStream_t{cudaStreamDefault}})
 {
   try {
     void* ptr = ref.allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -247,7 +247,8 @@ inline void test_random_allocations(resource_ref ref,
 inline void test_random_async_allocations(rmm::device_async_resource_ref ref,
                                           std::size_t num_allocations = default_num_allocations,
                                           size_in_bytes max_size      = default_max_size,
-                                          cuda::stream_ref stream     = rmm::cuda_stream_default)
+                                          cuda::stream_ref stream     = cuda::stream_ref{
+                                            cudaStream_t{cudaStreamDefault}})
 {
   std::vector<allocation> allocations(num_allocations);
 
@@ -321,10 +322,10 @@ inline void test_mixed_random_allocation_free(resource_ref ref,
   EXPECT_EQ(allocations.size(), active_allocations);
 }
 
-inline void test_mixed_random_async_allocation_free(
-  rmm::device_async_resource_ref ref,
-  size_in_bytes max_size  = default_max_size,
-  cuda::stream_ref stream = rmm::cuda_stream_default)
+inline void test_mixed_random_async_allocation_free(rmm::device_async_resource_ref ref,
+                                                    size_in_bytes max_size  = default_max_size,
+                                                    cuda::stream_ref stream = cuda::stream_ref{
+                                                      cudaStream_t{cudaStreamDefault}})
 {
   std::default_random_engine generator;
   constexpr std::size_t num_allocations{100};

--- a/cpp/tests/mr/mr_ref_test_allocation.hpp
+++ b/cpp/tests/mr/mr_ref_test_allocation.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@ TEST_P(mr_ref_allocation_test, AllocateDefault) { test_various_allocations(this-
 
 TEST_P(mr_ref_allocation_test, AllocateDefaultStream)
 {
-  test_various_async_allocations(this->ref, cuda_stream_view{});
+  test_various_async_allocations(this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TEST_P(mr_ref_allocation_test, AllocateOnStream)
@@ -28,7 +28,7 @@ TEST_P(mr_ref_allocation_test, RandomAllocations) { test_random_allocations(this
 TEST_P(mr_ref_allocation_test, RandomAllocationsDefaultStream)
 {
   test_random_async_allocations(
-    this->ref, default_num_allocations, default_max_size, cuda_stream_view{});
+    this->ref, default_num_allocations, default_max_size, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TEST_P(mr_ref_allocation_test, RandomAllocationsStream)
@@ -43,7 +43,8 @@ TEST_P(mr_ref_allocation_test, MixedRandomAllocationFree)
 
 TEST_P(mr_ref_allocation_test, MixedRandomAllocationFreeDefaultStream)
 {
-  test_mixed_random_async_allocation_free(this->ref, default_max_size, cuda_stream_view{});
+  test_mixed_random_async_allocation_free(
+    this->ref, default_max_size, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TEST_P(mr_ref_allocation_test, MixedRandomAllocationFreeStream)

--- a/cpp/tests/mr/mr_ref_test_allocation.hpp
+++ b/cpp/tests/mr/mr_ref_test_allocation.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/mr_ref_test_allocation.hpp
+++ b/cpp/tests/mr/mr_ref_test_allocation.hpp
@@ -7,6 +7,8 @@
 
 #include "mr_ref_test.hpp"
 
+#include <rmm/cuda_stream_view.hpp>
+
 namespace rmm::test {
 
 // Parameterized test definitions for mr_ref_allocation_test
@@ -15,7 +17,7 @@ TEST_P(mr_ref_allocation_test, AllocateDefault) { test_various_allocations(this-
 
 TEST_P(mr_ref_allocation_test, AllocateDefaultStream)
 {
-  test_various_async_allocations(this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
+  test_various_async_allocations(this->ref, rmm::cuda_stream_default);
 }
 
 TEST_P(mr_ref_allocation_test, AllocateOnStream)
@@ -28,7 +30,7 @@ TEST_P(mr_ref_allocation_test, RandomAllocations) { test_random_allocations(this
 TEST_P(mr_ref_allocation_test, RandomAllocationsDefaultStream)
 {
   test_random_async_allocations(
-    this->ref, default_num_allocations, default_max_size, cuda::stream_ref{cudaStream_t{nullptr}});
+    this->ref, default_num_allocations, default_max_size, rmm::cuda_stream_default);
 }
 
 TEST_P(mr_ref_allocation_test, RandomAllocationsStream)
@@ -43,8 +45,7 @@ TEST_P(mr_ref_allocation_test, MixedRandomAllocationFree)
 
 TEST_P(mr_ref_allocation_test, MixedRandomAllocationFreeDefaultStream)
 {
-  test_mixed_random_async_allocation_free(
-    this->ref, default_max_size, cuda::stream_ref{cudaStream_t{nullptr}});
+  test_mixed_random_async_allocation_free(this->ref, default_max_size, rmm::cuda_stream_default);
 }
 
 TEST_P(mr_ref_allocation_test, MixedRandomAllocationFreeStream)

--- a/cpp/tests/mr/mr_ref_test_allocation.hpp
+++ b/cpp/tests/mr/mr_ref_test_allocation.hpp
@@ -7,7 +7,7 @@
 
 #include "mr_ref_test.hpp"
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace rmm::test {
 
@@ -17,7 +17,7 @@ TEST_P(mr_ref_allocation_test, AllocateDefault) { test_various_allocations(this-
 
 TEST_P(mr_ref_allocation_test, AllocateDefaultStream)
 {
-  test_various_async_allocations(this->ref, rmm::cuda_stream_default);
+  test_various_async_allocations(this->ref, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TEST_P(mr_ref_allocation_test, AllocateOnStream)
@@ -29,8 +29,10 @@ TEST_P(mr_ref_allocation_test, RandomAllocations) { test_random_allocations(this
 
 TEST_P(mr_ref_allocation_test, RandomAllocationsDefaultStream)
 {
-  test_random_async_allocations(
-    this->ref, default_num_allocations, default_max_size, rmm::cuda_stream_default);
+  test_random_async_allocations(this->ref,
+                                default_num_allocations,
+                                default_max_size,
+                                cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TEST_P(mr_ref_allocation_test, RandomAllocationsStream)
@@ -45,7 +47,8 @@ TEST_P(mr_ref_allocation_test, MixedRandomAllocationFree)
 
 TEST_P(mr_ref_allocation_test, MixedRandomAllocationFreeDefaultStream)
 {
-  test_mixed_random_async_allocation_free(this->ref, default_max_size, rmm::cuda_stream_default);
+  test_mixed_random_async_allocation_free(
+    this->ref, default_max_size, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TEST_P(mr_ref_allocation_test, MixedRandomAllocationFreeStream)

--- a/cpp/tests/mr/mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/mr_ref_test_basic.hpp
@@ -18,15 +18,19 @@ TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
 
   // Old ref should be functional (verify by successful allocation)
   constexpr std::size_t size{100};
-  void* ptr = old.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr =
+    old.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  old.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  old.deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   // Current device resource should be usable for allocation
   auto current = rmm::mr::get_current_device_resource_ref();
-  ptr          = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr =
+    current.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   test_get_current_device_resource_ref();
 
@@ -34,9 +38,11 @@ TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
   rmm::mr::reset_current_device_resource();
   // Verify reset worked by checking allocation succeeds with initial resource
   current = rmm::mr::get_current_device_resource_ref();
-  ptr     = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr =
+    current.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(
+    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TEST_P(mr_ref_test, SelfEquality) { EXPECT_TRUE(this->ref == this->ref); }
@@ -46,7 +52,7 @@ TEST_P(mr_ref_test, AllocationsAreDifferent) { concurrent_allocations_are_differ
 
 TEST_P(mr_ref_test, AsyncAllocationsAreDifferentDefaultStream)
 {
-  concurrent_async_allocations_are_different(this->ref, cuda_stream_view{});
+  concurrent_async_allocations_are_different(this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TEST_P(mr_ref_test, AsyncAllocationsAreDifferent)

--- a/cpp/tests/mr/mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/mr_ref_test_basic.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/mr_ref_test_basic.hpp
@@ -7,6 +7,8 @@
 
 #include "mr_ref_test.hpp"
 
+#include <rmm/cuda_stream_view.hpp>
+
 namespace rmm::test {
 
 // Parameterized test definitions for mr_ref_test (basic tests)
@@ -18,19 +20,15 @@ TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
 
   // Old ref should be functional (verify by successful allocation)
   constexpr std::size_t size{100};
-  void* ptr =
-    old.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr = old.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  old.deallocate(
-    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  old.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   // Current device resource should be usable for allocation
   auto current = rmm::mr::get_current_device_resource_ref();
-  ptr =
-    current.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr          = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(
-    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   test_get_current_device_resource_ref();
 
@@ -38,11 +36,9 @@ TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
   rmm::mr::reset_current_device_resource();
   // Verify reset worked by checking allocation succeeds with initial resource
   current = rmm::mr::get_current_device_resource_ref();
-  ptr =
-    current.allocate(cuda::stream_ref{cudaStream_t{nullptr}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr     = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(
-    cuda::stream_ref{cudaStream_t{nullptr}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TEST_P(mr_ref_test, SelfEquality) { EXPECT_TRUE(this->ref == this->ref); }
@@ -52,7 +48,7 @@ TEST_P(mr_ref_test, AllocationsAreDifferent) { concurrent_allocations_are_differ
 
 TEST_P(mr_ref_test, AsyncAllocationsAreDifferentDefaultStream)
 {
-  concurrent_async_allocations_are_different(this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
+  concurrent_async_allocations_are_different(this->ref, rmm::cuda_stream_default);
 }
 
 TEST_P(mr_ref_test, AsyncAllocationsAreDifferent)

--- a/cpp/tests/mr/mr_ref_test_basic.hpp
+++ b/cpp/tests/mr/mr_ref_test_basic.hpp
@@ -7,7 +7,7 @@
 
 #include "mr_ref_test.hpp"
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace rmm::test {
 
@@ -20,15 +20,19 @@ TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
 
   // Old ref should be functional (verify by successful allocation)
   constexpr std::size_t size{100};
-  void* ptr = old.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* ptr = old.allocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  old.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  old.deallocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   // Current device resource should be usable for allocation
   auto current = rmm::mr::get_current_device_resource_ref();
-  ptr          = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr          = current.allocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   test_get_current_device_resource_ref();
 
@@ -36,9 +40,11 @@ TEST_P(mr_ref_test, SetCurrentDeviceResourceRef)
   rmm::mr::reset_current_device_resource();
   // Verify reset worked by checking allocation succeeds with initial resource
   current = rmm::mr::get_current_device_resource_ref();
-  ptr     = current.allocate(rmm::cuda_stream_default, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ptr     = current.allocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
   EXPECT_NE(ptr, nullptr);
-  current.deallocate(rmm::cuda_stream_default, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  current.deallocate(
+    cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 TEST_P(mr_ref_test, SelfEquality) { EXPECT_TRUE(this->ref == this->ref); }
@@ -48,7 +54,8 @@ TEST_P(mr_ref_test, AllocationsAreDifferent) { concurrent_allocations_are_differ
 
 TEST_P(mr_ref_test, AsyncAllocationsAreDifferentDefaultStream)
 {
-  concurrent_async_allocations_are_different(this->ref, rmm::cuda_stream_default);
+  concurrent_async_allocations_are_different(this->ref,
+                                             cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TEST_P(mr_ref_test, AsyncAllocationsAreDifferent)

--- a/cpp/tests/mr/mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/mr_ref_test_mt.hpp
@@ -82,12 +82,12 @@ TEST_P(mr_ref_test_mt, Allocate)
 
 TEST_P(mr_ref_test_mt, AllocateDefaultStream)
 {
-  spawn(test_various_async_allocations, this->ref, rmm::cuda_stream_view{});
+  spawn(test_various_async_allocations, this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TEST_P(mr_ref_test_mt, AllocateOnStream)
 {
-  spawn(test_various_async_allocations, this->ref, this->stream.view());
+  spawn(test_various_async_allocations, this->ref, cuda::stream_ref{this->stream});
 }
 
 TEST_P(mr_ref_test_mt, RandomAllocations)
@@ -101,7 +101,7 @@ TEST_P(mr_ref_test_mt, RandomAllocationsDefaultStream)
         this->ref,
         default_num_allocations,
         default_max_size,
-        rmm::cuda_stream_view{});
+        cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TEST_P(mr_ref_test_mt, RandomAllocationsStream)
@@ -110,7 +110,7 @@ TEST_P(mr_ref_test_mt, RandomAllocationsStream)
         this->ref,
         default_num_allocations,
         default_max_size,
-        this->stream.view());
+        cuda::stream_ref{this->stream});
 }
 
 TEST_P(mr_ref_test_mt, MixedRandomAllocationFree)
@@ -120,36 +120,43 @@ TEST_P(mr_ref_test_mt, MixedRandomAllocationFree)
 
 TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeDefaultStream)
 {
-  spawn(
-    test_mixed_random_async_allocation_free, this->ref, default_max_size, rmm::cuda_stream_view{});
+  spawn(test_mixed_random_async_allocation_free,
+        this->ref,
+        default_max_size,
+        cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeStream)
 {
-  spawn(test_mixed_random_async_allocation_free, this->ref, default_max_size, this->stream.view());
+  spawn(test_mixed_random_async_allocation_free,
+        this->ref,
+        default_max_size,
+        cuda::stream_ref{this->stream});
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, rmm::cuda_stream_default, rmm::cuda_stream_default);
+    this->ref, cuda::stream_ref{cudaStream_t{nullptr}}, cuda::stream_ref{cudaStream_t{nullptr}});
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsPerThreadDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, rmm::cuda_stream_per_thread, rmm::cuda_stream_per_thread);
+    this->ref, cuda::stream_ref{cudaStreamPerThread}, cuda::stream_ref{cudaStreamPerThread});
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsSameStream)
 {
-  test_async_allocate_free_different_threads(this->ref, this->stream, this->stream);
+  test_async_allocate_free_different_threads(
+    this->ref, cuda::stream_ref{this->stream}, cuda::stream_ref{this->stream});
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsDifferentStream)
 {
   rmm::cuda_stream streamB;
-  test_async_allocate_free_different_threads(this->ref, this->stream, streamB);
+  test_async_allocate_free_different_threads(
+    this->ref, cuda::stream_ref{this->stream}, cuda::stream_ref{streamB});
   streamB.synchronize();
 }
 

--- a/cpp/tests/mr/mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/mr_ref_test_mt.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/mr_ref_test_mt.hpp
@@ -148,15 +148,13 @@ TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsPerThreadDefaultStream)
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsSameStream)
 {
-  test_async_allocate_free_different_threads(
-    this->ref, cuda::stream_ref{this->stream}, cuda::stream_ref{this->stream});
+  test_async_allocate_free_different_threads(this->ref, this->stream, this->stream);
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsDifferentStream)
 {
   rmm::cuda_stream streamB;
-  test_async_allocate_free_different_threads(
-    this->ref, cuda::stream_ref{this->stream}, cuda::stream_ref{streamB});
+  test_async_allocate_free_different_threads(this->ref, this->stream, streamB);
   streamB.synchronize();
 }
 

--- a/cpp/tests/mr/mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/mr_ref_test_mt.hpp
@@ -7,6 +7,8 @@
 
 #include "mr_ref_test_mt_helpers.hpp"
 
+#include <rmm/cuda_stream_view.hpp>
+
 namespace rmm::test {
 
 // Multi-threaded test fixture
@@ -82,7 +84,7 @@ TEST_P(mr_ref_test_mt, Allocate)
 
 TEST_P(mr_ref_test_mt, AllocateDefaultStream)
 {
-  spawn(test_various_async_allocations, this->ref, cuda::stream_ref{cudaStream_t{nullptr}});
+  spawn(test_various_async_allocations, this->ref, rmm::cuda_stream_default);
 }
 
 TEST_P(mr_ref_test_mt, AllocateOnStream)
@@ -101,7 +103,7 @@ TEST_P(mr_ref_test_mt, RandomAllocationsDefaultStream)
         this->ref,
         default_num_allocations,
         default_max_size,
-        cuda::stream_ref{cudaStream_t{nullptr}});
+        rmm::cuda_stream_default);
 }
 
 TEST_P(mr_ref_test_mt, RandomAllocationsStream)
@@ -120,10 +122,8 @@ TEST_P(mr_ref_test_mt, MixedRandomAllocationFree)
 
 TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeDefaultStream)
 {
-  spawn(test_mixed_random_async_allocation_free,
-        this->ref,
-        default_max_size,
-        cuda::stream_ref{cudaStream_t{nullptr}});
+  spawn(
+    test_mixed_random_async_allocation_free, this->ref, default_max_size, rmm::cuda_stream_default);
 }
 
 TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeStream)
@@ -137,13 +137,13 @@ TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeStream)
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, cuda::stream_ref{cudaStream_t{nullptr}}, cuda::stream_ref{cudaStream_t{nullptr}});
+    this->ref, rmm::cuda_stream_default, rmm::cuda_stream_default);
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsPerThreadDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, cuda::stream_ref{cudaStreamPerThread}, cuda::stream_ref{cudaStreamPerThread});
+    this->ref, rmm::cuda_stream_per_thread, rmm::cuda_stream_per_thread);
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsSameStream)

--- a/cpp/tests/mr/mr_ref_test_mt.hpp
+++ b/cpp/tests/mr/mr_ref_test_mt.hpp
@@ -7,7 +7,7 @@
 
 #include "mr_ref_test_mt_helpers.hpp"
 
-#include <rmm/cuda_stream_view.hpp>
+#include <cuda/stream>
 
 namespace rmm::test {
 
@@ -84,7 +84,8 @@ TEST_P(mr_ref_test_mt, Allocate)
 
 TEST_P(mr_ref_test_mt, AllocateDefaultStream)
 {
-  spawn(test_various_async_allocations, this->ref, rmm::cuda_stream_default);
+  spawn(
+    test_various_async_allocations, this->ref, cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TEST_P(mr_ref_test_mt, AllocateOnStream)
@@ -103,7 +104,7 @@ TEST_P(mr_ref_test_mt, RandomAllocationsDefaultStream)
         this->ref,
         default_num_allocations,
         default_max_size,
-        rmm::cuda_stream_default);
+        cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TEST_P(mr_ref_test_mt, RandomAllocationsStream)
@@ -122,8 +123,10 @@ TEST_P(mr_ref_test_mt, MixedRandomAllocationFree)
 
 TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeDefaultStream)
 {
-  spawn(
-    test_mixed_random_async_allocation_free, this->ref, default_max_size, rmm::cuda_stream_default);
+  spawn(test_mixed_random_async_allocation_free,
+        this->ref,
+        default_max_size,
+        cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeStream)
@@ -136,14 +139,15 @@ TEST_P(mr_ref_test_mt, MixedRandomAllocationFreeStream)
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsDefaultStream)
 {
-  test_async_allocate_free_different_threads(
-    this->ref, rmm::cuda_stream_default, rmm::cuda_stream_default);
+  test_async_allocate_free_different_threads(this->ref,
+                                             cuda::stream_ref{cudaStream_t{cudaStreamDefault}},
+                                             cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsPerThreadDefaultStream)
 {
   test_async_allocate_free_different_threads(
-    this->ref, rmm::cuda_stream_per_thread, rmm::cuda_stream_per_thread);
+    this->ref, cuda::stream_ref{cudaStreamPerThread}, cuda::stream_ref{cudaStreamPerThread});
 }
 
 TEST_P(mr_ref_test_mt, AllocFreeDifferentThreadsSameStream)

--- a/cpp/tests/mr/mr_ref_test_mt_helpers.hpp
+++ b/cpp/tests/mr/mr_ref_test_mt_helpers.hpp
@@ -43,7 +43,7 @@ inline void async_allocate_loop(rmm::device_async_resource_ref ref,
                                 std::mutex& mtx,
                                 std::condition_variable& allocations_ready,
                                 cudaEvent_t& event,
-                                rmm::cuda_stream_view stream)
+                                cuda::stream_ref stream)
 {
   constexpr std::size_t max_size{1_MiB};
 
@@ -55,7 +55,7 @@ inline void async_allocate_loop(rmm::device_async_resource_ref ref,
     void* ptr        = ref.allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
     {
       std::lock_guard<std::mutex> lock(mtx);
-      RMM_CUDA_TRY(cudaEventRecord(event, stream.value()));
+      RMM_CUDA_TRY(cudaEventRecord(event, stream.get()));
       allocations.emplace_back(ptr, size);
     }
     allocations_ready.notify_one();
@@ -71,12 +71,12 @@ inline void async_deallocate_loop(rmm::device_async_resource_ref ref,
                                   std::mutex& mtx,
                                   std::condition_variable& allocations_ready,
                                   cudaEvent_t& event,
-                                  rmm::cuda_stream_view stream)
+                                  cuda::stream_ref stream)
 {
   for (std::size_t i = 0; i < num_allocations; i++) {
     std::unique_lock lock(mtx);
     allocations_ready.wait(lock, [&allocations] { return !allocations.empty(); });
-    RMM_CUDA_TRY(cudaStreamWaitEvent(stream.value(), event));
+    RMM_CUDA_TRY(cudaStreamWaitEvent(stream.get(), event));
     allocation alloc = allocations.front();
     allocations.pop_front();
     ref.deallocate(stream, alloc.ptr, alloc.size, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -87,8 +87,8 @@ inline void async_deallocate_loop(rmm::device_async_resource_ref ref,
 }
 
 inline void test_async_allocate_free_different_threads(rmm::device_async_resource_ref ref,
-                                                       rmm::cuda_stream_view streamA,
-                                                       rmm::cuda_stream_view streamB)
+                                                       cuda::stream_ref streamA,
+                                                       cuda::stream_ref streamB)
 {
   constexpr std::size_t num_allocations{100};
 

--- a/cpp/tests/mr/mr_ref_test_mt_helpers.hpp
+++ b/cpp/tests/mr/mr_ref_test_mt_helpers.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -62,7 +62,7 @@ inline void async_allocate_loop(rmm::device_async_resource_ref ref,
   }
 
   // Work around for threads going away before cudaEvent has finished async processing
-  cudaEventSynchronize(event);
+  RMM_CUDA_TRY(cudaEventSynchronize(event));
 }
 
 inline void async_deallocate_loop(rmm::device_async_resource_ref ref,
@@ -83,7 +83,7 @@ inline void async_deallocate_loop(rmm::device_async_resource_ref ref,
   }
 
   // Work around for threads going away before cudaEvent has finished async processing
-  cudaEventSynchronize(event);
+  RMM_CUDA_TRY(cudaEventSynchronize(event));
 }
 
 inline void test_async_allocate_free_different_threads(rmm::device_async_resource_ref ref,

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -89,7 +89,7 @@ TEST(PoolTest, DeletedStream)
   cudaStream_t stream{};  // we don't use rmm::cuda_stream here to make destruction more explicit
   const int size = 10000;
   EXPECT_EQ(cudaSuccess, cudaStreamCreate(&stream));
-  EXPECT_NO_THROW(rmm::device_buffer buff(size, cuda_stream_view{stream}, mr));
+  EXPECT_NO_THROW(rmm::device_buffer buff(size, cuda::stream_ref{stream}, mr));
   EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream));
   EXPECT_NO_THROW((void)mr.allocate_sync(size));
 }
@@ -151,11 +151,11 @@ TEST(PoolTest, MultidevicePool)
 
     {
       RMM_CUDA_TRY(cudaSetDevice(0));
-      rmm::device_buffer buf_a(16, rmm::cuda_stream_per_thread, mrs[0]);
+      rmm::device_buffer buf_a(16, cuda::stream_ref{cudaStreamPerThread}, mrs[0]);
 
       {
         RMM_CUDA_TRY(cudaSetDevice(1));
-        rmm::device_buffer buf_b(16, rmm::cuda_stream_per_thread, mrs[1]);
+        rmm::device_buffer buf_b(16, cuda::stream_ref{cudaStreamPerThread}, mrs[1]);
       }
 
       RMM_CUDA_TRY(cudaSetDevice(0));

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -8,6 +8,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
@@ -283,7 +284,7 @@ TEST(PoolTest, ReclaimIsStreamOrderedWithMergedPerThreadDefaultStream)
 
   auto* source_ptr = mr.allocate(rmm::cuda_stream_per_thread, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   RMM_CUDA_TRY(cudaLaunchHostFunc(
-    rmm::cuda_stream_per_thread.value(),
+    rmm::cuda_stream_per_thread.get(),
     [](void* data) { static_cast<host_func_gate*>(data)->wait(); },
     &prior_work));
   mr.deallocate(rmm::cuda_stream_per_thread, source_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -364,11 +365,11 @@ TEST(PoolTest, MultidevicePool)
 
     {
       RMM_CUDA_TRY(cudaSetDevice(0));
-      rmm::device_buffer buf_a(16, cuda::stream_ref{cudaStreamPerThread}, mrs[0]);
+      rmm::device_buffer buf_a(16, rmm::cuda_stream_per_thread, mrs[0]);
 
       {
         RMM_CUDA_TRY(cudaSetDevice(1));
-        rmm::device_buffer buf_b(16, cuda::stream_ref{cudaStreamPerThread}, mrs[1]);
+        rmm::device_buffer buf_b(16, rmm::cuda_stream_per_thread, mrs[1]);
       }
 
       RMM_CUDA_TRY(cudaSetDevice(0));

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -140,7 +140,7 @@ TEST(PoolTest, DeletedStream)
   cudaStream_t stream{};  // we don't use rmm::cuda_stream here to make destruction more explicit
   const int size = 10000;
   EXPECT_EQ(cudaSuccess, cudaStreamCreate(&stream));
-  EXPECT_NO_THROW(rmm::device_buffer buff(size, cuda_stream_view{stream}, mr));
+  EXPECT_NO_THROW(rmm::device_buffer buff(size, cuda::stream_ref{stream}, mr));
   EXPECT_EQ(cudaSuccess, cudaStreamDestroy(stream));
   EXPECT_NO_THROW((void)mr.allocate_sync(size));
 }
@@ -364,11 +364,11 @@ TEST(PoolTest, MultidevicePool)
 
     {
       RMM_CUDA_TRY(cudaSetDevice(0));
-      rmm::device_buffer buf_a(16, rmm::cuda_stream_per_thread, mrs[0]);
+      rmm::device_buffer buf_a(16, cuda::stream_ref{cudaStreamPerThread}, mrs[0]);
 
       {
         RMM_CUDA_TRY(cudaSetDevice(1));
-        rmm::device_buffer buf_b(16, rmm::cuda_stream_per_thread, mrs[1]);
+        rmm::device_buffer buf_b(16, cuda::stream_ref{cudaStreamPerThread}, mrs[1]);
       }
 
       RMM_CUDA_TRY(cudaSetDevice(0));

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -8,7 +8,6 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
@@ -18,6 +17,7 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
@@ -282,12 +282,14 @@ TEST(PoolTest, ReclaimIsStreamOrderedWithMergedPerThreadDefaultStream)
   host_func_gate prior_work;
   host_func_gate_release_guard const release_prior_work{prior_work};
 
-  auto* source_ptr = mr.allocate(rmm::cuda_stream_per_thread, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* source_ptr =
+    mr.allocate(cuda::stream_ref{cudaStreamPerThread}, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
   RMM_CUDA_TRY(cudaLaunchHostFunc(
-    rmm::cuda_stream_per_thread.get(),
+    cuda::stream_ref{cudaStreamPerThread}.get(),
     [](void* data) { static_cast<host_func_gate*>(data)->wait(); },
     &prior_work));
-  mr.deallocate(rmm::cuda_stream_per_thread, source_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(
+    cuda::stream_ref{cudaStreamPerThread}, source_ptr, 256, rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   rmm::cuda_stream destination;
   auto* destination_ptr = mr.allocate(destination.view(), 1024, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -365,11 +367,11 @@ TEST(PoolTest, MultidevicePool)
 
     {
       RMM_CUDA_TRY(cudaSetDevice(0));
-      rmm::device_buffer buf_a(16, rmm::cuda_stream_per_thread, mrs[0]);
+      rmm::device_buffer buf_a(16, cuda::stream_ref{cudaStreamPerThread}, mrs[0]);
 
       {
         RMM_CUDA_TRY(cudaSetDevice(1));
-        rmm::device_buffer buf_b(16, rmm::cuda_stream_per_thread, mrs[1]);
+        rmm::device_buffer buf_b(16, cuda::stream_ref{cudaStreamPerThread}, mrs[1]);
       }
 
       RMM_CUDA_TRY(cudaSetDevice(0));

--- a/cpp/tests/mr/resource_ref_conversion_tests.cpp
+++ b/cpp/tests/mr/resource_ref_conversion_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -134,7 +134,7 @@ class host_allocator {
   host_allocator() = delete;
 
   template <typename ResourceType>
-  host_allocator(ResourceType mr, rmm::cuda_stream_view stream) : mr_(mr), stream_(stream)
+  host_allocator(ResourceType mr, cuda::stream_ref stream) : mr_(mr), stream_(stream)
   {
   }
 
@@ -144,7 +144,7 @@ class host_allocator {
   T* allocate(std::size_t n)
   {
     auto const result = mr_.allocate(stream_, n * sizeof(T), rmm::CUDA_ALLOCATION_ALIGNMENT);
-    stream_.synchronize();
+    stream_.sync();
     return static_cast<T*>(result);
   }
 
@@ -158,7 +158,7 @@ class host_allocator {
 
  private:
   rmm::host_async_resource_ref mr_;
-  rmm::cuda_stream_view stream_;
+  cuda::stream_ref stream_;
 };
 
 // Function that returns host_device_async_resource_ref (like cudf::get_pinned_memory_resource)
@@ -171,7 +171,7 @@ rmm::host_device_async_resource_ref get_pinned_resource()
 // Helper to create a pinned vector (similar to cudf's make_pinned_vector_async)
 template <typename T>
 thrust::host_vector<T, host_allocator<T>> make_pinned_vector(std::size_t size,
-                                                             rmm::cuda_stream_view stream)
+                                                             cuda::stream_ref stream)
 {
   return thrust::host_vector<T, host_allocator<T>>(size, {get_pinned_resource(), stream});
 }

--- a/cpp/tests/mr/statistics_mr_tests.cpp
+++ b/cpp/tests/mr/statistics_mr_tests.cpp
@@ -178,7 +178,7 @@ TEST(StatisticsTest, MultiTracking)
   std::vector<std::shared_ptr<rmm::device_buffer>> allocations;
   for (std::size_t i = 0; i < num_allocations; ++i) {
     allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, mr));
+      std::make_shared<rmm::device_buffer>(ten_MiB, cuda::stream_ref{cudaStream_t{nullptr}}, mr));
   }
 
   EXPECT_EQ(mr.get_allocations_counter().value, 10);
@@ -187,8 +187,8 @@ TEST(StatisticsTest, MultiTracking)
 
   rmm::device_async_resource_ref inner_ref{inner_mr};
   for (std::size_t i = 0; i < num_more_allocations; ++i) {
-    allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, inner_ref));
+    allocations.emplace_back(std::make_shared<rmm::device_buffer>(
+      ten_MiB, cuda::stream_ref{cudaStream_t{nullptr}}, inner_ref));
   }
 
   // Check the allocated bytes for both MRs

--- a/cpp/tests/mr/statistics_mr_tests.cpp
+++ b/cpp/tests/mr/statistics_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/statistics_mr_tests.cpp
+++ b/cpp/tests/mr/statistics_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/statistics_mr_tests.cpp
+++ b/cpp/tests/mr/statistics_mr_tests.cpp
@@ -178,7 +178,7 @@ TEST(StatisticsTest, MultiTracking)
   std::vector<std::shared_ptr<rmm::device_buffer>> allocations;
   for (std::size_t i = 0; i < num_allocations; ++i) {
     allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, cuda::stream_ref{cudaStream_t{nullptr}}, mr));
+      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, mr));
   }
 
   EXPECT_EQ(mr.get_allocations_counter().value, 10);
@@ -187,8 +187,8 @@ TEST(StatisticsTest, MultiTracking)
 
   rmm::device_async_resource_ref inner_ref{inner_mr};
   for (std::size_t i = 0; i < num_more_allocations; ++i) {
-    allocations.emplace_back(std::make_shared<rmm::device_buffer>(
-      ten_MiB, cuda::stream_ref{cudaStream_t{nullptr}}, inner_ref));
+    allocations.emplace_back(
+      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, inner_ref));
   }
 
   // Check the allocated bytes for both MRs

--- a/cpp/tests/mr/statistics_mr_tests.cpp
+++ b/cpp/tests/mr/statistics_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,11 +8,12 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
+
+#include <cuda/stream>
 
 #include <gtest/gtest.h>
 
@@ -177,8 +178,8 @@ TEST(StatisticsTest, MultiTracking)
 
   std::vector<std::shared_ptr<rmm::device_buffer>> allocations;
   for (std::size_t i = 0; i < num_allocations; ++i) {
-    allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, mr));
+    allocations.emplace_back(std::make_shared<rmm::device_buffer>(
+      ten_MiB, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, mr));
   }
 
   EXPECT_EQ(mr.get_allocations_counter().value, 10);
@@ -187,8 +188,8 @@ TEST(StatisticsTest, MultiTracking)
 
   rmm::device_async_resource_ref inner_ref{inner_mr};
   for (std::size_t i = 0; i < num_more_allocations; ++i) {
-    allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, inner_ref));
+    allocations.emplace_back(std::make_shared<rmm::device_buffer>(
+      ten_MiB, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, inner_ref));
   }
 
   // Check the allocated bytes for both MRs

--- a/cpp/tests/mr/thrust_allocator_tests.cu
+++ b/cpp/tests/mr/thrust_allocator_tests.cu
@@ -6,7 +6,6 @@
 #include "mr_ref_test.hpp"
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_vector.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -36,8 +35,8 @@ TEST_P(allocator_test, first)
 TEST_P(allocator_test, defaults)
 {
   rmm::mr::set_current_device_resource(this->ref);
-  rmm::mr::thrust_allocator<int> allocator(rmm::cuda_stream_default);
-  EXPECT_EQ(allocator.stream(), rmm::cuda_stream_default);
+  rmm::mr::thrust_allocator<int> allocator(cuda::stream_ref{cudaStream_t{nullptr}});
+  EXPECT_EQ(allocator.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
   EXPECT_EQ(allocator.get_upstream_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
 }

--- a/cpp/tests/mr/thrust_allocator_tests.cu
+++ b/cpp/tests/mr/thrust_allocator_tests.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/thrust_allocator_tests.cu
+++ b/cpp/tests/mr/thrust_allocator_tests.cu
@@ -6,6 +6,7 @@
 #include "mr_ref_test.hpp"
 
 #include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_vector.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -35,7 +36,7 @@ TEST_P(allocator_test, first)
 TEST_P(allocator_test, defaults)
 {
   rmm::mr::set_current_device_resource(this->ref);
-  rmm::mr::thrust_allocator<int> allocator(cuda::stream_ref{cudaStream_t{nullptr}});
+  rmm::mr::thrust_allocator<int> allocator(rmm::cuda_stream_default);
   EXPECT_EQ(allocator.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
   EXPECT_EQ(allocator.get_upstream_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});

--- a/cpp/tests/mr/thrust_allocator_tests.cu
+++ b/cpp/tests/mr/thrust_allocator_tests.cu
@@ -37,7 +37,7 @@ TEST_P(allocator_test, defaults)
 {
   rmm::mr::set_current_device_resource(this->ref);
   rmm::mr::thrust_allocator<int> allocator(rmm::cuda_stream_default);
-  EXPECT_EQ(allocator.stream(), rmm::cuda_stream_view{cudaStream_t{nullptr}});
+  EXPECT_EQ(allocator.stream(), rmm::cuda_stream_view{rmm::cuda_stream_default});
   EXPECT_EQ(allocator.get_upstream_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
 }

--- a/cpp/tests/mr/thrust_allocator_tests.cu
+++ b/cpp/tests/mr/thrust_allocator_tests.cu
@@ -37,7 +37,7 @@ TEST_P(allocator_test, defaults)
 {
   rmm::mr::set_current_device_resource(this->ref);
   rmm::mr::thrust_allocator<int> allocator(rmm::cuda_stream_default);
-  EXPECT_EQ(allocator.stream(), rmm::cuda_stream_view{rmm::cuda_stream_default});
+  EXPECT_EQ(allocator.stream(), rmm::cuda_stream_default);
   EXPECT_EQ(allocator.get_upstream_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
 }
@@ -48,7 +48,7 @@ TEST_P(allocator_test, multi_device)
   cuda_set_device_raii with_device{rmm::get_current_cuda_device()};
   rmm::cuda_stream stream{};
   // make allocator on device-0
-  rmm::mr::thrust_allocator<int> allocator(stream.view(), this->ref);
+  rmm::mr::thrust_allocator<int> allocator(stream, this->ref);
   auto const size{100};
   EXPECT_NO_THROW([&]() {
     auto vec = rmm::device_vector<int>(size, allocator);

--- a/cpp/tests/mr/thrust_allocator_tests.cu
+++ b/cpp/tests/mr/thrust_allocator_tests.cu
@@ -6,13 +6,13 @@
 #include "mr_ref_test.hpp"
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_vector.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/thrust_allocator_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream>
 #include <thrust/reduce.h>
 
 #include <gtest/gtest.h>
@@ -36,8 +36,8 @@ TEST_P(allocator_test, first)
 TEST_P(allocator_test, defaults)
 {
   rmm::mr::set_current_device_resource(this->ref);
-  rmm::mr::thrust_allocator<int> allocator(rmm::cuda_stream_default);
-  EXPECT_EQ(allocator.stream(), rmm::cuda_stream_default);
+  rmm::mr::thrust_allocator<int> allocator(cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
+  EXPECT_EQ(allocator.stream(), cuda::stream_ref{cudaStream_t{cudaStreamDefault}});
   EXPECT_EQ(allocator.get_upstream_resource(),
             rmm::device_async_resource_ref{rmm::mr::get_current_device_resource_ref()});
 }

--- a/cpp/tests/mr/tracking_mr_tests.cpp
+++ b/cpp/tests/mr/tracking_mr_tests.cpp
@@ -153,7 +153,7 @@ TEST(TrackingTest, MultiTracking)
   std::vector<std::shared_ptr<rmm::device_buffer>> allocations;
   for (std::size_t i = 0; i < num_allocations; ++i) {
     allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, mr));
+      std::make_shared<rmm::device_buffer>(ten_MiB, cuda::stream_ref{cudaStream_t{nullptr}}, mr));
   }
 
   EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations);
@@ -162,8 +162,8 @@ TEST(TrackingTest, MultiTracking)
 
   rmm::device_async_resource_ref inner_ref{inner_mr};
   for (std::size_t i = 0; i < num_more_allocations; ++i) {
-    allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, inner_ref));
+    allocations.emplace_back(std::make_shared<rmm::device_buffer>(
+      ten_MiB, cuda::stream_ref{cudaStream_t{nullptr}}, inner_ref));
   }
 
   // Check the allocated bytes for both MRs

--- a/cpp/tests/mr/tracking_mr_tests.cpp
+++ b/cpp/tests/mr/tracking_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/tracking_mr_tests.cpp
+++ b/cpp/tests/mr/tracking_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/tracking_mr_tests.cpp
+++ b/cpp/tests/mr/tracking_mr_tests.cpp
@@ -153,7 +153,7 @@ TEST(TrackingTest, MultiTracking)
   std::vector<std::shared_ptr<rmm::device_buffer>> allocations;
   for (std::size_t i = 0; i < num_allocations; ++i) {
     allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, cuda::stream_ref{cudaStream_t{nullptr}}, mr));
+      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, mr));
   }
 
   EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations);
@@ -162,8 +162,8 @@ TEST(TrackingTest, MultiTracking)
 
   rmm::device_async_resource_ref inner_ref{inner_mr};
   for (std::size_t i = 0; i < num_more_allocations; ++i) {
-    allocations.emplace_back(std::make_shared<rmm::device_buffer>(
-      ten_MiB, cuda::stream_ref{cudaStream_t{nullptr}}, inner_ref));
+    allocations.emplace_back(
+      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, inner_ref));
   }
 
   // Check the allocated bytes for both MRs

--- a/cpp/tests/mr/tracking_mr_tests.cpp
+++ b/cpp/tests/mr/tracking_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,13 +8,14 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/tracking_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream>
 
 #include <gtest/gtest.h>
 
@@ -152,8 +153,8 @@ TEST(TrackingTest, MultiTracking)
 
   std::vector<std::shared_ptr<rmm::device_buffer>> allocations;
   for (std::size_t i = 0; i < num_allocations; ++i) {
-    allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, mr));
+    allocations.emplace_back(std::make_shared<rmm::device_buffer>(
+      ten_MiB, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, mr));
   }
 
   EXPECT_EQ(mr.get_outstanding_allocations().size(), num_allocations);
@@ -162,8 +163,8 @@ TEST(TrackingTest, MultiTracking)
 
   rmm::device_async_resource_ref inner_ref{inner_mr};
   for (std::size_t i = 0; i < num_more_allocations; ++i) {
-    allocations.emplace_back(
-      std::make_shared<rmm::device_buffer>(ten_MiB, rmm::cuda_stream_default, inner_ref));
+    allocations.emplace_back(std::make_shared<rmm::device_buffer>(
+      ten_MiB, cuda::stream_ref{cudaStream_t{cudaStreamDefault}}, inner_ref));
   }
 
   // Check the allocated bytes for both MRs

--- a/docs/migration_guide_2606.md
+++ b/docs/migration_guide_2606.md
@@ -506,7 +506,7 @@ resource has a different concrete type, including a derived or wrapped type.
 ### `cuda::stream_ref{}` Default Constructor Is Deprecated
 
 The default constructor `cuda::stream_ref{}` is deprecated in CCCL. Use
-`cuda::stream_ref{cudaStream_t{nullptr}}` when you need a null/default
+`rmm::cuda_stream_default` when you need a null/default
 stream reference (e.g., in `allocate_sync`/`deallocate_sync` implementations
 that delegate to the async methods):
 
@@ -518,7 +518,7 @@ void* allocate_sync(std::size_t bytes, std::size_t alignment) {
 
 // Fix
 void* allocate_sync(std::size_t bytes, std::size_t alignment) {
-  return allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);  // OK
+  return allocate(rmm::cuda_stream_default, bytes, alignment);  // OK
 }
 ```
 

--- a/docs/migration_guide_2606.md
+++ b/docs/migration_guide_2606.md
@@ -233,7 +233,8 @@ Key differences:
 - **Stream is the first parameter** (was second for `allocate`, third for `deallocate`).
 - **`alignment` parameter** is new (has a default value).
 - **`cuda::stream_ref`** replaces `rmm::cuda_stream_view` in the resource interface.
-  `rmm::cuda_stream_view` is implicitly convertible to `cuda::stream_ref`.
+  `rmm::cuda_stream_view` is implicitly convertible to `cuda::stream_ref`, but is deprecated as of
+  26.10. Use `cuda::stream_ref` in new and migrated code.
 - **`deallocate` is `noexcept`**.
 
 Resources also provide synchronous methods `allocate_sync(bytes, alignment)` and

--- a/python/rmm/CMakeLists.txt
+++ b/python/rmm/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -13,6 +13,9 @@ project(
   rmm-python
   VERSION "${RAPIDS_VERSION}"
   LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(rmm "${RAPIDS_VERSION}" REQUIRED)
 

--- a/python/rmm/rmm/librmm/_torch_allocator.cpp
+++ b/python/rmm/rmm/librmm/_torch_allocator.cpp
@@ -1,12 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/cuda_device.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 // These signatures must match those required by CUDAPluggableAllocator in
@@ -30,7 +30,7 @@ extern "C" void* allocate(std::size_t size, int device, void* stream)
   rmm::cuda_set_device_raii with_device{device_id};
   auto mr = rmm::mr::get_per_device_resource_ref(device_id);
   return mr.allocate(
-    rmm::cuda_stream_view{static_cast<cudaStream_t>(stream)}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    cuda::stream_ref{static_cast<cudaStream_t>(stream)}, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 /**
@@ -46,8 +46,6 @@ extern "C" void deallocate(void* ptr, std::size_t size, int device, void* stream
   rmm::cuda_device_id const device_id{device};
   rmm::cuda_set_device_raii with_device{device_id};
   auto mr = rmm::mr::get_per_device_resource_ref(device_id);
-  mr.deallocate(rmm::cuda_stream_view{static_cast<cudaStream_t>(stream)},
-                ptr,
-                size,
-                rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(
+    cuda::stream_ref{static_cast<cudaStream_t>(stream)}, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }

--- a/python/rmm/rmm/librmm/cuda_stream.pxd
+++ b/python/rmm/rmm/librmm/cuda_stream.pxd
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from cuda.bindings.cyruntime cimport cudaStream_t
 from libc.stdint cimport uint32_t
 from libcpp cimport bool
 
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 
 
 cdef extern from "rmm/cuda_stream.hpp" namespace "rmm" nogil:
@@ -18,6 +18,6 @@ cdef extern from "rmm/cuda_stream.hpp" namespace "rmm" nogil:
         cuda_stream(cuda_stream_flags flags) except +
         bool is_valid() except +
         cudaStream_t value() except +
-        cuda_stream_view view() except +
+        stream_ref view() except +
         void synchronize() except +
         void synchronize_no_throw()

--- a/python/rmm/rmm/librmm/cuda_stream_pool.pxd
+++ b/python/rmm/rmm/librmm/cuda_stream_pool.pxd
@@ -1,14 +1,14 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from rmm.librmm.cuda_stream cimport cuda_stream_flags
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
+from rmm.librmm.cuda_stream_view cimport stream_ref
 
 
 cdef extern from "rmm/cuda_stream_pool.hpp" namespace "rmm" nogil:
     cdef cppclass cuda_stream_pool:
         cuda_stream_pool(size_t pool_size)
         cuda_stream_pool(size_t pool_size, cuda_stream_flags flags)
-        cuda_stream_view get_stream()
-        cuda_stream_view get_stream(size_t stream_id) except +
+        stream_ref get_stream()
+        stream_ref get_stream(size_t stream_id) except +
         size_t get_pool_size()

--- a/python/rmm/rmm/librmm/cuda_stream_pool.pxd
+++ b/python/rmm/rmm/librmm/cuda_stream_pool.pxd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from rmm.librmm.cuda_stream cimport cuda_stream_flags
-from rmm.librmm.cuda_stream_view cimport stream_ref
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 
 
 cdef extern from "rmm/cuda_stream_pool.hpp" namespace "rmm" nogil:

--- a/python/rmm/rmm/librmm/cuda_stream_ref.pxd
+++ b/python/rmm/rmm/librmm/cuda_stream_ref.pxd
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from cuda.bindings.cyruntime cimport cudaStream_t
+
+
+cdef extern from "<cuda/stream>" namespace "cuda" nogil:
+    cdef cppclass stream_ref:
+        stream_ref()
+        stream_ref(cudaStream_t)
+        cudaStream_t get()
+        void wait() except +

--- a/python/rmm/rmm/librmm/cuda_stream_ref.pxd
+++ b/python/rmm/rmm/librmm/cuda_stream_ref.pxd
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from cuda.bindings.cyruntime cimport cudaStream_t
+from libcpp cimport bool
 
 
 cdef extern from "<cuda/stream>" namespace "cuda" nogil:
@@ -9,4 +10,8 @@ cdef extern from "<cuda/stream>" namespace "cuda" nogil:
         stream_ref()
         stream_ref(cudaStream_t)
         cudaStream_t get()
-        void wait() except +
+        void sync() except +
+
+
+cdef extern from "rmm/detail/cuda_stream.hpp" namespace "rmm::detail" nogil:
+    bool is_default_stream(stream_ref stream)

--- a/python/rmm/rmm/librmm/cuda_stream_view.pxd
+++ b/python/rmm/rmm/librmm/cuda_stream_view.pxd
@@ -4,10 +4,7 @@
 from cuda.bindings.cyruntime cimport cudaStream_t
 from libcpp cimport bool
 
-
-cdef extern from "<cuda/stream>" namespace "cuda" nogil:
-    cdef cppclass stream_ref:
-        cudaStream_t get()
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 
 
 cdef extern from "rmm/cuda_stream_view.hpp" namespace "rmm" nogil:

--- a/python/rmm/rmm/librmm/cuda_stream_view.pxd
+++ b/python/rmm/rmm/librmm/cuda_stream_view.pxd
@@ -5,6 +5,11 @@ from cuda.bindings.cyruntime cimport cudaStream_t
 from libcpp cimport bool
 
 
+cdef extern from "<cuda/stream>" namespace "cuda" nogil:
+    cdef cppclass stream_ref:
+        cudaStream_t get()
+
+
 cdef extern from "rmm/cuda_stream_view.hpp" namespace "rmm" nogil:
     cdef cppclass cuda_stream_view:
         cuda_stream_view()
@@ -18,6 +23,6 @@ cdef extern from "rmm/cuda_stream_view.hpp" namespace "rmm" nogil:
 
     cdef bool operator==(cuda_stream_view const, cuda_stream_view const)
 
-    const cuda_stream_view cuda_stream_default
-    const cuda_stream_view cuda_stream_legacy
-    const cuda_stream_view cuda_stream_per_thread
+    const stream_ref cuda_stream_default
+    const stream_ref cuda_stream_legacy
+    const stream_ref cuda_stream_per_thread

--- a/python/rmm/rmm/librmm/device_buffer.pxd
+++ b/python/rmm/rmm/librmm/device_buffer.pxd
@@ -1,10 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from cuda.bindings.cyruntime cimport cudaStream_t
-
 from rmm.librmm.cuda_stream_ref cimport stream_ref
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.memory_resource cimport any_resource, device_accessible
 
 
@@ -28,29 +25,23 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
         device_buffer()
         device_buffer(
             size_t size,
-            cuda_stream_view stream,
+            stream_ref stream,
             any_resource[device_accessible] mr
         ) except +
         device_buffer(
             const void* source_data,
             size_t size,
-            cuda_stream_view stream,
-            any_resource[device_accessible] mr
-        ) except +
-        device_buffer(
-            const void* source_data,
-            size_t size,
-            cudaStream_t stream,
+            stream_ref stream,
             any_resource[device_accessible] mr
         ) except +
         device_buffer(
             const device_buffer buf,
-            cuda_stream_view stream,
+            stream_ref stream,
             any_resource[device_accessible] mr
         ) except +
-        void reserve(size_t new_capacity, cuda_stream_view stream) except +
-        void resize(size_t new_size, cuda_stream_view stream) except +
-        void shrink_to_fit(cuda_stream_view stream) except +
+        void reserve(size_t new_capacity, stream_ref stream) except +
+        void resize(size_t new_size, stream_ref stream) except +
+        void shrink_to_fit(stream_ref stream) except +
         void* data()
         size_t size()
         size_t capacity()

--- a/python/rmm/rmm/librmm/device_buffer.pxd
+++ b/python/rmm/rmm/librmm/device_buffer.pxd
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from cuda.bindings.cyruntime cimport cudaStream_t
 
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.memory_resource cimport any_resource, device_accessible
 
@@ -20,7 +21,7 @@ cdef extern from "rmm/prefetch.hpp" namespace "rmm" nogil:
     cdef void prefetch(const void* ptr,
                        size_t bytes,
                        cuda_device_id device,
-                       cuda_stream_view stream) except +
+                       stream_ref stream) except +
 
 cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
     cdef cppclass device_buffer:

--- a/python/rmm/rmm/librmm/device_uvector.pxd
+++ b/python/rmm/rmm/librmm/device_uvector.pxd
@@ -1,28 +1,28 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from cuda.bindings.cyruntime cimport cudaStream_t
 
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 from rmm.librmm.device_buffer cimport device_buffer
 
 
 cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
     cdef cppclass device_uvector[T]:
-        device_uvector(size_t size, cuda_stream_view  stream) except +
+        device_uvector(size_t size, stream_ref stream) except +
         device_uvector(size_t size, cudaStream_t stream) except +
         T* element_ptr(size_t index)
-        void set_element(size_t element_index, const T& v, cuda_stream_view s)
+        void set_element(size_t element_index, const T& v, stream_ref s)
         void set_element_async(
             size_t element_index,
             const T& v,
-            cuda_stream_view s
+            stream_ref s
         ) except +
-        T front_element(cuda_stream_view s) except +
-        T back_element(cuda_stream_view s) except +
-        void reserve(size_t new_capacity, cuda_stream_view stream) except +
-        void resize(size_t new_size, cuda_stream_view stream) except +
-        void shrink_to_fit(cuda_stream_view stream) except +
+        T front_element(stream_ref s) except +
+        T back_element(stream_ref s) except +
+        void reserve(size_t new_capacity, stream_ref stream) except +
+        void resize(size_t new_size, stream_ref stream) except +
+        void shrink_to_fit(stream_ref stream) except +
         device_buffer release()
         size_t capacity()
         T* data()

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # This import is needed for Cython typing in translate_python_except_to_cpp
@@ -13,12 +13,13 @@ from libcpp.optional cimport optional
 from libcpp.pair cimport pair
 from libcpp.string cimport string
 
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 
 
 cdef extern from * nogil:
     """
     #include <optional>
+    #include <cuda/stream>
     #include <rmm/aligned.hpp>
     #include <rmm/resource_ref.hpp>
 
@@ -51,12 +52,12 @@ cdef extern from * nogil:
             return ref.value();
         }
 
-        void* allocate(rmm::cuda_stream_view stream, std::size_t bytes) {
+        void* allocate(cuda::stream_ref stream, std::size_t bytes) {
             return ref.value().allocate(stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
         }
 
         void deallocate(
-            rmm::cuda_stream_view stream,
+            cuda::stream_ref stream,
             void* ptr,
             std::size_t bytes) noexcept {
             ref.value().deallocate(stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -66,9 +67,9 @@ cdef extern from * nogil:
     cdef cppclass device_async_resource_ref \
             "cython_device_async_resource_ref":
         device_async_resource_ref() noexcept
-        void* allocate(cuda_stream_view stream, size_t bytes) except +
+        void* allocate(stream_ref stream, size_t bytes) except +
         void deallocate(
-            cuda_stream_view stream,
+            stream_ref stream,
             void* ptr,
             size_t bytes
         ) noexcept
@@ -266,8 +267,8 @@ cdef extern from "rmm/mr/fixed_size_memory_resource.hpp" \
 
 cdef extern from "rmm/mr/callback_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    ctypedef void* (*allocate_callback_t)(size_t, cuda_stream_view, void*)
-    ctypedef void (*deallocate_callback_t)(void*, size_t, cuda_stream_view, void*)
+    ctypedef void* (*allocate_callback_t)(size_t, stream_ref, void*)
+    ctypedef void (*deallocate_callback_t)(void*, size_t, stream_ref, void*)
 
     cdef cppclass callback_memory_resource:
         callback_memory_resource(

--- a/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyx
+++ b/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyx
@@ -57,11 +57,11 @@ cdef class CudaStreamPool:
         cdef size_t c_stream_id
         if stream_id is None:
             return Stream._from_cudaStream_t(
-                deref(self.c_obj).get_stream().value(), owner=self)
+                deref(self.c_obj).get_stream().get(), owner=self)
         else:
             c_stream_id = <size_t>(stream_id)
             return Stream._from_cudaStream_t(
-                deref(self.c_obj).get_stream(c_stream_id).value(), owner=self)
+                deref(self.c_obj).get_stream(c_stream_id).get(), owner=self)
 
     def get_pool_size(self) -> int:
         """

--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -21,6 +21,7 @@ from cuda.bindings.cyruntime cimport (
     cudaStream_t,
 )
 
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport (
     cuda_device_id,
@@ -171,11 +172,12 @@ cdef class DeviceBuffer:
                                    if device is None
                                    else cuda_device_id(device))
         cdef Stream strm = self.stream if stream is None else stream
+        cdef stream_ref cpp_stream = stream_ref(strm.view().value())
         with nogil:
             prefetch(self.c_obj.get()[0].data(),
                      self.c_obj.get()[0].size(),
                      dev,
-                     strm.view())
+                     cpp_stream)
 
     def copy(self):
         """Returns a copy of this :class:`DeviceBuffer`.

--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -18,11 +18,9 @@ from cuda.bindings.cyruntime cimport (
     cudaError_t,
     cudaMemcpyAsync,
     cudaMemcpyKind,
-    cudaStream_t,
 )
 
 from rmm.librmm.cuda_stream_ref cimport stream_ref
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport (
     cuda_device_id,
     device_buffer,
@@ -172,7 +170,7 @@ cdef class DeviceBuffer:
                                    if device is None
                                    else cuda_device_id(device))
         cdef Stream strm = self.stream if stream is None else stream
-        cdef stream_ref cpp_stream = stream_ref(strm.view().value())
+        cdef stream_ref cpp_stream = strm.view()
         with nogil:
             prefetch(self.c_obj.get()[0].data(),
                      self.c_obj.get()[0].size(),
@@ -471,7 +469,7 @@ cdef void _copy_async(const void* src,
                       void* dst,
                       size_t count,
                       cudaMemcpyKind kind,
-                      cuda_stream_view stream) except * nogil:
+                      stream_ref stream) except * nogil:
     """
     Asynchronously copy data between host and/or device pointers.
 
@@ -488,8 +486,7 @@ cdef void _copy_async(const void* src,
     """
     cdef cudaError_t err
     with nogil:
-        err = cudaMemcpyAsync(dst, src, count, kind,
-                              <cudaStream_t>(stream))
+        err = cudaMemcpyAsync(dst, src, count, kind, stream.get())
 
     if err != cudaError.cudaSuccess:
         raise RuntimeError(f"Memcpy failed with error: {err}")

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -27,7 +27,7 @@ from rmm.pylibrmm.utils cimport as_stream
 
 from rmm.pylibrmm.stream import DEFAULT_STREAM
 
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 from rmm.librmm.per_device_resource cimport (
     cuda_device_id,
     set_per_device_resource as cpp_set_per_device_resource,
@@ -575,7 +575,7 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
 
 cdef void* _allocate_callback_wrapper(
     size_t nbytes,
-    cuda_stream_view stream,
+    stream_ref stream,
     void* ctx
     # Note that this function is specifically designed to rethrow Python
     # exceptions as C++ exceptions when called as a callback from C++, so it is
@@ -586,7 +586,7 @@ cdef void* _allocate_callback_wrapper(
         try:
             return <void*>(<uintptr_t>((<object>(ctx))(
                 nbytes,
-                Stream._from_cudaStream_t(stream.value())
+                Stream._from_cudaStream_t(stream.get())
             )))
         except BaseException as e:
             err = translate_python_except_to_cpp(e)
@@ -595,10 +595,10 @@ cdef void* _allocate_callback_wrapper(
 cdef void _deallocate_callback_wrapper(
     void* ptr,
     size_t nbytes,
-    cuda_stream_view stream,
+    stream_ref stream,
     void* ctx
 ) except * with gil:
-    (<object>(ctx))(<uintptr_t>(ptr), nbytes, Stream._from_cudaStream_t(stream.value()))
+    (<object>(ctx))(<uintptr_t>(ptr), nbytes, Stream._from_cudaStream_t(stream.get()))
 
 
 cdef class CallbackMemoryResource(DeviceMemoryResource):

--- a/python/rmm/rmm/pylibrmm/stream.pxd
+++ b/python/rmm/rmm/pylibrmm/stream.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 cimport cython
@@ -8,7 +8,7 @@ from libcpp cimport bool
 from libcpp.memory cimport unique_ptr
 
 from rmm.librmm.cuda_stream cimport cuda_stream
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
+from rmm.librmm.cuda_stream_ref cimport stream_ref
 
 
 @cython.final
@@ -25,7 +25,7 @@ cdef class Stream:
     @staticmethod
     cdef Stream _from_cudaStream_t(cudaStream_t s, object owner=*)
 
-    cdef cuda_stream_view view(self) noexcept nogil
+    cdef stream_ref view(self) noexcept nogil
     cdef void c_synchronize(self) except * nogil
     cdef bool c_is_default(self) noexcept nogil
     cdef void _init_with_new_cuda_stream(self, flags=*) except *

--- a/python/rmm/rmm/pylibrmm/stream.pyx
+++ b/python/rmm/rmm/pylibrmm/stream.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 cimport cython
@@ -195,8 +195,8 @@ cdef class Stream:
         self._cuda_stream, self._owner = stream._cuda_stream, stream._owner
 
 
-DEFAULT_STREAM = Stream._from_cudaStream_t(cuda_stream_default.value())
-LEGACY_DEFAULT_STREAM = Stream._from_cudaStream_t(cuda_stream_legacy.value())
+DEFAULT_STREAM = Stream._from_cudaStream_t(cuda_stream_default.get())
+LEGACY_DEFAULT_STREAM = Stream._from_cudaStream_t(cuda_stream_legacy.get())
 PER_THREAD_DEFAULT_STREAM = Stream._from_cudaStream_t(
-    cuda_stream_per_thread.value()
+    cuda_stream_per_thread.get()
 )

--- a/python/rmm/rmm/pylibrmm/stream.pyx
+++ b/python/rmm/rmm/pylibrmm/stream.pyx
@@ -8,11 +8,11 @@ from libc.stdint cimport uintptr_t
 from libcpp cimport bool
 
 from rmm.librmm.cuda_stream cimport cuda_stream, cuda_stream_flags
+from rmm.librmm.cuda_stream_ref cimport is_default_stream, stream_ref
 from rmm.librmm.cuda_stream_view cimport (
     cuda_stream_default,
     cuda_stream_legacy,
     cuda_stream_per_thread,
-    cuda_stream_view,
 )
 
 
@@ -106,11 +106,11 @@ cdef class Stream:
         # https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol
         return (0, int(<uintptr_t>(self._cuda_stream)))
 
-    cdef cuda_stream_view view(self) noexcept nogil:
+    cdef stream_ref view(self) noexcept nogil:
         """
-        Generate a rmm::cuda_stream_view from this Stream instance
+        Generate a cuda::stream_ref from this Stream instance
         """
-        return cuda_stream_view(<cudaStream_t>(<uintptr_t>(self._cuda_stream)))
+        return stream_ref(<cudaStream_t>(<uintptr_t>(self._cuda_stream)))
 
     cdef void c_synchronize(self) except * nogil:
         """
@@ -118,7 +118,7 @@ cdef class Stream:
         This function *must* be called in a `with nogil` block
         """
         with nogil:
-            self.view().synchronize()
+            self.view().sync()
 
     def synchronize(self):
         """
@@ -131,7 +131,7 @@ cdef class Stream:
         """
         Check if we are the default CUDA stream
         """
-        return self.view().is_default()
+        return is_default_stream(self.view())
 
     def is_default(self):
         """
@@ -178,7 +178,7 @@ cdef class Stream:
 
     def __eq__(self, other):
         if isinstance(other, Stream):
-            return self.view() == (<Stream>(other)).view()
+            return self.view().get() == (<Stream>(other)).view().get()
         return False
 
     def __hash__(self):

--- a/python/rmm/rmm/pylibrmm/tests/test_device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/tests/test_device_buffer.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
@@ -16,7 +16,7 @@ def test_release():
 
     got = DeviceBuffer.c_from_unique_ptr(
         make_unique[device_buffer](buf.c_release(),
-                                   cuda_stream_default.value())
+                                   cuda_stream_default.get())
     )
     np.testing.assert_equal(expect.copy_to_host(), got.copy_to_host())
 


### PR DESCRIPTION
## Summary

Track the coordinated migration of stream APIs and call sites from `rmm::cuda_stream_view` to CCCL's `cuda::stream_ref`. This propagates `cuda::stream_ref` through RMM containers and memory resources, RAFT resource and handle APIs, downstream C++ interfaces, Python/Cython bindings, benchmarks, tests, and documentation.

This is the foundational RMM migration. It updates containers, memory resources, stream pools, default stream objects, tests, and Python/Cython bindings while retaining intentional compatibility with `rmm::cuda_stream_view`.

Tracked in rapidsai/build-planning#318.

## Migrations

- Pass `cuda::stream_ref` through stream pools, resource accessors, conditionals, and downstream APIs without converting to `rmm::cuda_stream_view`
- Use `cuda::stream_ref` constructions for default/legacy/per-thread streams
  - `rmm::cuda_stream_default` ➡️ `cuda::stream_ref{cudaStream_t{cudaStreamDefault}}`
  - `rmm::cuda_stream_legacy` ➡️ `cuda::stream_ref{cudaStreamLegacy}`
  - `rmm::cuda_stream_per_thread` ➡️ `cuda::stream_ref{cudaStreamPerThread}`
- Use `.get()` when calling an API that requires a raw `cudaStream_t`, including CUDA runtime, library, CUB, and legacy API boundaries (previously `rmm::cuda_stream_view` used `value()`)
- Use `.sync()` when synchronizing a `cuda::stream_ref` (previously `rmm::cuda_stream_view` used `synchronize()`)
- Update Cython declarations and call sites to pass stream references directly where supported
