### PR TITLE
fix(wheel): add search key for publishing cpp wheels

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,6 +181,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: librmm
       package-type: cpp
+      publish-wheel-search-key: rmm_wheel_cpp_librmm
   wheel-publish-python:
     needs: wheel-build-python
     permissions:


### PR DESCRIPTION
## Description
xref #2370 #2475

Also changed the cpp wheel name, so additional change is needed in the publishing step (for now)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
