### PR TITLE
Delegate logging_resource_adaptor_impl sync methods to their stream-ordered counterparts

### DIFF
--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -26,24 +26,14 @@ logging_resource_adaptor_impl::logging_resource_adaptor_impl(
 
 void* logging_resource_adaptor_impl::allocate_sync(std::size_t bytes, std::size_t alignment)
 {
-  auto const stream = cuda_stream_view{};
-  try {
-    auto const ptr = upstream_mr_.allocate(stream, bytes, alignment);
-    logger_->info("allocate,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
-    return ptr;
-  } catch (...) {
-    logger_->info("allocate failure,%p,%zu,%s", nullptr, bytes, rmm::detail::format_stream(stream));
-    throw;
-  }
+  return allocate(cuda_stream_view{}, bytes, alignment);
 }
 
 void logging_resource_adaptor_impl::deallocate_sync(void* ptr,
                                                     std::size_t bytes,
                                                     std::size_t alignment) noexcept
 {
-  auto const stream = cuda_stream_view{};
-  logger_->info("free,%p,%zu,%s", ptr, bytes, rmm::detail::format_stream(stream));
-  upstream_mr_.deallocate(stream, ptr, bytes, alignment);
+  deallocate(cuda_stream_view{}, ptr, bytes, alignment);
 }
 
 void* logging_resource_adaptor_impl::allocate(cuda::stream_ref stream,


### PR DESCRIPTION
## Description
`logging_resource_adaptor_impl::allocate_sync` and `deallocate_sync` duplicated the try/catch and logging bodies of their stream-ordered counterparts. This PR has them delegate to the `allocate` / `deallocate` methods by passing a default `cuda_stream_view{}`, matching the pattern already used by `limiting_resource_adaptor_impl` (introduced in #2277).

`cuda_stream_view` implicitly converts to `cuda::stream_ref`, and both code paths already emit identical log output via `format_stream(stream)` for the default stream, so this is a behavior-preserving cleanup that removes the duplicated logic.

closes #2444 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
