### PR TITLE
Align RMM documentation branding

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,12 +128,6 @@ html_theme_options = {
             "icon": "fa-brands fa-github",
             "type": "fontawesome",
         },
-        {
-            "name": "X",
-            "url": "https://x.com/rapidsai",
-            "icon": "fa-brands fa-x-twitter",
-            "type": "fontawesome",
-        },
     ],
     "show_toc_level": 1,
     "navbar_align": "right",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,8 +170,8 @@ latex_documents = [
     (
         master_doc,
         "rmm.tex",
-        "RMM Documentation",
-        "NVIDIA Corporation",
+        f"{project} Documentation",
+        author,
         "manual",
     )
 ]
@@ -181,7 +181,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "rmm", "RMM Documentation", [author], 1)]
+man_pages = [(master_doc, "rmm", f"{project} Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -193,7 +193,7 @@ texinfo_documents = [
     (
         master_doc,
         "rmm",
-        "RMM Documentation",
+        f"{project} Documentation",
         author,
         "rmm",
         "One line description of project.",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ from packaging.version import Version
 
 # -- Project information -----------------------------------------------------
 
-project = "RMM"
+project = "NVIDIA RMM"
 copyright = f"2018-{datetime.datetime.today().year}, NVIDIA Corporation"
 author = "NVIDIA Corporation"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# RMM: RAPIDS Memory Manager
+# NVIDIA RMM Documentation
 
-RMM (RAPIDS Memory Manager) is a library for allocating and managing GPU memory in C++ and Python.
+NVIDIA RMM (RAPIDS Memory Manager) is a library for allocating and managing GPU memory in C++ and Python.
 
 ```{toctree}
 :maxdepth: 2


### PR DESCRIPTION
## Description

- uses `NVIDIA RMM` for the documentation project and landing-page branding
- removes the inactive Twitter/X icon
- uses `NVIDIA RMM Documentation` consistently for HTML, LaTeX, man, and Texinfo output
- retains the GitHub icon and NVIDIA theme defaults

Follow-up to rapidsai/build-planning#300 and rapidsai/rmm#2443.

## Validation

- Doxygen generation passes
- strict Sphinx HTML build passes with `-n -W --keep-going`
- targeted pre-commit hooks pass

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
