### PR TITLE
Enforce base resource alignment limits

### DIFF
--- a/cpp/include/rmm/aligned.hpp
+++ b/cpp/include/rmm/aligned.hpp
@@ -43,6 +43,16 @@ static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
 [[nodiscard]] bool is_supported_alignment(std::size_t alignment) noexcept;
 
 /**
+ * @brief Returns whether or not `alignment` is supported by base CUDA memory resources.
+ *
+ * @param[in] alignment to check
+ *
+ * @return True if the alignment is a valid memory alignment and is no larger than
+ * CUDA_ALLOCATION_ALIGNMENT, false otherwise.
+ */
+[[nodiscard]] bool is_supported_base_resource_alignment(std::size_t alignment) noexcept;
+
+/**
  * @brief Align up to nearest multiple of specified power of 2
  *
  * @param[in] value value to align

--- a/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
@@ -80,12 +80,14 @@ class cuda_async_view_memory_resource final {
    */
   void* allocate(cuda::stream_ref stream,
                  std::size_t bytes,
-                 [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
+    if (bytes == 0) { return nullptr; }
+    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+                "Requested alignment is larger than this memory resource supports.",
+                rmm::bad_alloc);
     void* ptr{nullptr};
-    if (bytes > 0) {
-      RMM_CUDA_TRY_ALLOC(cudaMallocFromPoolAsync(&ptr, bytes, pool_handle(), stream.get()), bytes);
-    }
+    RMM_CUDA_TRY_ALLOC(cudaMallocFromPoolAsync(&ptr, bytes, pool_handle(), stream.get()), bytes);
     return ptr;
   }
 

--- a/cpp/include/rmm/mr/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_memory_resource.hpp
@@ -48,8 +48,12 @@ class cuda_memory_resource final {
    */
   void* allocate([[maybe_unused]] cuda::stream_ref stream,
                  std::size_t bytes,
-                 [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
+    if (bytes == 0) { return nullptr; }
+    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+                "Requested alignment is larger than this memory resource supports.",
+                rmm::bad_alloc);
     void* ptr{nullptr};
     RMM_CUDA_TRY_ALLOC(cudaMalloc(&ptr, bytes), bytes);
     return ptr;

--- a/cpp/include/rmm/mr/managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/managed_memory_resource.hpp
@@ -48,11 +48,14 @@ class managed_memory_resource final {
    */
   void* allocate([[maybe_unused]] cuda::stream_ref stream,
                  std::size_t bytes,
-                 [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
     // FIXME: Unlike cudaMalloc, cudaMallocManaged will throw an error for 0
     // size allocations.
     if (bytes == 0) { return nullptr; }
+    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+                "Requested alignment is larger than this memory resource supports.",
+                rmm::bad_alloc);
 
     void* ptr{nullptr};
     RMM_CUDA_TRY_ALLOC(cudaMallocManaged(&ptr, bytes), bytes);

--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -62,10 +62,13 @@ class pinned_host_memory_resource final {
    */
   void* allocate([[maybe_unused]] cuda::stream_ref stream,
                  std::size_t bytes,
-                 [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
     // don't allocate anything if the user requested zero bytes
     if (0 == bytes) { return nullptr; }
+    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+                "Requested alignment is larger than this memory resource supports.",
+                rmm::bad_alloc);
 
     std::size_t constexpr alloc_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
     return rmm::detail::aligned_host_allocate(bytes, alloc_alignment, [](std::size_t size) {

--- a/cpp/include/rmm/mr/system_memory_resource.hpp
+++ b/cpp/include/rmm/mr/system_memory_resource.hpp
@@ -94,8 +94,12 @@ class system_memory_resource final {
    */
   void* allocate([[maybe_unused]] cuda::stream_ref stream,
                  std::size_t bytes,
-                 [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
   {
+    if (bytes == 0) { return nullptr; }
+    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+                "Requested alignment is larger than this memory resource supports.",
+                rmm::bad_alloc);
     try {
       return rmm::detail::aligned_host_allocate(
         bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, [](std::size_t size) {

--- a/cpp/src/aligned.cpp
+++ b/cpp/src/aligned.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,6 +14,11 @@ namespace rmm {
 bool is_pow2(std::size_t value) noexcept { return (value != 0U) && ((value & (value - 1)) == 0U); }
 
 bool is_supported_alignment(std::size_t alignment) noexcept { return is_pow2(alignment); }
+
+bool is_supported_base_resource_alignment(std::size_t alignment) noexcept
+{
+  return is_pow2(alignment) && alignment <= rmm::CUDA_ALLOCATION_ALIGNMENT;
+}
 
 std::size_t align_up(std::size_t value, std::size_t alignment) noexcept
 {

--- a/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
@@ -41,9 +41,9 @@ cudaMemPool_t cuda_async_managed_memory_resource_impl::pool_handle() const noexc
 
 void* cuda_async_managed_memory_resource_impl::allocate(cuda::stream_ref stream,
                                                         std::size_t bytes,
-                                                        std::size_t /*alignment*/)
+                                                        std::size_t alignment)
 {
-  return pool_.allocate(stream, bytes);
+  return pool_.allocate(stream, bytes, alignment);
 }
 
 void cuda_async_managed_memory_resource_impl::deallocate(cuda::stream_ref stream,

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -77,9 +77,9 @@ cudaMemPool_t cuda_async_memory_resource_impl::pool_handle() const noexcept
 
 void* cuda_async_memory_resource_impl::allocate(cuda::stream_ref stream,
                                                 std::size_t bytes,
-                                                std::size_t /*alignment*/)
+                                                std::size_t alignment)
 {
-  return pool_.allocate(stream, bytes);
+  return pool_.allocate(stream, bytes, alignment);
 }
 
 void cuda_async_memory_resource_impl::deallocate(cuda::stream_ref stream,

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -535,9 +535,7 @@ TEST(DeviceBufferAlignmentTest, ExplicitAlignmentSmall)
   EXPECT_EQ(buff.size(), 100);
 }
 
-// Disabled: leaf MRs silently ignore unsupported alignment after #2324.
-// See https://github.com/rapidsai/rmm/issues/2342
-TEST(DeviceBufferAlignmentTest, DISABLED_ExplicitAlignmentTooLarge)
+TEST(DeviceBufferAlignmentTest, ExplicitAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
   EXPECT_THROW(rmm::device_buffer(100, alignment, rmm::cuda_stream_default), rmm::bad_alloc);
@@ -560,9 +558,7 @@ TEST(DeviceBufferAlignmentTest, CopyFromSourceExplicitAlignment)
   EXPECT_EQ(buff.size(), host_data.size());
 }
 
-// Disabled: leaf MRs silently ignore unsupported alignment after #2324.
-// See https://github.com/rapidsai/rmm/issues/2342
-TEST(DeviceBufferAlignmentTest, DISABLED_CopyFromSourceAlignmentTooLarge)
+TEST(DeviceBufferAlignmentTest, CopyFromSourceAlignmentTooLarge)
 {
   std::vector<uint8_t> host_data(100, 42);
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
@@ -622,10 +618,12 @@ TEST(DeviceBufferAlignmentTest, EmptyBufferAlignment)
 TEST(DeviceBufferAlignmentTest, EmptyBufferAlignmentTooLarge)
 {
   auto constexpr alignment = rmm::CUDA_ALLOCATION_ALIGNMENT * 2;
-  rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
-  EXPECT_EQ(buff.alignment(), alignment);
-  EXPECT_TRUE(buff.is_empty());
-  EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
+  EXPECT_NO_THROW({
+    rmm::device_buffer buff(std::size_t{0}, alignment, rmm::cuda_stream_default);
+    EXPECT_EQ(buff.alignment(), alignment);
+    EXPECT_TRUE(buff.is_empty());
+    EXPECT_TRUE(rmm::is_pointer_aligned(buff.data(), alignment));
+  });
 }
 
 TEST(DeviceBufferAlignmentTest, DefaultConstructedHasValidAlignment)

--- a/cpp/tests/device_scalar_tests.cpp
+++ b/cpp/tests/device_scalar_tests.cpp
@@ -149,9 +149,7 @@ TEST(DeviceScalarAlignmentTest, SmallAlignment)
   EXPECT_TRUE(rmm::is_pointer_aligned(s.data(), std::alignment_of_v<decltype(s)::value_type>));
 }
 
-// Disabled: leaf MRs silently ignore unsupported alignment after #2324.
-// See https://github.com/rapidsai/rmm/issues/2342
-TEST(DeviceScalarAlignmentTest, DISABLED_LargeAlignment)
+TEST(DeviceScalarAlignmentTest, LargeAlignment)
 {
   struct alignas(rmm::CUDA_ALLOCATION_ALIGNMENT * 2) OverAligned {
     int value;

--- a/cpp/tests/device_uvector_tests.cpp
+++ b/cpp/tests/device_uvector_tests.cpp
@@ -387,9 +387,7 @@ TEST(DeviceUVectorAlignmentTest, SmallAlignment)
   EXPECT_TRUE(rmm::is_pointer_aligned(v.data(), std::alignment_of_v<decltype(v)::value_type>));
 }
 
-// Disabled: leaf MRs silently ignore unsupported alignment after #2324.
-// See https://github.com/rapidsai/rmm/issues/2342
-TEST(DeviceUVectorAlignmentTest, DISABLED_LargeAlignment)
+TEST(DeviceUVectorAlignmentTest, LargeAlignment)
 {
   struct alignas(rmm::CUDA_ALLOCATION_ALIGNMENT * 2) OverAligned {
     int value;


### PR DESCRIPTION
## Description

Closes #2342.

Restores alignment enforcement for base CUDA memory resources by rejecting nonzero allocations whose requested alignment exceeds `CUDA_ALLOCATION_ALIGNMENT`. Zero-size allocations continue to return `nullptr` without validating the requested alignment.

Re-enables the previously disabled oversized-alignment tests for `device_buffer`, `device_scalar`, and `device_uvector`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.