### PR TITLE
feat(python): add cudaStream_t overloads to device_buffer and device_uvector Cython declarations

### DIFF
--- a/python/rmm/rmm/librmm/device_buffer.pxd
+++ b/python/rmm/rmm/librmm/device_buffer.pxd
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+from cuda.bindings.cyruntime cimport cudaStream_t
+
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.memory_resource cimport any_resource, device_accessible
 
@@ -32,6 +34,12 @@ cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
             const void* source_data,
             size_t size,
             cuda_stream_view stream,
+            any_resource[device_accessible] mr
+        ) except +
+        device_buffer(
+            const void* source_data,
+            size_t size,
+            cudaStream_t stream,
             any_resource[device_accessible] mr
         ) except +
         device_buffer(

--- a/python/rmm/rmm/librmm/device_uvector.pxd
+++ b/python/rmm/rmm/librmm/device_uvector.pxd
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
+from cuda.bindings.cyruntime cimport cudaStream_t
+
 from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.device_buffer cimport device_buffer
 
@@ -8,6 +10,7 @@ from rmm.librmm.device_buffer cimport device_buffer
 cdef extern from "rmm/device_buffer.hpp" namespace "rmm" nogil:
     cdef cppclass device_uvector[T]:
         device_uvector(size_t size, cuda_stream_view  stream) except +
+        device_uvector(size_t size, cudaStream_t stream) except +
         T* element_ptr(size_t index)
         void set_element(size_t element_index, const T& v, cuda_stream_view s)
         void set_element_async(


### PR DESCRIPTION
## Description
<!-- ALL RMM PULL REQUESTS SHOULD HAVE AN ASSOCIATED ISSUE -->
<!-- We use issues for tracking work and features in RMM. If no issue exists for this PR, first -->
<!-- create a new issue. -->

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Add cudaStream_t constructor overloads alongside existing cuda_stream_view ones. This allows downstream Cython code (cuml, pylibraft) that receives cudaStream_t from handle_t.get_stream() to pass it directly to rmm types without explicit <cuda_stream_view> casts. The C++ compiler handles the implicit cuda_stream_view(cudaStream_t) conversion.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
