### PR TITLE
Log GPU addressing mode in CI

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -33,8 +33,9 @@ set -u
 
 rapids-print-env
 
-rapids-logger "Check GPU usage"
+rapids-logger "Check GPU status"
 nvidia-smi
+nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
 
 # Run librmm gtests from librmm-tests package
 rapids-logger "Run gtests"

--- a/ci/test_cpp_debug.sh
+++ b/ci/test_cpp_debug.sh
@@ -33,8 +33,9 @@ set -u
 
 rapids-print-env
 
-rapids-logger "Check GPU usage"
+rapids-logger "Check GPU status"
 nvidia-smi
+nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
 
 rapids-logger "Building librmm in Debug mode"
 cmake -S cpp -B cpp/build \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -39,8 +39,9 @@ RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 
-rapids-logger "Check GPU usage"
+rapids-logger "Check GPU status"
 nvidia-smi
+nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
 
 rapids-logger "pytest rmm"
 

--- a/ci/test_python_integrations.sh
+++ b/ci/test_python_integrations.sh
@@ -22,8 +22,9 @@ RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 
-rapids-logger "Check GPU usage"
+rapids-logger "Check GPU status"
 nvidia-smi
+nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
 
 EXITCODE=0
 

--- a/ci/test_wheel_integrations.sh
+++ b/ci/test_wheel_integrations.sh
@@ -28,8 +28,9 @@ PIP_INSTALL_SHARED_ARGS=(
 
 EXITCODE=0
 
-rapids-logger "Check GPU usage"
+rapids-logger "Check GPU status"
 nvidia-smi
+nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
 
 echo "::group::PyTorch Tests"
 


### PR DESCRIPTION
## Description
Add `nvidia-smi -q` Addressing Mode output to GPU CI status logs so recent runs can be audited for HMM support.

Closes #1599.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.