### PR TITLE
Document thread-safety caveat for get_outstanding_allocations()

### DIFF
--- a/cpp/include/rmm/mr/detail/tracking_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/tracking_resource_adaptor_impl.hpp
@@ -67,6 +67,15 @@ class tracking_resource_adaptor_impl {
 
   [[nodiscard]] device_async_resource_ref get_upstream_resource() const noexcept;
 
+  /**
+   * @brief Get the outstanding allocations map.
+   *
+   * @warning The returned reference is a view of internal mutable state. It is only safe to use
+   * when the caller ensures no concurrent allocations or deallocations are made through this
+   * tracking resource adaptor.
+   *
+   * @return map of outstanding allocations (pointer → allocation_info)
+   */
   [[nodiscard]] std::map<void*, allocation_info> const& get_outstanding_allocations()
     const noexcept;
 

--- a/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
@@ -70,6 +70,10 @@ class RMM_EXPORT tracking_resource_adaptor
   /**
    * @brief Get the outstanding allocations map.
    *
+   * @warning The returned reference is a view of internal mutable state. It is only safe to use
+   * when the caller ensures no concurrent allocations or deallocations are made through this
+   * tracking resource adaptor.
+   *
    * @return map of outstanding allocations (pointer → allocation_info)
    */
   [[nodiscard]] std::map<void*, allocation_info> const& get_outstanding_allocations()


### PR DESCRIPTION
## Description

Closes https://github.com/rapidsai/rmm/issues/2395

Add `@warning` Doxygen comments to `get_outstanding_allocations()` in both the public and impl headers, noting that the returned reference is a view of internal mutable state and is only safe when the caller ensures no concurrent allocations or deallocations.

This implements Option 1 from the issue (Document Caller Synchronization).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.