### PR TITLE
Check device_uvector allocation size overflow

### DIFF
--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -17,6 +17,7 @@
 #include <cuda/std/span>
 
 #include <cstddef>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -119,6 +120,7 @@ class device_uvector {
    *
    * @throws rmm::bad_alloc If the provided memory resource cannot allocate with alignment to
    * satisfy the alignment requirements of the value type.
+   * @throws rmm::invalid_argument If the requested size overflows the maximum allocation size.
    *
    * @param size The number of elements to allocate storage for
    * @param stream The stream on which to perform the allocation
@@ -351,6 +353,8 @@ class device_uvector {
    * first `size()` elements from the current allocation are copied there as if by memcpy. Finally,
    * the old allocation is freed and replaced by the new allocation.
    *
+   * @throws rmm::invalid_argument If the requested capacity overflows the maximum allocation size.
+   *
    * @param new_capacity The desired capacity (number of elements)
    * @param stream The stream on which to perform the allocation/copy (if any)
    */
@@ -371,6 +375,8 @@ class device_uvector {
    * If `new_size > capacity()`, elements are copied as if by memcpy to a new allocation.
    *
    * The invariant `size() <= capacity()` holds.
+   *
+   * @throws rmm::invalid_argument If the requested size overflows the maximum allocation size.
    *
    * @param new_size The desired number of elements
    * @param stream The stream on which to perform the allocation/copy (if any)
@@ -617,8 +623,11 @@ class device_uvector {
  private:
   device_buffer _storage{};  ///< Device memory storage for vector elements
 
-  [[nodiscard]] size_type constexpr elements_to_bytes(size_type num_elements) const noexcept
+  [[nodiscard]] size_type elements_to_bytes(size_type num_elements) const
   {
+    RMM_EXPECTS(num_elements <= std::numeric_limits<size_type>::max() / sizeof(value_type),
+                "Requested size overflows device_uvector storage.",
+                rmm::invalid_argument);
     return num_elements * sizeof(value_type);
   }
 

--- a/cpp/tests/device_uvector_tests.cpp
+++ b/cpp/tests/device_uvector_tests.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iterator>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -59,6 +60,15 @@ TYPED_TEST(TypedUVectorTest, NonZeroSizeConstructor)
   EXPECT_EQ(vec.end(), vec.begin() + vec.size());
   EXPECT_FALSE(vec.is_empty());
   EXPECT_NE(vec.element_ptr(0), nullptr);
+}
+
+TEST(DeviceUVectorOverflowTest, Constructor)
+{
+  auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
+
+  EXPECT_THROW(
+    std::ignore = rmm::device_uvector<uint64_t>(overflowing_size, rmm::cuda_stream_view{}),
+    rmm::invalid_argument);
 }
 
 TYPED_TEST(TypedUVectorTest, CopyConstructor)
@@ -156,6 +166,14 @@ TYPED_TEST(TypedUVectorTest, ReserveLarger)
   EXPECT_EQ(vec.element(0, this->stream()), 1);
 }
 
+TEST(DeviceUVectorOverflowTest, Reserve)
+{
+  auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
+  rmm::device_uvector<uint64_t> vec(0, rmm::cuda_stream_view{});
+
+  EXPECT_THROW(vec.reserve(overflowing_size, rmm::cuda_stream_view{}), rmm::invalid_argument);
+}
+
 TYPED_TEST(TypedUVectorTest, ResizeToZero)
 {
   auto const original_size{12345};
@@ -168,6 +186,14 @@ TYPED_TEST(TypedUVectorTest, ResizeToZero)
 
   vec.shrink_to_fit(this->stream());
   EXPECT_EQ(vec.capacity(), 0);
+}
+
+TEST(DeviceUVectorOverflowTest, Resize)
+{
+  auto constexpr overflowing_size = std::numeric_limits<std::size_t>::max() / sizeof(uint64_t) + 1;
+  rmm::device_uvector<uint64_t> vec(0, rmm::cuda_stream_view{});
+
+  EXPECT_THROW(vec.resize(overflowing_size, rmm::cuda_stream_view{}), rmm::invalid_argument);
 }
 
 TYPED_TEST(TypedUVectorTest, Release)


### PR DESCRIPTION
## Summary

This adds an overflow check when `device_uvector` converts element counts to allocation byte sizes. Requests larger than `SIZE_MAX / sizeof(T)` now throw `rmm::invalid_argument` instead of wrapping and allocating too little storage.

The check is centralized in `elements_to_bytes()`, so it covers construction, `reserve()`, and `resize()`. The public docs now mention the new invalid-argument path, and tests cover all three entry points.

## Testing

- `pre-commit run --files cpp/include/rmm/device_uvector.hpp cpp/tests/device_uvector_tests.cpp`

Not run locally: `DEVICE_UVECTOR_TEST`, because this machine does not have a configured CUDA build tree or `nvcc` available.