### PR TITLE
Fetch rapids-cmake cmake-format with GitHub authentication

### DIFF
--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -21,10 +21,17 @@ conda activate checks
 
 RAPIDS_BRANCH="$(cat "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../RAPIDS_BRANCH)"
 FORMAT_FILE_URL="https://raw.githubusercontent.com/rapidsai/rapids-cmake/${RAPIDS_BRANCH}/cmake-format-rapids-cmake.json"
+FORMAT_FILE_API_PATH="repos/rapidsai/rapids-cmake/contents/cmake-format-rapids-cmake.json?ref=${RAPIDS_BRANCH}"
 RAPIDS_CMAKE_FORMAT_FILE=/tmp/rapids_cmake_ci/cmake-format-rapids-cmake.json
 export RAPIDS_CMAKE_FORMAT_FILE
-mkdir -p "$(dirname ${RAPIDS_CMAKE_FORMAT_FILE})"
-wget -O ${RAPIDS_CMAKE_FORMAT_FILE} "${FORMAT_FILE_URL}"
+mkdir -p "$(dirname "${RAPIDS_CMAKE_FORMAT_FILE}")"
+if ! command -v gh >/dev/null 2>&1 || ! gh api \
+  -H "Accept: application/vnd.github.raw+json" \
+  -H "X-GitHub-Api-Version: 2026-03-10" \
+  "${FORMAT_FILE_API_PATH}" \
+  > "${RAPIDS_CMAKE_FORMAT_FILE}"; then
+  wget -O "${RAPIDS_CMAKE_FORMAT_FILE}" "${FORMAT_FILE_URL}"
+fi
 
 # Run pre-commit checks
 pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## Description
This is a fix for the style check download failure observed in #2476: https://github.com/rapidsai/rmm/actions/runs/28987611693/job/86020175188

```
--2026-07-09 01:29:50--  https://raw.githubusercontent.com/rapidsai/rapids-cmake/main/cmake-format-rapids-cmake.json
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 429 Too Many Requests
2026-07-09 01:29:53 ERROR 429: Too Many Requests.
```

This updates `ci/check_style.sh` to fetch `cmake-format-rapids-cmake.json` through the GitHub contents API with `gh api` when available. The existing unauthenticated `wget` download remains as the fallback.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
