### PR TITLE
Fix device_buffer copy constructor exception safety

### DIFF
--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -56,8 +56,9 @@ device_buffer::device_buffer(void const* source_data,
               "Requested alignment is not a power of 2",
               rmm::invalid_argument);
   cuda_set_device_raii dev{_device};
-  allocate_async(size);
-  copy_async(source_data, size);
+  auto tmp = device_buffer{size, alignment, stream, _mr};
+  tmp.copy_async(source_data, size);
+  *this = std::move(tmp);
 }
 
 device_buffer::device_buffer(device_buffer const& other,

--- a/cpp/tests/device_buffer_tests.cu
+++ b/cpp/tests/device_buffer_tests.cu
@@ -14,6 +14,7 @@
 #include <rmm/mr/managed_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/mr/tracking_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <thrust/equal.h>
@@ -171,6 +172,16 @@ TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZero)
 {
   // can  copy from a nullptr only if size == 0
   EXPECT_THROW(rmm::device_buffer buff(nullptr, 1, rmm::cuda_stream_default), rmm::logic_error);
+}
+
+TYPED_TEST(DeviceBufferTest, CopyFromNullptrNonZeroFreesAllocation)
+{
+  rmm::mr::tracking_resource_adaptor mr{rmm::device_async_resource_ref{this->mr}};
+
+  EXPECT_THROW(std::ignore = rmm::device_buffer(nullptr, 1, rmm::cuda_stream_default, mr),
+               rmm::logic_error);
+  EXPECT_EQ(mr.get_outstanding_allocations().size(), 0);
+  EXPECT_EQ(mr.get_allocated_bytes(), 0);
 }
 
 TYPED_TEST(DeviceBufferTest, CopyConstructor)


### PR DESCRIPTION
## Summary

This fixes the raw-pointer `device_buffer` copy constructor so allocation and copy happen in a local temporary before the new object commits any state. If `copy_async` throws, the temporary releases the allocation instead of leaving memory owned by a partially constructed object.

The copy constructor that copies from another `device_buffer` also benefits because it delegates through this path.

Closes #2452.

## Testing

- `pre-commit run --files cpp/src/device_buffer.cpp cpp/tests/device_buffer_tests.cu`

Not run locally: `DEVICE_BUFFER_TEST`, because this machine does not have a configured CUDA build tree or `nvcc` available.