### PR TITLE
Update RMM docs to use NVIDIA theme

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -18,7 +18,6 @@ dependencies:
 - doxygen=1.9.1
 - gcc_linux-aarch64=14.*
 - gcovr>=5.0
-- graphviz
 - identify>=2.5.20
 - ipython
 - make

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -31,7 +31,6 @@ dependencies:
 - numpydoc
 - packaging
 - pre-commit
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - pytest-cov
 - python>=3.11
@@ -43,4 +42,6 @@ dependencies:
 - sphinx-markdown-tables
 - sphinxcontrib-jquery
 - sysroot_linux-aarch64==2.28
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-129_arch-aarch64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -31,7 +31,6 @@ dependencies:
 - numpydoc
 - packaging
 - pre-commit
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - pytest-cov
 - python>=3.11
@@ -43,4 +42,6 @@ dependencies:
 - sphinx-markdown-tables
 - sphinxcontrib-jquery
 - sysroot_linux-64==2.28
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-129_arch-x86_64

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -18,7 +18,6 @@ dependencies:
 - doxygen=1.9.1
 - gcc_linux-64=14.*
 - gcovr>=5.0
-- graphviz
 - identify>=2.5.20
 - ipython
 - make

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -18,7 +18,6 @@ dependencies:
 - doxygen=1.9.1
 - gcc_linux-aarch64=14.*
 - gcovr>=5.0
-- graphviz
 - identify>=2.5.20
 - ipython
 - make

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -31,7 +31,6 @@ dependencies:
 - numpydoc
 - packaging
 - pre-commit
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - pytest-cov
 - python>=3.11
@@ -43,4 +42,6 @@ dependencies:
 - sphinx-markdown-tables
 - sphinxcontrib-jquery
 - sysroot_linux-aarch64==2.28
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-132_arch-aarch64

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -31,7 +31,6 @@ dependencies:
 - numpydoc
 - packaging
 - pre-commit
-- pydata-sphinx-theme>=0.15.4
 - pytest
 - pytest-cov
 - python>=3.11
@@ -43,4 +42,6 @@ dependencies:
 - sphinx-markdown-tables
 - sphinxcontrib-jquery
 - sysroot_linux-64==2.28
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-132_arch-x86_64

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -18,7 +18,6 @@ dependencies:
 - doxygen=1.9.1
 - gcc_linux-64=14.*
 - gcovr>=5.0
-- graphviz
 - identify>=2.5.20
 - ipython
 - make

--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -2285,7 +2285,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = YES
+HAVE_DOT               = NO
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of

--- a/cpp/doxygen/header.html
+++ b/cpp/doxygen/header.html
@@ -17,11 +17,6 @@ $mathjax
 <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
 $extrastylesheet
 
-<!-- RAPIDS CUSTOM JS & CSS: START, Please add these two lines back after every version upgrade -->
-<script defer src="https://docs.rapids.ai/assets/js/custom.js"></script>
-<link rel="stylesheet" href="https://docs.rapids.ai/assets/css/custom.css">
-<!-- RAPIDS CUSTOM JS & CSS: END -->
-
 </head>
 <body>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -343,11 +343,12 @@ dependencies:
           - &numba numba>=0.60.0,<0.65.0
           - &numba_cuda numba-cuda>=0.22.1
           - numpydoc
-          - pydata-sphinx-theme>=0.15.4
           - sphinx
           - sphinx-copybutton
           - sphinx-markdown-tables
           - sphinxcontrib-jquery
+          - pip:
+              - nvidia-sphinx-theme
   py_version:
     specific:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -335,7 +335,6 @@ dependencies:
         packages:
           - breathe>=4.35.0
           - *doxygen
-          - graphviz
           - ipython
           - make
           - myst-parser

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ from packaging.version import Version
 
 # -- Project information -----------------------------------------------------
 
-project = "rmm"
+project = "RMM"
 copyright = f"2018-{datetime.datetime.today().year}, NVIDIA Corporation"
 author = "NVIDIA Corporation"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,7 +118,6 @@ todo_include_todos = False
 #
 
 html_theme = "nvidia_sphinx_theme"
-html_logo = "_static/RAPIDS-logo-purple.png"
 
 html_theme_options = {
     "external_links": [],
@@ -322,8 +321,4 @@ def on_missing_reference(app, env, node, contnode):
 
 
 def setup(app):
-    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
-    app.add_js_file(
-        "https://docs.rapids.ai/assets/js/custom.js", loading_method="defer"
-    )
     app.connect("missing-reference", on_missing_reference)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # Configuration file for the Sphinx documentation builder.
@@ -117,7 +117,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-html_theme = "pydata_sphinx_theme"
+html_theme = "nvidia_sphinx_theme"
 html_logo = "_static/RAPIDS-logo-purple.png"
 
 html_theme_options = {

--- a/docs/cpp/memory_resources/index.md
+++ b/docs/cpp/memory_resources/index.md
@@ -1,5 +1,11 @@
 # Memory Resources
 
+RMM memory resources are allocator objects that control where and how memory is allocated.
+
+Memory resources implement allocation and deallocation for a kind of memory, for example CUDA device memory, managed memory, or pinned host memory. Resource adaptors wrap another memory resource and change its behavior, such as adding logging, tracking, limits, alignment, or prefetching, while delegating the actual allocation to the wrapped upstream resource.
+
+Use the pages below to browse the core memory resource implementations and the adaptors that add behavior to an upstream resource.
+
 ```{toctree}
 :maxdepth: 1
 

--- a/docs/cpp/memory_resources/index.md
+++ b/docs/cpp/memory_resources/index.md
@@ -4,8 +4,6 @@ RMM memory resources are allocator objects that control where and how memory is 
 
 Memory resources implement allocation and deallocation for a kind of memory, for example CUDA device memory, managed memory, or pinned host memory. Resource adaptors wrap another memory resource and change its behavior, such as adding logging, tracking, limits, alignment, or prefetching, while delegating the actual allocation to the wrapped upstream resource.
 
-Use the pages below to browse the core memory resource implementations and the adaptors that add behavior to an upstream resource.
-
 ```{toctree}
 :maxdepth: 1
 


### PR DESCRIPTION
## Description
Updates the RMM docs to use the NVIDIA Sphinx theme, removes the local RAPIDS custom CSS/JS includes that are injected by docs post-processing, disables Doxygen dot graph generation to avoid the Graphviz/GTK/Wayland dependency chain, and adds context to the C++ memory resources landing page.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.