### PR TITLE
Check CUDA errors in stream pool benchmark

### DIFF
--- a/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
+++ b/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2021, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
+++ b/cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp
@@ -10,6 +10,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include <cstdint>
 #include <stdexcept>
 
 static void BM_StreamPoolGetStream(benchmark::State& state)
@@ -18,7 +19,7 @@ static void BM_StreamPoolGetStream(benchmark::State& state)
 
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     auto stream = stream_pool.get_stream();
-    cudaStreamQuery(stream.value());
+    RMM_CUDA_TRY(cudaStreamQuery(stream.value()));
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
@@ -29,7 +30,7 @@ static void BM_CudaStreamClass(benchmark::State& state)
 {
   for (auto _ : state) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
     auto stream = rmm::cuda_stream{};
-    cudaStreamQuery(stream.view().value());
+    RMM_CUDA_TRY(cudaStreamQuery(stream.view().value()));
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));


### PR DESCRIPTION
## What changed
Wrap both `cudaStreamQuery(...)` calls in `cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp` with `RMM_CUDA_TRY(...)` and add a direct `#include <cstdint>` for the `int64_t` usage.

## Why
The benchmark was calling CUDA runtime APIs without checking their return values, even though the file already includes RMM's CUDA error utilities. That can hide real CUDA failures in benchmark runs.

## Impact
Benchmark failures now surface immediately instead of being silently ignored, and the file no longer relies on transitive includes for `int64_t`.

## Validation
- `pre-commit run clang-format --files cpp/benchmarks/cuda_stream_pool/cuda_stream_pool_bench.cpp`
- `git diff --check`
- Not run: full benchmark/C++ build (no existing build directory in this environment)
