### PR TITLE
Deprecate is_resource_adaptor

### DIFF
--- a/cpp/include/rmm/mr/is_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/is_resource_adaptor.hpp
@@ -21,11 +21,15 @@ namespace mr {
 /**
  * @brief Concept to check whether a resource is a resource adaptor by checking for
  * `get_upstream_resource`.
+ *
+ * @deprecated This trait will be removed in a future release.
  */
 template <class Resource, class = void>
+[[deprecated("is_resource_adaptor is deprecated and will be removed in a future release.")]]  //
 inline constexpr bool is_resource_adaptor = false;
 
 template <class Resource>
+[[deprecated("is_resource_adaptor is deprecated and will be removed in a future release.")]]  //
 inline constexpr bool is_resource_adaptor<
   Resource,
   cuda::std::void_t<decltype(cuda::std::declval<Resource>().get_upstream_resource())>> =

--- a/cpp/tests/mr/adaptor_tests.cpp
+++ b/cpp/tests/mr/adaptor_tests.cpp
@@ -9,7 +9,6 @@
 #include <rmm/mr/aligned_resource_adaptor.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/failure_callback_resource_adaptor.hpp>
-#include <rmm/mr/is_resource_adaptor.hpp>
 #include <rmm/mr/limiting_resource_adaptor.hpp>
 #include <rmm/mr/logging_resource_adaptor.hpp>
 #include <rmm/mr/statistics_resource_adaptor.hpp>
@@ -102,7 +101,6 @@ TYPED_TEST(AdaptorTest, GetUpstreamResource)
 {
   rmm::device_async_resource_ref expected{this->cuda};
   EXPECT_EQ(this->mr->get_upstream_resource(), expected);
-  EXPECT_TRUE(rmm::mr::is_resource_adaptor<decltype(*this->mr)>);
 }
 
 TYPED_TEST(AdaptorTest, AllocFree)

--- a/cpp/tests/mr/cccl_adaptor_tests.cpp
+++ b/cpp/tests/mr/cccl_adaptor_tests.cpp
@@ -13,7 +13,6 @@
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/failure_callback_resource_adaptor.hpp>
 #include <rmm/mr/fixed_size_memory_resource.hpp>
-#include <rmm/mr/is_resource_adaptor.hpp>
 #include <rmm/mr/limiting_resource_adaptor.hpp>
 #include <rmm/mr/logging_resource_adaptor.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
@@ -133,7 +132,6 @@ TYPED_TEST(CcclAdaptorTest, GetUpstreamResource)
 {
   rmm::device_async_resource_ref expected{this->cuda};
   EXPECT_EQ(this->mr.get_upstream_resource(), expected);
-  EXPECT_TRUE(rmm::mr::is_resource_adaptor<TypeParam>);
 }
 
 TYPED_TEST(CcclAdaptorTest, AllocFree)


### PR DESCRIPTION
## Description

Part of #2011.

Deprecates `rmm::mr::is_resource_adaptor`. It is not used externally, and its implementation is no longer meaningfully standardized with the CCCL MR transition.

Removes internal adaptor test usage of the deprecated trait so RMM builds continue to pass with `-Werror=deprecated-declarations`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.