### PR TITLE
Default cuda_async_memory_resource release threshold to uint64_t max

### DIFF
--- a/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
@@ -93,7 +93,8 @@ class RMM_EXPORT cuda_async_memory_resource final
    * will be primed by allocating and immediately deallocating this amount of memory on the
    * default CUDA stream.
    * @param release_threshold Optional release threshold size in bytes of the pool. If no value is
-   * provided, the release threshold is set to the total amount of memory on the current device.
+   * provided, the release threshold is set to the maximum value of `std::size_t`, so that the pool
+   * retains memory across synchronization events unless the caller specifies otherwise.
    * @param export_handle_type Optional `cudaMemAllocationHandleType` that allocations from this
    * resource should support interprocess communication (IPC). Default is `cudaMemHandleTypeNone`
    * for no IPC support.

--- a/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
@@ -93,8 +93,8 @@ class RMM_EXPORT cuda_async_memory_resource final
    * will be primed by allocating and immediately deallocating this amount of memory on the
    * default CUDA stream.
    * @param release_threshold Optional release threshold size in bytes of the pool. If no value is
-   * provided, the release threshold is set to the maximum value of `std::size_t`, so that the pool
-   * retains memory across synchronization events unless the caller specifies otherwise.
+   * provided, the release threshold is set to the maximum value of `std::uint64_t`, so that the
+   * pool retains memory across synchronization events unless the caller specifies otherwise.
    * @param export_handle_type Optional `cudaMemAllocationHandleType` that allocations from this
    * resource should support interprocess communication (IPC). Default is `cudaMemHandleTypeNone`
    * for no IPC support.

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -51,7 +51,7 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
   pool_ = cuda_async_view_memory_resource{cuda_pool_handle};
 
   // Need an l-value to take address to pass to cudaMemPoolSetAttribute
-  std::size_t threshold = release_threshold.value_or(std::numeric_limits<std::size_t>::max());
+  std::uint64_t threshold = release_threshold.value_or(std::numeric_limits<std::uint64_t>::max());
   RMM_CUDA_TRY(cudaMemPoolSetAttribute(pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
 
   // Allocate and immediately deallocate the initial_pool_size to prime the pool with the

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -15,6 +15,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 namespace RMM_NAMESPACE {
 namespace mr {
@@ -50,10 +51,10 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
   RMM_CUDA_TRY(cudaMemPoolCreate(&cuda_pool_handle, &pool_props));
   pool_ = cuda_async_view_memory_resource{cuda_pool_handle};
 
-  auto const [free, total] = rmm::available_device_memory();
-
-  // Need an l-value to take address to pass to cudaMemPoolSetAttribute
-  uint64_t threshold = release_threshold.value_or(total);
+  // Default to the maximum representable value so the pool retains memory across
+  // synchronization events unless the caller specifies otherwise. Matches the
+  // default chosen by CCCL's memory pool wrappers in <cuda/memory_resource>.
+  uint64_t threshold = release_threshold.value_or(std::numeric_limits<std::size_t>::max());
   RMM_CUDA_TRY(cudaMemPoolSetAttribute(pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
 
   // Allocate and immediately deallocate the initial_pool_size to prime the pool with the

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -50,9 +50,6 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
   RMM_CUDA_TRY(cudaMemPoolCreate(&cuda_pool_handle, &pool_props));
   pool_ = cuda_async_view_memory_resource{cuda_pool_handle};
 
-  // Default to the maximum representable value so the pool retains memory across
-  // synchronization events unless the caller specifies otherwise. Matches the
-  // default chosen by CCCL's memory pool wrappers in <cuda/memory_resource>.
   // Need an l-value to take address to pass to cudaMemPoolSetAttribute
   std::size_t threshold = release_threshold.value_or(std::numeric_limits<std::size_t>::max());
   RMM_CUDA_TRY(cudaMemPoolSetAttribute(pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -53,6 +53,7 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
   // Default to the maximum representable value so the pool retains memory across
   // synchronization events unless the caller specifies otherwise. Matches the
   // default chosen by CCCL's memory pool wrappers in <cuda/memory_resource>.
+  // Need an l-value to take address to pass to cudaMemPoolSetAttribute
   std::size_t threshold = release_threshold.value_or(std::numeric_limits<std::size_t>::max());
   RMM_CUDA_TRY(cudaMemPoolSetAttribute(pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
 

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -54,7 +54,7 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
   // Default to the maximum representable value so the pool retains memory across
   // synchronization events unless the caller specifies otherwise. Matches the
   // default chosen by CCCL's memory pool wrappers in <cuda/memory_resource>.
-  uint64_t threshold = release_threshold.value_or(std::numeric_limits<std::size_t>::max());
+  std::size_t threshold = release_threshold.value_or(std::numeric_limits<std::size_t>::max());
   RMM_CUDA_TRY(cudaMemPoolSetAttribute(pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
 
   // Allocate and immediately deallocate the initial_pool_size to prime the pool with the

--- a/cpp/tests/mr/cuda_async_mr_tests.cpp
+++ b/cpp/tests/mr/cuda_async_mr_tests.cpp
@@ -10,6 +10,10 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
 namespace rmm::test {
 namespace {
 
@@ -47,6 +51,25 @@ TEST_F(AsyncMRTest, ExplicitReleaseThreshold)
   void* ptr = mr.allocate_sync(pool_init_size);
   mr.deallocate_sync(ptr, pool_init_size);
   RMM_CUDA_TRY(cudaDeviceSynchronize());
+}
+
+TEST_F(AsyncMRTest, DefaultReleaseThresholdIsSizeMax)
+{
+  cuda_async_mr mr{};
+  std::uint64_t threshold{0};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
+  EXPECT_EQ(threshold, std::numeric_limits<std::size_t>::max());
+}
+
+TEST_F(AsyncMRTest, ExplicitReleaseThresholdIsApplied)
+{
+  const std::size_t pool_release_threshold{1000};
+  cuda_async_mr mr{{}, pool_release_threshold};
+  std::uint64_t threshold{0};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
+  EXPECT_EQ(threshold, pool_release_threshold);
 }
 
 TEST_F(AsyncMRTest, DifferentPoolsUnequal)

--- a/cpp/tests/mr/cuda_async_mr_tests.cpp
+++ b/cpp/tests/mr/cuda_async_mr_tests.cpp
@@ -10,7 +10,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <cstdint>
 #include <limits>
 
@@ -53,18 +52,18 @@ TEST_F(AsyncMRTest, ExplicitReleaseThreshold)
   RMM_CUDA_TRY(cudaDeviceSynchronize());
 }
 
-TEST_F(AsyncMRTest, DefaultReleaseThresholdIsSizeMax)
+TEST_F(AsyncMRTest, DefaultReleaseThresholdIsUint64Max)
 {
   cuda_async_mr mr{};
   std::uint64_t threshold{0};
   RMM_CUDA_TRY(
     cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
-  EXPECT_EQ(threshold, std::numeric_limits<std::size_t>::max());
+  EXPECT_EQ(threshold, std::numeric_limits<std::uint64_t>::max());
 }
 
 TEST_F(AsyncMRTest, ExplicitReleaseThresholdIsApplied)
 {
-  const std::size_t pool_release_threshold{1000};
+  const std::uint64_t pool_release_threshold{1000};
   cuda_async_mr mr{{}, pool_release_threshold};
   std::uint64_t threshold{0};
   RMM_CUDA_TRY(

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -183,9 +183,9 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
         Release threshold in bytes. If the pool size grows beyond this
         value, unused memory held by the pool will be released at the
         next synchronization point. If not provided, the release threshold
-        is set to the maximum representable ``size_t`` value, so that the
-        pool retains memory across synchronization events unless the caller
-        specifies otherwise.
+        is set to the maximum representable ``uint64_t`` value, so that
+        the pool retains memory across synchronization events unless the
+        caller specifies otherwise.
     enable_ipc: bool, optional
         If True, enables export of POSIX file descriptor handles for the memory
         allocated by this resource so that it can be used with CUDA IPC.

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -182,7 +182,10 @@ cdef class CudaAsyncMemoryResource(DeviceMemoryResource):
     release_threshold: int, optional
         Release threshold in bytes. If the pool size grows beyond this
         value, unused memory held by the pool will be released at the
-        next synchronization point.
+        next synchronization point. If not provided, the release threshold
+        is set to the maximum representable ``size_t`` value, so that the
+        pool retains memory across synchronization events unless the caller
+        specifies otherwise.
     enable_ipc: bool, optional
         If True, enables export of POSIX file descriptor handles for the memory
         allocated by this resource so that it can be used with CUDA IPC.


### PR DESCRIPTION
## Description

Change the default release threshold of `rmm::mr::cuda_async_memory_resource` (and the Python `CudaAsyncMemoryResource`) from total device memory to `std::numeric_limits<std::size_t>::max()`. This matches the default chosen by CCCL's memory pool wrappers under `<cuda/memory_resource>` (see `libcudacxx/include/cuda/__memory_pool/memory_pool_base.h`). Note that the [CUDA runtime default](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html#group__CUDART__MEMORY__POOLS_1g0229135f7ef724b4f479a435ca300af5) for `cudaMemPoolAttrReleaseThreshold` is 0 (release on every sync); both RMM's previous default (total device memory) and the new default (`size_t` max) override that to keep memory in the pool, so existing single-device workloads should see no practical change. The Python binding already forwards `None` as an empty `std::optional`, so no Python code changes are required beyond the docstring.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.