### PR TITLE
add default permissions block in trigger-breaking-change-alert config

### DIFF
--- a/.github/workflows/trigger-breaking-change-alert.yaml
+++ b/.github/workflows/trigger-breaking-change-alert.yaml
@@ -11,6 +11,8 @@ on: # zizmor: ignore[dangerous-triggers]
       - labeled
       - unlabeled
 
+permissions: {}
+
 jobs:
   trigger-notifier:
     if: contains(github.event.pull_request.labels.*.name, 'breaking')


### PR DESCRIPTION
## Description

Follow-up to #2435

Adds a default `permissions: {}` block in the trigger-breaking-change-alert GitHub Actions configuration. This change reduces the risk of unnecessary permissions being granted to that workflow, and standardizes with all other RAPIDS repos (https://github.com/rapidsai/shared-workflows/issues/560).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
