### PR TITLE
fix(wheel): update wheel search key for publish job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -198,7 +198,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: rmm
       package-type: python
-      publish-wheel-search-key: rmm_wheel_python_abi3
+      publish-wheel-search-key: rmm_wheel_python_rmm
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4


### PR DESCRIPTION
## Description

Followup to #2370 -- need to update the prefix used to search for wheel artifacts to reflect the new naming scheme.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
