### PR TITLE
Add a versioned ABI namespace to RMM

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,6 +13,7 @@ jobs:
       - check-nightly-ci
       - changed-files
       - checks
+      - cmake-tests
       - conda-cpp-build
       - conda-cpp-tests
       - conda-cpp-debug-tests
@@ -208,6 +209,22 @@ jobs:
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize conda-python-tests-integration-optional wheel-tests-integration-optional"
+  cmake-tests:
+    needs: checks
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    with:
+      build_type: pull-request
+      node_type: cpu16
+      arch: "amd64"
+      container_image: "rapidsai/ci-conda:26.08-latest"
+      script: "ci/test_cmake.sh"
   conda-cpp-build:
     needs: checks
     permissions:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ If you frequently start new builds from scratch, consider setting the environmen
 `CPM_SOURCE_CACHE` to an external download directory to avoid repeated downloads of the third-party
 dependencies.
 
+### ABI versioning
+
+RMM symbols are placed in an inline namespace derived from the RAPIDS major and minor version. The
+public API remains available through the `rmm::` namespace, while static RMM libraries built for
+different ABI versions can coexist in one process. Process-global state is shared by RMM copies
+with the same ABI version and kept separate across different ABI versions.
+
 ## Using RMM in a downstream CMake project
 
 The installed RMM library provides a set of config files that makes it easy to

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ dependencies.
 
 ### ABI versioning
 
-RMM symbols are placed in an inline namespace derived from the RAPIDS major and minor version. The
+RMM symbols are placed in an inline namespace derived from the RMM major and minor version. The
 public API remains available through the `rmm::` namespace, while static RMM libraries built for
 different ABI versions can coexist in one process. Process-global state is shared by RMM copies
 with the same ABI version and kept separate across different ABI versions.

--- a/ci/test_cmake.sh
+++ b/ci/test_cmake.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# Support invoking test_cmake.sh outside the script directory
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
+
+rapids-logger "Create CMake test conda environment"
+. /opt/conda/etc/profile.d/conda.sh
+
+rapids-logger "Configuring conda strict channel priority"
+conda config --set channel_priority strict
+
+ENV_YAML_DIR="$(mktemp -d)"
+
+rapids-dependency-file-generator \
+  --output conda \
+  --file-key test_cmake \
+  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" | tee "${ENV_YAML_DIR}/env.yaml"
+
+rapids-mamba-retry env create --yes -f "${ENV_YAML_DIR}/env.yaml" -n cmake_tests
+
+# Temporarily allow unbound variables for conda activation.
+set +u
+conda activate cmake_tests
+set -u
+
+rapids-print-env
+
+rapids-logger "Run RMM CMake tests"
+cmake -S cpp/cmake/tests \
+      -B cpp/build/cmake-tests \
+      -GNinja \
+      -DRMM_REPOSITORY_DIR="${PWD}"
+ctest --test-dir cpp/build/cmake-tests --output-on-failure -j"$(nproc)"

--- a/cpp/cmake/tests/CMakeLists.txt
+++ b/cpp/cmake/tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+
+project(rmm_cmake_tests LANGUAGES NONE)
+
+enable_testing()
+
+set(RMM_REPOSITORY_DIR
+    ""
+    CACHE PATH "Path to the RMM repository root")
+if(NOT RMM_REPOSITORY_DIR)
+  cmake_path(SET RMM_REPOSITORY_DIR NORMALIZE "${CMAKE_CURRENT_LIST_DIR}/../../..")
+endif()
+
+set(rmm_abi_namespace_build_dir "${CMAKE_CURRENT_BINARY_DIR}/rmm_abi_namespace")
+
+add_test(
+  NAME rmm_abi_namespace_configure
+  COMMAND
+    ${CMAKE_COMMAND} -S "${CMAKE_CURRENT_LIST_DIR}/rmm_abi_namespace" -B
+    "${rmm_abi_namespace_build_dir}" -G "${CMAKE_GENERATOR}"
+    "-DRMM_REPOSITORY_DIR=${RMM_REPOSITORY_DIR}")
+
+add_test(NAME rmm_abi_namespace COMMAND ${CMAKE_COMMAND} --build "${rmm_abi_namespace_build_dir}")
+
+set_tests_properties(rmm_abi_namespace_configure PROPERTIES FIXTURES_SETUP rmm_abi_namespace)
+set_tests_properties(rmm_abi_namespace PROPERTIES FIXTURES_REQUIRED rmm_abi_namespace)

--- a/cpp/cmake/tests/rmm_abi_namespace/CMakeLists.txt
+++ b/cpp/cmake/tests/rmm_abi_namespace/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT RMM_REPOSITORY_DIR)
   cmake_path(SET RMM_REPOSITORY_DIR NORMALIZE "${CMAKE_CURRENT_LIST_DIR}/../../../..")
 endif()
 
-# Normalize a two-digit RAPIDS version component for use in a C++ identifier.
+# Normalize a two-digit RMM version component for use in a C++ identifier.
 function(normalize_version_component input output)
   string(REGEX REPLACE "^0+" "" normalized "${input}")
   if(normalized STREQUAL "")
@@ -32,11 +32,11 @@ if(NOT current_rmm_version MATCHES "^([0-9]+)\\.([0-9]+)\\.")
 endif()
 normalize_version_component("${CMAKE_MATCH_1}" current_rmm_version_major)
 normalize_version_component("${CMAKE_MATCH_2}" current_rmm_version_minor)
-set(current_rmm_abi_namespace "_RAPIDS_${current_rmm_version_major}_${current_rmm_version_minor}")
+set(current_rmm_abi_namespace "_RMM_${current_rmm_version_major}_${current_rmm_version_minor}")
 
 # rapids-pre-commit-hooks: disable-next-line[verify-hardcoded-version]
 set(previous_rmm_version "26.06.00")
-set(previous_rmm_abi_namespace "_RAPIDS_26_6")
+set(previous_rmm_abi_namespace "_RMM_26_6")
 if(current_rmm_abi_namespace STREQUAL previous_rmm_abi_namespace)
   message(FATAL_ERROR "The current and previous test ABI namespaces must be different")
 endif()

--- a/cpp/cmake/tests/rmm_abi_namespace/CMakeLists.txt
+++ b/cpp/cmake/tests/rmm_abi_namespace/CMakeLists.txt
@@ -1,0 +1,94 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+
+project(rmm_abi_namespace_test LANGUAGES CXX)
+
+set(RMM_REPOSITORY_DIR
+    ""
+    CACHE PATH "Path to the RMM repository root")
+if(NOT RMM_REPOSITORY_DIR)
+  cmake_path(SET RMM_REPOSITORY_DIR NORMALIZE "${CMAKE_CURRENT_LIST_DIR}/../../../..")
+endif()
+
+# Normalize a two-digit RAPIDS version component for use in a C++ identifier.
+function(normalize_version_component input output)
+  string(REGEX REPLACE "^0+" "" normalized "${input}")
+  if(normalized STREQUAL "")
+    set(normalized 0)
+  endif()
+  set(${output}
+      "${normalized}"
+      PARENT_SCOPE)
+endfunction()
+
+file(STRINGS "${RMM_REPOSITORY_DIR}/VERSION" current_rmm_version LIMIT_COUNT 1)
+if(NOT current_rmm_version MATCHES "^([0-9]+)\\.([0-9]+)\\.")
+  message(FATAL_ERROR "Unable to parse RMM version: ${current_rmm_version}")
+endif()
+normalize_version_component("${CMAKE_MATCH_1}" current_rmm_version_major)
+normalize_version_component("${CMAKE_MATCH_2}" current_rmm_version_minor)
+set(current_rmm_abi_namespace "_RAPIDS_${current_rmm_version_major}_${current_rmm_version_minor}")
+
+# rapids-pre-commit-hooks: disable-next-line[verify-hardcoded-version]
+set(previous_rmm_version "26.06.00")
+set(previous_rmm_abi_namespace "_RAPIDS_26_6")
+if(current_rmm_abi_namespace STREQUAL previous_rmm_abi_namespace)
+  message(FATAL_ERROR "The current and previous test ABI namespaces must be different")
+endif()
+
+set(previous_rmm_source_dir "${CMAKE_CURRENT_BINARY_DIR}/previous-rmm-source")
+file(REMOVE_RECURSE "${previous_rmm_source_dir}")
+file(MAKE_DIRECTORY "${previous_rmm_source_dir}")
+file(
+  COPY "${RMM_REPOSITORY_DIR}/cpp"
+  DESTINATION "${previous_rmm_source_dir}"
+  PATTERN "build" EXCLUDE)
+file(COPY "${RMM_REPOSITORY_DIR}/cmake" "${RMM_REPOSITORY_DIR}/RAPIDS_BRANCH"
+     DESTINATION "${previous_rmm_source_dir}")
+file(WRITE "${previous_rmm_source_dir}/VERSION" "${previous_rmm_version}\n")
+
+set(rmm_build_dir "${CMAKE_CURRENT_BINARY_DIR}/rmm-build")
+set(previous_rmm_build_dir "${CMAKE_CURRENT_BINARY_DIR}/previous-rmm-build")
+set(consumer_build_dir "${CMAKE_CURRENT_BINARY_DIR}/consumer-build")
+set(consumer_source_dir "${CMAKE_CURRENT_LIST_DIR}/consumer")
+set(rmm_library "${rmm_build_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}rmm${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(previous_rmm_library
+    "${previous_rmm_build_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}rmm${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(consumer_library
+    "${consumer_build_dir}/${CMAKE_SHARED_LIBRARY_PREFIX}rmm_abi_namespace_consumer${CMAKE_SHARED_LIBRARY_SUFFIX}"
+)
+set(state_test "${consumer_build_dir}/rmm_abi_state_test${CMAKE_EXECUTABLE_SUFFIX}")
+
+add_custom_target(
+  verify_rmm_abi_namespace ALL
+  COMMAND ${CMAKE_COMMAND} -E rm -rf "${rmm_build_dir}" "${previous_rmm_build_dir}"
+          "${consumer_build_dir}"
+  COMMAND
+    ${CMAKE_COMMAND} -S "${RMM_REPOSITORY_DIR}/cpp" -B "${rmm_build_dir}" -G "${CMAKE_GENERATOR}"
+    -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF
+  COMMAND ${CMAKE_COMMAND} --build "${rmm_build_dir}" --target rmm
+  COMMAND
+    ${CMAKE_COMMAND} -S "${previous_rmm_source_dir}/cpp" -B "${previous_rmm_build_dir}" -G
+    "${CMAKE_GENERATOR}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTS=OFF
+    -DBUILD_BENCHMARKS=OFF
+  COMMAND ${CMAKE_COMMAND} --build "${previous_rmm_build_dir}" --target rmm
+  COMMAND
+    ${CMAKE_COMMAND} -S "${consumer_source_dir}" -B "${consumer_build_dir}" -G "${CMAKE_GENERATOR}"
+    "-Drmm_DIR=${rmm_build_dir}" "-DPREVIOUS_RMM_SOURCE_DIR=${previous_rmm_source_dir}/cpp"
+    "-DPREVIOUS_RMM_BUILD_DIR=${previous_rmm_build_dir}"
+    "-DPREVIOUS_RMM_LIBRARY=${previous_rmm_library}"
+  COMMAND ${CMAKE_COMMAND} --build "${consumer_build_dir}"
+  COMMAND
+    ${CMAKE_COMMAND} "-DREADELF=${CMAKE_READELF}" "-DRMM_LIBRARY=${rmm_library}"
+    "-DPREVIOUS_RMM_LIBRARY=${previous_rmm_library}" "-DCONSUMER_LIBRARY=${consumer_library}"
+    "-DCURRENT_RMM_ABI_NAMESPACE=${current_rmm_abi_namespace}"
+    "-DPREVIOUS_RMM_ABI_NAMESPACE=${previous_rmm_abi_namespace}" -P
+    "${CMAKE_CURRENT_LIST_DIR}/verify_symbol_versions.cmake"
+  COMMAND "${state_test}"
+  COMMENT "Verifying composition and process state for multiple RMM ABI versions"
+  VERBATIM)

--- a/cpp/cmake/tests/rmm_abi_namespace/consumer/CMakeLists.txt
+++ b/cpp/cmake/tests/rmm_abi_namespace/consumer/CMakeLists.txt
@@ -1,0 +1,61 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+
+project(rmm_abi_namespace_consumer LANGUAGES CXX)
+
+foreach(required_path IN ITEMS PREVIOUS_RMM_SOURCE_DIR PREVIOUS_RMM_BUILD_DIR PREVIOUS_RMM_LIBRARY)
+  if(NOT DEFINED ${required_path} OR NOT EXISTS "${${required_path}}")
+    message(FATAL_ERROR "${required_path} must name an existing path")
+  endif()
+endforeach()
+
+find_package(rmm REQUIRED CONFIG)
+
+add_library(previous_rmm STATIC IMPORTED)
+set_target_properties(previous_rmm PROPERTIES IMPORTED_LOCATION "${PREVIOUS_RMM_LIBRARY}")
+
+get_target_property(rmm_link_libraries rmm::rmm INTERFACE_LINK_LIBRARIES)
+if(NOT rmm_link_libraries)
+  message(FATAL_ERROR "rmm::rmm has no interface link libraries")
+endif()
+
+add_library(previous_rmm_call OBJECT previous.cpp)
+target_include_directories(previous_rmm_call BEFORE PRIVATE "${PREVIOUS_RMM_SOURCE_DIR}/include"
+                                                            "${PREVIOUS_RMM_BUILD_DIR}/include")
+target_link_libraries(previous_rmm_call PRIVATE ${rmm_link_libraries})
+set_target_properties(
+  previous_rmm_call
+  PROPERTIES POSITION_INDEPENDENT_CODE ON
+             CXX_STANDARD 20
+             CXX_STANDARD_REQUIRED ON)
+
+add_library(rmm_abi_namespace_consumer SHARED current.cpp $<TARGET_OBJECTS:previous_rmm_call>)
+target_link_libraries(
+  rmm_abi_namespace_consumer
+  PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,rmm::rmm>" "$<LINK_LIBRARY:WHOLE_ARCHIVE,previous_rmm>"
+          ${rmm_link_libraries})
+set_property(TARGET rmm_abi_namespace_consumer PROPERTY CXX_STANDARD 20)
+set_property(TARGET rmm_abi_namespace_consumer PROPERTY CXX_STANDARD_REQUIRED ON)
+
+add_library(current_state_a SHARED current_state_a.cpp)
+add_library(current_state_b SHARED current_state_b.cpp)
+foreach(target IN ITEMS current_state_a current_state_b)
+  target_link_libraries(${target} PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,rmm::rmm>")
+  set_target_properties(${target} PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
+endforeach()
+
+add_library(previous_state SHARED previous_state.cpp)
+target_include_directories(previous_state BEFORE PRIVATE "${PREVIOUS_RMM_SOURCE_DIR}/include"
+                                                         "${PREVIOUS_RMM_BUILD_DIR}/include")
+target_link_libraries(previous_state PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,previous_rmm>"
+                                             ${rmm_link_libraries})
+set_target_properties(previous_state PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
+
+add_executable(rmm_abi_state_test state_test.cpp)
+target_link_libraries(rmm_abi_state_test PRIVATE current_state_a current_state_b previous_state)
+set_target_properties(rmm_abi_state_test PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)

--- a/cpp/cmake/tests/rmm_abi_namespace/consumer/current.cpp
+++ b/cpp/cmake/tests/rmm_abi_namespace/consumer/current.cpp
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/aligned.hpp>
+
+#include <cstddef>
+
+std::size_t call_current_rmm_align_up(std::size_t value, std::size_t alignment)
+{
+  return rmm::align_up(value, alignment);
+}

--- a/cpp/cmake/tests/rmm_abi_namespace/consumer/current_state_a.cpp
+++ b/cpp/cmake/tests/rmm_abi_namespace/consumer/current_state_a.cpp
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/mr/per_device_resource.hpp>
+
+extern "C" void const* current_state_a_map() { return &rmm::mr::detail::get_ref_map(); }

--- a/cpp/cmake/tests/rmm_abi_namespace/consumer/current_state_b.cpp
+++ b/cpp/cmake/tests/rmm_abi_namespace/consumer/current_state_b.cpp
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/mr/per_device_resource.hpp>
+
+extern "C" void const* current_state_b_map() { return &rmm::mr::detail::get_ref_map(); }

--- a/cpp/cmake/tests/rmm_abi_namespace/consumer/previous.cpp
+++ b/cpp/cmake/tests/rmm_abi_namespace/consumer/previous.cpp
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/aligned.hpp>
+
+#include <cstddef>
+
+std::size_t call_previous_rmm_align_up(std::size_t value, std::size_t alignment)
+{
+  return rmm::align_up(value, alignment);
+}

--- a/cpp/cmake/tests/rmm_abi_namespace/consumer/previous_state.cpp
+++ b/cpp/cmake/tests/rmm_abi_namespace/consumer/previous_state.cpp
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/mr/per_device_resource.hpp>
+
+extern "C" void const* previous_state_map() { return &rmm::mr::detail::get_ref_map(); }

--- a/cpp/cmake/tests/rmm_abi_namespace/consumer/state_test.cpp
+++ b/cpp/cmake/tests/rmm_abi_namespace/consumer/state_test.cpp
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+extern "C" void const* current_state_a_map();
+extern "C" void const* current_state_b_map();
+extern "C" void const* previous_state_map();
+
+int main()
+{
+  if (current_state_a_map() != current_state_b_map()) { return 1; }
+  if (current_state_a_map() == previous_state_map()) { return 2; }
+  return 0;
+}

--- a/cpp/cmake/tests/rmm_abi_namespace/verify_symbol_versions.cmake
+++ b/cpp/cmake/tests/rmm_abi_namespace/verify_symbol_versions.cmake
@@ -1,0 +1,90 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+
+foreach(required_file IN ITEMS READELF RMM_LIBRARY PREVIOUS_RMM_LIBRARY CONSUMER_LIBRARY)
+  if(NOT DEFINED ${required_file} OR NOT EXISTS "${${required_file}}")
+    message(FATAL_ERROR "${required_file} must name an existing file")
+  endif()
+endforeach()
+foreach(required_value IN ITEMS CURRENT_RMM_ABI_NAMESPACE PREVIOUS_RMM_ABI_NAMESPACE)
+  if(NOT DEFINED ${required_value} OR "${${required_value}}" STREQUAL "")
+    message(FATAL_ERROR "${required_value} must not be empty")
+  endif()
+endforeach()
+
+# Read demangled ELF symbols from library into output_variable.
+function(read_symbols library output_variable)
+  execute_process(
+    COMMAND "${READELF}" --symbols --wide --demangle "${library}"
+    OUTPUT_VARIABLE symbols
+    ERROR_VARIABLE error_output
+    RESULT_VARIABLE result)
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "readelf failed for ${library}: ${error_output}")
+  endif()
+  set(${output_variable}
+      "${symbols}"
+      PARENT_SCOPE)
+endfunction()
+
+# Read demangled dynamic ELF symbols from library into output_variable.
+function(read_dynamic_symbols library output_variable)
+  execute_process(
+    COMMAND "${READELF}" --dyn-syms --wide --demangle "${library}"
+    OUTPUT_VARIABLE symbols
+    ERROR_VARIABLE error_output
+    RESULT_VARIABLE result)
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "readelf failed for ${library}: ${error_output}")
+  endif()
+  set(${output_variable}
+      "${symbols}"
+      PARENT_SCOPE)
+endfunction()
+
+read_symbols("${RMM_LIBRARY}" rmm_symbols)
+read_symbols("${PREVIOUS_RMM_LIBRARY}" previous_rmm_symbols)
+read_symbols("${CONSUMER_LIBRARY}" consumer_symbols)
+read_dynamic_symbols("${CONSUMER_LIBRARY}" consumer_dynamic_symbols)
+
+set(current_align_up
+    "FUNC[ \t]+GLOBAL[ \t]+DEFAULT[ \t]+[0-9]+[ \t]+rmm::${CURRENT_RMM_ABI_NAMESPACE}::align_up\\(")
+set(previous_align_up
+    "FUNC[ \t]+GLOBAL[ \t]+DEFAULT[ \t]+[0-9]+[ \t]+rmm::${PREVIOUS_RMM_ABI_NAMESPACE}::align_up\\("
+)
+set(unversioned_align_up "FUNC[ \t]+GLOBAL[ \t]+DEFAULT[ \t]+[0-9]+[ \t]+rmm::align_up\\(")
+set(current_resource_map
+    "OBJECT[ \t]+UNIQUE[ \t]+DEFAULT[ \t]+[0-9]+[ \t]+rmm::${CURRENT_RMM_ABI_NAMESPACE}::mr::detail::get_ref_map\\(\\)::device_id_to_resource"
+)
+set(previous_resource_map
+    "OBJECT[ \t]+UNIQUE[ \t]+DEFAULT[ \t]+[0-9]+[ \t]+rmm::${PREVIOUS_RMM_ABI_NAMESPACE}::mr::detail::get_ref_map\\(\\)::device_id_to_resource"
+)
+
+if(NOT rmm_symbols MATCHES "${current_align_up}" OR NOT rmm_symbols MATCHES
+                                                    "${current_resource_map}")
+  message(FATAL_ERROR "Current static RMM does not contain the expected ABI-versioned symbols")
+endif()
+if(NOT previous_rmm_symbols MATCHES "${previous_align_up}" OR NOT previous_rmm_symbols MATCHES
+                                                              "${previous_resource_map}")
+  message(FATAL_ERROR "Previous static RMM does not contain the expected ABI-versioned symbols")
+endif()
+if(rmm_symbols MATCHES "${unversioned_align_up}" OR previous_rmm_symbols MATCHES
+                                                    "${unversioned_align_up}")
+  message(FATAL_ERROR "A static RMM library contains an unversioned rmm::align_up symbol")
+endif()
+foreach(expected_symbol IN ITEMS current_align_up previous_align_up current_resource_map
+                                 previous_resource_map)
+  if(NOT consumer_symbols MATCHES "${${expected_symbol}}")
+    message(FATAL_ERROR "Consumer DSO is missing ${expected_symbol}")
+  endif()
+endforeach()
+foreach(expected_symbol IN ITEMS current_align_up previous_align_up)
+  if(NOT consumer_dynamic_symbols MATCHES "${${expected_symbol}}")
+    message(FATAL_ERROR "Consumer DSO does not export ${expected_symbol}")
+  endif()
+endforeach()

--- a/cpp/cmake/tests/rmm_abi_namespace/verify_symbol_versions.cmake
+++ b/cpp/cmake/tests/rmm_abi_namespace/verify_symbol_versions.cmake
@@ -16,6 +16,9 @@ foreach(required_value IN ITEMS CURRENT_RMM_ABI_NAMESPACE PREVIOUS_RMM_ABI_NAMES
     message(FATAL_ERROR "${required_value} must not be empty")
   endif()
 endforeach()
+if(CURRENT_RMM_ABI_NAMESPACE STREQUAL PREVIOUS_RMM_ABI_NAMESPACE)
+  message(FATAL_ERROR "CURRENT_RMM_ABI_NAMESPACE and PREVIOUS_RMM_ABI_NAMESPACE must differ")
+endif()
 
 # Read demangled ELF symbols from library into output_variable.
 function(read_symbols library output_variable)

--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -2184,6 +2184,8 @@ PREDEFINED             = RMM_EXEC_CHECK_DISABLE \
                          RMM_EXPORT \
                          RMM_HIDDEN \
                          RMM_NAMESPACE=rmm \
+                         "RMM_NAMESPACE_BEGIN=namespace rmm {" \
+                         RMM_NAMESPACE_END=} \
                          DOXYGEN \
                          "RMM_CONSTEXPR_FRIEND=friend"
 

--- a/cpp/include/rmm/aligned.hpp
+++ b/cpp/include/rmm/aligned.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <cassert>
 #include <cstddef>
 
-namespace RMM_EXPORT rmm {
+RMM_NAMESPACE_BEGIN
 
 /**
  * @addtogroup utilities
@@ -95,4 +95,4 @@ static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
 
 /** @} */  // end of group
 
-}  // namespace RMM_EXPORT rmm
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/cuda_device.hpp
+++ b/cpp/include/rmm/cuda_device.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_EXPORT rmm {
+RMM_NAMESPACE_BEGIN
 
 struct cuda_device_id;
 cuda_device_id get_current_cuda_device();
@@ -135,4 +135,4 @@ struct cuda_set_device_raii {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/cuda_stream.hpp
+++ b/cpp/include/rmm/cuda_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <functional>
 #include <memory>
 
-namespace RMM_EXPORT rmm {
+RMM_NAMESPACE_BEGIN
 /**
  * @addtogroup cuda_streams
  * @{
@@ -127,4 +127,4 @@ class cuda_stream {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/cuda_stream_pool.hpp
+++ b/cpp/include/rmm/cuda_stream_pool.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace RMM_EXPORT rmm {
+RMM_NAMESPACE_BEGIN
 /**
  * @addtogroup cuda_streams
  * @{
@@ -87,4 +87,4 @@ class cuda_stream_pool {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/cuda_stream_view.hpp
+++ b/cpp/include/rmm/cuda_stream_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <ostream>
 
-namespace RMM_EXPORT rmm {
+RMM_NAMESPACE_BEGIN
 /**
  * @addtogroup cuda_streams
  * @{
@@ -152,4 +152,4 @@ bool operator!=(cuda_stream_view lhs, cuda_stream_view rhs);
 std::ostream& operator<<(std::ostream& os, cuda_stream_view stream);
 
 /** @} */  // end of group
-}  // namespace RMM_EXPORT rmm
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/aligned.hpp
+++ b/cpp/include/rmm/detail/aligned.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace detail {
 
 /**
@@ -104,4 +104,4 @@ void aligned_host_deallocate(void* ptr,
   }
 }
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/export.hpp
+++ b/cpp/include/rmm/detail/export.hpp
@@ -22,9 +22,9 @@
 #define RMM_HIDDEN
 #endif
 
-// Place RMM symbols in an inline namespace for the RAPIDS major/minor ABI version. This preserves
+// Place RMM symbols in an inline namespace for the RMM major/minor ABI version. This preserves
 // the rmm:: source-level API while allowing different RMM ABI versions to coexist in one process.
-#define RMM_DETAIL_ABI_NAMESPACE_IMPL(major, minor) _RAPIDS_##major##_##minor
+#define RMM_DETAIL_ABI_NAMESPACE_IMPL(major, minor) _RMM_##major##_##minor
 #define RMM_DETAIL_ABI_NAMESPACE(major, minor)      RMM_DETAIL_ABI_NAMESPACE_IMPL(major, minor)
 #define RMM_ABI_NAMESPACE                           RMM_DETAIL_ABI_NAMESPACE(RMM_VERSION_MAJOR, RMM_VERSION_MINOR)
 

--- a/cpp/include/rmm/detail/export.hpp
+++ b/cpp/include/rmm/detail/export.hpp
@@ -1,9 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
+
+#include <rmm/version_config.hpp>
 
 #include <cuda/version>
 
@@ -13,14 +15,26 @@
 
 // Macros used for defining symbol visibility, only GLIBC is supported
 #if (defined(__GNUC__) && !defined(__MINGW32__) && !defined(__MINGW64__))
-#define RMM_EXPORT    __attribute__((visibility("default")))
-#define RMM_HIDDEN    __attribute__((visibility("hidden")))
-#define RMM_NAMESPACE RMM_EXPORT rmm
+#define RMM_EXPORT __attribute__((visibility("default")))
+#define RMM_HIDDEN __attribute__((visibility("hidden")))
 #else
 #define RMM_EXPORT
 #define RMM_HIDDEN
-#define RMM_NAMESPACE rmm
 #endif
+
+// Place RMM symbols in an inline namespace for the RAPIDS major/minor ABI version. This preserves
+// the rmm:: source-level API while allowing different RMM ABI versions to coexist in one process.
+#define RMM_DETAIL_ABI_NAMESPACE_IMPL(major, minor) _RAPIDS_##major##_##minor
+#define RMM_DETAIL_ABI_NAMESPACE(major, minor)      RMM_DETAIL_ABI_NAMESPACE_IMPL(major, minor)
+#define RMM_ABI_NAMESPACE                           RMM_DETAIL_ABI_NAMESPACE(RMM_VERSION_MAJOR, RMM_VERSION_MINOR)
+
+#define RMM_NAMESPACE rmm::RMM_ABI_NAMESPACE
+#define RMM_NAMESPACE_BEGIN  \
+  namespace RMM_EXPORT rmm { \
+  inline namespace RMM_ABI_NAMESPACE {
+#define RMM_NAMESPACE_END \
+  }                       \
+  }
 
 // Work around breathe "friend constexpr friend" bug (breathe-doc/breathe#916).
 // Doxygen expands this to plain `friend`; normal builds get `constexpr friend`.

--- a/cpp/include/rmm/detail/format.hpp
+++ b/cpp/include/rmm/detail/format.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace detail {
 
 // Stringify a size in bytes to a human-readable value
@@ -39,4 +39,4 @@ inline std::string format_stream(rmm::cuda_stream_view stream)
 }
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/nvtx/ranges.hpp
+++ b/cpp/include/rmm/detail/nvtx/ranges.hpp
@@ -1,14 +1,16 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
+#include <rmm/detail/export.hpp>
+
 #if defined(RMM_NVTX)
 #include <nvtx3/nvtx3.hpp>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 /**
  * @brief Tag type for librmm's NVTX domain.
  */
@@ -31,7 +33,7 @@ struct librmm_domain {
  */
 using scoped_range = ::nvtx3::scoped_range_in<librmm_domain>;
 
-}  // namespace rmm
+RMM_NAMESPACE_END
 
 /**
  * @brief Convenience macro for generating an NVTX range in the `librmm` domain

--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 
 #include <dlfcn.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace detail {
 
 /**
@@ -174,4 +174,4 @@ struct device_integrated_memory {
 };
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/runtime_shutdown.hpp
+++ b/cpp/include/rmm/detail/runtime_shutdown.hpp
@@ -1,12 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 
 #include <rmm/detail/export.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace detail {
 
 /**
@@ -19,4 +19,4 @@ namespace detail {
 RMM_EXPORT void register_process_exit_hook() noexcept;
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/stack_trace.hpp
+++ b/cpp/include/rmm/detail/stack_trace.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,7 +25,7 @@
 #include <vector>
 #endif
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace detail {
 
 /**
@@ -93,4 +93,4 @@ class stack_trace {
 };
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/detail/thrust_namespace.h
+++ b/cpp/include/rmm/detail/thrust_namespace.h
@@ -1,9 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
+
+#include <rmm/detail/export.hpp>
 
 #include <thrust/detail/config.h>  // namespace macros
 
@@ -16,8 +18,8 @@ namespace thrust {
 }
 }  // namespace THRUST_WRAPPED_NAMESPACE
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 using namespace THRUST_WRAPPED_NAMESPACE;
-}
+RMM_NAMESPACE_END
 
 #endif

--- a/cpp/include/rmm/device_buffer.hpp
+++ b/cpp/include/rmm/device_buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -18,7 +18,7 @@
 #include <cassert>
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 /**
  * @addtogroup data_containers
  * @{
@@ -424,4 +424,4 @@ class device_buffer {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 
 #include <type_traits>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 /**
  * @addtogroup data_containers
  * @{
@@ -268,4 +268,4 @@ class device_scalar {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/device_uvector.hpp
+++ b/cpp/include/rmm/device_uvector.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -21,7 +21,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 /**
  * @addtogroup data_containers
  * @{
@@ -638,4 +638,4 @@ class device_uvector {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/device_vector.hpp
+++ b/cpp/include/rmm/device_vector.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 
 #include <thrust/device_vector.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -25,4 +25,4 @@ template <typename T>
 using device_vector = thrust::device_vector<T, rmm::mr::thrust_allocator<T>>;
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/error.hpp
+++ b/cpp/include/rmm/error.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 
 /**
  * @brief Exception thrown when logical precondition is violated.
@@ -109,4 +109,4 @@ class invalid_argument : public std::invalid_argument {
   using std::invalid_argument::invalid_argument;
 };
 
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/exec_policy.hpp
+++ b/cpp/include/rmm/exec_policy.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -19,7 +19,7 @@
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/version.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 /**
  * @addtogroup thrust_integrations
  * @{
@@ -77,4 +77,4 @@ class exec_policy_nosync : public thrust_exec_policy_nosync_t {
 };
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/logger.hpp
+++ b/cpp/include/rmm/logger.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 
 #include <rapids_logger/logger.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 
 /**
  * @brief Returns the default sink for the global logger.
@@ -36,4 +36,4 @@ std::string default_pattern();
  */
 rapids_logger::logger& default_logger();
 
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/aligned_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -77,4 +77,4 @@ static_assert(cuda::mr::resource_with<aligned_resource_adaptor, cuda::mr::device
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/arena_memory_resource.hpp
+++ b/cpp/include/rmm/mr/arena_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -93,4 +93,4 @@ static_assert(cuda::mr::resource_with<arena_memory_resource, cuda::mr::device_ac
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/binning_memory_resource.hpp
+++ b/cpp/include/rmm/mr/binning_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -99,4 +99,4 @@ static_assert(cuda::mr::resource_with<binning_memory_resource, cuda::mr::device_
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <functional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -104,4 +104,4 @@ static_assert(cuda::mr::resource_with<callback_memory_resource, cuda::mr::device
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -90,4 +90,4 @@ static_assert(
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -115,4 +115,4 @@ static_assert(cuda::mr::resource_with<cuda_async_memory_resource, cuda::mr::devi
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -144,4 +144,4 @@ static_assert(
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -119,4 +119,4 @@ static_assert(cuda::mr::resource_with<cuda_memory_resource, cuda::mr::device_acc
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/aligned_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/aligned_resource_adaptor_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -88,4 +88,4 @@ class aligned_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/arena.hpp
+++ b/cpp/include/rmm/mr/detail/arena.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -27,7 +27,7 @@
 #include <optional>
 #include <set>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr::detail::arena {
 
 /**
@@ -980,4 +980,4 @@ class arena_cleaner {
 };
 
 }  // namespace mr::detail::arena
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -18,7 +18,7 @@
 #include <shared_mutex>
 #include <thread>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -100,4 +100,4 @@ class arena_memory_resource_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/binning_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/binning_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -17,7 +17,7 @@
 #include <optional>
 #include <vector>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -90,4 +90,4 @@ class binning_memory_resource_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/callback_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/callback_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <functional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -79,4 +79,4 @@ class callback_memory_resource_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/coalescing_free_list.hpp
+++ b/cpp/include/rmm/mr/detail/coalescing_free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -17,7 +17,7 @@
 #endif
 #include <iterator>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr::detail {
 
 /**
@@ -255,4 +255,4 @@ struct coalescing_free_list : free_list<block> {
 };  // coalescing_free_list
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/cuda_async_managed_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/cuda_async_managed_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -15,7 +15,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -93,4 +93,4 @@ class cuda_async_managed_memory_resource_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/cuda_async_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/cuda_async_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -17,7 +17,7 @@
 #include <memory>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -87,4 +87,4 @@ class cuda_async_memory_resource_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -18,7 +18,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -117,4 +117,4 @@ class failure_callback_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/fixed_size_free_list.hpp
+++ b/cpp/include/rmm/mr/detail/fixed_size_free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,7 +10,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr::detail {
 
 struct fixed_size_free_list : free_list<block_base> {
@@ -66,4 +66,4 @@ struct fixed_size_free_list : free_list<block_base> {
 };
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/fixed_size_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/fixed_size_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -91,4 +91,4 @@ class fixed_size_memory_resource_impl final
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/free_list.hpp
+++ b/cpp/include/rmm/mr/detail/free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 #endif
 #include <list>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr::detail {
 
 struct block_base {
@@ -174,4 +174,4 @@ class free_list {
 };
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/limiting_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/limiting_resource_adaptor_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 #include <atomic>
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -82,4 +82,4 @@ class limiting_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/logging_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/logging_resource_adaptor_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <memory>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -73,4 +73,4 @@ class logging_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/pool_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -17,7 +17,7 @@
 #include <optional>
 #include <set>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -93,4 +93,4 @@ class pool_memory_resource_impl final
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/prefetch_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/prefetch_resource_adaptor_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -72,4 +72,4 @@ class prefetch_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/sam_headroom_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/sam_headroom_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -82,4 +82,4 @@ class sam_headroom_memory_resource_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/statistics_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/statistics_resource_adaptor_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -15,7 +15,7 @@
 #include <stack>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -117,4 +117,4 @@ class statistics_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -24,7 +24,7 @@
 #include <iostream>
 #endif
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr::detail {
 
 /**
@@ -536,4 +536,4 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
 };  // namespace detail
 
 }  // namespace mr::detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <mutex>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -76,4 +76,4 @@ class thread_safe_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/detail/tracking_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/tracking_resource_adaptor_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -17,7 +17,7 @@
 #include <shared_mutex>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -115,4 +115,4 @@ class tracking_resource_adaptor_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/failure_callback_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/failure_callback_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -15,7 +15,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -91,4 +91,4 @@ static_assert(
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/failure_callback_t.hpp
+++ b/cpp/include/rmm/mr/failure_callback_t.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <functional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -35,4 +35,4 @@ using failure_callback_t = std::function<bool(std::size_t, void*)>;
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
+++ b/cpp/include/rmm/mr/fixed_size_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -86,4 +86,4 @@ static_assert(cuda::mr::resource_with<fixed_size_memory_resource, cuda::mr::devi
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/limiting_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -90,4 +90,4 @@ static_assert(cuda::mr::resource_with<limiting_resource_adaptor, cuda::mr::devic
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/logging_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/logging_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 #include <ostream>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 /**
@@ -137,4 +137,4 @@ static_assert(cuda::mr::resource_with<logging_resource_adaptor, cuda::mr::device
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/managed_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -132,4 +132,4 @@ static_assert(cuda::mr::resource_with<managed_memory_resource, cuda::mr::host_ac
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/per_device_resource.hpp
+++ b/cpp/include/rmm/mr/per_device_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -29,7 +29,7 @@
  * that was active when the memory resource was created.
  */
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -262,4 +262,4 @@ inline cuda::mr::any_resource<cuda::mr::device_accessible> reset_current_device_
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 /**
@@ -145,4 +145,4 @@ static_assert(cuda::mr::resource_with<pinned_host_memory_resource, cuda::mr::hos
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/polymorphic_allocator.hpp
+++ b/cpp/include/rmm/mr/polymorphic_allocator.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,7 +16,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -291,4 +291,4 @@ bool operator!=(stream_allocator_adaptor<A> const& lhs, stream_allocator_adaptor
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/pool_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pool_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -83,4 +83,4 @@ static_assert(cuda::mr::resource_with<pool_memory_resource, cuda::mr::device_acc
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/prefetch_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/prefetch_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -59,4 +59,4 @@ static_assert(cuda::mr::resource_with<prefetch_resource_adaptor, cuda::mr::devic
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/sam_headroom_memory_resource.hpp
+++ b/cpp/include/rmm/mr/sam_headroom_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -84,4 +84,4 @@ static_assert(cuda::mr::resource_with<sam_headroom_memory_resource, cuda::mr::ho
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/statistics_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/statistics_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -99,4 +99,4 @@ static_assert(cuda::mr::resource_with<statistics_resource_adaptor, cuda::mr::dev
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/system_memory_resource.hpp
+++ b/cpp/include/rmm/mr/system_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -14,7 +14,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 namespace detail {
@@ -163,4 +163,4 @@ static_assert(cuda::mr::resource_with<system_memory_resource, cuda::mr::device_a
 static_assert(cuda::mr::resource_with<system_memory_resource, cuda::mr::host_accessible>);
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/thread_safe_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <mutex>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -67,4 +67,4 @@ static_assert(cuda::mr::resource_with<thread_safe_resource_adaptor, cuda::mr::de
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
+++ b/cpp/include/rmm/mr/thrust_allocator_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/memory.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -186,4 +186,4 @@ class thrust_allocator : public thrust::device_malloc_allocator<T> {
 };
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
+++ b/cpp/include/rmm/mr/tracking_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -15,7 +15,7 @@
 #include <memory>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resource_adaptors
@@ -104,4 +104,4 @@ static_assert(cuda::mr::resource_with<tracking_resource_adaptor, cuda::mr::devic
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/prefetch.hpp
+++ b/cpp/include/rmm/prefetch.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -13,7 +13,7 @@
 
 #include <cuda/std/span>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 
 /**
  * @addtogroup utilities
@@ -60,4 +60,4 @@ void prefetch(cuda::std::span<T const> data,
 
 /** @} */  // end of group
 
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/process_is_exiting.hpp
+++ b/cpp/include/rmm/process_is_exiting.hpp
@@ -1,12 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
 
 #include <rmm/detail/export.hpp>
 
-namespace RMM_EXPORT rmm {
+RMM_NAMESPACE_BEGIN
 
 /**
  * @addtogroup memory_resources
@@ -61,4 +61,4 @@ bool process_is_exiting() noexcept;
 
 /** @} */  // end of group
 
-}  // namespace RMM_EXPORT rmm
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/resource_ref.hpp
+++ b/cpp/include/rmm/resource_ref.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,7 +9,7 @@
 
 #include <cuda/memory_resource>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 
 /**
  * @addtogroup memory_resources
@@ -85,4 +85,4 @@ static_assert(std::is_constructible_v<host_resource_ref, host_device_resource_re
               "host_resource_ref must be constructible from host_device_resource_ref");
 
 /** @} */  // end of group
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/aligned.cpp
+++ b/cpp/src/aligned.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 bool is_pow2(std::size_t value) noexcept { return (value != 0U) && ((value & (value - 1)) == 0U); }
 
@@ -44,4 +44,4 @@ bool is_pointer_aligned(void* ptr, std::size_t alignment) noexcept
   return is_aligned(reinterpret_cast<std::uintptr_t>(ptr), alignment);
 }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/cuda_device.cpp
+++ b/cpp/src/cuda_device.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 cuda_device_id get_current_cuda_device()
 {
@@ -56,4 +56,4 @@ cuda_set_device_raii::~cuda_set_device_raii() noexcept
   if (needs_reset_) { RMM_ASSERT_CUDA_SUCCESS(cudaSetDevice(old_device_.value())); }
 }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/cuda_stream.cpp
+++ b/cpp/src/cuda_stream.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 
 #include <type_traits>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 cuda_stream::cuda_stream(cuda_stream::flags flags)
   : stream_{[flags]() {
@@ -51,4 +51,4 @@ void cuda_stream::synchronize_no_throw() const noexcept
   RMM_ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(value()));
 }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/cuda_stream_pool.cpp
+++ b/cpp/src/cuda_stream_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <atomic>
 #include <cstddef>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 cuda_stream_pool::cuda_stream_pool(std::size_t pool_size, cuda_stream::flags flags)
 {
@@ -33,4 +33,4 @@ rmm::cuda_stream_view cuda_stream_pool::get_stream(std::size_t stream_id) const
 
 std::size_t cuda_stream_pool::get_pool_size() const noexcept { return streams_.size(); }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/cuda_stream_view.cpp
+++ b/cpp/src/cuda_stream_view.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 
 #include <ostream>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 cuda_stream_view::cuda_stream_view(cudaStream_t stream) noexcept : stream_{stream} {}
 
@@ -59,4 +59,4 @@ std::ostream& operator<<(std::ostream& os, cuda_stream_view stream)
   return os;
 }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/device_buffer.cpp
+++ b/cpp/src/device_buffer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 
 #include <memory>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 device_buffer::device_buffer() : _mr{rmm::mr::get_current_device_resource_ref()} {}
 
@@ -183,4 +183,4 @@ void device_buffer::shrink_to_fit(cuda_stream_view stream)
   }
 }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/error.cpp
+++ b/cpp/src/error.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <string>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 bad_alloc::bad_alloc(const char* msg) : _what{std::string{std::bad_alloc::what()} + ": " + msg} {}
 
@@ -19,4 +19,4 @@ out_of_memory::out_of_memory(const char* msg) : bad_alloc{std::string{"out_of_me
 
 out_of_memory::out_of_memory(std::string const& msg) : out_of_memory{msg.c_str()} {}
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/exec_policy.cpp
+++ b/cpp/src/exec_policy.cpp
@@ -1,11 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/exec_policy.hpp>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 exec_policy::exec_policy(cuda_stream_view stream,
                          cuda::mr::any_resource<cuda::mr::device_accessible> mr)
@@ -22,4 +22,4 @@ exec_policy_nosync::exec_policy_nosync(cuda_stream_view stream,
 {
 }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/logger.cpp
+++ b/cpp/src/logger.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <memory>
 #include <string>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 rapids_logger::sink_ptr default_sink()
 {
@@ -32,4 +32,4 @@ rapids_logger::logger& default_logger()
   return logger_;
 }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/mr/aligned_resource_adaptor.cpp
+++ b/cpp/src/mr/aligned_resource_adaptor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 aligned_resource_adaptor::aligned_resource_adaptor(
@@ -25,4 +25,4 @@ device_async_resource_ref aligned_resource_adaptor::get_upstream_resource() cons
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/arena_memory_resource.cpp
+++ b/cpp/src/mr/arena_memory_resource.cpp
@@ -1,11 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/mr/arena_memory_resource.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 arena_memory_resource::arena_memory_resource(
@@ -18,4 +18,4 @@ arena_memory_resource::arena_memory_resource(
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/binning_memory_resource.cpp
+++ b/cpp/src/mr/binning_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 #include <cstddef>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 binning_memory_resource::binning_memory_resource(
@@ -39,4 +39,4 @@ void binning_memory_resource::add_bin(std::size_t allocation_size,
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/callback_memory_resource.cpp
+++ b/cpp/src/mr/callback_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 
 #include <utility>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 callback_memory_resource::callback_memory_resource(allocate_callback_t allocate_callback,
@@ -24,4 +24,4 @@ callback_memory_resource::callback_memory_resource(allocate_callback_t allocate_
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/cuda_async_managed_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_managed_memory_resource.cpp
@@ -1,12 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/cuda_async_managed_memory_resource.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 cuda_async_managed_memory_resource::cuda_async_managed_memory_resource()
@@ -21,4 +21,4 @@ cudaMemPool_t cuda_async_managed_memory_resource::pool_handle() const noexcept
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/cuda_async_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 cuda_async_memory_resource::cuda_async_memory_resource(
@@ -30,4 +30,4 @@ cudaMemPool_t cuda_async_memory_resource::pool_handle() const noexcept
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/cuda_async_view_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_view_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 cuda_async_view_memory_resource::cuda_async_view_memory_resource(cudaMemPool_t pool_handle)
@@ -81,4 +81,4 @@ bool cuda_async_view_memory_resource::operator!=(
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/cuda_memory_resource.cpp
+++ b/cpp/src/mr/cuda_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 void* cuda_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
@@ -54,4 +54,4 @@ bool cuda_memory_resource::operator==(cuda_memory_resource const&) const noexcep
 bool cuda_memory_resource::operator!=(cuda_memory_resource const&) const noexcept { return false; }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -109,4 +109,4 @@ void aligned_resource_adaptor_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -200,4 +200,4 @@ bool arena_memory_resource_impl::use_per_thread_arena(cuda_stream_view stream)
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/binning_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/binning_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <memory>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -90,4 +90,4 @@ void binning_memory_resource_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 
 #include <utility>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -61,4 +61,4 @@ void callback_memory_resource_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -78,4 +78,4 @@ void cuda_async_managed_memory_resource_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,7 +18,7 @@
 #include <cstdint>
 #include <limits>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -112,4 +112,4 @@ void cuda_async_memory_resource_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/fixed_size_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -22,7 +22,7 @@
 #include <iostream>
 #endif
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -133,4 +133,4 @@ void fixed_size_memory_resource_impl::print()
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -90,4 +90,4 @@ void limiting_resource_adaptor_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -83,4 +83,4 @@ std::string logging_resource_adaptor_impl::header() const
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/pool_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/pool_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,7 +25,7 @@
 #include <iostream>
 #endif
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -226,4 +226,4 @@ void pool_memory_resource_impl::print()
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -63,4 +63,4 @@ void prefetch_resource_adaptor_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/sam_headroom_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/sam_headroom_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@
 #include <algorithm>
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -91,4 +91,4 @@ void sam_headroom_memory_resource_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 
 #include <stdexcept>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -108,4 +108,4 @@ void statistics_resource_adaptor_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -61,4 +61,4 @@ void thread_safe_resource_adaptor_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <stdexcept>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -124,4 +124,4 @@ void tracking_resource_adaptor_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/fixed_size_memory_resource.cpp
+++ b/cpp/src/mr/fixed_size_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 fixed_size_memory_resource::fixed_size_memory_resource(
@@ -30,4 +30,4 @@ std::size_t fixed_size_memory_resource::get_block_size() const noexcept
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/limiting_resource_adaptor.cpp
+++ b/cpp/src/mr/limiting_resource_adaptor.cpp
@@ -1,11 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/mr/limiting_resource_adaptor.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 limiting_resource_adaptor::limiting_resource_adaptor(
@@ -33,4 +33,4 @@ std::size_t limiting_resource_adaptor::get_allocation_limit() const
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/logging_resource_adaptor.cpp
+++ b/cpp/src/mr/logging_resource_adaptor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <memory>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 namespace {
@@ -78,4 +78,4 @@ std::string logging_resource_adaptor::get_default_filename()
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/managed_memory_resource.cpp
+++ b/cpp/src/mr/managed_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 void* managed_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
@@ -63,4 +63,4 @@ bool managed_memory_resource::operator!=(managed_memory_resource const&) const n
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/pinned_host_memory_resource.cpp
+++ b/cpp/src/mr/pinned_host_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -12,7 +12,7 @@
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 void* pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
@@ -69,4 +69,4 @@ bool pinned_host_memory_resource::operator!=(pinned_host_memory_resource const&)
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/pool_memory_resource.cpp
+++ b/cpp/src/mr/pool_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <memory>
 #include <optional>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 pool_memory_resource::pool_memory_resource(
@@ -29,4 +29,4 @@ device_async_resource_ref pool_memory_resource::get_upstream_resource() const no
 std::size_t pool_memory_resource::pool_size() const noexcept { return get().pool_size(); }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/prefetch_resource_adaptor.cpp
+++ b/cpp/src/mr/prefetch_resource_adaptor.cpp
@@ -1,11 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/mr/prefetch_resource_adaptor.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 prefetch_resource_adaptor::prefetch_resource_adaptor(
@@ -21,4 +21,4 @@ device_async_resource_ref prefetch_resource_adaptor::get_upstream_resource() con
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/sam_headroom_memory_resource.cpp
+++ b/cpp/src/mr/sam_headroom_memory_resource.cpp
@@ -1,12 +1,12 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/sam_headroom_memory_resource.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 sam_headroom_memory_resource::sam_headroom_memory_resource(std::size_t headroom)
@@ -15,4 +15,4 @@ sam_headroom_memory_resource::sam_headroom_memory_resource(std::size_t headroom)
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/statistics_resource_adaptor.cpp
+++ b/cpp/src/mr/statistics_resource_adaptor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 statistics_resource_adaptor::statistics_resource_adaptor(
@@ -47,4 +47,4 @@ statistics_resource_adaptor::pop_counters()
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/system_memory_resource.cpp
+++ b/cpp/src/mr/system_memory_resource.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -15,7 +15,7 @@
 #include <new>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -94,4 +94,4 @@ bool system_memory_resource::operator!=(system_memory_resource const&) const noe
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/thread_safe_resource_adaptor.cpp
+++ b/cpp/src/mr/thread_safe_resource_adaptor.cpp
@@ -1,11 +1,11 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <rmm/mr/thread_safe_resource_adaptor.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 thread_safe_resource_adaptor::thread_safe_resource_adaptor(
@@ -21,4 +21,4 @@ device_async_resource_ref thread_safe_resource_adaptor::get_upstream_resource() 
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/tracking_resource_adaptor.cpp
+++ b/cpp/src/mr/tracking_resource_adaptor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,7 +9,7 @@
 #include <map>
 #include <string>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 tracking_resource_adaptor::tracking_resource_adaptor(
@@ -46,4 +46,4 @@ void tracking_resource_adaptor::log_outstanding_allocations() const
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/prefetch.cpp
+++ b/cpp/src/prefetch.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,7 +8,7 @@
 
 #include <cuda_runtime_api.h>
 
-namespace rmm {
+RMM_NAMESPACE_BEGIN
 
 void prefetch(void const* ptr,
               std::size_t size,
@@ -31,4 +31,4 @@ void prefetch(void const* ptr,
   if (result != cudaErrorInvalidValue && result != cudaSuccess) { RMM_CUDA_TRY(result); }
 }
 
-}  // namespace rmm
+RMM_NAMESPACE_END

--- a/cpp/src/runtime_shutdown.cpp
+++ b/cpp/src/runtime_shutdown.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 #include <cstdlib>
 #include <mutex>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 
 namespace {
 
@@ -39,4 +39,4 @@ void register_process_exit_hook() noexcept
 }
 
 }  // namespace detail
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -58,6 +58,13 @@ files:
       - depends_on_librmm
       - depends_on_librmm_tests
       - depends_on_librmm_example
+  test_cmake:
+    output: none
+    includes:
+      - build
+      - cuda_static
+      - cuda_version
+      - depends_on_rapids_logger
   checks:
     output: none
     includes:
@@ -238,6 +245,11 @@ dependencies:
       - output_types: conda
         packages:
           - &doxygen doxygen=1.9.1
+  cuda_static:
+    common:
+      - output_types: conda
+        packages:
+          - cuda-cudart-static
   # 'cuda_version' intentionally does not contain fallback entries... we want
   # a loud error if an unsupported 'cuda' value is passed
   cuda_version:


### PR DESCRIPTION
## Description

Place RMM APIs in an RMM major/minor versioned inline ABI namespace while preserving the existing `rmm::` source spelling. This allows different statically linked RMM ABI versions to coexist without duplicate strong symbols or ODR violations, while DSOs built against the same ABI version continue to share process-global resource state.

- Add paired `RMM_NAMESPACE_BEGIN` / `RMM_NAMESPACE_END` macros using the generated RMM major/minor version.
- Migrate RMM namespace blocks to the versioned inline namespace.
- Add standalone CMake tests for mixed-version static archive composition, ELF symbol versioning, and same-/different-version resource-map identity.
- Add the CMake test suite to CI.

Validation:
- Standalone CMake ABI tests passed.
- The same tests against the pre-change tree fail with duplicate unversioned `rmm::*` definitions.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
