### PR TITLE
Use C++20 in test and benchmark utilities

### DIFF
--- a/cpp/benchmarks/utilities/log_parser.hpp
+++ b/cpp/benchmarks/utilities/log_parser.hpp
@@ -94,37 +94,23 @@ inline std::ostream& operator<<(std::ostream& os, event const& evt)
  *
  * @note currently unused. Seemed necessary for ordering but it appears the log currently
  * is in timestamp order even for multithreaded logs.
- * @note This function can be simplified with C++20 and later.
- *
  * @param str_time The input time in format "HH:MM:SS:us" where us is a 6 digits microseconds part
  * of the current second. (This is the format rmm::mr::logging_resource_adaptor outputs)
  * @return std::chrono::time_point<std::chrono::system_clock> Converted time point.
  */
 inline std::chrono::time_point<std::chrono::system_clock> parse_time(std::string const& str_time)
 {
-  std::size_t current  = str_time.find(':');
-  std::size_t previous = 0;
-  int hours            = std::stoi(str_time.substr(previous, current - previous));
-  previous             = current;
-  current              = str_time.find(':');
-  int minutes          = std::stoi(str_time.substr(previous, current - previous));
-  previous             = current;
-  current              = str_time.find(':');
-  int seconds          = std::stoi(str_time.substr(previous, current - previous));
-  int microseconds     = std::stoi(str_time.substr(current + 1, str_time.length()));
+  int hours{};
+  int minutes{};
+  int seconds{};
+  int microseconds{};
+  char delimiter{};
+  std::istringstream{str_time} >> hours >> delimiter >> minutes >> delimiter >> seconds >>
+    delimiter >> microseconds;
 
-  auto const epoch_year{1970};
-  std::tm time{};
-  time.tm_sec  = seconds;
-  time.tm_min  = minutes;
-  time.tm_hour = hours;
-  time.tm_mday = 1;
-  time.tm_mon  = 0;
-  time.tm_year = epoch_year;
-
-  auto timepoint = std::chrono::system_clock::from_time_t(std::mktime(&time));
-  timepoint += std::chrono::microseconds{microseconds};
-  return timepoint;
+  return std::chrono::sys_days{std::chrono::year{1970} / std::chrono::January / 1} +
+         std::chrono::hours{hours} + std::chrono::minutes{minutes} + std::chrono::seconds{seconds} +
+         std::chrono::microseconds{microseconds};
 }
 
 /**

--- a/cpp/tests/device_scalar_tests.cpp
+++ b/cpp/tests/device_scalar_tests.cpp
@@ -31,24 +31,23 @@ struct DeviceScalarTest : public ::testing::Test {
 
   DeviceScalarTest() : value{random_value()} {}
 
-  template <typename U = T, std::enable_if_t<std::is_same_v<U, bool>, bool> = true>
-  U random_value()
+  template <typename U = T>
+  requires std::is_same_v<U, bool> U random_value()
   {
     static std::bernoulli_distribution distribution{};
     return distribution(generator);
   }
 
-  template <typename U                                                                     = T,
-            std::enable_if_t<(std::is_integral_v<U> && not std::is_same_v<U, bool>), bool> = true>
-  U random_value()
+  template <typename U = T>
+  requires(std::is_integral_v<U> && not std::is_same_v<U, bool>) U random_value()
   {
     static std::uniform_int_distribution<U> distribution{std::numeric_limits<T>::lowest(),
                                                          std::numeric_limits<T>::max()};
     return distribution(generator);
   }
 
-  template <typename U = T, std::enable_if_t<std::is_floating_point_v<U>, bool> = true>
-  U random_value()
+  template <typename U = T>
+  requires std::is_floating_point_v<U> U random_value()
   {
     auto const mean{100};
     auto const stddev{20};


### PR DESCRIPTION
## Description
This applies follow-up C++20 cleanups only in tests/benchmarks, which already require C++20:

- replaces test-only SFINAE overloads in `device_scalar_tests.cpp` with `requires` clauses
- simplifies the benchmark log timestamp parser with C++20 chrono calendar/duration types

Contributes to #2034.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.