### PR TITLE
Move public memory resource definitions to source files

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -93,6 +93,8 @@ add_library(
   src/mr/callback_memory_resource.cpp
   src/mr/cuda_async_managed_memory_resource.cpp
   src/mr/cuda_async_memory_resource.cpp
+  src/mr/cuda_async_view_memory_resource.cpp
+  src/mr/cuda_memory_resource.cpp
   src/mr/detail/aligned_resource_adaptor_impl.cpp
   src/mr/detail/arena_memory_resource_impl.cpp
   src/mr/detail/binning_memory_resource_impl.cpp
@@ -111,10 +113,13 @@ add_library(
   src/mr/fixed_size_memory_resource.cpp
   src/mr/limiting_resource_adaptor.cpp
   src/mr/logging_resource_adaptor.cpp
+  src/mr/managed_memory_resource.cpp
   src/mr/pool_memory_resource.cpp
   src/mr/prefetch_resource_adaptor.cpp
+  src/mr/pinned_host_memory_resource.cpp
   src/mr/sam_headroom_memory_resource.cpp
   src/mr/statistics_resource_adaptor.cpp
+  src/mr/system_memory_resource.cpp
   src/mr/thread_safe_resource_adaptor.cpp
   src/mr/tracking_resource_adaptor.cpp
   src/prefetch.cpp

--- a/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
@@ -5,9 +5,7 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
-#include <rmm/detail/runtime_capabilities.hpp>
 
 #include <cuda/memory_resource>
 #include <cuda/stream_ref>
@@ -27,7 +25,7 @@ namespace mr {
  * @brief Memory resource that uses `cudaMallocAsync`/`cudaFreeAsync` for
  * allocation/deallocation.
  */
-class cuda_async_view_memory_resource final {
+class RMM_EXPORT cuda_async_view_memory_resource final {
  public:
   /**
    * @brief Constructs a cuda_async_view_memory_resource which uses an existing CUDA memory pool.
@@ -39,23 +37,14 @@ class cuda_async_view_memory_resource final {
    * @param pool_handle Handle to a CUDA memory pool which will be used to
    * serve allocation requests.
    */
-  cuda_async_view_memory_resource(cudaMemPool_t pool_handle)
-    : cuda_pool_handle_{[pool_handle]() {
-        RMM_EXPECTS(nullptr != pool_handle, "Unexpected null pool handle.");
-        return pool_handle;
-      }()}
-  {
-    // Check if cudaMallocAsync Memory pool supported
-    RMM_EXPECTS(rmm::detail::runtime_async_alloc::is_supported(),
-                "cudaMallocAsync not supported with this CUDA driver/runtime version");
-  }
+  cuda_async_view_memory_resource(cudaMemPool_t pool_handle);
 
   /**
    * @brief Returns the underlying native handle to the CUDA pool
    *
    * @return cudaMemPool_t Handle to the underlying CUDA pool
    */
-  [[nodiscard]] cudaMemPool_t pool_handle() const noexcept { return cuda_pool_handle_; }
+  [[nodiscard]] cudaMemPool_t pool_handle() const noexcept;
 
   cuda_async_view_memory_resource()  = default;
   ~cuda_async_view_memory_resource() = default;
@@ -80,16 +69,7 @@ class cuda_async_view_memory_resource final {
    */
   void* allocate(cuda::stream_ref stream,
                  std::size_t bytes,
-                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    if (bytes == 0) { return nullptr; }
-    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
-                "Requested alignment is larger than this memory resource supports.",
-                rmm::bad_alloc);
-    void* ptr{nullptr};
-    RMM_CUDA_TRY_ALLOC(cudaMallocFromPoolAsync(&ptr, bytes, pool_handle(), stream.get()), bytes);
-    return ptr;
-  }
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr.
@@ -102,11 +82,8 @@ class cuda_async_view_memory_resource final {
    */
   void deallocate(cuda::stream_ref stream,
                   void* ptr,
-                  [[maybe_unused]] std::size_t bytes,
-                  [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    if (ptr != nullptr) { RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFreeAsync(ptr, stream.get())); }
-  }
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Allocates memory of size at least \p bytes synchronously.
@@ -115,12 +92,7 @@ class cuda_async_view_memory_resource final {
    * @param alignment The alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
-    RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
-    return ptr;
-  }
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr synchronously.
@@ -131,12 +103,7 @@ class cuda_async_view_memory_resource final {
    */
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
-                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
-    deallocate(stream, ptr, bytes, alignment);
-    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
-  }
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Compare this resource to another.
@@ -145,18 +112,12 @@ class cuda_async_view_memory_resource final {
    * @return true If the two resources are equivalent
    * @return false If the two resources are not equal
    */
-  [[nodiscard]] bool operator==(cuda_async_view_memory_resource const& other) const noexcept
-  {
-    return pool_handle() == other.pool_handle();
-  }
+  [[nodiscard]] bool operator==(cuda_async_view_memory_resource const& other) const noexcept;
 
   /**
    * @copydoc operator==
    */
-  [[nodiscard]] bool operator!=(cuda_async_view_memory_resource const& other) const noexcept
-  {
-    return !operator==(other);
-  }
+  [[nodiscard]] bool operator!=(cuda_async_view_memory_resource const& other) const noexcept;
 
   /**
    * @brief Enables the `cuda::mr::device_accessible` property

--- a/cpp/include/rmm/mr/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_memory_resource.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>
@@ -23,7 +22,7 @@ namespace mr {
 /**
  * @brief Memory resource that uses cudaMalloc/Free for allocation/deallocation.
  */
-class cuda_memory_resource final {
+class RMM_EXPORT cuda_memory_resource final {
  public:
   cuda_memory_resource()                            = default;
   ~cuda_memory_resource()                           = default;
@@ -48,16 +47,7 @@ class cuda_memory_resource final {
    */
   void* allocate([[maybe_unused]] cuda::stream_ref stream,
                  std::size_t bytes,
-                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    if (bytes == 0) { return nullptr; }
-    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
-                "Requested alignment is larger than this memory resource supports.",
-                rmm::bad_alloc);
-    void* ptr{nullptr};
-    RMM_CUDA_TRY_ALLOC(cudaMalloc(&ptr, bytes), bytes);
-    return ptr;
-  }
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr.
@@ -72,11 +62,8 @@ class cuda_memory_resource final {
    */
   void deallocate([[maybe_unused]] cuda::stream_ref stream,
                   void* ptr,
-                  [[maybe_unused]] std::size_t bytes,
-                  [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFree(ptr));
-  }
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Allocates memory of size at least \p bytes synchronously.
@@ -85,12 +72,7 @@ class cuda_memory_resource final {
    * @param alignment The alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
-    RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
-    return ptr;
-  }
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr synchronously.
@@ -101,10 +83,7 @@ class cuda_memory_resource final {
    */
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
-                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
-  }
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Enables the `cuda::mr::device_accessible` property
@@ -123,12 +102,12 @@ class cuda_memory_resource final {
    *
    * @return true Always
    */
-  [[nodiscard]] bool operator==(cuda_memory_resource const&) const noexcept { return true; }
+  [[nodiscard]] bool operator==(cuda_memory_resource const&) const noexcept;
 
   /**
    * @copydoc operator==
    */
-  [[nodiscard]] bool operator!=(cuda_memory_resource const&) const noexcept { return false; }
+  [[nodiscard]] bool operator!=(cuda_memory_resource const&) const noexcept;
 };
 
 // static property checks

--- a/cpp/include/rmm/mr/managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/managed_memory_resource.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>
@@ -23,7 +22,7 @@ namespace mr {
 /**
  * @brief Memory resource that uses cudaMallocManaged/Free for allocation/deallocation.
  */
-class managed_memory_resource final {
+class RMM_EXPORT managed_memory_resource final {
  public:
   managed_memory_resource()                               = default;
   ~managed_memory_resource()                              = default;
@@ -48,19 +47,7 @@ class managed_memory_resource final {
    */
   void* allocate([[maybe_unused]] cuda::stream_ref stream,
                  std::size_t bytes,
-                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    // FIXME: Unlike cudaMalloc, cudaMallocManaged will throw an error for 0
-    // size allocations.
-    if (bytes == 0) { return nullptr; }
-    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
-                "Requested alignment is larger than this memory resource supports.",
-                rmm::bad_alloc);
-
-    void* ptr{nullptr};
-    RMM_CUDA_TRY_ALLOC(cudaMallocManaged(&ptr, bytes), bytes);
-    return ptr;
-  }
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr.
@@ -75,11 +62,8 @@ class managed_memory_resource final {
    */
   void deallocate([[maybe_unused]] cuda::stream_ref stream,
                   void* ptr,
-                  [[maybe_unused]] std::size_t bytes,
-                  [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFree(ptr));
-  }
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Allocates memory of size at least \p bytes synchronously.
@@ -88,12 +72,7 @@ class managed_memory_resource final {
    * @param alignment The alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
-    RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
-    return ptr;
-  }
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr synchronously.
@@ -104,10 +83,7 @@ class managed_memory_resource final {
    */
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
-                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
-  }
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Enables the `cuda::mr::device_accessible` property
@@ -136,12 +112,12 @@ class managed_memory_resource final {
    *
    * @return true Always
    */
-  [[nodiscard]] bool operator==(managed_memory_resource const&) const noexcept { return true; }
+  [[nodiscard]] bool operator==(managed_memory_resource const&) const noexcept;
 
   /**
    * @copydoc operator==
    */
-  [[nodiscard]] bool operator!=(managed_memory_resource const&) const noexcept { return false; }
+  [[nodiscard]] bool operator!=(managed_memory_resource const&) const noexcept;
 };
 
 // static property checks

--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -5,8 +5,6 @@
 #pragma once
 
 #include <rmm/aligned.hpp>
-#include <rmm/detail/aligned.hpp>
-#include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>
@@ -31,7 +29,7 @@ namespace mr {
  * `cuda::mr::resource` and `cuda::mr::synchronous_resource` concepts, and
  * the `cuda::mr::host_accessible` and `cuda::mr::device_accessible` properties.
  */
-class pinned_host_memory_resource final {
+class RMM_EXPORT pinned_host_memory_resource final {
  public:
   pinned_host_memory_resource()  = default;
   ~pinned_host_memory_resource() = default;
@@ -62,21 +60,7 @@ class pinned_host_memory_resource final {
    */
   void* allocate([[maybe_unused]] cuda::stream_ref stream,
                  std::size_t bytes,
-                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    // don't allocate anything if the user requested zero bytes
-    if (0 == bytes) { return nullptr; }
-    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
-                "Requested alignment is larger than this memory resource supports.",
-                rmm::bad_alloc);
-
-    std::size_t constexpr alloc_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
-    return rmm::detail::aligned_host_allocate(bytes, alloc_alignment, [](std::size_t size) {
-      void* ptr{nullptr};
-      RMM_CUDA_TRY_ALLOC(cudaHostAlloc(&ptr, size, cudaHostAllocDefault), size);
-      return ptr;
-    });
-  }
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr.
@@ -92,13 +76,7 @@ class pinned_host_memory_resource final {
   void deallocate([[maybe_unused]] cuda::stream_ref stream,
                   void* ptr,
                   std::size_t bytes,
-                  [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    std::size_t constexpr alloc_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
-    rmm::detail::aligned_host_deallocate(ptr, bytes, alloc_alignment, [](void* ptr) {
-      RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFreeHost(ptr));
-    });
-  }
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Allocates pinned host memory of size at least \p bytes bytes synchronously.
@@ -107,12 +85,7 @@ class pinned_host_memory_resource final {
    * @param alignment The alignment of the allocation
    * @return Pointer to the newly allocated memory.
    */
-  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
-    RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
-    return ptr;
-  }
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr synchronously.
@@ -123,10 +96,7 @@ class pinned_host_memory_resource final {
    */
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
-                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
-  }
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Enables the `cuda::mr::device_accessible` property
@@ -155,12 +125,12 @@ class pinned_host_memory_resource final {
    *
    * @return true Always
    */
-  [[nodiscard]] bool operator==(pinned_host_memory_resource const&) const noexcept { return true; }
+  [[nodiscard]] bool operator==(pinned_host_memory_resource const&) const noexcept;
 
   /**
    * @copydoc operator==
    */
-  [[nodiscard]] bool operator!=(pinned_host_memory_resource const&) const noexcept { return false; }
+  [[nodiscard]] bool operator!=(pinned_host_memory_resource const&) const noexcept;
 };
 
 // static property checks

--- a/cpp/include/rmm/mr/system_memory_resource.hpp
+++ b/cpp/include/rmm/mr/system_memory_resource.hpp
@@ -6,17 +6,13 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
-#include <rmm/detail/aligned.hpp>
-#include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
-#include <rmm/detail/format.hpp>
 
 #include <cuda/memory_resource>
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
-#include <string>
 
 namespace RMM_NAMESPACE {
 namespace mr {
@@ -28,14 +24,7 @@ namespace detail {
  * @param device_id The device to check
  * @return true if SAM is supported on the device, false otherwise
  */
-static bool is_system_memory_supported(cuda_device_id device_id)
-{
-  // Check if pageable memory access is supported
-  int pageableMemoryAccess;
-  RMM_CUDA_TRY(cudaDeviceGetAttribute(
-    &pageableMemoryAccess, cudaDevAttrPageableMemoryAccess, device_id.value()));
-  return pageableMemoryAccess == 1;
-}
+RMM_EXPORT bool is_system_memory_supported(cuda_device_id device_id);
 }  // namespace detail
 
 /**
@@ -65,13 +54,9 @@ static bool is_system_memory_supported(cuda_device_id device_id)
  *  more information, see
  *  https://developer.nvidia.com/blog/nvidia-grace-hopper-superchip-architecture-in-depth/.
  */
-class system_memory_resource final {
+class RMM_EXPORT system_memory_resource final {
  public:
-  system_memory_resource()
-  {
-    RMM_EXPECTS(rmm::mr::detail::is_system_memory_supported(rmm::get_current_cuda_device()),
-                "System memory allocator is not supported with this hardware/software version.");
-  }
+  system_memory_resource();
   ~system_memory_resource()                             = default;
   system_memory_resource(system_memory_resource const&) = default;  ///< @default_copy_constructor
   system_memory_resource(system_memory_resource&&)      = default;  ///< @default_copy_constructor
@@ -94,23 +79,7 @@ class system_memory_resource final {
    */
   void* allocate([[maybe_unused]] cuda::stream_ref stream,
                  std::size_t bytes,
-                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    if (bytes == 0) { return nullptr; }
-    RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
-                "Requested alignment is larger than this memory resource supports.",
-                rmm::bad_alloc);
-    try {
-      return rmm::detail::aligned_host_allocate(
-        bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, [](std::size_t size) {
-          return ::operator new(size);
-        });
-    } catch (std::bad_alloc const& e) {
-      auto const msg = std::string("Failed to allocate ") + rmm::detail::format_bytes(bytes) +
-                       std::string("of memory: ") + e.what();
-      RMM_FAIL(msg.c_str(), rmm::out_of_memory);
-    }
-  }
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr.
@@ -126,17 +95,7 @@ class system_memory_resource final {
   void deallocate(cuda::stream_ref stream,
                   void* ptr,
                   std::size_t bytes,
-                  [[maybe_unused]] std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    // With `cudaFree`, the CUDA runtime keeps track of dependent operations and does implicit
-    // synchronization. However, with SAM, since `free` is immediate, we need to wait for in-flight
-    // CUDA operations to finish before freeing the memory, to avoid potential use-after-free errors
-    // or race conditions.
-    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
-
-    rmm::detail::aligned_host_deallocate(
-      ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, [](void* ptr) { ::operator delete(ptr); });
-  }
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Allocates memory of size at least \p bytes synchronously.
@@ -145,12 +104,7 @@ class system_memory_resource final {
    * @param alignment The alignment of the allocation
    * @return void* Pointer to the newly allocated memory
    */
-  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT)
-  {
-    auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
-    RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
-    return ptr;
-  }
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   /**
    * @brief Deallocate memory pointed to by \p ptr synchronously.
@@ -161,10 +115,7 @@ class system_memory_resource final {
    */
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
-                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept
-  {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
-  }
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
   /**
    * @brief Enables the `cuda::mr::device_accessible` property
@@ -193,12 +144,12 @@ class system_memory_resource final {
    *
    * @return true Always
    */
-  [[nodiscard]] bool operator==(system_memory_resource const&) const noexcept { return true; }
+  [[nodiscard]] bool operator==(system_memory_resource const&) const noexcept;
 
   /**
    * @copydoc operator==
    */
-  [[nodiscard]] bool operator!=(system_memory_resource const&) const noexcept { return false; }
+  [[nodiscard]] bool operator!=(system_memory_resource const&) const noexcept;
 };
 
 // static property checks

--- a/cpp/src/mr/cuda_async_view_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_view_memory_resource.cpp
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/detail/error.hpp>
+#include <rmm/detail/runtime_capabilities.hpp>
+#include <rmm/mr/cuda_async_view_memory_resource.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+
+cuda_async_view_memory_resource::cuda_async_view_memory_resource(cudaMemPool_t pool_handle)
+  : cuda_pool_handle_{[pool_handle]() {
+      RMM_EXPECTS(nullptr != pool_handle, "Unexpected null pool handle.");
+      return pool_handle;
+    }()}
+{
+  // Check if cudaMallocAsync Memory pool supported
+  RMM_EXPECTS(rmm::detail::runtime_async_alloc::is_supported(),
+              "cudaMallocAsync not supported with this CUDA driver/runtime version");
+}
+
+cudaMemPool_t cuda_async_view_memory_resource::pool_handle() const noexcept
+{
+  return cuda_pool_handle_;
+}
+
+void* cuda_async_view_memory_resource::allocate(cuda::stream_ref stream,
+                                                std::size_t bytes,
+                                                std::size_t alignment)
+{
+  if (bytes == 0) { return nullptr; }
+  RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+              "Requested alignment is larger than this memory resource supports.",
+              rmm::bad_alloc);
+  void* ptr{nullptr};
+  RMM_CUDA_TRY_ALLOC(cudaMallocFromPoolAsync(&ptr, bytes, pool_handle(), stream.get()), bytes);
+  return ptr;
+}
+
+void cuda_async_view_memory_resource::deallocate(cuda::stream_ref stream,
+                                                 void* ptr,
+                                                 [[maybe_unused]] std::size_t bytes,
+                                                 [[maybe_unused]] std::size_t alignment) noexcept
+{
+  if (ptr != nullptr) { RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFreeAsync(ptr, stream.get())); }
+}
+
+void* cuda_async_view_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
+  return ptr;
+}
+
+void cuda_async_view_memory_resource::deallocate_sync(void* ptr,
+                                                      std::size_t bytes,
+                                                      std::size_t alignment) noexcept
+{
+  auto const stream = cuda::stream_ref{cudaStream_t{nullptr}};
+  deallocate(stream, ptr, bytes, alignment);
+  RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
+}
+
+bool cuda_async_view_memory_resource::operator==(
+  cuda_async_view_memory_resource const& other) const noexcept
+{
+  return pool_handle() == other.pool_handle();
+}
+
+bool cuda_async_view_memory_resource::operator!=(
+  cuda_async_view_memory_resource const& other) const noexcept
+{
+  return !operator==(other);
+}
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/cuda_memory_resource.cpp
+++ b/cpp/src/mr/cuda_memory_resource.cpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+
+void* cuda_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
+                                     std::size_t bytes,
+                                     std::size_t alignment)
+{
+  if (bytes == 0) { return nullptr; }
+  RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+              "Requested alignment is larger than this memory resource supports.",
+              rmm::bad_alloc);
+  void* ptr{nullptr};
+  RMM_CUDA_TRY_ALLOC(cudaMalloc(&ptr, bytes), bytes);
+  return ptr;
+}
+
+void cuda_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref stream,
+                                      void* ptr,
+                                      [[maybe_unused]] std::size_t bytes,
+                                      [[maybe_unused]] std::size_t alignment) noexcept
+{
+  RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFree(ptr));
+}
+
+void* cuda_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
+  return ptr;
+}
+
+void cuda_memory_resource::deallocate_sync(void* ptr,
+                                           std::size_t bytes,
+                                           std::size_t alignment) noexcept
+{
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+}
+
+bool cuda_memory_resource::operator==(cuda_memory_resource const&) const noexcept { return true; }
+
+bool cuda_memory_resource::operator!=(cuda_memory_resource const&) const noexcept { return false; }
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/managed_memory_resource.cpp
+++ b/cpp/src/mr/managed_memory_resource.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/managed_memory_resource.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+
+void* managed_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
+                                        std::size_t bytes,
+                                        std::size_t alignment)
+{
+  // FIXME: Unlike cudaMalloc, cudaMallocManaged will throw an error for 0
+  // size allocations.
+  if (bytes == 0) { return nullptr; }
+  RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+              "Requested alignment is larger than this memory resource supports.",
+              rmm::bad_alloc);
+
+  void* ptr{nullptr};
+  RMM_CUDA_TRY_ALLOC(cudaMallocManaged(&ptr, bytes), bytes);
+  return ptr;
+}
+
+void managed_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref stream,
+                                         void* ptr,
+                                         [[maybe_unused]] std::size_t bytes,
+                                         [[maybe_unused]] std::size_t alignment) noexcept
+{
+  RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFree(ptr));
+}
+
+void* managed_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
+  return ptr;
+}
+
+void managed_memory_resource::deallocate_sync(void* ptr,
+                                              std::size_t bytes,
+                                              std::size_t alignment) noexcept
+{
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+}
+
+bool managed_memory_resource::operator==(managed_memory_resource const&) const noexcept
+{
+  return true;
+}
+
+bool managed_memory_resource::operator!=(managed_memory_resource const&) const noexcept
+{
+  return false;
+}
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/pinned_host_memory_resource.cpp
+++ b/cpp/src/mr/pinned_host_memory_resource.cpp
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/detail/aligned.hpp>
+#include <rmm/detail/error.hpp>
+#include <rmm/mr/pinned_host_memory_resource.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+
+void* pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
+                                            std::size_t bytes,
+                                            std::size_t alignment)
+{
+  // don't allocate anything if the user requested zero bytes
+  if (0 == bytes) { return nullptr; }
+  RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+              "Requested alignment is larger than this memory resource supports.",
+              rmm::bad_alloc);
+
+  std::size_t constexpr alloc_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
+  return rmm::detail::aligned_host_allocate(bytes, alloc_alignment, [](std::size_t size) {
+    void* ptr{nullptr};
+    RMM_CUDA_TRY_ALLOC(cudaHostAlloc(&ptr, size, cudaHostAllocDefault), size);
+    return ptr;
+  });
+}
+
+void pinned_host_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref stream,
+                                             void* ptr,
+                                             std::size_t bytes,
+                                             [[maybe_unused]] std::size_t alignment) noexcept
+{
+  std::size_t constexpr alloc_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
+  rmm::detail::aligned_host_deallocate(ptr, bytes, alloc_alignment, [](void* ptr) {
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFreeHost(ptr));
+  });
+}
+
+void* pinned_host_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
+  return ptr;
+}
+
+void pinned_host_memory_resource::deallocate_sync(void* ptr,
+                                                  std::size_t bytes,
+                                                  std::size_t alignment) noexcept
+{
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+}
+
+bool pinned_host_memory_resource::operator==(pinned_host_memory_resource const&) const noexcept
+{
+  return true;
+}
+
+bool pinned_host_memory_resource::operator!=(pinned_host_memory_resource const&) const noexcept
+{
+  return false;
+}
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/system_memory_resource.cpp
+++ b/cpp/src/mr/system_memory_resource.cpp
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/detail/aligned.hpp>
+#include <rmm/detail/error.hpp>
+#include <rmm/detail/format.hpp>
+#include <rmm/mr/system_memory_resource.hpp>
+
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <new>
+#include <string>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+namespace detail {
+
+bool is_system_memory_supported(cuda_device_id device_id)
+{
+  // Check if pageable memory access is supported
+  int pageableMemoryAccess;
+  RMM_CUDA_TRY(cudaDeviceGetAttribute(
+    &pageableMemoryAccess, cudaDevAttrPageableMemoryAccess, device_id.value()));
+  return pageableMemoryAccess == 1;
+}
+
+}  // namespace detail
+
+system_memory_resource::system_memory_resource()
+{
+  RMM_EXPECTS(rmm::mr::detail::is_system_memory_supported(rmm::get_current_cuda_device()),
+              "System memory allocator is not supported with this hardware/software version.");
+}
+
+void* system_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
+                                       std::size_t bytes,
+                                       std::size_t alignment)
+{
+  if (bytes == 0) { return nullptr; }
+  RMM_EXPECTS(rmm::is_supported_base_resource_alignment(alignment),
+              "Requested alignment is larger than this memory resource supports.",
+              rmm::bad_alloc);
+  try {
+    return rmm::detail::aligned_host_allocate(
+      bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, [](std::size_t size) { return ::operator new(size); });
+  } catch (std::bad_alloc const& e) {
+    auto const msg = std::string("Failed to allocate ") + rmm::detail::format_bytes(bytes) +
+                     std::string("of memory: ") + e.what();
+    RMM_FAIL(msg.c_str(), rmm::out_of_memory);
+  }
+}
+
+void system_memory_resource::deallocate(cuda::stream_ref stream,
+                                        void* ptr,
+                                        std::size_t bytes,
+                                        [[maybe_unused]] std::size_t alignment) noexcept
+{
+  // With `cudaFree`, the CUDA runtime keeps track of dependent operations and does implicit
+  // synchronization. However, with SAM, since `free` is immediate, we need to wait for in-flight
+  // CUDA operations to finish before freeing the memory, to avoid potential use-after-free errors
+  // or race conditions.
+  RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream.get()));
+
+  rmm::detail::aligned_host_deallocate(
+    ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT, [](void* ptr) { ::operator delete(ptr); });
+}
+
+void* system_memory_resource::allocate_sync(std::size_t bytes, std::size_t alignment)
+{
+  auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+  RMM_CUDA_TRY(cudaStreamSynchronize(cudaStream_t{nullptr}));
+  return ptr;
+}
+
+void system_memory_resource::deallocate_sync(void* ptr,
+                                             std::size_t bytes,
+                                             std::size_t alignment) noexcept
+{
+  deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+}
+
+bool system_memory_resource::operator==(system_memory_resource const&) const noexcept
+{
+  return true;
+}
+
+bool system_memory_resource::operator!=(system_memory_resource const&) const noexcept
+{
+  return false;
+}
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/tests/mr/cuda_async_mr_tests.cpp
+++ b/cpp/tests/mr/cuda_async_mr_tests.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 
 #include <cuda_runtime_api.h>

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -13,6 +13,7 @@
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/binning_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>

--- a/cpp/tests/mr/resource_ref_conversion_tests.cpp
+++ b/cpp/tests/mr/resource_ref_conversion_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
+#include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/limiting_resource_adaptor.hpp>


### PR DESCRIPTION
## Description
Moves several "base" memory resource definitions from headers to corresponding source files under `cpp/src/mr`, matching the style used by other RMM memory resources. These were missed during the earlier migration to CCCL memory resources because the heavier focus was on adaptors.

This also exports the affected public memory resource classes for shared-library builds and adds direct test includes that were previously satisfied transitively by implementation-heavy headers.

Closes #2414

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
