### PR TITLE
Key arena per-stream state by CUDA stream ID

### DIFF
--- a/cpp/include/rmm/mr/arena_memory_resource.hpp
+++ b/cpp/include/rmm/mr/arena_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/rmm/mr/arena_memory_resource.hpp
+++ b/cpp/include/rmm/mr/arena_memory_resource.hpp
@@ -29,7 +29,10 @@ namespace mr {
  *
  * GPU memory is divided into a global arena, per-thread arenas for default streams, and per-stream
  * arenas for non-default streams. Each arena allocates memory from the global arena in chunks
- * called superblocks.
+ * called superblocks. Per-stream arenas are keyed by CUDA stream ID, so a newly created stream
+ * cannot reuse an arena associated with a destroyed stream's handle. These arenas remain for the
+ * lifetime of the resource; applications that continually create and destroy streams will grow
+ * the resource's internal bookkeeping.
  *
  * Blocks in each arena are allocated using address-ordered first fit. When a block is freed, it is
  * coalesced with neighbouring free blocks if the addresses are contiguous. Free superblocks are

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -123,6 +123,10 @@ class arena_memory_resource_impl {
 
   global_arena global_arena_;
   std::map<std::thread::id, std::shared_ptr<arena>> thread_arenas_;
+  /// Arenas keyed by CUDA stream ID. Stream IDs are unique for the lifetime of the process and
+  /// entries are never erased, so this map grows by one entry per distinct stream ever used with
+  /// this resource. Applications that continually create and destroy streams will see unbounded
+  /// growth; evicting entries for destroyed streams is planned follow-up work.
   std::map<stream_id_type, arena> stream_arenas_;
   bool dump_log_on_failure_{};
   std::shared_ptr<rapids_logger::logger> logger_{};

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -22,6 +22,27 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
+/// The type used to key per-stream arenas by CUDA stream ID.
+using stream_id_type = unsigned long long;
+
+/**
+ * @brief Return the CUDA stream ID used to key per-stream arenas.
+ *
+ * Normalizes the default stream to `cudaStreamLegacy` for consistency between
+ * PTDS and non-PTDS mode, then returns the stream's ID from `cudaStreamGetId`.
+ * Keying by ID (rather than the raw `cudaStream_t` handle) prevents a newly
+ * created stream that reuses a destroyed stream's handle value from inheriting
+ * stale arena state (ABA reuse).
+ *
+ * @param stream The stream for which to get the ID.
+ * @param may_throw If `true`, a `cudaStreamGetId` failure throws `rmm::cuda_error` (only safe to
+ * pass from a context that is not `noexcept`, e.g. the `allocate` path). If `false`, failure is
+ * only asserted in debug builds and silently ignored in release builds, matching the
+ * `noexcept`-safe requirements of the `deallocate`/`deallocate_sync` path.
+ * @return The CUDA stream ID.
+ */
+stream_id_type get_stream_id(cuda_stream_view stream, bool may_throw);
+
 /**
  * @brief Implementation class for arena_memory_resource.
  *
@@ -81,9 +102,9 @@ class arena_memory_resource_impl {
 
   void deallocate_from_other_arena(cuda_stream_view stream, void* ptr, std::size_t bytes);
 
-  arena& get_arena(cuda_stream_view stream);
+  arena& get_arena(cuda_stream_view stream, bool may_throw);
   arena& get_thread_arena();
-  arena& get_stream_arena(cuda_stream_view stream);
+  arena& get_stream_arena(cuda_stream_view stream, bool may_throw);
 
   void dump_memory_log(std::size_t bytes);
 
@@ -91,7 +112,7 @@ class arena_memory_resource_impl {
 
   global_arena global_arena_;
   std::map<std::thread::id, std::shared_ptr<arena>> thread_arenas_;
-  std::map<cudaStream_t, arena> stream_arenas_;
+  std::map<stream_id_type, arena> stream_arenas_;
   bool dump_log_on_failure_{};
   std::shared_ptr<rapids_logger::logger> logger_{};
   mutable std::shared_mutex map_mtx_;

--- a/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/arena_memory_resource_impl.hpp
@@ -35,13 +35,24 @@ using stream_id_type = unsigned long long;
  * stale arena state (ABA reuse).
  *
  * @param stream The stream for which to get the ID.
- * @param may_throw If `true`, a `cudaStreamGetId` failure throws `rmm::cuda_error` (only safe to
- * pass from a context that is not `noexcept`, e.g. the `allocate` path). If `false`, failure is
- * only asserted in debug builds and silently ignored in release builds, matching the
- * `noexcept`-safe requirements of the `deallocate`/`deallocate_sync` path.
  * @return The CUDA stream ID.
+ * @throws rmm::cuda_error if `cudaStreamGetId` fails.
  */
-stream_id_type get_stream_id(cuda_stream_view stream, bool may_throw);
+stream_id_type get_stream_id(cuda_stream_view stream);
+
+/**
+ * @brief Try to return the CUDA stream ID used to key per-stream arenas.
+ *
+ * Normalizes the default stream to `cudaStreamLegacy` for consistency between
+ * PTDS and non-PTDS mode, then returns the stream's ID from `cudaStreamGetId`.
+ * Keying by ID (rather than the raw `cudaStream_t` handle) prevents a newly
+ * created stream that reuses a destroyed stream's handle value from inheriting
+ * stale arena state (ABA reuse).
+ *
+ * @param stream The stream for which to get the ID.
+ * @return The CUDA stream ID, or `std::nullopt` if `cudaStreamGetId` fails.
+ */
+std::optional<stream_id_type> try_get_stream_id(cuda_stream_view stream) noexcept;
 
 /**
  * @brief Implementation class for arena_memory_resource.
@@ -100,11 +111,11 @@ class arena_memory_resource_impl {
 
   void defragment();
 
-  void deallocate_from_other_arena(cuda_stream_view stream, void* ptr, std::size_t bytes);
+  void deallocate_from_other_arena(cuda_stream_view stream, void* ptr, std::size_t bytes) noexcept;
 
-  arena& get_arena(cuda_stream_view stream, bool may_throw);
+  arena& get_arena(cuda_stream_view stream);
   arena& get_thread_arena();
-  arena& get_stream_arena(cuda_stream_view stream, bool may_throw);
+  arena& get_stream_arena(stream_id_type stream_id);
 
   void dump_memory_log(std::size_t bytes);
 

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -16,6 +16,26 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
+stream_id_type get_stream_id(cuda_stream_view stream, bool may_throw)
+{
+  // We use cudaStreamLegacy as the arena map key for the default stream for consistency between
+  // PTDS and non-PTDS mode. Keying by the stream ID (rather than the raw cudaStream_t handle)
+  // prevents a newly created stream that reuses a destroyed stream's handle value from inheriting
+  // stale arena state (ABA reuse).
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+  auto* const stream_to_store = stream.is_default() ? cudaStreamLegacy : stream.value();
+  stream_id_type stream_id{};
+  if (may_throw) {
+    // Safe to throw: only called from the non-noexcept allocate() path.
+    RMM_CUDA_TRY(cudaStreamGetId(stream_to_store, &stream_id));
+  } else {
+    // Called from the noexcept deallocate()/deallocate_sync() path: must not throw. A failure
+    // here is only surfaced via assertion in debug builds.
+    RMM_ASSERT_CUDA_SUCCESS(cudaStreamGetId(stream_to_store, &stream_id));
+  }
+  return stream_id;
+}
+
 arena_memory_resource_impl::arena_memory_resource_impl(
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr,
   std::optional<std::size_t> arena_size,
@@ -40,7 +60,7 @@ void* arena_memory_resource_impl::allocate(cuda::stream_ref stream,
 #else
   bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
 #endif
-  auto& arena = get_arena(sv);
+  auto& arena = get_arena(sv, /*may_throw=*/true);
 
   {
     std::shared_lock lock(mtx_);
@@ -74,7 +94,7 @@ void arena_memory_resource_impl::deallocate(cuda::stream_ref stream,
 #else
   bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
 #endif
-  auto& arena = get_arena(sv);
+  auto& arena = get_arena(sv, /*may_throw=*/false);
 
   {
     std::shared_lock lock(mtx_);
@@ -144,10 +164,11 @@ void arena_memory_resource_impl::deallocate_from_other_arena(cuda_stream_view st
   }
 }
 
-arena_memory_resource_impl::arena& arena_memory_resource_impl::get_arena(cuda_stream_view stream)
+arena_memory_resource_impl::arena& arena_memory_resource_impl::get_arena(cuda_stream_view stream,
+                                                                         bool may_throw)
 {
   if (use_per_thread_arena(stream)) { return get_thread_arena(); }
-  return get_stream_arena(stream);
+  return get_stream_arena(stream, may_throw);
 }
 
 arena_memory_resource_impl::arena& arena_memory_resource_impl::get_thread_arena()
@@ -168,18 +189,19 @@ arena_memory_resource_impl::arena& arena_memory_resource_impl::get_thread_arena(
 }
 
 arena_memory_resource_impl::arena& arena_memory_resource_impl::get_stream_arena(
-  cuda_stream_view stream)
+  cuda_stream_view stream, bool may_throw)
 {
   RMM_LOGGING_ASSERT(!use_per_thread_arena(stream));
+  auto const stream_id = get_stream_id(stream, may_throw);
   {
     std::shared_lock lock(map_mtx_);
-    auto const iter = stream_arenas_.find(stream.value());
+    auto const iter = stream_arenas_.find(stream_id);
     if (iter != stream_arenas_.end()) { return iter->second; }
   }
   {
     std::unique_lock lock(map_mtx_);
-    stream_arenas_.emplace(stream.value(), global_arena_);
-    return stream_arenas_.at(stream.value());
+    stream_arenas_.emplace(stream_id, global_arena_);
+    return stream_arenas_.at(stream_id);
   }
 }
 

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -183,6 +183,10 @@ void arena_memory_resource_impl::deallocate_from_other_arena(cuda_stream_view st
         if (thread_arena.second->deallocate_sync(ptr, bytes)) { return; }
       }
     }
+    RMM_LOG_DEBUG("[deallocate][Stream %s][%zuB][Pointer %p] allocation not found",
+                  rmm::detail::format_stream(stream),
+                  bytes,
+                  ptr);
     return;
   }
 }

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -5,7 +5,6 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/detail/format.hpp>
-#include <rmm/detail/logging_assert.hpp>
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/arena_memory_resource_impl.hpp>
 
@@ -16,22 +15,33 @@ namespace RMM_NAMESPACE {
 namespace mr {
 namespace detail {
 
-stream_id_type get_stream_id(cuda_stream_view stream, bool may_throw)
+namespace {
+
+cudaStream_t normalize_arena_stream(cuda_stream_view stream)
 {
-  // We use cudaStreamLegacy as the arena map key for the default stream for consistency between
-  // PTDS and non-PTDS mode. Keying by the stream ID (rather than the raw cudaStream_t handle)
-  // prevents a newly created stream that reuses a destroyed stream's handle value from inheriting
-  // stale arena state (ABA reuse).
+  // Use cudaStreamLegacy as the arena map key for the default stream so PTDS and non-PTDS agree.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-  auto* const stream_to_store = stream.is_default() ? cudaStreamLegacy : stream.value();
+  return stream.is_default() ? cudaStreamLegacy : stream.value();
+}
+
+}  // namespace
+
+stream_id_type get_stream_id(cuda_stream_view stream)
+{
+  // The default stream normalizes to cudaStreamLegacy, and its ID prevents stale arena state if
+  // CUDA reuses a destroyed stream handle value (ABA reuse).
   stream_id_type stream_id{};
-  if (may_throw) {
-    // Safe to throw: only called from the non-noexcept allocate() path.
-    RMM_CUDA_TRY(cudaStreamGetId(stream_to_store, &stream_id));
-  } else {
-    // Called from the noexcept deallocate()/deallocate_sync() path: must not throw. A failure
-    // here is only surfaced via assertion in debug builds.
-    RMM_ASSERT_CUDA_SUCCESS(cudaStreamGetId(stream_to_store, &stream_id));
+  RMM_CUDA_TRY(cudaStreamGetId(normalize_arena_stream(stream), &stream_id));
+  return stream_id;
+}
+
+std::optional<stream_id_type> try_get_stream_id(cuda_stream_view stream) noexcept
+{
+  // The default stream normalizes to cudaStreamLegacy, and its ID prevents stale arena state if
+  // CUDA reuses a destroyed stream handle value (ABA reuse).
+  stream_id_type stream_id{};
+  if (cudaStreamGetId(normalize_arena_stream(stream), &stream_id) != cudaSuccess) {
+    return std::nullopt;
   }
   return stream_id;
 }
@@ -60,7 +70,7 @@ void* arena_memory_resource_impl::allocate(cuda::stream_ref stream,
 #else
   bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
 #endif
-  auto& arena = get_arena(sv, /*may_throw=*/true);
+  auto& arena = get_arena(sv);
 
   {
     std::shared_lock lock(mtx_);
@@ -94,13 +104,23 @@ void arena_memory_resource_impl::deallocate(cuda::stream_ref stream,
 #else
   bytes = rmm::align_up(bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
 #endif
-  auto& arena = get_arena(sv, /*may_throw=*/false);
-
-  {
-    std::shared_lock lock(mtx_);
-    if (arena.deallocate(sv, ptr, bytes)) { return; }
+  arena* arena = nullptr;
+  if (use_per_thread_arena(sv)) {
+    std::shared_lock lock(map_mtx_);
+    auto const iter = thread_arenas_.find(std::this_thread::get_id());
+    if (iter != thread_arenas_.end()) { arena = iter->second.get(); }
+  } else if (auto const stream_id = try_get_stream_id(sv); stream_id.has_value()) {
+    std::shared_lock lock(map_mtx_);
+    auto const iter = stream_arenas_.find(*stream_id);
+    if (iter != stream_arenas_.end()) { arena = std::addressof(iter->second); }
   }
 
+  if (arena != nullptr) {
+    std::shared_lock lock(mtx_);
+    if (arena->deallocate(sv, ptr, bytes)) { return; }
+  }
+
+  // A failed stream-ID lookup leaves `arena` null, so search all arenas to avoid leaking it.
   {
     sv.synchronize_no_throw();
     std::unique_lock lock(mtx_);
@@ -138,8 +158,9 @@ void arena_memory_resource_impl::defragment()
 
 void arena_memory_resource_impl::deallocate_from_other_arena(cuda_stream_view stream,
                                                              void* ptr,
-                                                             std::size_t bytes)
+                                                             std::size_t bytes) noexcept
 {
+  std::shared_lock map_lock(map_mtx_);
   if (use_per_thread_arena(stream)) {
     for (auto const& thread_arena : thread_arenas_) {
       if (thread_arena.second->deallocate_sync(ptr, bytes)) { return; }
@@ -160,15 +181,14 @@ void arena_memory_resource_impl::deallocate_from_other_arena(cuda_stream_view st
         if (thread_arena.second->deallocate_sync(ptr, bytes)) { return; }
       }
     }
-    RMM_FAIL("allocation not found");
+    return;
   }
 }
 
-arena_memory_resource_impl::arena& arena_memory_resource_impl::get_arena(cuda_stream_view stream,
-                                                                         bool may_throw)
+arena_memory_resource_impl::arena& arena_memory_resource_impl::get_arena(cuda_stream_view stream)
 {
   if (use_per_thread_arena(stream)) { return get_thread_arena(); }
-  return get_stream_arena(stream, may_throw);
+  return get_stream_arena(get_stream_id(stream));
 }
 
 arena_memory_resource_impl::arena& arena_memory_resource_impl::get_thread_arena()
@@ -189,10 +209,8 @@ arena_memory_resource_impl::arena& arena_memory_resource_impl::get_thread_arena(
 }
 
 arena_memory_resource_impl::arena& arena_memory_resource_impl::get_stream_arena(
-  cuda_stream_view stream, bool may_throw)
+  stream_id_type stream_id)
 {
-  RMM_LOGGING_ASSERT(!use_per_thread_arena(stream));
-  auto const stream_id = get_stream_id(stream, may_throw);
   {
     std::shared_lock lock(map_mtx_);
     auto const iter = stream_arenas_.find(stream_id);

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -147,6 +147,8 @@ void arena_memory_resource_impl::deallocate_sync(void* ptr,
 
 void arena_memory_resource_impl::defragment()
 {
+  // Guard map iteration against concurrent emplace in the arena getters.
+  std::shared_lock lock(map_mtx_);
   RMM_CUDA_TRY(cudaDeviceSynchronize());
   for (auto& thread_arena : thread_arenas_) {
     thread_arena.second->clean();

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -643,29 +643,40 @@ TEST(ArenaStreamIdTest, DistinctStreamsHaveDistinctStableIds)  // NOLINT
   rmm::cuda_stream stream_a{};
   rmm::cuda_stream stream_b{};
 
-  EXPECT_NE(rmm::mr::detail::get_stream_id(stream_a.view(), /*may_throw=*/true),
-            rmm::mr::detail::get_stream_id(stream_b.view(), /*may_throw=*/true));
-  EXPECT_EQ(rmm::mr::detail::get_stream_id(stream_a.view(), /*may_throw=*/true),
-            rmm::mr::detail::get_stream_id(stream_a.view(), /*may_throw=*/true));
+  EXPECT_NE(rmm::mr::detail::get_stream_id(stream_a.view()),
+            rmm::mr::detail::get_stream_id(stream_b.view()));
+  EXPECT_EQ(rmm::mr::detail::get_stream_id(stream_a.view()),
+            rmm::mr::detail::get_stream_id(stream_a.view()));
+}
+
+TEST(ArenaStreamIdTest, TryGetStreamIdReturnsCudaStreamId)  // NOLINT
+{
+  rmm::cuda_stream stream{};
+  rmm::mr::detail::stream_id_type expected_id{};
+
+  ASSERT_EQ(cudaStreamGetId(stream.view().value(), &expected_id), cudaSuccess);
+  auto const stream_id = rmm::mr::detail::try_get_stream_id(stream.view());
+  ASSERT_TRUE(stream_id.has_value());
+  EXPECT_EQ(*stream_id, expected_id);
 }
 
 // The default stream is normalized via cudaStreamLegacy, so it maps to one consistent key.
 TEST(ArenaStreamIdTest, DefaultStreamNormalizesToLegacyId)  // NOLINT
 {
-  auto const id = rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{}, /*may_throw=*/true);
-  EXPECT_EQ(id, rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{}, /*may_throw=*/true));
+  auto const id = rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{});
+  EXPECT_EQ(id, rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{}));
 
 #ifndef CUDA_API_PER_THREAD_DEFAULT_STREAM
   // Non-PTDS: the default stream normalizes to cudaStreamLegacy, so it keys to the legacy id.
-  EXPECT_EQ(rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{}, /*may_throw=*/true),
-            rmm::mr::detail::get_stream_id(rmm::cuda_stream_legacy, /*may_throw=*/true));
+  EXPECT_EQ(rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{}),
+            rmm::mr::detail::get_stream_id(rmm::cuda_stream_legacy));
 #endif
 
   // In both modes, a real created stream must never collide with the legacy key. This catches a
   // regression that collapses every stream to a single key.
   rmm::cuda_stream stream{};
-  EXPECT_NE(rmm::mr::detail::get_stream_id(stream.view(), /*may_throw=*/true),
-            rmm::mr::detail::get_stream_id(rmm::cuda_stream_legacy, /*may_throw=*/true));
+  EXPECT_NE(rmm::mr::detail::get_stream_id(stream.view()),
+            rmm::mr::detail::get_stream_id(rmm::cuda_stream_legacy));
 }
 
 // Regression for #2394: CUDA can hand a destroyed stream's raw handle value to a new stream (ABA
@@ -682,7 +693,7 @@ TEST(ArenaStreamIdTest, ReusedRawHandleYieldsDistinctId)  // NOLINT
   {
     rmm::cuda_stream original{};
     raw = original.view().value();
-    id  = rmm::mr::detail::get_stream_id(original.view(), /*may_throw=*/true);
+    id  = rmm::mr::detail::get_stream_id(original.view());
   }  // original destroyed here, freeing its raw handle for potential reuse
 
   constexpr int max_iterations = 2048;
@@ -691,7 +702,7 @@ TEST(ArenaStreamIdTest, ReusedRawHandleYieldsDistinctId)  // NOLINT
     rmm::cuda_stream candidate{};
     if (candidate.view().value() == raw) {
       // Same raw handle, but the ID must differ so no stale arena is inherited.
-      EXPECT_NE(rmm::mr::detail::get_stream_id(candidate.view(), /*may_throw=*/true), id);
+      EXPECT_NE(rmm::mr::detail::get_stream_id(candidate.view()), id);
       observed_reuse = true;
       break;
     }

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -637,5 +637,68 @@ TEST_F(ArenaTest, DumpLogOnFailure)  // NOLINT
   EXPECT_GE(file_status.st_size, 0);
 }
 
+// Distinct live streams get distinct IDs, and a stream's ID is stable across calls.
+TEST(ArenaStreamIdTest, DistinctStreamsHaveDistinctStableIds)  // NOLINT
+{
+  rmm::cuda_stream stream_a{};
+  rmm::cuda_stream stream_b{};
+
+  EXPECT_NE(rmm::mr::detail::get_stream_id(stream_a.view(), /*may_throw=*/true),
+            rmm::mr::detail::get_stream_id(stream_b.view(), /*may_throw=*/true));
+  EXPECT_EQ(rmm::mr::detail::get_stream_id(stream_a.view(), /*may_throw=*/true),
+            rmm::mr::detail::get_stream_id(stream_a.view(), /*may_throw=*/true));
+}
+
+// The default stream is normalized via cudaStreamLegacy, so it maps to one consistent key.
+TEST(ArenaStreamIdTest, DefaultStreamNormalizesToLegacyId)  // NOLINT
+{
+  auto const id = rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{}, /*may_throw=*/true);
+  EXPECT_EQ(id, rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{}, /*may_throw=*/true));
+
+#ifndef CUDA_API_PER_THREAD_DEFAULT_STREAM
+  // Non-PTDS: the default stream normalizes to cudaStreamLegacy, so it keys to the legacy id.
+  EXPECT_EQ(rmm::mr::detail::get_stream_id(rmm::cuda_stream_view{}, /*may_throw=*/true),
+            rmm::mr::detail::get_stream_id(rmm::cuda_stream_legacy, /*may_throw=*/true));
+#endif
+
+  // In both modes, a real created stream must never collide with the legacy key. This catches a
+  // regression that collapses every stream to a single key.
+  rmm::cuda_stream stream{};
+  EXPECT_NE(rmm::mr::detail::get_stream_id(stream.view(), /*may_throw=*/true),
+            rmm::mr::detail::get_stream_id(rmm::cuda_stream_legacy, /*may_throw=*/true));
+}
+
+// Regression for #2394: CUDA can hand a destroyed stream's raw handle value to a new stream (ABA
+// reuse). Keying arenas by the raw handle would let the new stream inherit stale arena state.
+// Keying by cudaStreamGetId prevents this: a reused handle yields a distinct ID.
+//
+// This test cannot force reuse deterministically because CUDA does not guarantee handle-reuse
+// timing (see the issue's own caveat), so it probes up to a bounded number of iterations and
+// skips if reuse is never observed. It either proves the property or skips, never falsely fails.
+TEST(ArenaStreamIdTest, ReusedRawHandleYieldsDistinctId)  // NOLINT
+{
+  cudaStream_t raw{};
+  rmm::mr::detail::stream_id_type id{};
+  {
+    rmm::cuda_stream original{};
+    raw = original.view().value();
+    id  = rmm::mr::detail::get_stream_id(original.view(), /*may_throw=*/true);
+  }  // original destroyed here, freeing its raw handle for potential reuse
+
+  constexpr int max_iterations = 2048;
+  bool observed_reuse          = false;
+  for (int i = 0; i < max_iterations; ++i) {
+    rmm::cuda_stream candidate{};
+    if (candidate.view().value() == raw) {
+      // Same raw handle, but the ID must differ so no stale arena is inherited.
+      EXPECT_NE(rmm::mr::detail::get_stream_id(candidate.view(), /*may_throw=*/true), id);
+      observed_reuse = true;
+      break;
+    }
+  }
+
+  if (!observed_reuse) { GTEST_SKIP() << "CUDA did not reuse the stream handle within the bound"; }
+}
+
 }  // namespace
 }  // namespace rmm::test

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -8,6 +8,7 @@
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
+#include <rmm/detail/error.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -654,7 +655,7 @@ TEST(ArenaStreamIdTest, TryGetStreamIdReturnsCudaStreamId)  // NOLINT
   rmm::cuda_stream stream{};
   rmm::mr::detail::stream_id_type expected_id{};
 
-  ASSERT_EQ(cudaStreamGetId(stream.view().value(), &expected_id), cudaSuccess);
+  RMM_CUDA_TRY(cudaStreamGetId(stream.view().value(), &expected_id));
   auto const stream_id = rmm::mr::detail::try_get_stream_id(stream.view());
   ASSERT_TRUE(stream_id.has_value());
   EXPECT_EQ(*stream_id, expected_id);


### PR DESCRIPTION
## Description

`arena_memory_resource_impl` stored per-stream arena state in a `std::map` keyed by the raw `cudaStream_t` handle, looked up with `stream.value()`.
CUDA can reassign a destroyed stream's raw handle value to a newly created stream (ABA reuse), so a new logical stream could inherit stale arena state left behind by an earlier, unrelated stream that happened to share the same handle value.

This mirrors the fix already applied to `stream_ordered_memory_resource` in #2252, which keys stream state by `cudaStreamGetId` for exactly this reason.

Changes:
- Add a `rmm::mr::detail::get_stream_id` helper that normalizes the default stream to `cudaStreamLegacy` and returns the ID from `cudaStreamGetId`.
- Key `stream_arenas_` by `stream_id_type` (the stream ID) instead of the raw `cudaStream_t` handle.
- `get_stream_arena` now looks up and inserts by the stream ID.

closes #2394

### Before / After

| | Key for `stream_arenas_` | ABA reuse hazard |
|---|---|---|
| Before | raw `cudaStream_t` handle (`stream.value()`) | a reused handle inherits the dead stream's arena |
| After | `cudaStreamGetId(stream)` | a reused handle gets a distinct ID, so a fresh arena |

### Tests

Added three tests to `cpp/tests/mr/arena_mr_tests.cpp`:
- distinct live streams get distinct, stable IDs;
- the default stream normalizes to the legacy stream ID (non-PTDS) and never collides with a real stream's key;
- a bounded, non-flaky regression that cycles stream create/destroy until a raw handle is observably reused, then asserts the IDs still differ (skips if reuse is never observed, since CUDA gives no handle-reuse-timing guarantee).

`ARENA_MR_TEST` and `ARENA_MR_PTDS_TEST` both pass 44/44.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
