### PR TITLE
Improve devcontainer startup times

### DIFF
--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -6,7 +6,10 @@
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "conda",
       "BASE": "rapidsai/devcontainers:26.08-cpp-mambaforge"
-    }
+    },
+    "cacheFrom": [
+      "ghcr.io/rapidsai/rmm/devcontainer:26.08-cuda12.9-conda"
+    ]
   },
   "runArgs": [
     "--rm",

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -6,7 +6,10 @@
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "pip",
       "BASE": "rapidsai/devcontainers:26.08-cpp-cuda12.9"
-    }
+    },
+    "cacheFrom": [
+      "ghcr.io/rapidsai/rmm/devcontainer:26.08-cuda12.9-pip"
+    ]
   },
   "runArgs": [
     "--rm",

--- a/.devcontainer/cuda13.2-conda/devcontainer.json
+++ b/.devcontainer/cuda13.2-conda/devcontainer.json
@@ -6,7 +6,10 @@
       "CUDA": "13.2",
       "PYTHON_PACKAGE_MANAGER": "conda",
       "BASE": "rapidsai/devcontainers:26.08-cpp-mambaforge"
-    }
+    },
+    "cacheFrom": [
+      "ghcr.io/rapidsai/rmm/devcontainer:26.08-cuda13.2-conda"
+    ]
   },
   "runArgs": [
     "--rm",

--- a/.devcontainer/cuda13.2-pip/devcontainer.json
+++ b/.devcontainer/cuda13.2-pip/devcontainer.json
@@ -6,7 +6,10 @@
       "CUDA": "13.2",
       "PYTHON_PACKAGE_MANAGER": "pip",
       "BASE": "rapidsai/devcontainers:26.08-cpp-cuda13.2"
-    }
+    },
+    "cacheFrom": [
+      "ghcr.io/rapidsai/rmm/devcontainer:26.08-cuda13.2-pip"
+    ]
   },
   "runArgs": [
     "--rm",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -215,3 +215,12 @@ jobs:
 
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-summarize@main
+  devcontainers:
+    name: Build devcontainers
+    secrets: inherit  # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/build-devcontainers.yaml@main
+    permissions:
+      packages: write
+    with:
+      push: true
+      cuda: '["12.9", "13.2"]'


### PR DESCRIPTION
This PR builds and publishes devcontainers to `ghcr.io` and uses the new images to improve CI and local devcontainer startup times.

In `rapidsai/devcontainers`, devcontainer startup times went from [`3m28s`](https://github.com/rapidsai/devcontainers/actions/runs/26123239225/job/76830349936#step:9:2006) to [`34s`](https://github.com/rapidsai/devcontainers/actions/runs/26132932976/job/76861774810?pr=706#step:9:305).

Contributes to https://github.com/rapidsai/build-planning/issues/280.
