### PR TITLE
Allow construction of CudaStreamPool from shared_ptr

### DIFF
--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -89,7 +89,7 @@ cdef extern from "<cuda/memory_resource>" namespace "cuda::mr" nogil:
 # forwarding constructor that cannot see through this proxy. A free function
 # performs the conversion in pure C++ where it works directly.
 # TODO: Remove once CCCL merges NVIDIA/cccl#8320 and RMM upgrades.
-cdef extern from *:
+cdef extern from * nogil:
     """
     #include <cuda/memory_resource>
     #include <rmm/resource_ref.hpp>
@@ -99,7 +99,7 @@ cdef extern from *:
     }
     """
     any_resource[device_accessible] make_any_device_resource(
-        device_async_resource_ref) nogil except +
+        device_async_resource_ref) except +
 
 
 # Inline C++ helper to construct optional[device_async_resource_ref] from any
@@ -107,7 +107,7 @@ cdef extern from *:
 # (self.c_ref = make_device_async_resource_ref(...)) uses optional's
 # default-constructible temporary instead of device_async_resource_ref's
 # non-default-constructible one.
-cdef extern from *:
+cdef extern from * nogil:
     """
     #include <optional>
     #include <rmm/resource_ref.hpp>
@@ -381,7 +381,7 @@ ctypedef failure_callback_resource_adaptor[out_of_memory] \
 # The make_device_async_resource_ref template (declared above) also covers
 # failure_callback_resource_adaptor_oom; just declare the overload here
 # since the typedef is only available after the class is declared.
-cdef extern from *:
+cdef extern from * nogil:
     """
     // already defined above via template
     """

--- a/python/rmm/rmm/pylibrmm/cuda_stream_pool.pxd
+++ b/python/rmm/rmm/pylibrmm/cuda_stream_pool.pxd
@@ -11,3 +11,6 @@ from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
 @cython.final
 cdef class CudaStreamPool:
     cdef shared_ptr[cuda_stream_pool] c_obj
+
+    @staticmethod
+    cdef CudaStreamPool c_from_shared_ptr(shared_ptr[cuda_stream_pool] pool)

--- a/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyx
+++ b/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyx
@@ -5,6 +5,7 @@ cimport cython
 from cython.operator cimport dereference as deref
 from libc.stddef cimport size_t
 from libcpp.memory cimport make_shared
+from libcpp.utility cimport move
 
 from rmm.librmm.cuda_stream cimport cuda_stream_flags
 from rmm.librmm.cuda_stream_pool cimport cuda_stream_pool
@@ -26,6 +27,14 @@ cdef class CudaStreamPool:
                   cuda_stream_flags flags = cuda_stream_flags.sync_default):
         with nogil:
             self.c_obj = make_shared[cuda_stream_pool](pool_size, flags)
+
+    @staticmethod
+    cdef CudaStreamPool c_from_shared_ptr(shared_ptr[cuda_stream_pool] pool):
+        if pool == NULL:
+            raise ValueError("Provided pool must not be null")
+        cdef CudaStreamPool obj = CudaStreamPool.__new__(CudaStreamPool)
+        obj.c_obj = move(pool)
+        return obj
 
     def __dealloc__(self):
         with nogil:


### PR DESCRIPTION
## Description

- Closes #2446

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
