### PR TITLE
Remove Cython any resource helper

### DIFF
--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -81,27 +81,6 @@ cdef extern from "<cuda/memory_resource>" namespace "cuda::mr" nogil:
         any_resource() except +
         any_resource(device_async_resource_ref) except +
 
-
-# Inline C++ helper to convert device_async_resource_ref to
-# any_resource<device_accessible> for passing to constructor parameters.
-# Needed because Cython wraps intermediate values in __Pyx_FakeReference<T>,
-# a proxy with operator T&(). CCCL's any_resource only has a constrained
-# forwarding constructor that cannot see through this proxy. A free function
-# performs the conversion in pure C++ where it works directly.
-# TODO: Remove once CCCL merges NVIDIA/cccl#8320 and RMM upgrades.
-cdef extern from *:
-    """
-    #include <cuda/memory_resource>
-    #include <rmm/resource_ref.hpp>
-    inline cuda::mr::any_resource<cuda::mr::device_accessible>
-    make_any_device_resource(rmm::device_async_resource_ref ref) {
-        return cuda::mr::any_resource<cuda::mr::device_accessible>(ref);
-    }
-    """
-    any_resource[device_accessible] make_any_device_resource(
-        device_async_resource_ref) nogil except +
-
-
 # Inline C++ helper to construct optional[device_async_resource_ref] from any
 # concrete resource type. Returns optional so that Cython assignment
 # (self.c_ref = make_device_async_resource_ref(...)) uses optional's


### PR DESCRIPTION
## Description
Remove the Cython-only `make_any_device_resource` helper after RMM has migrated to direct `any_resource[device_accessible](...)` construction.

This is a follow-up to #2436 and is based on an upstream branch mirroring that PR.

This depends on the downstream migrations completing first:

- https://github.com/rapidsai/cuml/pull/8197
- https://github.com/rapidsai/rapidsmpf/pull/1076

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.