### PR TITLE
Fix cuda.core stream round-trip test

### DIFF
--- a/python/rmm/rmm/tests/test_stream.py
+++ b/python/rmm/rmm/tests/test_stream.py
@@ -38,7 +38,7 @@ def test_cuda_core_stream_to_rmm(current_device):
     rmm_stream = rmm.pylibrmm.stream.Stream(cuda_stream)
     cuda_stream_2 = current_device.create_stream(rmm_stream)
 
-    assert cuda_stream_2.__cuda_stream__() == cuda_stream_2.__cuda_stream__()
+    assert cuda_stream_2.__cuda_stream__() == cuda_stream.__cuda_stream__()
 
 
 def test_rmm_stream_from_cuda_core_default_stream(current_device):


### PR DESCRIPTION
## What changed
Fix `test_cuda_core_stream_to_rmm()` so it compares the reconstructed `cuda.core` stream handle against the original stream handle instead of comparing the new stream to itself.

## Why
The previous assertion was a self-comparison:

`cuda_stream_2.__cuda_stream__() == cuda_stream_2.__cuda_stream__()`

That always passes, so it doesn't actually verify the cuda.core -> RMM -> cuda.core round trip.

## Impact
This makes the test prove the intended behavior and improves coverage for stream protocol interoperability.

## Validation
- `python3 -m py_compile python/rmm/rmm/tests/test_stream.py`
- Attempted: `python3 -m pytest python/rmm/rmm/tests/test_stream.py::test_cuda_core_stream_to_rmm -v` (could not run here because `pytest` is not installed in this environment)
