### PR TITLE
Preserve memory resource in DeviceBuffer.copy

### DIFF
--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -196,9 +196,9 @@ cdef class DeviceBuffer:
         >>> assert db is not db_copy
         >>> assert db.ptr != db_copy.ptr
         """
-        ret = DeviceBuffer(ptr=self.ptr, size=self.size, stream=self.stream)
-        ret.mr = self.mr
-        return ret
+        return DeviceBuffer(
+            ptr=self.ptr, size=self.size, stream=self.stream, mr=self.mr
+        )
 
     def __copy__(self):
         return self.copy()

--- a/python/rmm/rmm/tests/test_device_buffer.py
+++ b/python/rmm/rmm/tests/test_device_buffer.py
@@ -271,35 +271,19 @@ def test_rmm_device_buffer_copy(
 
 
 def test_rmm_device_buffer_copy_uses_source_memory_resource() -> None:
-    base = rmm.mr.CudaMemoryResource()
-    source_allocations: list[int] = []
-    current_allocations: list[int] = []
-
-    def make_callback_mr(
-        allocations: list[int],
-    ) -> rmm.mr.DeviceMemoryResource:
-        def allocate(size: int, stream: object) -> int:
-            allocations.append(size)
-            return base.allocate(size, stream)
-
-        def deallocate(ptr: int, size: int, stream: object) -> None:
-            base.deallocate(ptr, size, stream)
-
-        return rmm.mr.CallbackMemoryResource(allocate, deallocate)
-
-    source_mr = make_callback_mr(source_allocations)
-    current_mr = make_callback_mr(current_allocations)
+    source_mr = rmm.mr.StatisticsResourceAdaptor(rmm.mr.CudaMemoryResource())
+    current_mr = rmm.mr.StatisticsResourceAdaptor(rmm.mr.CudaMemoryResource())
 
     rmm.mr.set_current_device_resource(source_mr)
     db = rmm.DeviceBuffer(size=256)
-    assert source_allocations == [256]
-    assert current_allocations == []
+    assert source_mr.allocation_counts.total_bytes == 256
+    assert current_mr.allocation_counts.total_bytes == 0
 
     rmm.mr.set_current_device_resource(current_mr)
     db.copy()
 
-    assert source_allocations == [256, 256]
-    assert current_allocations == []
+    assert source_mr.allocation_counts.total_bytes == 512
+    assert current_mr.allocation_counts.total_bytes == 0
 
 
 # Tests for stream=None validation (PR #2120)

--- a/python/rmm/rmm/tests/test_device_buffer.py
+++ b/python/rmm/rmm/tests/test_device_buffer.py
@@ -270,6 +270,38 @@ def test_rmm_device_buffer_copy(
     np.testing.assert_equal(expected, result)
 
 
+def test_rmm_device_buffer_copy_uses_source_memory_resource() -> None:
+    base = rmm.mr.CudaMemoryResource()
+    source_allocations: list[int] = []
+    current_allocations: list[int] = []
+
+    def make_callback_mr(
+        allocations: list[int],
+    ) -> rmm.mr.DeviceMemoryResource:
+        def allocate(size: int, stream: object) -> int:
+            allocations.append(size)
+            return base.allocate(size, stream)
+
+        def deallocate(ptr: int, size: int, stream: object) -> None:
+            base.deallocate(ptr, size, stream)
+
+        return rmm.mr.CallbackMemoryResource(allocate, deallocate)
+
+    source_mr = make_callback_mr(source_allocations)
+    current_mr = make_callback_mr(current_allocations)
+
+    rmm.mr.set_current_device_resource(source_mr)
+    db = rmm.DeviceBuffer(size=256)
+    assert source_allocations == [256]
+    assert current_allocations == []
+
+    rmm.mr.set_current_device_resource(current_mr)
+    db.copy()
+
+    assert source_allocations == [256, 256]
+    assert current_allocations == []
+
+
 # Tests for stream=None validation (PR #2120)
 def test_device_buffer_init_stream_none() -> None:
     """Test that DeviceBuffer.__init__ raises TypeError for stream=None"""


### PR DESCRIPTION
## What changed
Update `DeviceBuffer.copy()` to pass `mr=self.mr` when constructing the copied buffer, and add a regression test that changes the current device resource before copying.

## Why
The old copy path allocated the new `DeviceBuffer` using the current device resource and then reassigned `ret.mr = self.mr` afterward. If the current resource differed from the source buffer's resource, the underlying allocation could come from one resource while the Python wrapper recorded another for ownership and deallocation.

## Impact
Copied buffers now allocate from the same memory resource as the source buffer, and the new test covers the mismatch case directly.

## Validation
- `python3 -m py_compile python/rmm/rmm/tests/test_device_buffer.py`
- `pre-commit run ruff-format --files python/rmm/rmm/tests/test_device_buffer.py`
- `pre-commit run ruff-check --files python/rmm/rmm/tests/test_device_buffer.py`
- `pre-commit run cython-lint --files python/rmm/rmm/pylibrmm/device_buffer.pyx`
- `git diff --check`
- Not run: pytest / built RMM Python extension in this environment
