### PR TITLE
Fix Python docs for initial async mr size

### DIFF
--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -176,8 +176,9 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
     Parameters
     ----------
     initial_pool_size : int | str, optional
-        Initial pool size in bytes. By default, half the available memory
-        on the device is used. A string argument is parsed using `parse_bytes`.
+        Initial pool size in bytes. If provided, the pool will be primed by
+        allocating and immediately deallocating this amount of memory on the
+        default CUDA stream.
     release_threshold: int, optional
         Release threshold in bytes. If the pool size grows beyond this
         value, unused memory held by the pool will be released at the

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -178,7 +178,7 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
     initial_pool_size : int | str, optional
         Initial pool size in bytes. If provided, the pool will be primed by
         allocating and immediately deallocating this amount of memory on the
-        default CUDA stream.
+        default CUDA stream. A string argument is parsed using `parse_bytes`.
     release_threshold: int, optional
         Release threshold in bytes. If the pool size grows beyond this
         value, unused memory held by the pool will be released at the


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

https://github.com/rapidsai/rmm/pull/2051 changed the behavior in C++ and the doxygen docs, but did not update the Python docs accordingly. This PR matches the Python docs to the [current C++ docs](https://github.com/rapidsai/rmm/blob/c5d25378bfffa04f46666b0fb0e7e21e533fe00d/cpp/include/rmm/mr/cuda_async_memory_resource.hpp#L92) as set in #2051.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
