### PR TITLE
Add constructor tag to avoid bug NVIDIA/cccl#9043

### DIFF
--- a/cpp/include/rmm/mr/detail/cuda_async_managed_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/cuda_async_managed_memory_resource_impl.hpp
@@ -30,7 +30,10 @@ namespace detail {
  */
 class cuda_async_managed_memory_resource_impl {
  public:
+  struct construction_tag {};
+
   cuda_async_managed_memory_resource_impl();
+  explicit cuda_async_managed_memory_resource_impl(construction_tag);
 
   ~cuda_async_managed_memory_resource_impl() = default;
 

--- a/cpp/src/mr/cuda_async_managed_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_managed_memory_resource.cpp
@@ -10,7 +10,8 @@ namespace RMM_NAMESPACE {
 namespace mr {
 
 cuda_async_managed_memory_resource::cuda_async_managed_memory_resource()
-  : shared_base(cuda::mr::make_shared_resource<detail::cuda_async_managed_memory_resource_impl>())
+  : shared_base(cuda::mr::make_shared_resource<detail::cuda_async_managed_memory_resource_impl>(
+      detail::cuda_async_managed_memory_resource_impl::construction_tag{}))
 {
 }
 

--- a/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
@@ -34,6 +34,11 @@ cuda_async_managed_memory_resource_impl::cuda_async_managed_memory_resource_impl
 #endif
 }
 
+cuda_async_managed_memory_resource_impl::cuda_async_managed_memory_resource_impl(construction_tag)
+  : cuda_async_managed_memory_resource_impl()
+{
+}
+
 cudaMemPool_t cuda_async_managed_memory_resource_impl::pool_handle() const noexcept
 {
   return pool_.pool_handle();


### PR DESCRIPTION
## Description
There is a bug in CCCL's `make_shared_resource<T>()` that doesn't work with types that have no constructor arguments. https://github.com/NVIDIA/cccl/issues/9043

https://github.com/NVIDIA/cccl/pull/9044 fixes it, but we need a workaround to unblock CI until that is backported (https://github.com/NVIDIA/cccl/pull/9047) and rapids-cmake is updated.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
