### PR TITLE
Store shared_ptr to cuda_stream_pool in python wrapper

### DIFF
--- a/python/rmm/rmm/pylibrmm/cuda_stream_pool.pxd
+++ b/python/rmm/rmm/pylibrmm/cuda_stream_pool.pxd
@@ -1,13 +1,13 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 cimport cython
 from libc.stddef cimport size_t
-from libcpp.memory cimport unique_ptr
+from libcpp.memory cimport shared_ptr
 
 from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
 
 
 @cython.final
 cdef class CudaStreamPool:
-    cdef unique_ptr[cuda_stream_pool] c_obj
+    cdef shared_ptr[cuda_stream_pool] c_obj

--- a/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyx
+++ b/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyx
@@ -1,9 +1,10 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 cimport cython
 from cython.operator cimport dereference as deref
 from libc.stddef cimport size_t
+from libcpp.memory cimport make_shared
 
 from rmm.librmm.cuda_stream cimport cuda_stream_flags
 from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
@@ -24,7 +25,7 @@ cdef class CudaStreamPool:
     def __cinit__(self, size_t pool_size = 16,
                   cuda_stream_flags flags = cuda_stream_flags.sync_default):
         with nogil:
-            self.c_obj.reset(new cuda_stream_pool(pool_size, flags))
+            self.c_obj = make_shared[cuda_stream_pool](pool_size, flags)
 
     def __dealloc__(self):
         with nogil:


### PR DESCRIPTION
## Description

This object shouldn't be uniquely owned, otherwise we can't share the underlying stream pool between C++ and Python libraries.

- Closes #2430

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
