### PR TITLE
Use RMM_EXPORT_NAMESPACE and re-forward MR methods to avoid inlined impl symbols.

### DIFF
--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -2184,6 +2184,7 @@ PREDEFINED             = RMM_EXEC_CHECK_DISABLE \
                          RMM_EXPORT \
                          RMM_HIDDEN \
                          RMM_NAMESPACE=rmm \
+                         RMM_EXPORT_NAMESPACE=rmm \
                          DOXYGEN \
                          "RMM_CONSTEXPR_FRIEND=friend"
 

--- a/cpp/include/rmm/aligned.hpp
+++ b/cpp/include/rmm/aligned.hpp
@@ -10,7 +10,7 @@
 #include <cassert>
 #include <cstddef>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_EXPORT_NAMESPACE {
 
 /**
  * @addtogroup utilities
@@ -85,4 +85,4 @@ static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
 
 /** @} */  // end of group
 
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/cuda_device.hpp
+++ b/cpp/include/rmm/cuda_device.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_EXPORT_NAMESPACE {
 
 struct cuda_device_id;
 cuda_device_id get_current_cuda_device();
@@ -135,4 +135,4 @@ struct cuda_set_device_raii {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/cuda_stream.hpp
+++ b/cpp/include/rmm/cuda_stream.hpp
@@ -14,7 +14,7 @@
 #include <functional>
 #include <memory>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_EXPORT_NAMESPACE {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -127,4 +127,4 @@ class cuda_stream {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/cuda_stream_pool.hpp
+++ b/cpp/include/rmm/cuda_stream_pool.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_EXPORT_NAMESPACE {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -87,4 +87,4 @@ class cuda_stream_pool {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/cuda_stream_view.hpp
+++ b/cpp/include/rmm/cuda_stream_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <ostream>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_EXPORT_NAMESPACE {
 /**
  * @addtogroup cuda_streams
  * @{
@@ -152,4 +152,4 @@ bool operator!=(cuda_stream_view lhs, cuda_stream_view rhs);
 std::ostream& operator<<(std::ostream& os, cuda_stream_view stream);
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/detail/export.hpp
+++ b/cpp/include/rmm/detail/export.hpp
@@ -13,13 +13,15 @@
 
 // Macros used for defining symbol visibility, only GLIBC is supported
 #if (defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__))
-#define RMM_EXPORT    __attribute__((visibility("default")))
-#define RMM_HIDDEN    __attribute__((visibility("hidden")))
-#define RMM_NAMESPACE RMM_EXPORT rmm
+#define RMM_EXPORT           __attribute__((visibility("default")))
+#define RMM_HIDDEN           __attribute__((visibility("hidden")))
+#define RMM_NAMESPACE        rmm
+#define RMM_EXPORT_NAMESPACE RMM_EXPORT rmm
 #else
 #define RMM_EXPORT
 #define RMM_HIDDEN
-#define RMM_NAMESPACE rmm
+#define RMM_NAMESPACE        rmm
+#define RMM_EXPORT_NAMESPACE rmm
 #endif
 
 // Work around breathe "friend constexpr friend" bug (breathe-doc/breathe#916).

--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -18,7 +18,7 @@
 #include <cassert>
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 /**
  * @addtogroup data_containers
  * @{
@@ -424,4 +424,4 @@ class device_buffer {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -13,7 +13,7 @@
 
 #include <type_traits>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 /**
  * @addtogroup data_containers
  * @{
@@ -268,4 +268,4 @@ class device_scalar {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 /**
  * @addtogroup data_containers
  * @{
@@ -629,4 +629,4 @@ class device_uvector {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/device_vector.hpp
+++ b/cpp/include/rmm/device_vector.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 
 #include <thrust/device_vector.h>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -25,4 +25,4 @@ template <typename T>
 using device_vector = thrust::device_vector<T, rmm::mr::thrust_allocator<T>>;
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/error.hpp
+++ b/cpp/include/rmm/error.hpp
@@ -10,7 +10,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 
 /**
  * @brief Exception thrown when logical precondition is violated.
@@ -109,4 +109,4 @@ class invalid_argument : public std::invalid_argument {
   using std::invalid_argument::invalid_argument;
 };
 
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/exec_policy.hpp
+++ b/cpp/include/rmm/exec_policy.hpp
@@ -19,7 +19,7 @@
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -77,4 +77,4 @@ class exec_policy_nosync : public thrust_exec_policy_nosync_t {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/logger.hpp
+++ b/cpp/include/rmm/logger.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 
 #include <rapids_logger/logger.hpp>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 
 /**
  * @brief Returns the default sink for the global logger.
@@ -36,4 +36,4 @@ std::string default_pattern();
  */
 rapids_logger::logger& default_logger();
 
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
@@ -10,10 +10,11 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -64,7 +65,71 @@ class RMM_EXPORT aligned_resource_adaptor
                                     std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT,
                                     std::size_t alignment_threshold = default_alignment_threshold);
 
-  ~aligned_resource_adaptor() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(aligned_resource_adaptor const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(aligned_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~aligned_resource_adaptor();
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
@@ -77,4 +142,4 @@ static_assert(cuda::mr::resource_with<aligned_resource_adaptor, cuda::mr::device
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/arena_memory_resource.hpp
+++ b/cpp/include/rmm/mr/arena_memory_resource.hpp
@@ -4,16 +4,18 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/arena_memory_resource_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -85,7 +87,71 @@ class RMM_EXPORT arena_memory_resource
                                  std::optional<std::size_t> arena_size = std::nullopt,
                                  bool dump_log_on_failure              = false);
 
-  ~arena_memory_resource() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(arena_memory_resource const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(arena_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~arena_memory_resource();
 };
 
 static_assert(cuda::mr::resource_with<arena_memory_resource, cuda::mr::device_accessible>,
@@ -93,4 +159,4 @@ static_assert(cuda::mr::resource_with<arena_memory_resource, cuda::mr::device_ac
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/binning_memory_resource.hpp
+++ b/cpp/include/rmm/mr/binning_memory_resource.hpp
@@ -4,16 +4,18 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/binning_memory_resource_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -68,7 +70,71 @@ class RMM_EXPORT binning_memory_resource
                           int8_t min_size_exponent,  // NOLINT(bugprone-easily-swappable-parameters)
                           int8_t max_size_exponent);
 
-  ~binning_memory_resource() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(binning_memory_resource const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(binning_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~binning_memory_resource();
 
   /**
    * @briefreturn{device_async_resource_ref to the upstream resource}
@@ -99,4 +165,4 @@ static_assert(cuda::mr::resource_with<binning_memory_resource, cuda::mr::device_
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -4,16 +4,18 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/callback_memory_resource_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <functional>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -95,8 +97,72 @@ class RMM_EXPORT callback_memory_resource
                            void* allocate_callback_arg   = nullptr,
                            void* deallocate_callback_arg = nullptr);
 
-  callback_memory_resource()  = delete;
-  ~callback_memory_resource() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(callback_memory_resource const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(callback_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  callback_memory_resource() = delete;
+  ~callback_memory_resource();
 };
 
 static_assert(cuda::mr::resource_with<callback_memory_resource, cuda::mr::device_accessible>,
@@ -104,4 +170,4 @@ static_assert(cuda::mr::resource_with<callback_memory_resource, cuda::mr::device
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
@@ -9,11 +9,12 @@
 #include <rmm/mr/detail/cuda_async_managed_memory_resource_impl.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -59,13 +60,77 @@ class RMM_EXPORT cuda_async_managed_memory_resource final
   cuda_async_managed_memory_resource();
 
   /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(cuda_async_managed_memory_resource const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(cuda_async_managed_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  /**
    * @brief Returns the underlying native handle to the CUDA pool
    *
    * @return cudaMemPool_t Handle to the underlying CUDA pool
    */
   [[nodiscard]] cudaMemPool_t pool_handle() const noexcept;
 
-  ~cuda_async_managed_memory_resource() = default;
+  ~cuda_async_managed_memory_resource();
   cuda_async_managed_memory_resource(cuda_async_managed_memory_resource const&) =
     default;  ///< @default_copy_constructor
   cuda_async_managed_memory_resource(cuda_async_managed_memory_resource&&) =
@@ -90,4 +155,4 @@ static_assert(
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
@@ -9,13 +9,14 @@
 #include <rmm/mr/detail/cuda_async_memory_resource_impl.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -105,13 +106,77 @@ class RMM_EXPORT cuda_async_memory_resource final
                              std::optional<allocation_handle_type> export_handle_type = {});
 
   /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(cuda_async_memory_resource const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(cuda_async_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  /**
    * @brief Returns the underlying native handle to the CUDA pool
    *
    * @return cudaMemPool_t Handle to the underlying CUDA pool
    */
   [[nodiscard]] cudaMemPool_t pool_handle() const noexcept;
 
-  ~cuda_async_memory_resource() = default;
+  ~cuda_async_memory_resource();
   cuda_async_memory_resource(cuda_async_memory_resource const&) =
     default;  ///< @default_copy_constructor
   cuda_async_memory_resource(cuda_async_memory_resource&&) =
@@ -131,4 +196,4 @@ static_assert(cuda::mr::resource_with<cuda_async_memory_resource, cuda::mr::devi
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
@@ -15,7 +15,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -179,4 +179,4 @@ static_assert(
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_memory_resource.hpp
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -136,4 +136,4 @@ static_assert(cuda::mr::resource_with<cuda_memory_resource, cuda::mr::device_acc
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -15,7 +15,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 namespace detail {
 
@@ -109,4 +109,4 @@ class failure_callback_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/failure_callback_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/failure_callback_resource_adaptor.hpp
@@ -15,7 +15,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -91,4 +91,4 @@ static_assert(
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/failure_callback_t.hpp
+++ b/cpp/include/rmm/mr/failure_callback_t.hpp
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <functional>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -35,4 +35,4 @@ using failure_callback_t = std::function<bool(std::size_t, void*)>;
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
+++ b/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
@@ -4,15 +4,17 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/fixed_size_memory_resource_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -66,7 +68,71 @@ class RMM_EXPORT fixed_size_memory_resource
     std::size_t block_size            = default_block_size,
     std::size_t blocks_to_preallocate = default_blocks_to_preallocate);
 
-  ~fixed_size_memory_resource() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(fixed_size_memory_resource const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(fixed_size_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~fixed_size_memory_resource();
 
   /**
    * @briefreturn{device_async_resource_ref to the upstream resource}
@@ -86,4 +152,4 @@ static_assert(cuda::mr::resource_with<fixed_size_memory_resource, cuda::mr::devi
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
@@ -10,10 +10,11 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -57,7 +58,71 @@ class RMM_EXPORT limiting_resource_adaptor
                             std::size_t allocation_limit,
                             std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
-  ~limiting_resource_adaptor() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(limiting_resource_adaptor const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(limiting_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~limiting_resource_adaptor();
 
   /**
    * @briefreturn{device_async_resource_ref to the upstream resource}
@@ -90,4 +155,4 @@ static_assert(cuda::mr::resource_with<limiting_resource_adaptor, cuda::mr::devic
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/logging_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/logging_resource_adaptor.hpp
@@ -4,17 +4,19 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/logging_resource_adaptor_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <initializer_list>
 #include <ostream>
 #include <string>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 
 /**
@@ -106,6 +108,72 @@ class RMM_EXPORT logging_resource_adaptor
                            bool auto_flush = false);
 
   /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(logging_resource_adaptor const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(logging_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~logging_resource_adaptor();
+
+  /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
    */
   [[nodiscard]] rmm::device_async_resource_ref get_upstream_resource() const noexcept;
@@ -137,4 +205,4 @@ static_assert(cuda::mr::resource_with<logging_resource_adaptor, cuda::mr::device
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/managed_memory_resource.hpp
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -153,4 +153,4 @@ static_assert(cuda::mr::resource_with<managed_memory_resource, cuda::mr::host_ac
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/per_device_resource.hpp
+++ b/cpp/include/rmm/mr/per_device_resource.hpp
@@ -29,7 +29,7 @@
  * that was active when the memory resource was created.
  */
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -381,4 +381,4 @@ reset_current_device_resource_ref()
 }
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -15,7 +15,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 
 /**
@@ -172,4 +172,4 @@ static_assert(cuda::mr::resource_with<pinned_host_memory_resource, cuda::mr::hos
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -16,7 +16,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -291,4 +291,4 @@ bool operator!=(stream_allocator_adaptor<A> const& lhs, stream_allocator_adaptor
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/pool_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pool_memory_resource.hpp
@@ -4,16 +4,18 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/pool_memory_resource_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -64,6 +66,72 @@ class RMM_EXPORT pool_memory_resource
                                 std::optional<std::size_t> maximum_pool_size = std::nullopt);
 
   /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(pool_memory_resource const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(pool_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~pool_memory_resource();
+
+  /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
    */
   [[nodiscard]] device_async_resource_ref get_upstream_resource() const noexcept;
@@ -83,4 +151,4 @@ static_assert(cuda::mr::resource_with<pool_memory_resource, cuda::mr::device_acc
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/prefetch_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/prefetch_resource_adaptor.hpp
@@ -4,15 +4,17 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/prefetch_resource_adaptor_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -46,7 +48,71 @@ class RMM_EXPORT prefetch_resource_adaptor
    */
   explicit prefetch_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
-  ~prefetch_resource_adaptor() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(prefetch_resource_adaptor const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(prefetch_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~prefetch_resource_adaptor();
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
@@ -59,4 +125,4 @@ static_assert(cuda::mr::resource_with<prefetch_resource_adaptor, cuda::mr::devic
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/sam_headroom_memory_resource.hpp
+++ b/cpp/include/rmm/mr/sam_headroom_memory_resource.hpp
@@ -9,10 +9,11 @@
 #include <rmm/mr/detail/sam_headroom_memory_resource_impl.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -60,8 +61,72 @@ class RMM_EXPORT sam_headroom_memory_resource final
    */
   explicit sam_headroom_memory_resource(std::size_t headroom);
 
-  sam_headroom_memory_resource()  = delete;
-  ~sam_headroom_memory_resource() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(sam_headroom_memory_resource const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(sam_headroom_memory_resource const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  sam_headroom_memory_resource() = delete;
+  ~sam_headroom_memory_resource();
   sam_headroom_memory_resource(sam_headroom_memory_resource const&) =
     default;  ///< @default_copy_constructor
   sam_headroom_memory_resource(sam_headroom_memory_resource&&) =
@@ -84,4 +149,4 @@ static_assert(cuda::mr::resource_with<sam_headroom_memory_resource, cuda::mr::ho
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/statistics_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/statistics_resource_adaptor.hpp
@@ -4,16 +4,18 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/statistics_resource_adaptor_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -57,7 +59,71 @@ class RMM_EXPORT statistics_resource_adaptor
   explicit statistics_resource_adaptor(
     cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
-  ~statistics_resource_adaptor() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(statistics_resource_adaptor const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(statistics_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~statistics_resource_adaptor();
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
@@ -99,4 +165,4 @@ static_assert(cuda::mr::resource_with<statistics_resource_adaptor, cuda::mr::dev
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/system_memory_resource.hpp
+++ b/cpp/include/rmm/mr/system_memory_resource.hpp
@@ -18,7 +18,7 @@
 #include <cstddef>
 #include <string>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 
 namespace detail {
@@ -208,4 +208,4 @@ static_assert(cuda::mr::resource_with<system_memory_resource, cuda::mr::device_a
 static_assert(cuda::mr::resource_with<system_memory_resource, cuda::mr::host_accessible>);
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
@@ -4,16 +4,18 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <mutex>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -54,7 +56,71 @@ class RMM_EXPORT thread_safe_resource_adaptor
   explicit thread_safe_resource_adaptor(
     cuda::mr::any_resource<cuda::mr::device_accessible> upstream);
 
-  ~thread_safe_resource_adaptor() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(thread_safe_resource_adaptor const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(thread_safe_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~thread_safe_resource_adaptor();
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
@@ -67,4 +133,4 @@ static_assert(cuda::mr::resource_with<thread_safe_resource_adaptor, cuda::mr::de
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -18,7 +18,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -186,4 +186,4 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
 };
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
@@ -4,18 +4,20 @@
  */
 #pragma once
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/mr/detail/tracking_resource_adaptor_impl.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <map>
 #include <memory>
 #include <string>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -60,7 +62,71 @@ class RMM_EXPORT tracking_resource_adaptor
   tracking_resource_adaptor(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
                             bool capture_stacks = false);
 
-  ~tracking_resource_adaptor() = default;
+  /**
+   * @brief Allocate memory using this resource.
+   *
+   * @param stream Stream on which to perform the allocation
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory using this resource.
+   *
+   * @param stream Stream on which to perform deallocation
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Allocate memory synchronously using this resource.
+   *
+   * @param bytes The size of the allocation
+   * @param alignment The alignment of the allocation
+   * @return Pointer to the newly allocated memory
+   */
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  /**
+   * @brief Deallocate memory synchronously using this resource.
+   *
+   * @param ptr Pointer to be deallocated
+   * @param bytes The size in bytes of the allocation
+   * @param alignment The alignment that was passed to the allocation call
+   */
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  /**
+   * @brief Compare two resources for equality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator==(tracking_resource_adaptor const& other) const noexcept;
+  /**
+   * @brief Compare two resources for inequality.
+   *
+   * @param other The other resource to compare against
+   * @return true if the resources do not compare equal, false otherwise
+   */
+  [[nodiscard]] bool operator!=(tracking_resource_adaptor const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  ~tracking_resource_adaptor();
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
@@ -100,4 +166,4 @@ static_assert(cuda::mr::resource_with<tracking_resource_adaptor, cuda::mr::devic
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/prefetch.hpp
+++ b/cpp/include/rmm/prefetch.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 
 #include <cuda/std/span>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 
 /**
  * @addtogroup utilities
@@ -60,4 +60,4 @@ void prefetch(cuda::std::span<T const> data,
 
 /** @} */  // end of group
 
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/process_is_exiting.hpp
+++ b/cpp/include/rmm/process_is_exiting.hpp
@@ -6,7 +6,7 @@
 
 #include <rmm/detail/export.hpp>
 
-namespace RMM_EXPORT rmm {
+namespace RMM_EXPORT_NAMESPACE {
 
 /**
  * @addtogroup memory_resources
@@ -61,4 +61,4 @@ bool process_is_exiting() noexcept;
 
 /** @} */  // end of group
 
-}  // namespace RMM_EXPORT rmm
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/include/rmm/resource_ref.hpp
+++ b/cpp/include/rmm/resource_ref.hpp
@@ -9,7 +9,7 @@
 
 #include <cuda/memory_resource>
 
-namespace RMM_NAMESPACE {
+namespace RMM_EXPORT_NAMESPACE {
 
 /**
  * @addtogroup memory_resources
@@ -85,4 +85,4 @@ static_assert(std::is_constructible_v<host_resource_ref, host_device_resource_re
               "host_resource_ref must be constructible from host_device_resource_ref");
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+}  // namespace RMM_EXPORT_NAMESPACE

--- a/cpp/src/mr/aligned_resource_adaptor.cpp
+++ b/cpp/src/mr/aligned_resource_adaptor.cpp
@@ -19,6 +19,40 @@ aligned_resource_adaptor::aligned_resource_adaptor(
 {
 }
 
+aligned_resource_adaptor::~aligned_resource_adaptor() = default;
+
+void* aligned_resource_adaptor::allocate(cuda::stream_ref stream,
+                                         std::size_t bytes,
+                                         std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void aligned_resource_adaptor::deallocate(cuda::stream_ref stream,
+                                          void* ptr,
+                                          std::size_t bytes,
+                                          std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* aligned_resource_adaptor::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void aligned_resource_adaptor::deallocate_sync(void* ptr,
+                                               std::size_t bytes,
+                                               std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool aligned_resource_adaptor::operator==(aligned_resource_adaptor const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref aligned_resource_adaptor::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/arena_memory_resource.cpp
+++ b/cpp/src/mr/arena_memory_resource.cpp
@@ -17,5 +17,39 @@ arena_memory_resource::arena_memory_resource(
 {
 }
 
+arena_memory_resource::~arena_memory_resource() = default;
+
+void* arena_memory_resource::allocate(cuda::stream_ref stream,
+                                      std::size_t bytes,
+                                      std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void arena_memory_resource::deallocate(cuda::stream_ref stream,
+                                       void* ptr,
+                                       std::size_t bytes,
+                                       std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* arena_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void arena_memory_resource::deallocate_sync(void* ptr,
+                                            std::size_t bytes,
+                                            std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool arena_memory_resource::operator==(arena_memory_resource const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 }  // namespace mr
 }  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/binning_memory_resource.cpp
+++ b/cpp/src/mr/binning_memory_resource.cpp
@@ -27,6 +27,40 @@ binning_memory_resource::binning_memory_resource(
 {
 }
 
+binning_memory_resource::~binning_memory_resource() = default;
+
+void* binning_memory_resource::allocate(cuda::stream_ref stream,
+                                        std::size_t bytes,
+                                        std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void binning_memory_resource::deallocate(cuda::stream_ref stream,
+                                         void* ptr,
+                                         std::size_t bytes,
+                                         std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* binning_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void binning_memory_resource::deallocate_sync(void* ptr,
+                                              std::size_t bytes,
+                                              std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool binning_memory_resource::operator==(binning_memory_resource const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref binning_memory_resource::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/callback_memory_resource.cpp
+++ b/cpp/src/mr/callback_memory_resource.cpp
@@ -23,5 +23,39 @@ callback_memory_resource::callback_memory_resource(allocate_callback_t allocate_
 {
 }
 
+callback_memory_resource::~callback_memory_resource() = default;
+
+void* callback_memory_resource::allocate(cuda::stream_ref stream,
+                                         std::size_t bytes,
+                                         std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void callback_memory_resource::deallocate(cuda::stream_ref stream,
+                                          void* ptr,
+                                          std::size_t bytes,
+                                          std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* callback_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void callback_memory_resource::deallocate_sync(void* ptr,
+                                               std::size_t bytes,
+                                               std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool callback_memory_resource::operator==(callback_memory_resource const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 }  // namespace mr
 }  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/cuda_async_managed_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_managed_memory_resource.cpp
@@ -14,6 +14,41 @@ cuda_async_managed_memory_resource::cuda_async_managed_memory_resource()
 {
 }
 
+cuda_async_managed_memory_resource::~cuda_async_managed_memory_resource() = default;
+
+void* cuda_async_managed_memory_resource::allocate(cuda::stream_ref stream,
+                                                   std::size_t bytes,
+                                                   std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void cuda_async_managed_memory_resource::deallocate(cuda::stream_ref stream,
+                                                    void* ptr,
+                                                    std::size_t bytes,
+                                                    std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* cuda_async_managed_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void cuda_async_managed_memory_resource::deallocate_sync(void* ptr,
+                                                         std::size_t bytes,
+                                                         std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool cuda_async_managed_memory_resource::operator==(
+  cuda_async_managed_memory_resource const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 cudaMemPool_t cuda_async_managed_memory_resource::pool_handle() const noexcept
 {
   return get().pool_handle();

--- a/cpp/src/mr/cuda_async_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_memory_resource.cpp
@@ -24,6 +24,40 @@ cuda_async_memory_resource::cuda_async_memory_resource(
 {
 }
 
+cuda_async_memory_resource::~cuda_async_memory_resource() = default;
+
+void* cuda_async_memory_resource::allocate(cuda::stream_ref stream,
+                                           std::size_t bytes,
+                                           std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void cuda_async_memory_resource::deallocate(cuda::stream_ref stream,
+                                            void* ptr,
+                                            std::size_t bytes,
+                                            std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* cuda_async_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void cuda_async_memory_resource::deallocate_sync(void* ptr,
+                                                 std::size_t bytes,
+                                                 std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool cuda_async_memory_resource::operator==(cuda_async_memory_resource const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 cudaMemPool_t cuda_async_memory_resource::pool_handle() const noexcept
 {
   return get().pool_handle();

--- a/cpp/src/mr/fixed_size_memory_resource.cpp
+++ b/cpp/src/mr/fixed_size_memory_resource.cpp
@@ -19,6 +19,40 @@ fixed_size_memory_resource::fixed_size_memory_resource(
 {
 }
 
+fixed_size_memory_resource::~fixed_size_memory_resource() = default;
+
+void* fixed_size_memory_resource::allocate(cuda::stream_ref stream,
+                                           std::size_t bytes,
+                                           std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void fixed_size_memory_resource::deallocate(cuda::stream_ref stream,
+                                            void* ptr,
+                                            std::size_t bytes,
+                                            std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* fixed_size_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void fixed_size_memory_resource::deallocate_sync(void* ptr,
+                                                 std::size_t bytes,
+                                                 std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool fixed_size_memory_resource::operator==(fixed_size_memory_resource const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref fixed_size_memory_resource::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/limiting_resource_adaptor.cpp
+++ b/cpp/src/mr/limiting_resource_adaptor.cpp
@@ -17,6 +17,40 @@ limiting_resource_adaptor::limiting_resource_adaptor(
 {
 }
 
+limiting_resource_adaptor::~limiting_resource_adaptor() = default;
+
+void* limiting_resource_adaptor::allocate(cuda::stream_ref stream,
+                                          std::size_t bytes,
+                                          std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void limiting_resource_adaptor::deallocate(cuda::stream_ref stream,
+                                           void* ptr,
+                                           std::size_t bytes,
+                                           std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* limiting_resource_adaptor::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void limiting_resource_adaptor::deallocate_sync(void* ptr,
+                                                std::size_t bytes,
+                                                std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool limiting_resource_adaptor::operator==(limiting_resource_adaptor const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref limiting_resource_adaptor::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/logging_resource_adaptor.cpp
+++ b/cpp/src/mr/logging_resource_adaptor.cpp
@@ -60,6 +60,40 @@ logging_resource_adaptor::logging_resource_adaptor(
 {
 }
 
+logging_resource_adaptor::~logging_resource_adaptor() = default;
+
+void* logging_resource_adaptor::allocate(cuda::stream_ref stream,
+                                         std::size_t bytes,
+                                         std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void logging_resource_adaptor::deallocate(cuda::stream_ref stream,
+                                          void* ptr,
+                                          std::size_t bytes,
+                                          std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* logging_resource_adaptor::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void logging_resource_adaptor::deallocate_sync(void* ptr,
+                                               std::size_t bytes,
+                                               std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool logging_resource_adaptor::operator==(logging_resource_adaptor const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 rmm::device_async_resource_ref logging_resource_adaptor::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/pool_memory_resource.cpp
+++ b/cpp/src/mr/pool_memory_resource.cpp
@@ -21,6 +21,40 @@ pool_memory_resource::pool_memory_resource(
 {
 }
 
+pool_memory_resource::~pool_memory_resource() = default;
+
+void* pool_memory_resource::allocate(cuda::stream_ref stream,
+                                     std::size_t bytes,
+                                     std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void pool_memory_resource::deallocate(cuda::stream_ref stream,
+                                      void* ptr,
+                                      std::size_t bytes,
+                                      std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* pool_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void pool_memory_resource::deallocate_sync(void* ptr,
+                                           std::size_t bytes,
+                                           std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool pool_memory_resource::operator==(pool_memory_resource const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref pool_memory_resource::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/prefetch_resource_adaptor.cpp
+++ b/cpp/src/mr/prefetch_resource_adaptor.cpp
@@ -15,6 +15,40 @@ prefetch_resource_adaptor::prefetch_resource_adaptor(
 {
 }
 
+prefetch_resource_adaptor::~prefetch_resource_adaptor() = default;
+
+void* prefetch_resource_adaptor::allocate(cuda::stream_ref stream,
+                                          std::size_t bytes,
+                                          std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void prefetch_resource_adaptor::deallocate(cuda::stream_ref stream,
+                                           void* ptr,
+                                           std::size_t bytes,
+                                           std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* prefetch_resource_adaptor::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void prefetch_resource_adaptor::deallocate_sync(void* ptr,
+                                                std::size_t bytes,
+                                                std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool prefetch_resource_adaptor::operator==(prefetch_resource_adaptor const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref prefetch_resource_adaptor::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/sam_headroom_memory_resource.cpp
+++ b/cpp/src/mr/sam_headroom_memory_resource.cpp
@@ -14,5 +14,40 @@ sam_headroom_memory_resource::sam_headroom_memory_resource(std::size_t headroom)
 {
 }
 
+sam_headroom_memory_resource::~sam_headroom_memory_resource() = default;
+
+void* sam_headroom_memory_resource::allocate(cuda::stream_ref stream,
+                                             std::size_t bytes,
+                                             std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void sam_headroom_memory_resource::deallocate(cuda::stream_ref stream,
+                                              void* ptr,
+                                              std::size_t bytes,
+                                              std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* sam_headroom_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void sam_headroom_memory_resource::deallocate_sync(void* ptr,
+                                                   std::size_t bytes,
+                                                   std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool sam_headroom_memory_resource::operator==(
+  sam_headroom_memory_resource const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 }  // namespace mr
 }  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/statistics_resource_adaptor.cpp
+++ b/cpp/src/mr/statistics_resource_adaptor.cpp
@@ -18,6 +18,41 @@ statistics_resource_adaptor::statistics_resource_adaptor(
 {
 }
 
+statistics_resource_adaptor::~statistics_resource_adaptor() = default;
+
+void* statistics_resource_adaptor::allocate(cuda::stream_ref stream,
+                                            std::size_t bytes,
+                                            std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void statistics_resource_adaptor::deallocate(cuda::stream_ref stream,
+                                             void* ptr,
+                                             std::size_t bytes,
+                                             std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* statistics_resource_adaptor::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void statistics_resource_adaptor::deallocate_sync(void* ptr,
+                                                  std::size_t bytes,
+                                                  std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool statistics_resource_adaptor::operator==(
+  statistics_resource_adaptor const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref statistics_resource_adaptor::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/thread_safe_resource_adaptor.cpp
+++ b/cpp/src/mr/thread_safe_resource_adaptor.cpp
@@ -15,6 +15,41 @@ thread_safe_resource_adaptor::thread_safe_resource_adaptor(
 {
 }
 
+thread_safe_resource_adaptor::~thread_safe_resource_adaptor() = default;
+
+void* thread_safe_resource_adaptor::allocate(cuda::stream_ref stream,
+                                             std::size_t bytes,
+                                             std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void thread_safe_resource_adaptor::deallocate(cuda::stream_ref stream,
+                                              void* ptr,
+                                              std::size_t bytes,
+                                              std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* thread_safe_resource_adaptor::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void thread_safe_resource_adaptor::deallocate_sync(void* ptr,
+                                                   std::size_t bytes,
+                                                   std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool thread_safe_resource_adaptor::operator==(
+  thread_safe_resource_adaptor const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref thread_safe_resource_adaptor::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();

--- a/cpp/src/mr/tracking_resource_adaptor.cpp
+++ b/cpp/src/mr/tracking_resource_adaptor.cpp
@@ -19,6 +19,40 @@ tracking_resource_adaptor::tracking_resource_adaptor(
 {
 }
 
+tracking_resource_adaptor::~tracking_resource_adaptor() = default;
+
+void* tracking_resource_adaptor::allocate(cuda::stream_ref stream,
+                                          std::size_t bytes,
+                                          std::size_t alignment)
+{
+  return get().allocate(stream, bytes, alignment);
+}
+
+void tracking_resource_adaptor::deallocate(cuda::stream_ref stream,
+                                           void* ptr,
+                                           std::size_t bytes,
+                                           std::size_t alignment) noexcept
+{
+  get().deallocate(stream, ptr, bytes, alignment);
+}
+
+void* tracking_resource_adaptor::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  return get().allocate_sync(bytes, alignment);
+}
+
+void tracking_resource_adaptor::deallocate_sync(void* ptr,
+                                                std::size_t bytes,
+                                                std::size_t alignment) noexcept
+{
+  get().deallocate_sync(ptr, bytes, alignment);
+}
+
+bool tracking_resource_adaptor::operator==(tracking_resource_adaptor const& other) const noexcept
+{
+  return static_cast<shared_base const&>(*this) == static_cast<shared_base const&>(other);
+}
+
 device_async_resource_ref tracking_resource_adaptor::get_upstream_resource() const noexcept
 {
   return get().get_upstream_resource();


### PR DESCRIPTION
## Description
This is a possible solution for https://github.com/rapidsai/rmm/issues/2390, option 1.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
