### PR TITLE
Fix hardware decompression support detection for CUDA async memory pools

### DIFF
--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -16,9 +16,9 @@ namespace RMM_NAMESPACE {
 namespace detail {
 
 /**
- * @brief Minimum CUDA driver version for hardware decompression support
+ * @brief Minimum CUDA runtime and driver version for hardware decompression support
  */
-#define RMM_MIN_HWDECOMPRESS_CUDA_DRIVER_VERSION 12080
+#define RMM_MIN_HWDECOMPRESS_CUDA_VERSION 12080
 
 /**
  * @brief Minimum CUDA driver version for stream-ordered managed memory allocator support
@@ -76,10 +76,10 @@ struct export_handle_type {
 
 /**
  * @brief Check whether `cudaMemPoolCreateUsageHwDecompress` is a supported
- * pool property on the present CUDA driver version.
+ * pool property on the present CUDA runtime and driver.
  *
- * Requires RMM to be built with a supported CUDA version 12.8+, otherwise
- * this always returns false.
+ * Requires RMM to be built with CUDA headers that define
+ * `cudaMemPoolCreateUsageHwDecompress`, otherwise this always returns false.
  *
  * @return true if supported
  * @return false if unsupported
@@ -93,12 +93,14 @@ struct export_handle_type {
 struct hwdecompress {
   static bool is_supported()
   {
-#if defined(CUDA_VERSION) && CUDA_VERSION >= RMM_MIN_HWDECOMPRESS_CUDA_DRIVER_VERSION
-    // Check if hardware decompression is supported (requires CUDA 12.8 driver or higher)
+#if defined(cudaMemPoolCreateUsageHwDecompress)
     static bool is_supported = []() {
       int driver_version{};
       RMM_CUDA_TRY(cudaDriverGetVersion(&driver_version));
-      return driver_version >= RMM_MIN_HWDECOMPRESS_CUDA_DRIVER_VERSION;
+      int runtime_version{};
+      RMM_CUDA_TRY(cudaRuntimeGetVersion(&runtime_version));
+      return driver_version >= RMM_MIN_HWDECOMPRESS_CUDA_VERSION and
+             runtime_version >= RMM_MIN_HWDECOMPRESS_CUDA_VERSION;
     }();
     return is_supported;
 #else

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -37,7 +37,9 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
     static_cast<cudaMemAllocationHandleType>(export_handle_type.value_or(cudaMemHandleTypeNone));
 
 #if defined(cudaMemPoolCreateUsageHwDecompress)
-  if (enable_hw_decompress) { pool_props.usage = cudaMemPoolCreateUsageHwDecompress; }
+  if (enable_hw_decompress && rmm::detail::hwdecompress::is_supported()) {
+    pool_props.usage = cudaMemPoolCreateUsageHwDecompress;
+  }
 #else
   (void)enable_hw_decompress;
 #endif

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -36,8 +36,8 @@ cuda_async_memory_resource_impl::cuda_async_memory_resource_impl(
   pool_props.handleTypes =
     static_cast<cudaMemAllocationHandleType>(export_handle_type.value_or(cudaMemHandleTypeNone));
 
-#if defined(CUDA_VERSION) && CUDA_VERSION >= RMM_MIN_HWDECOMPRESS_CUDA_DRIVER_VERSION
-  if (enable_hw_decompress) { pool_props.usage = 0x2; }
+#if defined(cudaMemPoolCreateUsageHwDecompress)
+  if (enable_hw_decompress) { pool_props.usage = cudaMemPoolCreateUsageHwDecompress; }
 #else
   (void)enable_hw_decompress;
 #endif

--- a/cpp/tests/mr/hwdecompress_tests.cpp
+++ b/cpp/tests/mr/hwdecompress_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/hwdecompress_tests.cpp
+++ b/cpp/tests/mr/hwdecompress_tests.cpp
@@ -20,7 +20,7 @@ class HWDecompressTest : public ::testing::Test {
  protected:
   static void check_decompress_capable(void* ptr)
   {
-#if defined(CUDA_VERSION) && CUDA_VERSION >= RMM_MIN_HWDECOMPRESS_CUDA_DRIVER_VERSION
+#if defined(cudaMemPoolCreateUsageHwDecompress)
     if (rmm::detail::hwdecompress::is_supported()) {
       bool is_capable{};
       auto err =
@@ -36,7 +36,7 @@ class HWDecompressTest : public ::testing::Test {
     }
 #else
     GTEST_SKIP() << "Skipping since hardware decompression is not supported "
-                 << "by the CUDA version used to build RMM.";
+                 << "by the CUDA headers used to build RMM.";
 #endif
   }
 };


### PR DESCRIPTION
Update RMM’s HW decompression capability check to guard on the specific `cudaMemPoolCreateUsageHwDecompress` CUDA feature and verify both runtime and driver versions are at least CUDA 12.8. This ensures `cuda_async_memory_resource` creates HW-decompression-capable pools when the required CUDA support is present, avoiding nvCOMP HW decompression failures with cuda-async allocations.