### PR TITLE
DNM: test wheel ci on cuda base

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,18 +13,18 @@ jobs:
       - check-nightly-ci
       - changed-files
       - checks
-      - conda-cpp-build
-      - conda-cpp-tests
-      - conda-cpp-debug-tests
-      - conda-python-build
-      - conda-python-tests
-      - conda-python-tests-integration-optional
-      - docs-build
+      # - conda-cpp-build
+      # - conda-cpp-tests
+      # - conda-cpp-debug-tests
+      # - conda-python-build
+      # - conda-python-tests
+      # - conda-python-tests-integration-optional
+      # - docs-build
       - wheel-build-cpp
       - wheel-build-python
       - wheel-tests
       - wheel-tests-integration-optional
-      - devcontainer
+      # - devcontainer
       - telemetry-setup
     permissions:
       actions: read
@@ -216,111 +216,111 @@ jobs:
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize conda-python-tests-integration-optional wheel-tests-integration-optional"
-  conda-cpp-build:
-    needs: checks
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
-    with:
-      build_type: pull-request
-      node_type: cpu8
-      script: ci/build_cpp.sh
-  conda-cpp-tests:
-    needs: [conda-cpp-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
-    with:
-      build_type: pull-request
-      script: ci/test_cpp.sh
-  conda-cpp-debug-tests:
-    needs: [checks, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/test_cpp_debug.sh"
-  conda-python-build:
-    needs: conda-cpp-build
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
-    with:
-      build_type: pull-request
-      script: ci/build_python.sh
-      # Build a conda package for each CUDA x ARCH x minimum supported Python version
-      matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
-  conda-python-tests:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      build_type: pull-request
-      script: ci/test_python.sh
-  conda-python-tests-integration-optional:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
-    with:
-      build_type: pull-request
-      script: ci/test_python_integrations.sh
-  docs-build:
-    needs: [conda-python-build, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
-    with:
-      build_type: pull-request
-      node_type: "gpu-l4-latest-1"
-      arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
-      script: "ci/build_docs.sh"
+  # conda-cpp-build:
+  #   needs: checks
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     node_type: cpu8
+  #     script: ci/build_cpp.sh
+  # conda-cpp-tests:
+  #   needs: [conda-cpp-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_cpp.sh
+  # conda-cpp-debug-tests:
+  #   needs: [checks, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-l4-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/test_cpp_debug.sh"
+  # conda-python-build:
+  #   needs: conda-cpp-build
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/build_python.sh
+  #     # Build a conda package for each CUDA x ARCH x minimum supported Python version
+  #     matrix_filter: group_by({CUDA_VER, ARCH}) | map(min_by(.PY_VER | split(".") | map(tonumber)))
+  # conda-python-tests:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_python.sh
+  # conda-python-tests-integration-optional:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
+  #   with:
+  #     build_type: pull-request
+  #     script: ci/test_python_integrations.sh
+  # docs-build:
+  #   needs: [conda-python-build, changed-files]
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  #   if: fromJSON(needs.changed-files.outputs.changed_file_groups).build_docs
+  #   with:
+  #     build_type: pull-request
+  #     node_type: "gpu-l4-latest-1"
+  #     arch: "amd64"
+  #     container_image: "rapidsai/ci-conda:26.08-latest"
+  #     script: "ci/build_docs.sh"
   wheel-build-cpp:
     needs: checks
     permissions:
@@ -365,7 +365,7 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@smaller_citestwheel
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
@@ -379,34 +379,34 @@ jobs:
       packages: read
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@smaller_citestwheel
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
       script: ci/test_wheel_integrations.sh
-  devcontainer:
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    needs:
-      - telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
-    with:
-      arch: '["amd64", "arm64"]'
-      cuda: '["13.3"]'
-      node_type: "cpu8"
-      env: |
-        SCCACHE_DIST_MAX_RETRIES=inf
-        SCCACHE_SERVER_LOG=sccache=debug
-        SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
-      build_command: |
-        sccache --zero-stats;
-        build-all -j0 -DBUILD_BENCHMARKS=ON --verbose 2>&1 | tee telemetry-artifacts/build.log;
-        sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
+  # devcontainer:
+  #   permissions:
+  #     actions: read
+  #     contents: read
+  #     id-token: write
+  #     packages: read
+  #     pull-requests: read
+  #   secrets: inherit # zizmor: ignore[secrets-inherit]
+  #   needs:
+  #     - telemetry-setup
+  #   uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@main
+  #   with:
+  #     arch: '["amd64", "arm64"]'
+  #     cuda: '["13.3"]'
+  #     node_type: "cpu8"
+  #     env: |
+  #       SCCACHE_DIST_MAX_RETRIES=inf
+  #       SCCACHE_SERVER_LOG=sccache=debug
+  #       SCCACHE_DIST_FALLBACK_TO_LOCAL_COMPILE=false
+  #     build_command: |
+  #       sccache --zero-stats;
+  #       build-all -j0 -DBUILD_BENCHMARKS=ON --verbose 2>&1 | tee telemetry-artifacts/build.log;
+  #       sccache --show-adv-stats | tee telemetry-artifacts/sccache-stats.txt;
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4


### PR DESCRIPTION
xref rapidsai/build-planning#143
xref rapidsai/ci-imgs#400
xref rapidsai/shared-workflows#521

Test run using the smaller `cuda-base` image as the parent image of `citestwheel`

This shouldn't be merged. If all projects can run wheel tests with this image, we'll swap out the image upstream in `shared-workflows`.
