### PR TITLE
fix(aligned): assert align_up invariants and remove noexcept

### DIFF
--- a/cpp/include/rmm/aligned.hpp
+++ b/cpp/include/rmm/aligned.hpp
@@ -55,12 +55,18 @@ static constexpr std::size_t CUDA_ALLOCATION_ALIGNMENT{256};
 /**
  * @brief Align up to nearest multiple of specified power of 2
  *
+ * Enforces that `alignment` is a power of 2, and that the result does not overflow and wrap
+ * around past `std::numeric_limits<std::size_t>::max()`.
+ *
  * @param[in] value value to align
  * @param[in] alignment amount, in bytes, must be a power of 2
  *
  * @return the aligned value
+ *
+ * @throws rmm::logic_error if `alignment` is not a power of 2, or if aligning `value` would
+ * overflow `std::size_t`
  */
-[[nodiscard]] std::size_t align_up(std::size_t value, std::size_t alignment) noexcept;
+[[nodiscard]] std::size_t align_up(std::size_t value, std::size_t alignment);
 
 /**
  * @brief Align down to the nearest multiple of specified power of 2

--- a/cpp/src/aligned.cpp
+++ b/cpp/src/aligned.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <rmm/aligned.hpp>
+#include <rmm/detail/error.hpp>
 
 #include <cassert>
 #include <cstddef>
@@ -20,10 +21,13 @@ bool is_supported_base_resource_alignment(std::size_t alignment) noexcept
   return is_pow2(alignment) && alignment <= rmm::CUDA_ALLOCATION_ALIGNMENT;
 }
 
-std::size_t align_up(std::size_t value, std::size_t alignment) noexcept
+std::size_t align_up(std::size_t value, std::size_t alignment)
 {
-  assert(is_supported_alignment(alignment));
-  return (value + (alignment - 1)) & ~(alignment - 1);
+  RMM_EXPECTS(is_supported_alignment(alignment), "Alignment is not a power of 2");
+  auto const aligned_value = (value + (alignment - 1)) & ~(alignment - 1);
+  RMM_EXPECTS(aligned_value >= value,
+              "Overflow: value is too large to align without overflowing std::size_t");
+  return aligned_value;
 }
 
 std::size_t align_down(std::size_t value, std::size_t alignment) noexcept

--- a/cpp/tests/mr/aligned_mr_tests.cpp
+++ b/cpp/tests/mr/aligned_mr_tests.cpp
@@ -16,6 +16,8 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <limits>
+#include <tuple>
 
 namespace rmm::test {
 namespace {
@@ -24,6 +26,9 @@ using ::testing::_;
 using ::testing::Return;
 
 using aligned_adaptor = rmm::mr::aligned_resource_adaptor;
+
+static_assert(!noexcept(rmm::align_up(std::size_t{}, std::size_t{})),
+              "align_up must not be noexcept: it throws rmm::logic_error on invalid input");
 
 void* int_to_address(std::size_t val)
 {
@@ -246,6 +251,73 @@ TEST(AlignedTest, AlignRealPointer)
   void* alloc = mr.allocate_sync(threshold);
   EXPECT_TRUE(rmm::is_pointer_aligned(alloc, alignment));
   mr.deallocate_sync(alloc, threshold);
+}
+
+TEST(AlignedTest, AlignUpThrowsOnNonPowerOfTwoAlignment)
+{
+  EXPECT_THROW(std::ignore = rmm::align_up(100, 3), rmm::logic_error);
+  EXPECT_THROW(std::ignore = rmm::align_up(100, 100), rmm::logic_error);
+}
+
+TEST(AlignedTest, AlignUpThrowsOnZeroAlignment)
+{
+  EXPECT_THROW(std::ignore = rmm::align_up(100, 0), rmm::logic_error);
+}
+
+TEST(AlignedTest, AlignUpThrowsOnOverflow)
+{
+  EXPECT_THROW(std::ignore = rmm::align_up(std::numeric_limits<std::size_t>::max(),
+                                           rmm::CUDA_ALLOCATION_ALIGNMENT),
+               rmm::logic_error);
+}
+
+TEST(AlignedTest, AlignUpJustBelowOverflowBoundarySucceeds)
+{
+  auto const max_value = std::numeric_limits<std::size_t>::max();
+  auto const alignment = std::size_t{256};
+  auto const value     = max_value - alignment;
+  // The largest multiple of `alignment` representable in std::size_t is `max_value - 255`,
+  // since `max_value + 1` is the next multiple of 256 above it, which overflows. `value` is
+  // exactly one less than that multiple, so aligning up must land on it.
+  auto const expected = max_value - (alignment - 1);
+  std::size_t result{};
+  EXPECT_NO_THROW(result = rmm::align_up(value, alignment));
+  EXPECT_EQ(result, expected);
+  EXPECT_GE(result, value);
+}
+
+TEST(AlignedTest, AlignUpExactOverflowBoundary)
+{
+  auto const max_value = std::numeric_limits<std::size_t>::max();
+  auto const alignment = std::size_t{256};
+  // `max_value - 255` is the largest value that is itself already a multiple of 256, i.e. the
+  // true boundary of the safe region: aligning it up must be a no-op.
+  auto const boundary = max_value - (alignment - 1);
+  std::size_t result{};
+  EXPECT_NO_THROW(result = rmm::align_up(boundary, alignment));
+  EXPECT_EQ(result, boundary);
+
+  // One more than the boundary is the smallest value whose correctly-rounded result would be
+  // `max_value + 1`, which wraps around to 0.
+  EXPECT_THROW(std::ignore = rmm::align_up(boundary + 1, alignment), rmm::logic_error);
+}
+
+TEST(AlignedTest, AlignUpAlignmentOfOneIsNoOp)
+{
+  // `1` is a valid power of two, so `alignment - 1 == 0` and the mask is all-ones: align_up
+  // becomes a pure no-op that can never trigger the overflow guard, even at SIZE_MAX.
+  auto const max_value = std::numeric_limits<std::size_t>::max();
+  std::size_t result{};
+  EXPECT_NO_THROW(result = rmm::align_up(max_value, std::size_t{1}));
+  EXPECT_EQ(result, max_value);
+  EXPECT_EQ(rmm::align_up(12345, 1), 12345);
+}
+
+TEST(AlignedTest, AlignUpHappyPathUnchanged)
+{
+  EXPECT_EQ(rmm::align_up(257, 256), 512);
+  EXPECT_EQ(rmm::align_up(256, 256), 256);
+  EXPECT_EQ(rmm::align_up(0, 256), 0);
 }
 
 TEST(AlignedTest, SmallAlignmentsBumpedTo256Bytes)


### PR DESCRIPTION
## Intent

The developer wanted a merge-ready fix for rapidsai/rmm issue #2005, which asks that rmm::align_up assert its invariants: that the alignment is a power of two and that the computation does not overflow near SIZE_MAX. They required the work to follow the repo's strict rules, meaning all C++/CUDA had to be authored by the cpp-implementer agent and reviewed by the cpp-reviewer agent to zero findings, using the correct RMM assertion idiom (RMM_EXPECTS) and keeping the diff minimal with new gtests covering non-power-of-two alignment and overflow boundaries. They specified building and running ALIGNED_TEST locally as a host-only check using the CCCL_IGNORE_DEPRECATED_STREAM_REF_HEADER flag (which must not be committed), then passing scrutinize review, pre-commit, and a DCO-signed commit. The change had to be validated through the no-mistakes pipeline (run via codex, with --skip pr) driving review/test/lint green, then held for the captain with no upstream push or PR opened. They also insisted that tooling artifacts like treehouse.toml never be committed and that work stay within the isolated worktree.

## What Changed

- `align_up` now validates its invariants with `RMM_EXPECTS`: it throws `rmm::logic_error` when `alignment` is not a power of 2, and when the aligned result would overflow and wrap past `std::size_t` max, replacing the old debug-only `assert`.
- The function drops `noexcept` in both the declaration (`cpp/include/rmm/aligned.hpp`) and definition (`cpp/src/aligned.cpp`), with the doc comment updated to describe the new `@throws` behavior.
- Adds gtest coverage in `aligned_mr_tests.cpp` for non-power-of-2 alignment and the overflow boundaries near `SIZE_MAX`.

## Risk Assessment

⚠️ Medium: The core align_up logic and tests are correct, but removing noexcept turns the function into a throwing call inside several noexcept deallocate paths, creating a latent std::terminate hazard on API misuse that should be acknowledged before merge.

## Testing

No CUDA toolkit (nvcc) is present and the ALIGNED_TEST target compiles as CUDA, so I could not build it directly; since align_up and all new test cases are pure host code, I compiled the real aligned.cpp host-only with the intended CCCL_IGNORE_DEPRECATED_STREAM_REF_HEADER flag and ran the verbatim new gtest cases (7/7 pass) plus an API demo showing the real thrown rmm::logic_error messages and overflow-boundary behavior. This is a C++ library API change with no UI surface, so no screenshot/visual artifact applies; the CLI transcript is the end-user-visible evidence.

<details>
<summary>Evidence: align_up invariants gtest run (7/7 passed)</summary>

<code>[ ===] 7 tests from 1 test suite ran. (0 ms total)&#10;[ PASSED ] 7 tests.</code>

```text
Running main() from /tmp/rmm-build-arena/_deps/gtest-src/googletest/src/gtest_main.cc
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from AlignedTest
[ RUN      ] AlignedTest.AlignUpThrowsOnNonPowerOfTwoAlignment
[       OK ] AlignedTest.AlignUpThrowsOnNonPowerOfTwoAlignment (0 ms)
[ RUN      ] AlignedTest.AlignUpThrowsOnZeroAlignment
[       OK ] AlignedTest.AlignUpThrowsOnZeroAlignment (0 ms)
[ RUN      ] AlignedTest.AlignUpThrowsOnOverflow
[       OK ] AlignedTest.AlignUpThrowsOnOverflow (0 ms)
[ RUN      ] AlignedTest.AlignUpJustBelowOverflowBoundarySucceeds
[       OK ] AlignedTest.AlignUpJustBelowOverflowBoundarySucceeds (0 ms)
[ RUN      ] AlignedTest.AlignUpExactOverflowBoundary
[       OK ] AlignedTest.AlignUpExactOverflowBoundary (0 ms)
[ RUN      ] AlignedTest.AlignUpAlignmentOfOneIsNoOp
[       OK ] AlignedTest.AlignUpAlignmentOfOneIsNoOp (0 ms)
[ RUN      ] AlignedTest.AlignUpHappyPathUnchanged
[       OK ] AlignedTest.AlignUpHappyPathUnchanged (0 ms)
[----------] 7 tests from AlignedTest (0 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.
```
</details>
<details>
<summary>Evidence: align_up API behavior demo (real exception messages + boundaries)</summary>

<code>align_up(257, 256) [happy path] -&gt; OK result=512&#10;align_up(100, 3) [non-power-of-2] -&gt; THREW rmm::logic_error: ... Alignment is not a power of 2&#10;align_up(100, 0) [zero alignment] -&gt; THREW rmm::logic_error: ... Alignment is not a power of 2&#10;align_up(SIZE_MAX, 256) [overflow] -&gt; THREW rmm::logic_error: ... Overflow: value is too large to align without overflowing std::size_t&#10;align_up(MAX-256, 256) [just below bound] -&gt; OK result=18446744073709551360&#10;align_up(MAX-255, 256) [exact bound no-op] -&gt; OK result=18446744073709551360&#10;align_up(MAX-254, 256) [1 past bound] -&gt; THREW rmm::logic_error: ... Overflow ...&#10;align_up(SIZE_MAX, 1) [align-1 no-op] -&gt; OK result=18446744073709551615</code>

```text
align_up(257, 256)      [happy path]         -> OK  result=512
align_up(100, 3)        [non-power-of-2]     -> THREW rmm::logic_error: RMM failure at: src/aligned.cpp:26: Alignment is not a power of 2
align_up(100, 0)        [zero alignment]     -> THREW rmm::logic_error: RMM failure at: src/aligned.cpp:26: Alignment is not a power of 2
align_up(SIZE_MAX, 256) [overflow]           -> THREW rmm::logic_error: RMM failure at: src/aligned.cpp:28: Overflow: value is too large to align without overflowing std::size_t
align_up(MAX-256, 256)  [just below bound]   -> OK  result=18446744073709551360
align_up(MAX-255, 256)  [exact bound no-op]  -> OK  result=18446744073709551360
align_up(MAX-254, 256)  [1 past bound]       -> THREW rmm::logic_error: RMM failure at: src/aligned.cpp:28: Overflow: value is too large to align without overflowing std::size_t
align_up(SIZE_MAX, 1)   [align-1 no-op]      -> OK  result=18446744073709551615
```
</details>
<details>
<summary>Evidence: Standalone host gtest driver source</summary>

```text
// Host-only driver exercising the align_up invariant assertions from
// cpp/tests/mr/aligned_mr_tests.cpp verbatim. ALIGNED_TEST itself compiles as
// CUDA (it pulls in aligned_resource_adaptor); these AlignUp cases only touch
// rmm::align_up + rmm::logic_error, so they run identically on the host.

#include <rmm/aligned.hpp>
#include <rmm/error.hpp>

#include <gtest/gtest.h>

#include <cstddef>
#include <limits>
#include <tuple>

namespace rmm::test {
namespace {

static_assert(!noexcept(rmm::align_up(std::size_t{}, std::size_t{})),
              "align_up must not be noexcept: it throws rmm::logic_error on invalid input");

TEST(AlignedTest, AlignUpThrowsOnNonPowerOfTwoAlignment)
{
  EXPECT_THROW(std::ignore = rmm::align_up(100, 3), rmm::logic_error);
  EXPECT_THROW(std::ignore = rmm::align_up(100, 100), rmm::logic_error);
}

TEST(AlignedTest, AlignUpThrowsOnZeroAlignment)
{
  EXPECT_THROW(std::ignore = rmm::align_up(100, 0), rmm::logic_error);
}

TEST(AlignedTest, AlignUpThrowsOnOverflow)
{
  EXPECT_THROW(std::ignore = rmm::align_up(std::numeric_limits<std::size_t>::max(),
                                           rmm::CUDA_ALLOCATION_ALIGNMENT),
               rmm::logic_error);
}

TEST(AlignedTest, AlignUpJustBelowOverflowBoundarySucceeds)
{
  auto const max_value = std::numeric_limits<std::size_t>::max();
  auto const alignment = std::size_t{256};
  auto const value     = max_value - alignment;
  auto const expected  = max_value - (alignment - 1);
  std::size_t result{};
  EXPECT_NO_THROW(result = rmm::align_up(value, alignment));
  EXPECT_EQ(result, expected);
  EXPECT_GE(result, value);
}

TEST(AlignedTest, AlignUpExactOverflowBoundary)
{
  auto const max_value = std::numeric_limits<std::size_t>::max();
  auto const alignment = std::size_t{256};
  auto const boundary  = max_value - (alignment - 1);
  std::size_t result{};
  EXPECT_NO_THROW(result = rmm::align_up(boundary, alignment));
  EXPECT_EQ(result, boundary);

  EXPECT_THROW(std::ignore = rmm::align_up(boundary + 1, alignment), rmm::logic_error);
}

TEST(AlignedTest, AlignUpAlignmentOfOneIsNoOp)
{
  auto const max_value = std::numeric_limits<std::size_t>::max();
  std::size_t result{};
  EXPECT_NO_THROW(result = rmm::align_up(max_value, std::size_t{1}));
  EXPECT_EQ(result, max_value);
  EXPECT_EQ(rmm::align_up(12345, 1), 12345);
}

TEST(AlignedTest, AlignUpHappyPathUnchanged)
{
  EXPECT_EQ(rmm::align_up(257, 256), 512);
  EXPECT_EQ(rmm::align_up(256, 256), 256);
  EXPECT_EQ(rmm::align_up(0, 256), 0);
}

}  // namespace
}  // namespace rmm::test
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp:142` - align_up dropped noexcept and now throws rmm::logic_error, but it is still called inside noexcept deallocate paths (stream_ordered_memory_resource.hpp:142 in the noexcept deallocate at :131, and arena_memory_resource_impl.cpp:74 in the noexcept deallocate at :67; also pool_memory_resource_impl.cpp:160 via RMM_LOGGING_ASSERT in debug). If align_up throws there, the noexcept boundary turns it into std::terminate instead of a catchable exception. In correct round-trip usage the size already passed align_up at allocate time so this is unreachable, but on a mismatched deallocate size (previously a silent wrap) it now aborts the process. Consider guarding these deallocate paths with the non-throwing align math or documenting that align_up must not throw here.
- ℹ️ `cpp/src/aligned.cpp:27` - In allocate hot paths (e.g. stream_ordered_memory_resource.hpp:103, arena/pool/limiting/fixed_size/binning), an oversized request that overflows align_up now surfaces as rmm::logic_error rather than the resource&#39;s own rmm::out_of_memory / std::bad_alloc. Callers catching bad_alloc/out_of_memory for large requests will miss it, since logic_error signals programmer error rather than an allocation-capacity condition. This matches the intent of issue #2005 but is a caller-visible error-classification change worth confirming.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Compiled real cpp/src/aligned.cpp host-only with g++ -std=c++20 -DCCCL_IGNORE_DEPRECATED_STREAM_REF_HEADER (exit 0)`
- `Built+ran standalone gtest driver with verbatim new AlignUp cases and the !noexcept static_assert against real aligned.o + prebuilt libgtest: 7/7 passed`
- `Ran API-level demo align_up_demo across happy-path, non-power-of-2, zero, overflow, and SIZE_MAX boundary inputs showing real rmm::logic_error messages`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
