### PR TITLE
Caching allocator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ Debug
 build/
 RelWithDebInfo/
 thirdparty/googletest/
+caching-allocator-reports/
 
 ## Eclipse IDE
 .project

--- a/caching_allocator.md
+++ b/caching_allocator.md
@@ -1,0 +1,456 @@
+# Caching Memory Resource Design Notes
+
+## Context
+
+This document records the current state of the `rmm::mr::caching_memory_resource` prototype, the
+parts of PyTorch's `CUDACachingAllocator` that informed the design, what has been implemented in
+RMM so far, and what still needs investigation before this should be treated as production-ready.
+
+The goal is not to port PyTorch's allocator wholesale. RMM has an existing memory-resource model,
+existing stream-ordered resource infrastructure, and existing allocator components such as
+`pool_memory_resource`, `arena_memory_resource`, `binning_memory_resource`, and
+`fixed_size_memory_resource`. The intent of this work is to implement the PyTorch allocator policy
+shape in an RMM-native resource with the smallest viable new surface area.
+
+## PyTorch Allocator Behavior Studied
+
+The relevant PyTorch implementation is in `~/rmm/pytorch/c10/cuda/CUDACachingAllocator.cpp` and
+`~/rmm/pytorch/c10/cuda/CUDACachingAllocator.h`.
+
+The allocator is built around these core ideas:
+
+- Allocations are associated with streams.
+- Freed blocks are reused preferentially on the same stream.
+- Blocks can be split and coalesced.
+- Small and large allocations use separate pools.
+- Small requests are packed into larger upstream segments.
+- Medium-large requests use a fixed large segment size to reduce fragmentation.
+- Very large requests are rounded to a fixed granularity.
+- On upstream allocation failure, cached free segments can be returned to CUDA and the allocation is retried.
+- Some advanced behavior exists for CUDA Graph capture, expandable segments, tracing, snapshots, statistics, peer access, and IPC limitations.
+
+The key size constants in PyTorch are:
+
+- `kMinBlockSize = 512`
+- `kSmallSize = 1 MiB`
+- `kSmallBuffer = 2 MiB`
+- `kLargeBuffer = 20 MiB`
+- `kMinLargeAlloc = 10 MiB`
+- `kRoundLarge = 2 MiB`
+
+The key upstream allocation policy is equivalent to:
+
+```cpp
+if (size <= 1_MiB) {
+  return 2_MiB;
+} else if (size < 10_MiB) {
+  return 20_MiB;
+} else {
+  return align_up(size, 2_MiB);
+}
+```
+
+PyTorch's split policy is roughly:
+
+- Small-pool blocks split when the remainder is at least 512 bytes.
+- Expandable-segment blocks split when the remainder is at least 512 bytes.
+- Large-pool blocks split only when the requested size is below `max_split_size` and the remainder is larger than 1 MiB.
+- Oversized cached blocks have additional reuse constraints to avoid excessive fragmentation.
+
+## RMM Components Reused
+
+The current prototype reuses RMM's `stream_ordered_memory_resource` CRTP base and
+`coalescing_free_list` block representation.
+
+This gives the new resource:
+
+- Thread-safe allocation and deallocation through the base resource mutex.
+- Stream-event tracking.
+- Same-stream reuse without synchronization.
+- Reuse from other streams with event waits.
+- Coalescing free lists.
+- Best-fit search through `coalescing_free_list::get_block`.
+- Compatibility with the RMM async memory-resource interface.
+
+The prototype does not currently compose `pool_memory_resource`, `arena_memory_resource`, or
+`binning_memory_resource` directly. A pure composition approach was considered but does not expose
+enough of the required segment-level policy:
+
+- The resource needs to decide upstream segment size before calling upstream.
+- The resource needs to distinguish small-pool and large-pool split behavior.
+- The resource needs to know which whole upstream segments can be released after allocation failure.
+- The resource needs one coherent stream-ordered block model.
+
+## Implemented Files
+
+The prototype added these source files:
+
+- `cpp/include/rmm/mr/caching_memory_resource.hpp`
+- `cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp`
+- `cpp/src/mr/caching_memory_resource.cpp`
+- `cpp/src/mr/detail/caching_memory_resource_impl.cpp`
+- `cpp/tests/mr/caching_mr_tests.cpp`
+
+The build was wired through:
+
+- `cpp/CMakeLists.txt`
+- `cpp/tests/CMakeLists.txt`
+
+Documentation was added to:
+
+- `docs/cpp/memory_resources/memory_resources.md`
+
+The benchmark harnesses were started but not completed:
+
+- `cpp/benchmarks/random_allocations/random_allocations.cpp`
+- `cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu`
+
+## Current Public API
+
+The current public resource is `rmm::mr::caching_memory_resource`.
+
+Construction:
+
+```cpp
+explicit caching_memory_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::optional<std::size_t> max_split_size = std::nullopt);
+```
+
+Public helper methods:
+
+- `get_upstream_resource()`
+- `release()`
+- `release_small_blocks()`
+- `release_large_blocks()`
+- `cached_small_bytes()`
+- `cached_large_bytes()`
+- `upstream_allocation_size(bytes)`
+
+The helper methods were added to make early behavior testable and observable. Before stabilizing the
+API, we should decide which of these belong in the long-term public interface and which should move
+behind testing-only utilities or statistics adaptors.
+
+## Implemented Behavior
+
+### Upstream Segment Sizing
+
+The prototype implements the PyTorch sizing policy:
+
+- Requests of `0` bytes return `nullptr` through the inherited base behavior.
+- Requests `<= 1 MiB` allocate `2 MiB` upstream segments.
+- Requests `> 1 MiB` and `< 10 MiB` allocate `20 MiB` upstream segments.
+- Requests `>= 10 MiB` allocate upstream sizes rounded up to `2 MiB`.
+
+This is exposed by `upstream_allocation_size(bytes)` and covered by tests.
+
+### Stream-Ordered Reuse
+
+The resource inherits the stream ordering model from `stream_ordered_memory_resource`.
+
+This means allocation uses a stream-associated event and free-list. Same-stream blocks can be reused
+without waiting. Blocks freed on other streams can be reused after the allocating stream waits on the
+other stream's event.
+
+This has not yet received a dedicated cross-stream correctness test for `caching_memory_resource`.
+It is inherited from existing RMM infrastructure, but because this resource has new block sizing and
+release behavior, it still needs direct tests.
+
+### Best-Fit Suballocation and Coalescing
+
+The resource uses `coalescing_free_list`, so free blocks are searched using best fit and coalesced
+when returned to the free list.
+
+The prototype's allocation path is:
+
+1. Align the requested size to RMM's CUDA allocation alignment in the base class.
+2. Search the current stream's free list.
+3. Search other stream free lists.
+4. Merge and search other stream free lists if needed.
+5. Grow from upstream using the caching allocator segment-size policy.
+6. Split a block if the split policy permits it.
+
+### Split Policy
+
+The implemented split policy follows PyTorch's non-expandable segment policy:
+
+- Small-pool blocks split when the remainder is at least 512 bytes.
+- Large-pool blocks split only when the requested size is below `max_split_size` and the remainder
+  is greater than 1 MiB.
+- The default `max_split_size` is `std::numeric_limits<std::size_t>::max()`, matching PyTorch's
+  default behavior when no `max_split_size_mb` setting is supplied.
+- Oversized large-pool blocks are rejected for smaller requests using the same broad constraints as
+  PyTorch: requests below `max_split_size` do not reuse blocks at or above `max_split_size`, and
+  requests at or above `max_split_size` do not reuse blocks at least 20 MiB larger than requested.
+
+Expandable-segment split behavior is not implemented.
+
+### Cached Segment Release
+
+The prototype tracks upstream segments separately from free-list blocks. On upstream allocation
+failure during pool growth, it releases cached whole segments from the relevant pool and retries.
+
+The current release logic follows PyTorch's native allocator invariant for non-expandable segments:
+only whole, non-split free segments are returned to the upstream resource. The RMM implementation
+tracks allocated blocks, synchronizes and merges all stream free lists during explicit release, then
+removes an exact whole-segment free block before calling upstream deallocation.
+
+This behavior is covered by tests for release after allocation failure, explicit release, live
+segments, partially free segments, and cross-stream frees.
+
+## Validation So Far
+
+The new test target was built successfully:
+
+```bash
+SCCACHE_DISABLE=1 cmake --build cpp/build-caching-opencode -j2 --target CACHING_MR_TEST
+```
+
+The test binary was run directly:
+
+```bash
+./cpp/build-caching-opencode/gtests/CACHING_MR_TEST
+```
+
+Result:
+
+- 15 tests passed.
+
+Covered scenarios:
+
+- Upstream segment sizing policy.
+- Small allocation reuse.
+- Cached segment release after forced upstream allocation failure.
+- Explicit release of cached small-pool and large-pool bytes.
+- No release while a segment contains a live allocation.
+- No release while a segment is only partially free.
+- Cross-stream free-list merge before release.
+- Cross-stream allocation reuse.
+- Deleted-stream allocation reuse.
+- Destructor release of cached blocks.
+- Small-pool no-split boundary behavior.
+- Same-stream large-pool split behavior.
+- Medium allocation behavior using 20 MiB upstream segments.
+- Large-pool split behavior and `max_split_size` behavior.
+
+The existing `cpp/build-opencode` tree was not reusable from `/home/coder/rmm` because its CMake
+cache was created from a different absolute path. A fresh `cpp/build-caching-opencode` tree was used.
+The first build attempt failed because `sccache` remote access returned HTTP 401, so validation was
+rerun with `SCCACHE_DISABLE=1`.
+
+## Known Correctness Gaps
+
+### Remaining Test Gaps
+
+The current focused tests cover the highest-risk release, split, stream reuse, and destructor cache
+release behavior.
+
+### Public API Needs Review
+
+The introspection methods are useful for tests and benchmarking, but they may not all belong in the
+stable public API.
+
+Questions to answer:
+
+- Should `cached_small_bytes()` and `cached_large_bytes()` be public?
+- Should `upstream_allocation_size()` be public, or only documented as behavior?
+- Should `release_small_blocks()` and `release_large_blocks()` be public, or should there only be `release()`?
+- Should this resource expose statistics through `statistics_resource_adaptor` instead of bespoke counters?
+
+### Destruction and Static Teardown Need Attention
+
+RMM has known sensitivity around stateful memory resources during static teardown. The prototype's
+destructor calls `release()`, and the base class also releases stream events and free lists.
+
+This needs explicit validation against the static teardown patterns that affected
+`pool_memory_resource`.
+
+### Exception Safety Needs Review
+
+The allocation failure path releases cached segments and retries. This path must be audited for:
+
+- preserving CUDA error state behavior consistently with other RMM resources
+- not swallowing non-OOM upstream failures
+- not corrupting segment bookkeeping if retry throws
+- correct behavior when upstream deallocation fails during release
+
+### Alignment and Requested Size Semantics Need Review
+
+The base resource aligns requests to `rmm::CUDA_ALLOCATION_ALIGNMENT`. The PyTorch allocator tracks
+both rounded block size and originally requested size for statistics and snapshots.
+
+The prototype currently only manages rounded allocation sizes. This is enough for allocation and
+deallocation, but insufficient for PyTorch-like statistics or diagnostics.
+
+## Features Not Yet Implemented
+
+### CUDA Graph Private Pools
+
+PyTorch has graph-private pools so memory addresses captured by CUDA Graphs remain valid across
+graph replay. The current RMM prototype does not implement private graph pools.
+
+This should be treated as a separate design effort. It likely needs an API for associating
+allocations with a graph capture or user-provided pool identity.
+
+### Expandable Segments
+
+PyTorch optionally uses CUDA virtual memory APIs to reserve a large virtual address range and map
+physical memory into it over time. This reduces fragmentation for workloads with slightly changing
+allocation sizes.
+
+The RMM prototype does not implement expandable segments. This would require new RMM components
+around CUDA driver memory mapping APIs, peer access, IPC limitations, and unmap/remap policy.
+
+### Statistics, Snapshots, and Tracing
+
+PyTorch exposes detailed allocator state and trace history. The RMM prototype does not.
+
+RMM already has `statistics_resource_adaptor` and `tracking_resource_adaptor`. We should first decide
+how much can be achieved by composing those adaptors around `caching_memory_resource` before adding
+resource-specific stats.
+
+### Age-Based Garbage Collection
+
+PyTorch can free older unused blocks when a garbage collection threshold is exceeded. The prototype
+does not track block ages or implement threshold-based garbage collection.
+
+This may be useful later, but it should come after exact segment accounting is implemented.
+
+## Benchmarking Status
+
+The benchmark harness work has started but was not completed in the interrupted session.
+
+The following benchmark files were updated to include a `caching` resource option:
+
+- `cpp/benchmarks/random_allocations/random_allocations.cpp`
+- `cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu`
+
+The intended comparison set is:
+
+- `cuda_async_memory_resource`
+- `pool_memory_resource`
+- `caching_memory_resource`
+
+The intended benchmark targets are:
+
+- `RANDOM_ALLOCATIONS_BENCH`
+- `MULTI_STREAM_ALLOCATIONS_BENCH`
+
+The existing `cpp/build-opencode` tree was configured with `BUILD_BENCHMARKS=OFF`, so those targets
+were unavailable. A separate benchmark build tree was started with:
+
+```bash
+cmake -S cpp -B cpp/build-bench-opencode -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
+```
+
+That configure was interrupted before benchmark builds and runs completed.
+
+Suggested next benchmark commands:
+
+```bash
+cmake -S cpp -B cpp/build-bench-opencode -DBUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build cpp/build-bench-opencode -j2 --target RANDOM_ALLOCATIONS_BENCH MULTI_STREAM_ALLOCATIONS_BENCH
+```
+
+Example random-allocation runs:
+
+```bash
+./cpp/build-bench-opencode/gbenchmarks/RANDOM_ALLOCATIONS_BENCH \
+  --resource=cuda_async \
+  --numallocs=1000 \
+  --maxsize=64 \
+  --benchmark_min_time=0.2
+
+./cpp/build-bench-opencode/gbenchmarks/RANDOM_ALLOCATIONS_BENCH \
+  --resource=pool \
+  --numallocs=1000 \
+  --maxsize=64 \
+  --benchmark_min_time=0.2
+
+./cpp/build-bench-opencode/gbenchmarks/RANDOM_ALLOCATIONS_BENCH \
+  --resource=caching \
+  --numallocs=1000 \
+  --maxsize=64 \
+  --benchmark_min_time=0.2
+```
+
+Example multi-stream runs:
+
+```bash
+./cpp/build-bench-opencode/gbenchmarks/MULTI_STREAM_ALLOCATIONS_BENCH \
+  --resource=cuda_async \
+  --kernels=4 \
+  --streams=4 \
+  --warm=true \
+  --benchmark_min_time=0.2
+
+./cpp/build-bench-opencode/gbenchmarks/MULTI_STREAM_ALLOCATIONS_BENCH \
+  --resource=pool \
+  --kernels=4 \
+  --streams=4 \
+  --warm=true \
+  --benchmark_min_time=0.2
+
+./cpp/build-bench-opencode/gbenchmarks/MULTI_STREAM_ALLOCATIONS_BENCH \
+  --resource=caching \
+  --kernels=4 \
+  --streams=4 \
+  --warm=true \
+  --benchmark_min_time=0.2
+```
+
+The benchmark command-line handling in these existing benchmarks should also be checked. In both
+files, `--resource` is parsed by `cxxopts`, while Google Benchmark also consumes its own flags. The
+benchmark declarations are filtered by the selected resource name. For side-by-side comparison in a
+single process, it may be cleaner to add a dedicated mode or allow `--resource=all`.
+
+## Recommended Next Implementation Work
+
+### 1. Strengthen Tests
+
+The deleted-stream reuse, destructor cache release, small-pool no-split boundary, and direct
+same-stream large-pool split tests have been added.
+
+### 2. Finish Benchmarks
+
+Complete benchmark configuration with `BUILD_BENCHMARKS=ON`, build the benchmark targets, and record
+results for at least:
+
+- small allocation churn
+- medium allocation churn
+- mixed small/large allocation churn
+- multi-stream temporary allocations
+- warmed and cold cache cases
+
+### 3. Decide Public API Shape
+
+Before merging broadly, decide whether the public helper methods are stable API or test aids. Remove
+or hide anything that is not needed by users.
+
+### 4. Revisit Composition with Existing Resources
+
+Revisit whether any logic should move into reusable components:
+
+- a segment-size policy helper
+- a PyTorch-style split policy helper
+- protected base-class hooks for release-capable stream-ordered resources
+
+This should happen only after the behavior is correct; premature abstraction would make the current
+prototype harder to reason about.
+
+## Open Design Questions
+
+- Should `caching_memory_resource` use `cuda_memory_resource` or `cuda_async_memory_resource` as the recommended upstream default?
+- Should the constructor accept a memory limit similar to PyTorch's memory fraction behavior?
+- Should cached whole segments be released only on OOM, or should there be threshold-based proactive trimming?
+- Should small and large segment sizes be configurable?
+- Should this resource support graph-private pools, or should graph capture be handled by a separate adaptor/resource?
+- Should expandable segments be a mode of this resource or a separate upstream resource?
+
+## Current Recommendation
+
+The current prototype now has the core non-expandable PyTorch-style segment sizing, split policy,
+stream-ordered reuse, and whole-segment release behavior needed for further evaluation.
+
+The next step is broader validation: deleted-stream/destructor tests, API review, and benchmark
+results for small, medium, mixed, and multi-stream workloads.

--- a/caching_allocator_plan.md
+++ b/caching_allocator_plan.md
@@ -1,0 +1,317 @@
+# Caching Allocator Plan
+
+## Goal
+
+Make `rmm::mr::caching_memory_resource` correct and reviewable as an RMM-native allocator inspired by PyTorch's `CUDACachingAllocator`, without accidentally implying full PyTorch behavioral compatibility.
+
+## Decisions To Make
+
+### 1. Compatibility Target
+
+Question: Should this allocator be PyTorch-compatible where possible, or PyTorch-inspired but RMM-native?
+
+Decision: Treat it as PyTorch-inspired and RMM-native. RMM already has stream-ordered memory-resource semantics, and forcing exact PyTorch stream behavior would fight that architecture.
+
+Consequence: Document intentional divergences clearly, especially cross-stream reuse.
+
+### 2. Stream Reuse Semantics
+
+Question: Should freed blocks be reusable across streams through RMM's event-wait machinery, or should reuse be restricted to the original allocation stream like PyTorch?
+
+Decision: Preserve the ability to test both policies. Performance should determine whether the default allows RMM stream-ordered cross-stream reuse or uses PyTorch-style same-stream reuse.
+
+Implementation shape: Add constructor options on `caching_memory_resource`.
+
+Default: Match PyTorch behavior where feasible. For stream reuse, this means the default should be same-stream-oriented unless RMM's existing stream-ordered model makes exact PyTorch behavior impractical.
+
+Required work:
+
+- Document this as a configurable policy, not accidental behavior.
+- Add tests for cross-stream reuse policy.
+- Add tests for same-stream-only policy.
+- Add benchmarks that compare cross-stream and same-stream-only reuse on single-stream, multi-stream, warm-cache, and cold-cache workloads.
+
+### 3. Small And Large Pool Separation
+
+Question: Must small and large pools be physically separate free lists, or is segment-origin metadata sufficient?
+
+Decision: Preserve the ability to test both policies. Performance and fragmentation results should determine whether the default uses structurally separate pools or segment-origin filtering.
+
+Implementation shape: Add constructor options on `caching_memory_resource`. Prefer policy plumbing that can select the current segment-origin filtering behavior and a PyTorch-style separated-pool behavior.
+
+Default: Match PyTorch behavior where feasible. For pool handling, this means structurally separate small and large allocation pools should be the default target unless benchmark results or RMM architecture show a clear reason not to.
+
+Required work:
+
+- Add tests that expose the intended behavior first.
+- Add benchmarks that compare structurally separate pools against segment-origin filtering.
+- If separate pools are required, change the block storage model deliberately rather than adding more predicates.
+
+### 4. Invalid Free Handling
+
+Question: Should invalid pointer or double-free behavior be checked in release builds, debug builds, or left undefined like some allocator APIs?
+
+Decision: Deallocation must remain `noexcept`; invalid pointer and double-free behavior is undefined behavior.
+
+Future option: Add compile-time allocation tracking, for example `RMM_POOL_TRACK_ALLOCATIONS`, with debug assertions if needed.
+
+Required work:
+
+- Do not add runtime throwing behavior to deallocation.
+- Do not make safety tracking part of the default implementation.
+- If tracking is added later, guard it behind a compile-time option and test only that option.
+
+### 5. Request Rounding
+
+Question: Should RMM implement PyTorch's 512-byte minimum rounding and optional power-of-two divisions, or keep `CUDA_ALLOCATION_ALIGNMENT` rounding?
+
+Recommendation: Keep RMM alignment for now. Add PyTorch-style configurable rounding only if benchmark results show fragmentation problems or compatibility requires it.
+
+Required work:
+
+- Document the divergence.
+- Add boundary tests around sizes below 512 bytes and around split thresholds.
+
+### 6. OOM Release Policy
+
+Question: Should OOM retry release only same-pool whole segments, or should it match PyTorch's broader release sequence?
+
+Recommendation: Keep same-pool whole-segment release initially. Expand only after pool separation and invalid-free behavior are settled.
+
+Required work:
+
+- Add explicit tests for same-pool release.
+- Add explicit tests that opposite-pool cached blocks are not released, if this remains the policy.
+
+### 7. Public API Shape
+
+Question: Are `cached_small_bytes()`, `cached_large_bytes()`, `upstream_allocation_size()`, `release_small_blocks()`, and `release_large_blocks()` stable public API or test scaffolding?
+
+Decision: Keep the helper methods public for now. They can be refactored later after the allocator behavior and benchmark needs are clearer.
+
+Required work:
+
+- Prefer testing via behavior and upstream limiter state where possible.
+- Avoid adding more public helper APIs until there is a concrete user need.
+
+## Proposed Implementation Order
+
+### Phase 1: Lock Down Intentional Semantics
+
+1. Add design documentation for intentional divergences from PyTorch.
+2. Add policy tests for stream reuse: cross-stream reuse enabled and same-stream-only behavior.
+3. Add policy tests for pool handling: segment-origin filtering and structurally separate pools.
+4. Add tests for request-size and split-boundary behavior.
+
+Exit criteria:
+
+- We can state exactly which PyTorch semantics are intentionally not implemented.
+- Tests fail if small/large pool behavior drifts unexpectedly.
+- Benchmarks can compare the stream and pool policy choices without changing test expectations.
+
+### Phase 2: Add Performance Gates
+
+1. Finish benchmark support for selecting allocator policy.
+2. Compare stream reuse policies on multi-stream churn workloads.
+3. Compare pool representation policies on mixed small/large allocation workloads.
+4. Generate Markdown benchmark reports but do not commit them until explicitly requested.
+
+Exit criteria:
+
+- The default stream and pool policies are selected by measured behavior, not assumption.
+- Non-default policy remains available if it has plausible workload value.
+
+### Phase 3: Revisit Pool Representation
+
+1. If pool-isolation tests show current predicate filtering is insufficient, split free-list storage into small and large pools.
+2. Keep the diff minimal and avoid rewriting stream-ordering machinery unless required.
+3. Re-run caching tests and add one fragmentation-focused test.
+
+Exit criteria:
+
+- Small and large segment policies are enforced structurally, not accidentally.
+
+### Phase 4: Expand OOM Behavior Deliberately
+
+1. Decide whether opposite-pool cached segments should be releasable on OOM.
+2. Decide whether oversize cached segments need PyTorch-like preferential release.
+3. Add tests before implementation.
+
+Exit criteria:
+
+- OOM retry behavior is explicit, covered, and documented.
+
+### Phase 5: Defer Larger Features
+
+Defer these until the core allocator is stable:
+
+- CUDA graph private pools
+- expandable segments
+- memory snapshots and tracing
+- PyTorch-style runtime configuration parsing
+- garbage-collection threshold
+
+## Immediate Next Step
+
+Start with pool policy first. Add separate enum constructor options for stream reuse and pool handling, but implement the pool policy before changing stream reuse behavior.
+
+Initial enum shape:
+
+- `enum class stream_reuse_policy { same_stream, cross_stream };`
+- `enum class pool_policy { separate, unified };`
+
+Default target:
+
+- `stream_reuse_policy::same_stream`, matching PyTorch where feasible.
+- `pool_policy::separate`, matching PyTorch where feasible.
+
+Compatibility option:
+
+- Preserve current behavior with `stream_reuse_policy::cross_stream` and `pool_policy::unified` if the implementation can support it without excessive complexity.
+
+Benchmark report location:
+
+- Generate Markdown benchmark reports under `caching-allocator-reports/` at the repository root.
+- Do not commit benchmark reports unless explicitly requested.
+
+## Open Questions
+
+1. Which OOM fallback subset should RMM implement first after pool separation?
+
+## Decisions Made
+
+- Compatibility target: PyTorch-inspired but RMM-native.
+- Policy selection: constructor options, not separate classes.
+- Constructor option shape: separate enums.
+- Implementation order: pool policy first, then stream policy.
+- Defaults: PyTorch behavior where feasible.
+- Benchmark priorities: multi-stream churn and mixed allocation patterns.
+- Benchmark reports: generate Markdown reports in `caching-allocator-reports/`, but do not commit them until explicitly requested.
+- Benchmark report filenames should include workload, policy, git commit, CUDA device, and timestamp.
+- Separate pool OOM fallback: match PyTorch where feasible; likely allow OOM fallback to release across pools.
+- `pool_policy::unified`: public for now.
+- Stream policy implementation: avoid changing `stream_ordered_memory_resource`; implement any same-stream behavior in `caching_memory_resource_impl` or adjacent caching-specific code.
+- Invalid deallocation: deallocation remains `noexcept`; invalid pointer and double-free behavior is undefined behavior. Optional debug tracking can be considered later behind a compile-time option.
+- Public helper API: leave existing helpers public for now.
+
+## Pool-Policy-First Work Breakdown
+
+### Step 1: Add Public Enum Plumbing
+
+- Add `pool_policy` and `stream_reuse_policy` enums to the public caching allocator header.
+- Add constructor parameters with defaults matching the target behavior.
+- Thread those values into `caching_memory_resource_impl`.
+- Do not change behavior yet unless required to compile cleanly.
+
+### Step 2: Add Pool Policy Tests
+
+- Add tests that differentiate separate pools from unified pools.
+- Separate-pool test: a small request should not consume a large-pool free block.
+- Separate-pool test: a large request should not consume a small-pool free block.
+- Unified-pool test: preserve current behavior where a fitting block can be reused across pool categories, if that remains supported.
+
+### Step 3: Implement Separate Pool Policy
+
+- Prefer the smallest structural change that keeps stream-ordering behavior intact.
+- Avoid large refactors of `stream_ordered_memory_resource` unless the existing free-list model cannot express pool separation cleanly.
+- Keep `pool_policy::unified` available for benchmarks if the extra complexity is modest.
+
+### Step 4: Benchmark Mixed Allocations
+
+- Build mixed small/large allocation benchmark coverage.
+- Compare `pool_policy::separate` and `pool_policy::unified`.
+- Write Markdown reports under `caching-allocator-reports/`.
+
+### Step 5: Revisit Stream Policy
+
+- After pool behavior is explicit, add stream policy tests and implementation.
+- Benchmark multi-stream churn for `stream_reuse_policy::same_stream` versus `stream_reuse_policy::cross_stream`.
+
+## OOM Fallback Options
+
+PyTorch's native allocator has a staged OOM path. It does not simply release one pool and retry. The relevant simplified sequence is:
+
+1. Try allocator callbacks.
+2. Try garbage collection if configured.
+3. Try the upstream allocation.
+4. Release cached oversize blocks that could satisfy the request, then retry.
+5. Release all non-split cached blocks, then retry.
+6. Report OOM.
+
+RMM does not need to implement all of this immediately. The useful implementation choices are below.
+
+### Option A: Same-Pool Whole-Segment Release Only
+
+Behavior: On upstream allocation failure, release cached whole segments from the same pool as the request, then retry once.
+
+Pros:
+
+- This is closest to the current implementation.
+- Small diff and easy to reason about.
+- Avoids surprising cross-pool cache eviction.
+
+Cons:
+
+- Not PyTorch-like when memory is stranded in the opposite pool.
+- Can fail an allocation even though enough releasable cached memory exists globally.
+- Weak benchmark comparator for PyTorch-inspired behavior.
+
+Use if: We prioritize minimal allocator complexity over PyTorch-like OOM recovery.
+
+### Option B: Release All Whole Segments Across Pools
+
+Behavior: On upstream allocation failure, release all cached whole segments from both small and large pools, then retry once.
+
+Pros:
+
+- Simple and robust.
+- Closer to PyTorch's final `release_cached_blocks` stage.
+- Handles memory stranded in the opposite pool.
+- Easy to test with `limiting_resource_adaptor`.
+
+Cons:
+
+- More aggressive than PyTorch's staged path because it skips targeted oversize release.
+- May hurt performance by flushing useful cached segments unnecessarily.
+- Blurs small/large pool isolation during OOM recovery.
+
+Use if: We want a simple PyTorch-inspired recovery path before implementing finer-grained release.
+
+### Option C: Targeted Oversize Whole-Segment Release, Then All Whole Segments
+
+Behavior: On upstream allocation failure, first release cached whole segments that are oversized relative to the failed request and likely to reduce fragmentation, then retry. If that fails, release all whole segments and retry again.
+
+Pros:
+
+- Closest practical subset of PyTorch's native path without implementing full stats, GC, and callbacks.
+- Avoids flushing the entire cache when a targeted release is enough.
+- Better benchmark candidate for mixed allocation workloads.
+
+Cons:
+
+- More complex release selection and tests.
+- Requires carefully defining `oversize` in RMM terms.
+- More chances to diverge subtly from PyTorch while appearing compatible.
+
+Use if: Benchmark evidence shows Option B is too disruptive and we need a more selective release path.
+
+### Option D: Full PyTorch-Like OOM Pipeline
+
+Behavior: Implement callbacks, garbage collection threshold, upstream retry staging, oversize release, all non-split cached release, detailed OOM accounting, and diagnostics.
+
+Pros:
+
+- Best PyTorch behavioral match.
+- Enables future statistics and diagnostics work.
+
+Cons:
+
+- Too large for the current prototype.
+- Adds features RMM may not need or may prefer to express through existing adaptors.
+- High review and maintenance cost.
+
+Use if: We explicitly decide this resource should become a near-port of PyTorch's allocator policy.
+
+Implementation status: Options B and C are implemented behind `caching_memory_resource_oom_fallback_policy`.
+
+Default: `release_oversized_then_all`, because it is the closer PyTorch-inspired staged fallback.

--- a/caching_allocator_plan.md
+++ b/caching_allocator_plan.md
@@ -212,6 +212,8 @@ Benchmark report location:
 
 ### Step 3: Implement Separate Pool Policy
 
+Status: Implemented with `caching_memory_resource_pool_policy`.
+
 - Prefer the smallest structural change that keeps stream-ordering behavior intact.
 - Avoid large refactors of `stream_ordered_memory_resource` unless the existing free-list model cannot express pool separation cleanly.
 - Keep `pool_policy::unified` available for benchmarks if the extra complexity is modest.

--- a/caching_allocator_plan.md
+++ b/caching_allocator_plan.md
@@ -220,6 +220,8 @@ Status: Implemented with `caching_memory_resource_pool_policy`.
 
 ### Step 4: Benchmark Mixed Allocations
 
+Status: Benchmark binaries accept caching pool and stream policy options. Report generation is available through `cpp/benchmarks/caching_allocator_reports.py`.
+
 - Build mixed small/large allocation benchmark coverage.
 - Compare `pool_policy::separate` and `pool_policy::unified`.
 - Write Markdown reports under `caching-allocator-reports/`.
@@ -230,6 +232,8 @@ Status: Implemented with `caching_memory_resource_stream_reuse_policy`.
 
 - After pool behavior is explicit, add stream policy tests and implementation.
 - Benchmark multi-stream churn for `stream_reuse_policy::same_stream` versus `stream_reuse_policy::cross_stream`.
+
+Benchmark reports are generated but intentionally ignored by git.
 
 ## OOM Fallback Options
 

--- a/caching_allocator_plan.md
+++ b/caching_allocator_plan.md
@@ -226,6 +226,8 @@ Status: Implemented with `caching_memory_resource_pool_policy`.
 
 ### Step 5: Revisit Stream Policy
 
+Status: Implemented with `caching_memory_resource_stream_reuse_policy`.
+
 - After pool behavior is explicit, add stream policy tests and implementation.
 - Benchmark multi-stream churn for `stream_reuse_policy::same_stream` versus `stream_reuse_policy::cross_stream`.
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(
   src/mr/aligned_resource_adaptor.cpp
   src/mr/arena_memory_resource.cpp
   src/mr/binning_memory_resource.cpp
+  src/mr/caching_memory_resource.cpp
   src/mr/callback_memory_resource.cpp
   src/mr/cuda_async_managed_memory_resource.cpp
   src/mr/cuda_async_memory_resource.cpp
@@ -98,6 +99,7 @@ add_library(
   src/mr/detail/aligned_resource_adaptor_impl.cpp
   src/mr/detail/arena_memory_resource_impl.cpp
   src/mr/detail/binning_memory_resource_impl.cpp
+  src/mr/detail/caching_memory_resource_impl.cpp
   src/mr/detail/callback_memory_resource_impl.cpp
   src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
   src/mr/detail/cuda_async_memory_resource_impl.cpp

--- a/cpp/benchmarks/caching_allocator_reports.py
+++ b/cpp/benchmarks/caching_allocator_reports.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+import subprocess
+from pathlib import Path
+
+POOL_POLICIES = ("separate", "unified")
+STREAM_POLICIES = ("same_stream", "cross_stream")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def run_text(command: list[str], cwd: Path) -> str:
+    try:
+        return subprocess.check_output(command, cwd=cwd, text=True).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def sanitize(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "unknown"
+
+
+def benchmark_min_time(value: str) -> str:
+    return value if value[-1].isalpha() else f"{value}s"
+
+
+def cuda_device_name(root: Path) -> str:
+    return run_text(
+        ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader", "-i", "0"],
+        root,
+    ).splitlines()[0]
+
+
+def benchmark_json_summary(path: Path) -> list[dict[str, object]]:
+    data = json.loads(path.read_text())
+    return [
+        {
+            "name": item["name"],
+            "real_time": item.get("real_time"),
+            "cpu_time": item.get("cpu_time"),
+            "time_unit": item.get("time_unit"),
+        }
+        for item in data.get("benchmarks", [])
+    ]
+
+
+def write_markdown_report(
+    report_path: Path,
+    *,
+    workload: str,
+    command: list[str],
+    json_path: Path,
+    pool_policy: str,
+    stream_policy: str,
+    git_commit: str,
+    device_name: str,
+    timestamp: str,
+) -> None:
+    rows = benchmark_json_summary(json_path)
+    lines = [
+        f"# Caching Allocator Benchmark: {workload}",
+        "",
+        f"- Git commit: `{git_commit}`",
+        f"- CUDA device: `{device_name}`",
+        f"- Timestamp UTC: `{timestamp}`",
+        f"- Pool policy: `{pool_policy}`",
+        f"- Stream policy: `{stream_policy}`",
+        f"- Raw JSON: `{json_path.name}`",
+        "",
+        "## Command",
+        "",
+        "```bash",
+        " ".join(command),
+        "```",
+        "",
+        "## Results",
+        "",
+        "| Benchmark | Real Time | CPU Time | Unit |",
+        "| --- | ---: | ---: | --- |",
+    ]
+    lines.extend(
+        f"| `{row['name']}` | {row['real_time']} | {row['cpu_time']} | {row['time_unit']} |"
+        for row in rows
+    )
+    report_path.write_text("\n".join(lines) + "\n")
+
+
+def run_benchmark_report(
+    *,
+    binary: Path,
+    workload: str,
+    extra_args: list[str],
+    output_dir: Path,
+    root: Path,
+    pool_policy: str,
+    stream_policy: str,
+    git_commit: str,
+    device_name: str,
+    timestamp: str,
+) -> None:
+    name = sanitize(
+        f"{workload}_{pool_policy}_{stream_policy}_{git_commit}_{device_name}_{timestamp}"
+    )
+    json_path = output_dir / f"{name}.json"
+    report_path = output_dir / f"{name}.md"
+    command = [
+        str(binary),
+        "--resource=caching",
+        f"--pool-policy={pool_policy}",
+        f"--stream-policy={stream_policy}",
+        "--benchmark_out_format=json",
+        f"--benchmark_out={json_path}",
+        *extra_args,
+    ]
+    subprocess.run(command, cwd=root, check=True)
+    write_markdown_report(
+        report_path,
+        workload=workload,
+        command=command,
+        json_path=json_path,
+        pool_policy=pool_policy,
+        stream_policy=stream_policy,
+        git_commit=git_commit,
+        device_name=device_name,
+        timestamp=timestamp,
+    )
+
+
+def main() -> None:
+    root = repo_root()
+    default_build = root / "cpp" / "build-bench-opencode" / "gbenchmarks"
+    parser = argparse.ArgumentParser(
+        description="Generate caching allocator benchmark reports."
+    )
+    parser.add_argument(
+        "--random-bench",
+        type=Path,
+        default=default_build / "RANDOM_ALLOCATIONS_BENCH",
+    )
+    parser.add_argument(
+        "--multi-stream-bench",
+        type=Path,
+        default=default_build / "MULTI_STREAM_ALLOCATIONS_BENCH",
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, default=root / "caching-allocator-reports"
+    )
+    parser.add_argument("--benchmark-min-time", default="0.2s")
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    git_commit = run_text(["git", "rev-parse", "--short", "HEAD"], root)
+    device_name = cuda_device_name(root)
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y%m%dT%H%M%SZ")
+    min_time = benchmark_min_time(args.benchmark_min_time)
+
+    workloads = [
+        (
+            args.random_bench,
+            "mixed_allocations",
+            [
+                "--numallocs=1000",
+                "--maxsize=64",
+                f"--benchmark_min_time={min_time}",
+            ],
+        ),
+        (
+            args.multi_stream_bench,
+            "multi_stream_churn",
+            [
+                "--kernels=4",
+                "--streams=4",
+                "--warm=true",
+                f"--benchmark_min_time={min_time}",
+            ],
+        ),
+    ]
+
+    for binary, workload, extra_args in workloads:
+        for pool_policy in POOL_POLICIES:
+            for stream_policy in STREAM_POLICIES:
+                run_benchmark_report(
+                    binary=binary,
+                    workload=workload,
+                    extra_args=extra_args,
+                    output_dir=args.output_dir,
+                    root=root,
+                    pool_policy=pool_policy,
+                    stream_policy=stream_policy,
+                    git_commit=git_commit,
+                    device_name=device_name,
+                    timestamp=timestamp,
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
+++ b/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
@@ -9,6 +9,7 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/binning_memory_resource.hpp>
+#include <rmm/mr/caching_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -90,6 +91,11 @@ inline any_device_resource make_pool()
                                        rmm::percent_of_free_device_memory(50)};
 }
 
+inline any_device_resource make_caching()
+{
+  return rmm::mr::caching_memory_resource{rmm::mr::cuda_memory_resource{}};
+}
+
 inline any_device_resource make_arena()
 {
   return rmm::mr::arena_memory_resource{rmm::mr::get_current_device_resource_ref()};
@@ -118,6 +124,7 @@ MRFactoryFunc get_mr_factory(std::string const& resource_name)
   if (resource_name == "cuda") { return &make_cuda; }
   if (resource_name == "cuda_async") { return &make_cuda_async; }
   if (resource_name == "pool") { return &make_pool; }
+  if (resource_name == "caching") { return &make_caching; }
   if (resource_name == "arena") { return &make_arena; }
   if (resource_name == "binning") { return &make_binning; }
 
@@ -140,6 +147,12 @@ void declare_benchmark(std::string const& name)
 
   if (name == "pool") {
     BENCHMARK_CAPTURE(BM_MultiStreamAllocations, pool_mr, &make_pool)  //
+      ->Apply(benchmark_range);
+    return;
+  }
+
+  if (name == "caching") {
+    BENCHMARK_CAPTURE(BM_MultiStreamAllocations, caching_mr, &make_caching)  //
       ->Apply(benchmark_range);
     return;
   }
@@ -227,6 +240,7 @@ int main(int argc, char** argv)
         resource_names.emplace_back("cuda");
         resource_names.emplace_back("cuda_async");
         resource_names.emplace_back("pool");
+        resource_names.emplace_back("caching");
         resource_names.emplace_back("arena");
         resource_names.emplace_back("binning");
       }

--- a/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
+++ b/cpp/benchmarks/multi_stream_allocations/multi_stream_allocations_bench.cu
@@ -41,6 +41,29 @@ __global__ void compute_bound_kernel(int64_t* out)
 using any_device_resource = cuda::mr::any_resource<cuda::mr::device_accessible>;
 using MRFactoryFunc       = std::function<any_device_resource()>;
 
+rmm::mr::caching_memory_resource_pool_policy caching_pool_policy =
+  rmm::mr::caching_memory_resource_pool_policy::separate;
+rmm::mr::caching_memory_resource_stream_reuse_policy caching_stream_policy =
+  rmm::mr::caching_memory_resource_stream_reuse_policy::same_stream;
+
+rmm::mr::caching_memory_resource_pool_policy parse_pool_policy(std::string const& policy)
+{
+  if (policy == "separate") { return rmm::mr::caching_memory_resource_pool_policy::separate; }
+  if (policy == "unified") { return rmm::mr::caching_memory_resource_pool_policy::unified; }
+  RMM_FAIL("Invalid caching pool policy: " + policy);
+}
+
+rmm::mr::caching_memory_resource_stream_reuse_policy parse_stream_policy(std::string const& policy)
+{
+  if (policy == "same_stream") {
+    return rmm::mr::caching_memory_resource_stream_reuse_policy::same_stream;
+  }
+  if (policy == "cross_stream") {
+    return rmm::mr::caching_memory_resource_stream_reuse_policy::cross_stream;
+  }
+  RMM_FAIL("Invalid caching stream reuse policy: " + policy);
+}
+
 static void run_prewarm(rmm::cuda_stream_pool& stream_pool, rmm::device_async_resource_ref mr)
 {
   auto buffers = std::vector<rmm::device_uvector<int64_t>>();
@@ -93,7 +116,12 @@ inline any_device_resource make_pool()
 
 inline any_device_resource make_caching()
 {
-  return rmm::mr::caching_memory_resource{rmm::mr::cuda_memory_resource{}};
+  return rmm::mr::caching_memory_resource{
+    rmm::mr::cuda_memory_resource{},
+    std::nullopt,
+    rmm::mr::caching_memory_resource_oom_fallback_policy::release_oversized_then_all,
+    caching_pool_policy,
+    caching_stream_policy};
 }
 
 inline any_device_resource make_arena()
@@ -218,8 +246,19 @@ int main(int argc, char** argv)
       "w,warm",
       "Ensure each stream has enough memory to satisfy allocations.",
       cxxopts::value<bool>()->default_value("false"));
+    options.add_options()(  //
+      "pool-policy",
+      "Caching MR pool policy: separate or unified",
+      cxxopts::value<std::string>()->default_value("separate"));
+    options.add_options()(  //
+      "stream-policy",
+      "Caching MR stream reuse policy: same_stream or cross_stream",
+      cxxopts::value<std::string>()->default_value("same_stream"));
 
     auto args = options.parse(argc, argv);
+
+    caching_pool_policy   = parse_pool_policy(args["pool-policy"].as<std::string>());
+    caching_stream_policy = parse_stream_policy(args["stream-policy"].as<std::string>());
 
     if (args.count("profile") > 0) {
       auto resource_name = args["resource"].as<std::string>();

--- a/cpp/benchmarks/random_allocations/random_allocations.cpp
+++ b/cpp/benchmarks/random_allocations/random_allocations.cpp
@@ -7,6 +7,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/arena_memory_resource.hpp>
 #include <rmm/mr/binning_memory_resource.hpp>
+#include <rmm/mr/caching_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
@@ -161,6 +162,11 @@ inline any_device_resource make_pool()
                                        rmm::percent_of_free_device_memory(50)};
 }
 
+inline any_device_resource make_caching()
+{
+  return rmm::mr::caching_memory_resource{rmm::mr::cuda_memory_resource{}};
+}
+
 inline any_device_resource make_arena()
 {
   auto free = rmm::available_device_memory().first;
@@ -253,6 +259,9 @@ void declare_benchmark(std::string const& name)
   } else if (name == "pool") {
     BENCHMARK_CAPTURE(BM_RandomAllocations, pool_mr, &make_pool)  // NOLINT
       ->Apply(benchmark_range);
+  } else if (name == "caching") {
+    BENCHMARK_CAPTURE(BM_RandomAllocations, caching_mr, &make_caching)  // NOLINT
+      ->Apply(benchmark_range);
   } else if (name == "arena") {
     BENCHMARK_CAPTURE(BM_RandomAllocations, arena_mr, &make_arena)  // NOLINT
       ->Apply(benchmark_range);
@@ -304,6 +313,7 @@ int main(int argc, char** argv)
     if (args.count("profile") > 0) {
       std::map<std::string, MRFactoryFunc> const funcs({{"arena", &make_arena},
                                                         {"binning", &make_binning},
+                                                        {"caching", &make_caching},
                                                         {"cuda", &make_cuda},
                                                         {"cuda_async", &make_cuda_async},
                                                         {"pool", &make_pool}});
@@ -329,7 +339,7 @@ int main(int argc, char** argv)
         std::string mr_name = args["resource"].as<std::string>();
         declare_benchmark(mr_name);
       } else {
-        std::vector<std::string> mrs{"pool", "binning", "arena", "cuda_async", "cuda"};
+        std::vector<std::string> mrs{"pool", "caching", "binning", "arena", "cuda_async", "cuda"};
         std::for_each(
           std::cbegin(mrs), std::cend(mrs), [](auto const& mr) { declare_benchmark(mr); });
       }

--- a/cpp/benchmarks/random_allocations/random_allocations.cpp
+++ b/cpp/benchmarks/random_allocations/random_allocations.cpp
@@ -152,6 +152,11 @@ void uniform_random_allocations(
 /// MR factory functions
 using any_device_resource = cuda::mr::any_resource<cuda::mr::device_accessible>;
 
+rmm::mr::caching_memory_resource_pool_policy caching_pool_policy =
+  rmm::mr::caching_memory_resource_pool_policy::separate;
+rmm::mr::caching_memory_resource_stream_reuse_policy caching_stream_policy =
+  rmm::mr::caching_memory_resource_stream_reuse_policy::same_stream;
+
 inline any_device_resource make_cuda() { return rmm::mr::cuda_memory_resource{}; }
 
 inline any_device_resource make_cuda_async() { return rmm::mr::cuda_async_memory_resource{}; }
@@ -164,7 +169,12 @@ inline any_device_resource make_pool()
 
 inline any_device_resource make_caching()
 {
-  return rmm::mr::caching_memory_resource{rmm::mr::cuda_memory_resource{}};
+  return rmm::mr::caching_memory_resource{
+    rmm::mr::cuda_memory_resource{},
+    std::nullopt,
+    rmm::mr::caching_memory_resource_oom_fallback_policy::release_oversized_then_all,
+    caching_pool_policy,
+    caching_stream_policy};
 }
 
 inline any_device_resource make_arena()
@@ -227,6 +237,24 @@ static void num_size_range(benchmark::Benchmark* bench)
 
 int num_allocations = -1;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 int max_size        = -1;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+rmm::mr::caching_memory_resource_pool_policy parse_pool_policy(std::string const& policy)
+{
+  if (policy == "separate") { return rmm::mr::caching_memory_resource_pool_policy::separate; }
+  if (policy == "unified") { return rmm::mr::caching_memory_resource_pool_policy::unified; }
+  RMM_FAIL("Invalid caching pool policy: " + policy);
+}
+
+rmm::mr::caching_memory_resource_stream_reuse_policy parse_stream_policy(std::string const& policy)
+{
+  if (policy == "same_stream") {
+    return rmm::mr::caching_memory_resource_stream_reuse_policy::same_stream;
+  }
+  if (policy == "cross_stream") {
+    return rmm::mr::caching_memory_resource_stream_reuse_policy::cross_stream;
+  }
+  RMM_FAIL("Invalid caching stream reuse policy: " + policy);
+}
 
 void benchmark_range(benchmark::Benchmark* bench)
 {
@@ -305,10 +333,18 @@ int main(int argc, char** argv)
     options.add_options()("m,maxsize",
                           "Maximum allocation size (default of 0 tests a range)",
                           cxxopts::value<int>()->default_value("4096"));
+    options.add_options()("pool-policy",
+                          "Caching MR pool policy: separate or unified",
+                          cxxopts::value<std::string>()->default_value("separate"));
+    options.add_options()("stream-policy",
+                          "Caching MR stream reuse policy: same_stream or cross_stream",
+                          cxxopts::value<std::string>()->default_value("same_stream"));
 
-    auto args       = options.parse(argc, argv);
-    num_allocations = args["numallocs"].as<int>();
-    max_size        = args["maxsize"].as<int>();
+    auto args             = options.parse(argc, argv);
+    num_allocations       = args["numallocs"].as<int>();
+    max_size              = args["maxsize"].as<int>();
+    caching_pool_policy   = parse_pool_policy(args["pool-policy"].as<std::string>());
+    caching_stream_policy = parse_stream_policy(args["stream-policy"].as<std::string>());
 
     if (args.count("profile") > 0) {
       std::map<std::string, MRFactoryFunc> const funcs({{"arena", &make_arena},

--- a/cpp/include/rmm/mr/caching_memory_resource.hpp
+++ b/cpp/include/rmm/mr/caching_memory_resource.hpp
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <rmm/detail/export.hpp>
+#include <rmm/mr/detail/caching_memory_resource_impl.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
+
+#include <cstddef>
+#include <optional>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+/**
+ * @addtogroup memory_resources
+ * @{
+ * @file
+ */
+
+/**
+ * @brief A stream-ordered caching suballocator with separate small and large allocation policies.
+ *
+ * This resource is modeled after the broad design of PyTorch's CUDA caching allocator. It
+ * allocates larger segments from an upstream resource, then suballocates from cached free blocks
+ * using best fit with coalescing.
+ *
+ * Allocation and deallocation are thread-safe. Also,
+ * this class is compatible with CUDA per-thread default stream.
+ *
+ * Requests are rounded to upstream segment sizes using the following policy:
+ * - requests <= 1 MiB allocate from 2 MiB upstream segments
+ * - requests in (1 MiB, 10 MiB) allocate from 20 MiB upstream segments
+ * - requests >= 10 MiB allocate from upstream sizes rounded up to 2 MiB
+ *
+ * When an upstream allocation fails while growing the cache, the resource releases cached whole
+ * segments from the relevant pool and retries once.
+ *
+ * This class is copyable and shares ownership of its internal state, allowing multiple instances
+ * to safely reference the same underlying cache.
+ */
+class RMM_EXPORT caching_memory_resource
+  : public cuda::mr::shared_resource<detail::caching_memory_resource_impl> {
+  using shared_base = cuda::mr::shared_resource<detail::caching_memory_resource_impl>;
+
+ public:
+  /**
+   * @brief Enables the `cuda::mr::device_accessible` property.
+   */
+  RMM_CONSTEXPR_FRIEND void get_property(caching_memory_resource const&,
+                                         cuda::mr::device_accessible) noexcept
+  {
+  }
+
+  /**
+   * @brief Construct a `caching_memory_resource`.
+   *
+   * @param upstream The resource from which cached segments are allocated.
+   * @param max_split_size Optional threshold for the large-allocation pool. If set, large cached
+   * blocks at or above this size will not be split to satisfy smaller requests.
+   */
+  explicit caching_memory_resource(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+                                   std::optional<std::size_t> max_split_size = std::nullopt);
+
+  /**
+   * @briefreturn{rmm::device_async_resource_ref to the upstream resource}
+   */
+  [[nodiscard]] device_async_resource_ref get_upstream_resource() const noexcept;
+
+  /**
+   * @brief Release all cached whole segments.
+   *
+   * Outstanding allocations are not affected.
+   *
+   * @return Number of bytes returned to the upstream resource.
+   */
+  [[nodiscard]] std::size_t release() noexcept;
+
+  /**
+   * @brief Release cached whole segments from the small-allocation pool.
+   *
+   * @return Number of bytes returned to the upstream resource.
+   */
+  [[nodiscard]] std::size_t release_small_blocks() noexcept;
+
+  /**
+   * @brief Release cached whole segments from the large-allocation pool.
+   *
+   * @return Number of bytes returned to the upstream resource.
+   */
+  [[nodiscard]] std::size_t release_large_blocks() noexcept;
+
+  /**
+   * @brief Return the total number of cached bytes currently owned by the small-allocation pool.
+   */
+  [[nodiscard]] std::size_t cached_small_bytes() const noexcept;
+
+  /**
+   * @brief Return the total number of cached bytes currently owned by the large-allocation pool.
+   */
+  [[nodiscard]] std::size_t cached_large_bytes() const noexcept;
+
+  /**
+   * @brief Return the upstream segment size used for a request of `bytes` bytes.
+   *
+   * This exposes the allocator's request-rounding policy.
+   */
+  [[nodiscard]] std::size_t upstream_allocation_size(std::size_t bytes) const noexcept;
+};
+
+static_assert(cuda::mr::resource_with<caching_memory_resource, cuda::mr::device_accessible>,
+              "caching_memory_resource does not satisfy the cuda::mr::resource concept");
+
+/** @} */  // end of group
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/include/rmm/mr/caching_memory_resource.hpp
+++ b/cpp/include/rmm/mr/caching_memory_resource.hpp
@@ -62,12 +62,15 @@ class RMM_EXPORT caching_memory_resource
    * @param max_split_size Optional threshold for the large-allocation pool. If set, large cached
    * blocks at or above this size will not be split to satisfy smaller requests.
    * @param oom_fallback_policy Policy used after an upstream allocation failure.
+   * @param pool_policy Policy controlling cross-pool cached block reuse.
    */
   explicit caching_memory_resource(
     cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
     std::optional<std::size_t> max_split_size = std::nullopt,
     caching_memory_resource_oom_fallback_policy oom_fallback_policy =
-      caching_memory_resource_oom_fallback_policy::release_oversized_then_all);
+      caching_memory_resource_oom_fallback_policy::release_oversized_then_all,
+    caching_memory_resource_pool_policy pool_policy =
+      caching_memory_resource_pool_policy::separate);
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}

--- a/cpp/include/rmm/mr/caching_memory_resource.hpp
+++ b/cpp/include/rmm/mr/caching_memory_resource.hpp
@@ -63,14 +63,16 @@ class RMM_EXPORT caching_memory_resource
    * blocks at or above this size will not be split to satisfy smaller requests.
    * @param oom_fallback_policy Policy used after an upstream allocation failure.
    * @param pool_policy Policy controlling cross-pool cached block reuse.
+   * @param stream_reuse_policy Policy controlling cross-stream cached block reuse.
    */
   explicit caching_memory_resource(
     cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
     std::optional<std::size_t> max_split_size = std::nullopt,
     caching_memory_resource_oom_fallback_policy oom_fallback_policy =
       caching_memory_resource_oom_fallback_policy::release_oversized_then_all,
-    caching_memory_resource_pool_policy pool_policy =
-      caching_memory_resource_pool_policy::separate);
+    caching_memory_resource_pool_policy pool_policy = caching_memory_resource_pool_policy::separate,
+    caching_memory_resource_stream_reuse_policy stream_reuse_policy =
+      caching_memory_resource_stream_reuse_policy::same_stream);
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}

--- a/cpp/include/rmm/mr/caching_memory_resource.hpp
+++ b/cpp/include/rmm/mr/caching_memory_resource.hpp
@@ -95,11 +95,15 @@ class RMM_EXPORT caching_memory_resource
 
   /**
    * @brief Return the total number of cached bytes currently owned by the small-allocation pool.
+   *
+   * @return Total cached bytes in the small-allocation pool.
    */
   [[nodiscard]] std::size_t cached_small_bytes() const noexcept;
 
   /**
    * @brief Return the total number of cached bytes currently owned by the large-allocation pool.
+   *
+   * @return Total cached bytes in the large-allocation pool.
    */
   [[nodiscard]] std::size_t cached_large_bytes() const noexcept;
 
@@ -107,6 +111,9 @@ class RMM_EXPORT caching_memory_resource
    * @brief Return the upstream segment size used for a request of `bytes` bytes.
    *
    * This exposes the allocator's request-rounding policy.
+   *
+   * @param bytes The requested allocation size in bytes.
+   * @return Upstream segment size used for the request.
    */
   [[nodiscard]] std::size_t upstream_allocation_size(std::size_t bytes) const noexcept;
 };

--- a/cpp/include/rmm/mr/caching_memory_resource.hpp
+++ b/cpp/include/rmm/mr/caching_memory_resource.hpp
@@ -61,9 +61,13 @@ class RMM_EXPORT caching_memory_resource
    * @param upstream The resource from which cached segments are allocated.
    * @param max_split_size Optional threshold for the large-allocation pool. If set, large cached
    * blocks at or above this size will not be split to satisfy smaller requests.
+   * @param oom_fallback_policy Policy used after an upstream allocation failure.
    */
-  explicit caching_memory_resource(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
-                                   std::optional<std::size_t> max_split_size = std::nullopt);
+  explicit caching_memory_resource(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+    std::optional<std::size_t> max_split_size = std::nullopt,
+    caching_memory_resource_oom_fallback_policy oom_fallback_policy =
+      caching_memory_resource_oom_fallback_policy::release_oversized_then_all);
 
   /**
    * @briefreturn{rmm::device_async_resource_ref to the upstream resource}

--- a/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/detail/coalescing_free_list.hpp>
+#include <rmm/mr/detail/stream_ordered_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
+
+#include <cstddef>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <set>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+namespace detail {
+
+class caching_memory_resource_impl final
+  : public stream_ordered_memory_resource<caching_memory_resource_impl, coalescing_free_list> {
+ public:
+  friend class stream_ordered_memory_resource<caching_memory_resource_impl, coalescing_free_list>;
+
+  static constexpr std::size_t minimum_block_size{512};
+  static constexpr std::size_t small_size_threshold{1UL << 20};
+  static constexpr std::size_t small_segment_size{2UL << 20};
+  static constexpr std::size_t large_segment_size{20UL << 20};
+  static constexpr std::size_t minimum_large_allocation{10UL << 20};
+  static constexpr std::size_t large_rounding{2UL << 20};
+
+  caching_memory_resource_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+                               std::optional<std::size_t> max_split_size = std::nullopt);
+
+  ~caching_memory_resource_impl();
+
+  bool operator==(caching_memory_resource_impl const& other) const noexcept
+  {
+    return this == std::addressof(other);
+  }
+
+  bool operator!=(caching_memory_resource_impl const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  [[nodiscard]] device_async_resource_ref get_upstream_resource() const noexcept;
+
+  [[nodiscard]] std::size_t release() noexcept;
+
+  [[nodiscard]] std::size_t release_small_blocks() noexcept;
+
+  [[nodiscard]] std::size_t release_large_blocks() noexcept;
+
+  [[nodiscard]] std::size_t cached_small_bytes() const noexcept;
+
+  [[nodiscard]] std::size_t cached_large_bytes() const noexcept;
+
+  [[nodiscard]] std::size_t upstream_allocation_size(std::size_t bytes) const noexcept;
+
+  RMM_CONSTEXPR_FRIEND void get_property(caching_memory_resource_impl const&,
+                                         cuda::mr::device_accessible) noexcept
+  {
+  }
+
+ protected:
+  using free_list  = coalescing_free_list;
+  using block_type = free_list::block_type;
+  using typename stream_ordered_memory_resource<caching_memory_resource_impl,
+                                                coalescing_free_list>::split_block;
+  using lock_guard = std::lock_guard<std::mutex>;
+
+  [[nodiscard]] std::size_t get_maximum_allocation_size() const;
+
+  block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream);
+
+  split_block allocate_from_block(block_type const& block, std::size_t size);
+
+  block_type free_block(void* ptr, std::size_t size) noexcept;
+
+  std::pair<std::size_t, std::size_t> free_list_summary(free_list const& blocks);
+
+ private:
+  struct segment {
+    char* pointer{};
+    std::size_t size{};
+    bool is_small{};
+
+    bool operator<(segment const& other) const noexcept { return pointer < other.pointer; }
+  };
+
+  struct released_block {
+    std::size_t size{};
+    bool is_small{};
+  };
+
+  [[nodiscard]] bool is_small_allocation(std::size_t size) const noexcept;
+
+  [[nodiscard]] bool should_split(block_type const& block, std::size_t size) const noexcept;
+
+  [[nodiscard]] bool block_is_small(block_type const& block) const noexcept;
+
+  [[nodiscard]] std::size_t release_pool(bool is_small) noexcept;
+
+  block_type block_from_upstream(std::size_t size, cuda_stream_view stream, bool is_small);
+
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr_;
+  std::optional<std::size_t> max_split_size_{};
+  std::set<segment> upstream_blocks_{};
+  std::map<char*, released_block, std::less<>> releasable_blocks_{};
+  std::size_t cached_small_bytes_{};
+  std::size_t cached_large_bytes_{};
+};
+
+}  // namespace detail
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
@@ -27,6 +27,15 @@ enum class caching_memory_resource_oom_fallback_policy {
   release_oversized_then_all,  ///< Release oversized whole segments first, then all segments.
 };
 
+/**
+ * @brief Policy controlling whether small and large cached segments can satisfy each other's
+ * allocation requests.
+ */
+enum class caching_memory_resource_pool_policy {
+  separate,  ///< Small requests use small segments and large requests use large segments.
+  unified,   ///< Any cached segment large enough for a request may be reused.
+};
+
 namespace detail {
 
 class caching_memory_resource_impl final
@@ -45,7 +54,9 @@ class caching_memory_resource_impl final
     cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
     std::optional<std::size_t> max_split_size = std::nullopt,
     caching_memory_resource_oom_fallback_policy oom_fallback_policy =
-      caching_memory_resource_oom_fallback_policy::release_oversized_then_all);
+      caching_memory_resource_oom_fallback_policy::release_oversized_then_all,
+    caching_memory_resource_pool_policy pool_policy =
+      caching_memory_resource_pool_policy::separate);
 
   ~caching_memory_resource_impl();
 
@@ -123,6 +134,7 @@ class caching_memory_resource_impl final
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr_;
   std::optional<std::size_t> max_split_size_{};
   caching_memory_resource_oom_fallback_policy oom_fallback_policy_{};
+  caching_memory_resource_pool_policy pool_policy_{};
   std::set<segment> upstream_blocks_{};
   std::set<block_type, compare_blocks<block_type>> allocated_blocks_{};
   std::size_t cached_small_bytes_{};

--- a/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
@@ -36,6 +36,14 @@ enum class caching_memory_resource_pool_policy {
   unified,   ///< Any cached segment large enough for a request may be reused.
 };
 
+/**
+ * @brief Policy controlling reuse of cached blocks from streams other than the allocation stream.
+ */
+enum class caching_memory_resource_stream_reuse_policy {
+  same_stream,   ///< Reuse cached blocks from the same stream only.
+  cross_stream,  ///< Reuse cached blocks from other streams by inserting CUDA event waits.
+};
+
 namespace detail {
 
 class caching_memory_resource_impl final
@@ -55,8 +63,9 @@ class caching_memory_resource_impl final
     std::optional<std::size_t> max_split_size = std::nullopt,
     caching_memory_resource_oom_fallback_policy oom_fallback_policy =
       caching_memory_resource_oom_fallback_policy::release_oversized_then_all,
-    caching_memory_resource_pool_policy pool_policy =
-      caching_memory_resource_pool_policy::separate);
+    caching_memory_resource_pool_policy pool_policy = caching_memory_resource_pool_policy::separate,
+    caching_memory_resource_stream_reuse_policy stream_reuse_policy =
+      caching_memory_resource_stream_reuse_policy::same_stream);
 
   ~caching_memory_resource_impl();
 
@@ -83,6 +92,8 @@ class caching_memory_resource_impl final
   [[nodiscard]] std::size_t cached_large_bytes() const noexcept;
 
   [[nodiscard]] std::size_t upstream_allocation_size(std::size_t bytes) const noexcept;
+
+  [[nodiscard]] bool supports_cross_stream_reuse() const noexcept;
 
   RMM_CONSTEXPR_FRIEND void get_property(caching_memory_resource_impl const&,
                                          cuda::mr::device_accessible) noexcept
@@ -135,6 +146,7 @@ class caching_memory_resource_impl final
   std::optional<std::size_t> max_split_size_{};
   caching_memory_resource_oom_fallback_policy oom_fallback_policy_{};
   caching_memory_resource_pool_policy pool_policy_{};
+  caching_memory_resource_stream_reuse_policy stream_reuse_policy_{};
   std::set<segment> upstream_blocks_{};
   std::set<block_type, compare_blocks<block_type>> allocated_blocks_{};
   std::size_t cached_small_bytes_{};

--- a/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
@@ -18,6 +18,15 @@
 
 namespace RMM_NAMESPACE {
 namespace mr {
+
+/**
+ * @brief Policy used after an upstream allocation fails while growing a caching memory resource.
+ */
+enum class caching_memory_resource_oom_fallback_policy {
+  release_all,                 ///< Release all cached whole segments, then retry.
+  release_oversized_then_all,  ///< Release oversized whole segments first, then all segments.
+};
+
 namespace detail {
 
 class caching_memory_resource_impl final
@@ -32,8 +41,11 @@ class caching_memory_resource_impl final
   static constexpr std::size_t minimum_large_allocation{10UL << 20};
   static constexpr std::size_t large_rounding{2UL << 20};
 
-  caching_memory_resource_impl(cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
-                               std::optional<std::size_t> max_split_size = std::nullopt);
+  caching_memory_resource_impl(
+    cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+    std::optional<std::size_t> max_split_size = std::nullopt,
+    caching_memory_resource_oom_fallback_policy oom_fallback_policy =
+      caching_memory_resource_oom_fallback_policy::release_oversized_then_all);
 
   ~caching_memory_resource_impl();
 
@@ -102,10 +114,15 @@ class caching_memory_resource_impl final
 
   [[nodiscard]] std::size_t release_pool(bool is_small) noexcept;
 
+  [[nodiscard]] std::size_t release_all_pools() noexcept;
+
+  [[nodiscard]] std::size_t release_oversized_blocks(std::size_t size) noexcept;
+
   block_type block_from_upstream(std::size_t size, cuda_stream_view stream, bool is_small);
 
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr_;
   std::optional<std::size_t> max_split_size_{};
+  caching_memory_resource_oom_fallback_policy oom_fallback_policy_{};
   std::set<segment> upstream_blocks_{};
   std::set<block_type, compare_blocks<block_type>> allocated_blocks_{};
   std::size_t cached_small_bytes_{};

--- a/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/caching_memory_resource_impl.hpp
@@ -12,7 +12,6 @@
 #include <cuda/memory_resource>
 
 #include <cstddef>
-#include <map>
 #include <mutex>
 #include <optional>
 #include <set>
@@ -78,6 +77,8 @@ class caching_memory_resource_impl final
 
   block_type expand_pool(std::size_t size, free_list& blocks, cuda_stream_view stream);
 
+  block_type get_block_from_free_list(free_list& blocks, std::size_t size);
+
   split_block allocate_from_block(block_type const& block, std::size_t size);
 
   block_type free_block(void* ptr, std::size_t size) noexcept;
@@ -93,11 +94,6 @@ class caching_memory_resource_impl final
     bool operator<(segment const& other) const noexcept { return pointer < other.pointer; }
   };
 
-  struct released_block {
-    std::size_t size{};
-    bool is_small{};
-  };
-
   [[nodiscard]] bool is_small_allocation(std::size_t size) const noexcept;
 
   [[nodiscard]] bool should_split(block_type const& block, std::size_t size) const noexcept;
@@ -111,7 +107,7 @@ class caching_memory_resource_impl final
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream_mr_;
   std::optional<std::size_t> max_split_size_{};
   std::set<segment> upstream_blocks_{};
-  std::map<char*, released_block, std::less<>> releasable_blocks_{};
+  std::set<block_type, compare_blocks<block_type>> allocated_blocks_{};
   std::size_t cached_small_bytes_{};
   std::size_t cached_large_bytes_{};
 };

--- a/cpp/include/rmm/mr/detail/coalescing_free_list.hpp
+++ b/cpp/include/rmm/mr/detail/coalescing_free_list.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -226,13 +226,29 @@ struct coalescing_free_list : free_list<block> {
    */
   block_type get_block(std::size_t size)
   {
+    return get_block(size, [](block_type const&) { return true; });
+  }
+
+  /**
+   * @brief Finds the smallest acceptable block in the `free_list` large enough to fit `size` bytes.
+   *
+   * @tparam Predicate Unary predicate returning true for acceptable blocks.
+   * @param size The size in bytes of the desired block.
+   * @param pred Predicate used to reject blocks that should not satisfy this request.
+   * @return A block large enough to store `size` bytes.
+   */
+  template <typename Predicate>
+  block_type get_block(std::size_t size, Predicate pred)
+  {
     // find best fit block
-    auto finder = [size](block_type const& lhs, block_type const& rhs) {
+    auto finder = [size, pred](block_type const& lhs, block_type const& rhs) {
+      if (!pred(lhs)) { return false; }
+      if (!pred(rhs)) { return lhs.fits(size); }
       return lhs.is_better_fit(size, rhs);
     };
     auto const iter = std::min_element(cbegin(), cend(), finder);
 
-    if (iter != cend() && iter->fits(size)) {
+    if (iter != cend() && iter->fits(size) && pred(*iter)) {
       // Remove the block from the free_list and return it.
       block_type const found = *iter;
       erase(iter);
@@ -240,6 +256,24 @@ struct coalescing_free_list : free_list<block> {
     }
 
     return block_type{};  // not found
+  }
+
+  /**
+   * @brief Removes the block exactly matching `block` from the free list.
+   *
+   * @param block The block to remove.
+   * @return true If an exact matching block was removed.
+   */
+  bool remove_block(block_type const& block)
+  {
+    auto const iter = std::find_if(cbegin(), cend(), [block](block_type const& candidate) {
+      return candidate.pointer() == block.pointer() && candidate.size() == block.size();
+    });
+
+    if (iter == cend()) { return false; }
+
+    erase(iter);
+    return true;
   }
 
 #ifdef RMM_DEBUG_PRINT

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -16,6 +16,7 @@
 #include <cuda_runtime_api.h>
 
 #include <algorithm>
+#include <concepts>
 #include <cstddef>
 #include <map>
 #include <mutex>
@@ -407,16 +408,18 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     free_list& blocks =
       (iter != stream_free_blocks_.end()) ? iter->second : stream_free_blocks_[stream_event];
 
-    // Try to find an existing block in another stream
-    {
-      block_type const block = get_block_from_other_stream(size, stream_event, blocks, false);
-      if (block.is_valid()) { return block; }
-    }
+    if (cross_stream_reuse_enabled_for_resource()) {
+      // Try to find an existing block in another stream
+      {
+        block_type const block = get_block_from_other_stream(size, stream_event, blocks, false);
+        if (block.is_valid()) { return block; }
+      }
 
-    // no large enough blocks available on other streams, so sync and merge until we find one
-    {
-      block_type const block = get_block_from_other_stream(size, stream_event, blocks, true);
-      if (block.is_valid()) { return block; }
+      // no large enough blocks available on other streams, so sync and merge until we find one
+      {
+        block_type const block = get_block_from_other_stream(size, stream_event, blocks, true);
+        if (block.is_valid()) { return block; }
+      }
     }
 
     log_summary_trace();
@@ -426,6 +429,16 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
       this->underlying().expand_pool(size, blocks, cuda_stream_view{stream_event.stream});
 
     return allocate_and_insert_remainder(block, size, blocks);
+  }
+
+  [[nodiscard]] bool cross_stream_reuse_enabled_for_resource() const noexcept
+  {
+    if constexpr (requires(PoolResource const& resource) {
+                    { resource.supports_cross_stream_reuse() } -> std::convertible_to<bool>;
+                  }) {
+      return this->underlying().supports_cross_stream_reuse();
+    }
+    return true;
   }
 
   /**

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -263,6 +263,35 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     stream_free_blocks_[get_event(stream)].insert(std::move(blocks));
   }
 
+  void merge_all_free_blocks()
+  {
+    auto iter = stream_free_blocks_.begin();
+    if (iter == stream_free_blocks_.end()) { return; }
+
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaEventSynchronize(iter->first.event));
+    auto& blocks = iter->second;
+    ++iter;
+
+    while (iter != stream_free_blocks_.end()) {
+      RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaEventSynchronize(iter->first.event));
+      blocks.insert(std::move(iter->second));
+      iter = stream_free_blocks_.erase(iter);
+    }
+  }
+
+  bool remove_free_block(block_type const& block)
+  {
+    for (auto& free_blocks : stream_free_blocks_) {
+      if (free_blocks.second.remove_block(block)) { return true; }
+    }
+    return false;
+  }
+
+  block_type get_block_from_free_list(free_list& blocks, std::size_t size)
+  {
+    return blocks.get_block(size);
+  }
+
 #ifdef RMM_DEBUG_PRINT
   void print_free_blocks() const
   {
@@ -371,7 +400,7 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
     // Try to find a satisfactory block in free list for the same stream (no sync required)
     auto iter = stream_free_blocks_.find(stream_event);
     if (iter != stream_free_blocks_.end()) {
-      block_type const block = iter->second.get_block(size);
+      block_type const block = this->underlying().get_block_from_free_list(iter->second, size);
       if (block.is_valid()) { return allocate_and_insert_remainder(block, size, iter->second); }
     }
 
@@ -430,10 +459,10 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
 
         stream_free_blocks_.erase(iter);
 
-        block_type const block = blocks.get_block(size);  // get the best fit block in merged lists
+        block_type const block = this->underlying().get_block_from_free_list(blocks, size);
         if (block.is_valid()) { return allocate_and_insert_remainder(block, size, blocks); }
       } else {
-        block_type const block = other_blocks.get_block(size);
+        block_type const block = this->underlying().get_block_from_free_list(other_blocks, size);
         if (block.is_valid()) {
           // Since we found a block associated with a different stream, we have to insert a wait
           // on the stream's associated event into the allocating stream.

--- a/cpp/src/mr/caching_memory_resource.cpp
+++ b/cpp/src/mr/caching_memory_resource.cpp
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/mr/caching_memory_resource.hpp>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+
+caching_memory_resource::caching_memory_resource(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::optional<std::size_t> max_split_size)
+  : shared_base(cuda::mr::make_shared_resource<detail::caching_memory_resource_impl>(
+      std::move(upstream), max_split_size))
+{
+}
+
+device_async_resource_ref caching_memory_resource::get_upstream_resource() const noexcept
+{
+  return get().get_upstream_resource();
+}
+
+std::size_t caching_memory_resource::release() noexcept { return get().release(); }
+
+std::size_t caching_memory_resource::release_small_blocks() noexcept
+{
+  return get().release_small_blocks();
+}
+
+std::size_t caching_memory_resource::release_large_blocks() noexcept
+{
+  return get().release_large_blocks();
+}
+
+std::size_t caching_memory_resource::cached_small_bytes() const noexcept
+{
+  return get().cached_small_bytes();
+}
+
+std::size_t caching_memory_resource::cached_large_bytes() const noexcept
+{
+  return get().cached_large_bytes();
+}
+
+std::size_t caching_memory_resource::upstream_allocation_size(std::size_t bytes) const noexcept
+{
+  return get().upstream_allocation_size(bytes);
+}
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/caching_memory_resource.cpp
+++ b/cpp/src/mr/caching_memory_resource.cpp
@@ -11,9 +11,10 @@ namespace mr {
 caching_memory_resource::caching_memory_resource(
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
   std::optional<std::size_t> max_split_size,
-  caching_memory_resource_oom_fallback_policy oom_fallback_policy)
+  caching_memory_resource_oom_fallback_policy oom_fallback_policy,
+  caching_memory_resource_pool_policy pool_policy)
   : shared_base(cuda::mr::make_shared_resource<detail::caching_memory_resource_impl>(
-      std::move(upstream), max_split_size, oom_fallback_policy))
+      std::move(upstream), max_split_size, oom_fallback_policy, pool_policy))
 {
 }
 

--- a/cpp/src/mr/caching_memory_resource.cpp
+++ b/cpp/src/mr/caching_memory_resource.cpp
@@ -12,9 +12,10 @@ caching_memory_resource::caching_memory_resource(
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
   std::optional<std::size_t> max_split_size,
   caching_memory_resource_oom_fallback_policy oom_fallback_policy,
-  caching_memory_resource_pool_policy pool_policy)
+  caching_memory_resource_pool_policy pool_policy,
+  caching_memory_resource_stream_reuse_policy stream_reuse_policy)
   : shared_base(cuda::mr::make_shared_resource<detail::caching_memory_resource_impl>(
-      std::move(upstream), max_split_size, oom_fallback_policy, pool_policy))
+      std::move(upstream), max_split_size, oom_fallback_policy, pool_policy, stream_reuse_policy))
 {
 }
 

--- a/cpp/src/mr/caching_memory_resource.cpp
+++ b/cpp/src/mr/caching_memory_resource.cpp
@@ -10,9 +10,10 @@ namespace mr {
 
 caching_memory_resource::caching_memory_resource(
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
-  std::optional<std::size_t> max_split_size)
+  std::optional<std::size_t> max_split_size,
+  caching_memory_resource_oom_fallback_policy oom_fallback_policy)
   : shared_base(cuda::mr::make_shared_resource<detail::caching_memory_resource_impl>(
-      std::move(upstream), max_split_size))
+      std::move(upstream), max_split_size, oom_fallback_policy))
 {
 }
 

--- a/cpp/src/mr/detail/caching_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/caching_memory_resource_impl.cpp
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/aligned.hpp>
+#include <rmm/mr/detail/caching_memory_resource_impl.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+namespace detail {
+
+caching_memory_resource_impl::caching_memory_resource_impl(
+  cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
+  std::optional<std::size_t> max_split_size)
+  : upstream_mr_{std::move(upstream)}, max_split_size_{max_split_size}
+{
+}
+
+caching_memory_resource_impl::~caching_memory_resource_impl() { (void)release(); }
+
+device_async_resource_ref caching_memory_resource_impl::get_upstream_resource() const noexcept
+{
+  return device_async_resource_ref{
+    const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(upstream_mr_)};
+}
+
+std::size_t caching_memory_resource_impl::release() noexcept
+{
+  lock_guard lock(this->get_mutex());
+  return release_pool(true) + release_pool(false);
+}
+
+std::size_t caching_memory_resource_impl::release_small_blocks() noexcept
+{
+  lock_guard lock(this->get_mutex());
+  return release_pool(true);
+}
+
+std::size_t caching_memory_resource_impl::release_large_blocks() noexcept
+{
+  lock_guard lock(this->get_mutex());
+  return release_pool(false);
+}
+
+std::size_t caching_memory_resource_impl::cached_small_bytes() const noexcept
+{
+  return cached_small_bytes_;
+}
+
+std::size_t caching_memory_resource_impl::cached_large_bytes() const noexcept
+{
+  return cached_large_bytes_;
+}
+
+std::size_t caching_memory_resource_impl::upstream_allocation_size(std::size_t bytes) const noexcept
+{
+  if (bytes == 0) { return 0; }
+  if (bytes <= small_size_threshold) { return small_segment_size; }
+  if (bytes < minimum_large_allocation) { return large_segment_size; }
+  return rmm::align_up(bytes, large_rounding);
+}
+
+std::size_t caching_memory_resource_impl::get_maximum_allocation_size() const
+{
+  return std::numeric_limits<std::size_t>::max();
+}
+
+caching_memory_resource_impl::block_type caching_memory_resource_impl::expand_pool(
+  std::size_t size, free_list&, cuda_stream_view stream)
+{
+  auto const is_small      = is_small_allocation(size);
+  auto const upstream_size = upstream_allocation_size(size);
+
+  try {
+    return block_from_upstream(upstream_size, stream, is_small);
+  } catch (rmm::out_of_memory const&) {
+    auto const released = release_pool(is_small);
+    if (released == 0) { throw; }
+    return block_from_upstream(upstream_size, stream, is_small);
+  }
+}
+
+caching_memory_resource_impl::split_block caching_memory_resource_impl::allocate_from_block(
+  block_type const& block, std::size_t size)
+{
+  releasable_blocks_.erase(block.pointer());
+
+  auto const alloc = block_type{block.pointer(), size, block.is_head()};
+  if (!should_split(block, size)) { return {block, {}}; }
+
+  auto rest = block_type{block.pointer() + size, block.size() - size, false};
+  return {alloc, rest};
+}
+
+caching_memory_resource_impl::block_type caching_memory_resource_impl::free_block(
+  void* ptr, std::size_t size) noexcept
+{
+  auto const aligned_size = rmm::align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto const block        = block_type{static_cast<char*>(ptr), aligned_size, false};
+
+  auto const iter = upstream_blocks_.upper_bound(segment{static_cast<char*>(ptr), 0, false});
+  if (iter != upstream_blocks_.begin()) {
+    auto const candidate   = std::prev(iter);
+    auto const segment_end = candidate->pointer + candidate->size;
+    if (candidate->pointer <= static_cast<char*>(ptr) && static_cast<char*>(ptr) < segment_end) {
+      return block_type{
+        static_cast<char*>(ptr), aligned_size, candidate->pointer == static_cast<char*>(ptr)};
+    }
+  }
+
+  return block;
+}
+
+std::pair<std::size_t, std::size_t> caching_memory_resource_impl::free_list_summary(
+  free_list const& blocks)
+{
+  std::size_t largest{};
+  std::size_t total{};
+  std::for_each(blocks.cbegin(), blocks.cend(), [&largest, &total](auto const& block) {
+    total += block.size();
+    largest = std::max(largest, block.size());
+  });
+  return {largest, total};
+}
+
+bool caching_memory_resource_impl::is_small_allocation(std::size_t size) const noexcept
+{
+  return size <= small_size_threshold;
+}
+
+bool caching_memory_resource_impl::should_split(block_type const& block,
+                                                std::size_t size) const noexcept
+{
+  auto const remaining = block.size() - size;
+  if (block_is_small(block)) { return remaining >= minimum_block_size; }
+  if (!max_split_size_.has_value()) { return remaining >= minimum_block_size; }
+  if (block.size() >= max_split_size_.value() && size < max_split_size_.value()) { return false; }
+  return remaining > small_size_threshold;
+}
+
+bool caching_memory_resource_impl::block_is_small(block_type const& block) const noexcept
+{
+  auto const iter = upstream_blocks_.upper_bound(segment{block.pointer(), 0, false});
+  if (iter == upstream_blocks_.begin()) { return block.size() <= small_size_threshold; }
+
+  auto const candidate   = std::prev(iter);
+  auto const segment_end = candidate->pointer + candidate->size;
+  if (candidate->pointer <= block.pointer() && block.pointer() < segment_end) {
+    return candidate->is_small;
+  }
+
+  return block.size() <= small_size_threshold;
+}
+
+std::size_t caching_memory_resource_impl::release_pool(bool is_small) noexcept
+{
+  for (auto const& upstream : upstream_blocks_) {
+    if (upstream.is_small != is_small) { continue; }
+    releasable_blocks_[upstream.pointer] = released_block{upstream.size, upstream.is_small};
+  }
+
+  std::size_t released{};
+
+  for (auto it = releasable_blocks_.begin(); it != releasable_blocks_.end();) {
+    auto const [ptr, info] = *it;
+    if (info.is_small != is_small) {
+      ++it;
+      continue;
+    }
+
+    auto const segment_it = upstream_blocks_.find(segment{ptr, 0, is_small});
+    if (segment_it == upstream_blocks_.end() || segment_it->size != info.size ||
+        segment_it->is_small != is_small) {
+      it = releasable_blocks_.erase(it);
+      continue;
+    }
+
+    get_upstream_resource().deallocate_sync(ptr, info.size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    released += info.size;
+    if (is_small) {
+      cached_small_bytes_ -= info.size;
+    } else {
+      cached_large_bytes_ -= info.size;
+    }
+    upstream_blocks_.erase(segment_it);
+    it = releasable_blocks_.erase(it);
+  }
+
+  return released;
+}
+
+caching_memory_resource_impl::block_type caching_memory_resource_impl::block_from_upstream(
+  std::size_t size, cuda_stream_view stream, bool is_small)
+{
+  void* ptr = get_upstream_resource().allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  upstream_blocks_.insert(segment{static_cast<char*>(ptr), size, is_small});
+  if (is_small) {
+    cached_small_bytes_ += size;
+  } else {
+    cached_large_bytes_ += size;
+  }
+  return block_type{static_cast<char*>(ptr), size, true};
+}
+
+}  // namespace detail
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/detail/caching_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/caching_memory_resource_impl.cpp
@@ -17,10 +17,12 @@ namespace detail {
 caching_memory_resource_impl::caching_memory_resource_impl(
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
   std::optional<std::size_t> max_split_size,
-  caching_memory_resource_oom_fallback_policy oom_fallback_policy)
+  caching_memory_resource_oom_fallback_policy oom_fallback_policy,
+  caching_memory_resource_pool_policy pool_policy)
   : upstream_mr_{std::move(upstream)},
     max_split_size_{max_split_size},
-    oom_fallback_policy_{oom_fallback_policy}
+    oom_fallback_policy_{oom_fallback_policy},
+    pool_policy_{pool_policy}
 {
 }
 
@@ -110,7 +112,12 @@ caching_memory_resource_impl::block_type caching_memory_resource_impl::get_block
 {
   auto const max_split_size = max_split_size_.value_or(std::numeric_limits<std::size_t>::max());
   return blocks.get_block(size, [this, size, max_split_size](block_type const& block) {
-    if (block_is_small(block)) { return true; }
+    auto const block_is_small_pool = block_is_small(block);
+    if (pool_policy_ == caching_memory_resource_pool_policy::separate &&
+        block_is_small_pool != is_small_allocation(size)) {
+      return false;
+    }
+    if (block_is_small_pool) { return true; }
     if (size < max_split_size && block.size() >= max_split_size) { return false; }
     return size < max_split_size || block.size() < size + large_segment_size;
   });

--- a/cpp/src/mr/detail/caching_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/caching_memory_resource_impl.cpp
@@ -18,11 +18,13 @@ caching_memory_resource_impl::caching_memory_resource_impl(
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
   std::optional<std::size_t> max_split_size,
   caching_memory_resource_oom_fallback_policy oom_fallback_policy,
-  caching_memory_resource_pool_policy pool_policy)
+  caching_memory_resource_pool_policy pool_policy,
+  caching_memory_resource_stream_reuse_policy stream_reuse_policy)
   : upstream_mr_{std::move(upstream)},
     max_split_size_{max_split_size},
     oom_fallback_policy_{oom_fallback_policy},
-    pool_policy_{pool_policy}
+    pool_policy_{pool_policy},
+    stream_reuse_policy_{stream_reuse_policy}
 {
 }
 
@@ -68,6 +70,11 @@ std::size_t caching_memory_resource_impl::upstream_allocation_size(std::size_t b
   if (bytes <= small_size_threshold) { return small_segment_size; }
   if (bytes < minimum_large_allocation) { return large_segment_size; }
   return rmm::align_up(bytes, large_rounding);
+}
+
+bool caching_memory_resource_impl::supports_cross_stream_reuse() const noexcept
+{
+  return stream_reuse_policy_ == caching_memory_resource_stream_reuse_policy::cross_stream;
 }
 
 std::size_t caching_memory_resource_impl::get_maximum_allocation_size() const

--- a/cpp/src/mr/detail/caching_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/caching_memory_resource_impl.cpp
@@ -16,8 +16,11 @@ namespace detail {
 
 caching_memory_resource_impl::caching_memory_resource_impl(
   cuda::mr::any_resource<cuda::mr::device_accessible> upstream,
-  std::optional<std::size_t> max_split_size)
-  : upstream_mr_{std::move(upstream)}, max_split_size_{max_split_size}
+  std::optional<std::size_t> max_split_size,
+  caching_memory_resource_oom_fallback_policy oom_fallback_policy)
+  : upstream_mr_{std::move(upstream)},
+    max_split_size_{max_split_size},
+    oom_fallback_policy_{oom_fallback_policy}
 {
 }
 
@@ -79,7 +82,24 @@ caching_memory_resource_impl::block_type caching_memory_resource_impl::expand_po
   try {
     return block_from_upstream(upstream_size, stream, is_small);
   } catch (rmm::out_of_memory const&) {
-    auto const released = release_pool(is_small);
+    if (oom_fallback_policy_ == caching_memory_resource_oom_fallback_policy::release_all) {
+      auto const released = release_all_pools();
+      if (released == 0) { throw; }
+      return block_from_upstream(upstream_size, stream, is_small);
+    }
+
+    if (release_oversized_blocks(upstream_size) != 0) {
+      auto const block = [&]() {
+        try {
+          return block_from_upstream(upstream_size, stream, is_small);
+        } catch (rmm::out_of_memory const&) {
+          return block_type{};
+        }
+      }();
+      if (block.is_valid()) { return block; }
+    }
+
+    auto const released = release_all_pools();
     if (released == 0) { throw; }
     return block_from_upstream(upstream_size, stream, is_small);
   }
@@ -198,6 +218,49 @@ std::size_t caching_memory_resource_impl::release_pool(bool is_small) noexcept
       cached_small_bytes_ -= size;
     } else {
       cached_large_bytes_ -= size;
+    }
+    it = upstream_blocks_.erase(it);
+  }
+
+  return released;
+}
+
+std::size_t caching_memory_resource_impl::release_all_pools() noexcept
+{
+  return release_pool(true) + release_pool(false);
+}
+
+std::size_t caching_memory_resource_impl::release_oversized_blocks(std::size_t size) noexcept
+{
+  auto const max_split_size = max_split_size_.value_or(std::numeric_limits<std::size_t>::max());
+  if (max_split_size == std::numeric_limits<std::size_t>::max()) { return 0; }
+
+  this->merge_all_free_blocks();
+
+  auto const target_size = std::max(size, max_split_size);
+  std::size_t released{};
+
+  for (auto it = upstream_blocks_.begin();
+       it != upstream_blocks_.end() && released < target_size;) {
+    if (it->size < max_split_size) {
+      ++it;
+      continue;
+    }
+
+    auto const block = block_type{it->pointer, it->size, true};
+    if (!this->remove_free_block(block)) {
+      ++it;
+      continue;
+    }
+
+    auto const block_size = it->size;
+    get_upstream_resource().deallocate_sync(
+      it->pointer, block_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    released += block_size;
+    if (it->is_small) {
+      cached_small_bytes_ -= block_size;
+    } else {
+      cached_large_bytes_ -= block_size;
     }
     it = upstream_blocks_.erase(it);
   }

--- a/cpp/src/mr/detail/caching_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/caching_memory_resource_impl.cpp
@@ -85,13 +85,24 @@ caching_memory_resource_impl::block_type caching_memory_resource_impl::expand_po
   }
 }
 
+caching_memory_resource_impl::block_type caching_memory_resource_impl::get_block_from_free_list(
+  free_list& blocks, std::size_t size)
+{
+  auto const max_split_size = max_split_size_.value_or(std::numeric_limits<std::size_t>::max());
+  return blocks.get_block(size, [this, size, max_split_size](block_type const& block) {
+    if (block_is_small(block)) { return true; }
+    if (size < max_split_size && block.size() >= max_split_size) { return false; }
+    return size < max_split_size || block.size() < size + large_segment_size;
+  });
+}
+
 caching_memory_resource_impl::split_block caching_memory_resource_impl::allocate_from_block(
   block_type const& block, std::size_t size)
 {
-  releasable_blocks_.erase(block.pointer());
-
-  auto const alloc = block_type{block.pointer(), size, block.is_head()};
-  if (!should_split(block, size)) { return {block, {}}; }
+  auto const split = should_split(block, size);
+  auto const alloc = block_type{block.pointer(), split ? size : block.size(), block.is_head()};
+  allocated_blocks_.insert(alloc);
+  if (!split) { return {alloc, {}}; }
 
   auto rest = block_type{block.pointer() + size, block.size() - size, false};
   return {alloc, rest};
@@ -100,12 +111,18 @@ caching_memory_resource_impl::split_block caching_memory_resource_impl::allocate
 caching_memory_resource_impl::block_type caching_memory_resource_impl::free_block(
   void* ptr, std::size_t size) noexcept
 {
-  auto const aligned_size = rmm::align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  auto const block        = block_type{static_cast<char*>(ptr), aligned_size, false};
+  auto const iter = allocated_blocks_.find(static_cast<char*>(ptr));
+  if (iter != allocated_blocks_.end()) {
+    auto block = *iter;
+    allocated_blocks_.erase(iter);
+    return block;
+  }
 
-  auto const iter = upstream_blocks_.upper_bound(segment{static_cast<char*>(ptr), 0, false});
-  if (iter != upstream_blocks_.begin()) {
-    auto const candidate   = std::prev(iter);
+  auto const aligned_size = rmm::align_up(size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto const upstream_iter =
+    upstream_blocks_.upper_bound(segment{static_cast<char*>(ptr), 0, false});
+  if (upstream_iter != upstream_blocks_.begin()) {
+    auto const candidate   = std::prev(upstream_iter);
     auto const segment_end = candidate->pointer + candidate->size;
     if (candidate->pointer <= static_cast<char*>(ptr) && static_cast<char*>(ptr) < segment_end) {
       return block_type{
@@ -113,7 +130,7 @@ caching_memory_resource_impl::block_type caching_memory_resource_impl::free_bloc
     }
   }
 
-  return block;
+  return block_type{static_cast<char*>(ptr), aligned_size, false};
 }
 
 std::pair<std::size_t, std::size_t> caching_memory_resource_impl::free_list_summary(
@@ -138,9 +155,8 @@ bool caching_memory_resource_impl::should_split(block_type const& block,
 {
   auto const remaining = block.size() - size;
   if (block_is_small(block)) { return remaining >= minimum_block_size; }
-  if (!max_split_size_.has_value()) { return remaining >= minimum_block_size; }
-  if (block.size() >= max_split_size_.value() && size < max_split_size_.value()) { return false; }
-  return remaining > small_size_threshold;
+  auto const max_split_size = max_split_size_.value_or(std::numeric_limits<std::size_t>::max());
+  return size < max_split_size && remaining > small_size_threshold;
 }
 
 bool caching_memory_resource_impl::block_is_small(block_type const& block) const noexcept
@@ -159,36 +175,31 @@ bool caching_memory_resource_impl::block_is_small(block_type const& block) const
 
 std::size_t caching_memory_resource_impl::release_pool(bool is_small) noexcept
 {
-  for (auto const& upstream : upstream_blocks_) {
-    if (upstream.is_small != is_small) { continue; }
-    releasable_blocks_[upstream.pointer] = released_block{upstream.size, upstream.is_small};
-  }
+  this->merge_all_free_blocks();
 
   std::size_t released{};
 
-  for (auto it = releasable_blocks_.begin(); it != releasable_blocks_.end();) {
-    auto const [ptr, info] = *it;
-    if (info.is_small != is_small) {
+  for (auto it = upstream_blocks_.begin(); it != upstream_blocks_.end();) {
+    if (it->is_small != is_small) {
       ++it;
       continue;
     }
 
-    auto const segment_it = upstream_blocks_.find(segment{ptr, 0, is_small});
-    if (segment_it == upstream_blocks_.end() || segment_it->size != info.size ||
-        segment_it->is_small != is_small) {
-      it = releasable_blocks_.erase(it);
+    auto const block = block_type{it->pointer, it->size, true};
+    if (!this->remove_free_block(block)) {
+      ++it;
       continue;
     }
 
-    get_upstream_resource().deallocate_sync(ptr, info.size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-    released += info.size;
+    auto const size = it->size;
+    get_upstream_resource().deallocate_sync(it->pointer, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    released += size;
     if (is_small) {
-      cached_small_bytes_ -= info.size;
+      cached_small_bytes_ -= size;
     } else {
-      cached_large_bytes_ -= info.size;
+      cached_large_bytes_ -= size;
     }
-    upstream_blocks_.erase(segment_it);
-    it = releasable_blocks_.erase(it);
+    it = upstream_blocks_.erase(it);
   }
 
   return released;

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -154,6 +154,7 @@ ConfigureTest(THREAD_SAFE_MR_REF_TEST mr/mr_ref_thread_safe_tests.cpp GPUS 1 PER
 
 # pool mr tests
 ConfigureTest(POOL_MR_TEST mr/pool_mr_tests.cpp GPUS 1 PERCENT 100)
+ConfigureTest(CACHING_MR_TEST mr/caching_mr_tests.cpp GPUS 1 PERCENT 100)
 ConfigureTest(POOL_MR_REF_TEST mr/mr_ref_pool_tests.cpp GPUS 1 PERCENT 100)
 ConfigureTest(PINNED_POOL_MR_REF_TEST mr/mr_ref_pinned_pool_tests.cpp)
 

--- a/cpp/tests/mr/caching_mr_tests.cpp
+++ b/cpp/tests/mr/caching_mr_tests.cpp
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/error.hpp>
+#include <rmm/mr/caching_memory_resource.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/limiting_resource_adaptor.hpp>
+#include <rmm/mr/per_device_resource.hpp>
+
+#include <gtest/gtest.h>
+
+namespace rmm::test {
+namespace {
+
+using caching_mr  = rmm::mr::caching_memory_resource;
+using cuda_mr     = rmm::mr::cuda_memory_resource;
+using limiting_mr = rmm::mr::limiting_resource_adaptor;
+
+TEST(CachingMemoryResourceTest, UpstreamSizingPolicy)
+{
+  caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+  EXPECT_EQ(mr.upstream_allocation_size(1), 2UL << 20);
+  EXPECT_EQ(mr.upstream_allocation_size(1UL << 20), 2UL << 20);
+  EXPECT_EQ(mr.upstream_allocation_size((1UL << 20) + 1), 20UL << 20);
+  EXPECT_EQ(mr.upstream_allocation_size((10UL << 20) + 1), 12UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, ReusesSmallAllocation)
+{
+  caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+  auto* ptr1 = mr.allocate_sync(4096);
+  ASSERT_NE(ptr1, nullptr);
+  mr.deallocate_sync(ptr1, 4096);
+  auto* ptr2 = mr.allocate_sync(4096);
+  EXPECT_EQ(ptr1, ptr2);
+  mr.deallocate_sync(ptr2, 4096);
+}
+
+TEST(CachingMemoryResourceTest, ReleasesCachedBlocksOnFailure)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 22UL << 20};
+  caching_mr mr{limiter};
+
+  auto* small = mr.allocate_sync(4096);
+  mr.deallocate_sync(small, 4096);
+
+  EXPECT_EQ(mr.cached_small_bytes(), 2UL << 20);
+  EXPECT_NO_THROW((void)mr.allocate_sync(20UL << 20));
+}
+
+TEST(CachingMemoryResourceTest, ReleaseDropsCachedBytes)
+{
+  caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+  auto* ptr = mr.allocate_sync(4096);
+  mr.deallocate_sync(ptr, 4096);
+  EXPECT_GT(mr.cached_small_bytes(), 0);
+  EXPECT_GT(mr.release_small_blocks(), 0);
+  EXPECT_EQ(mr.cached_small_bytes(), 0);
+}
+
+}  // namespace
+
+namespace test_properties {
+
+static_assert(
+  cuda::mr::resource_with<rmm::mr::caching_memory_resource, cuda::mr::device_accessible>);
+
+}  // namespace test_properties
+
+}  // namespace rmm::test

--- a/cpp/tests/mr/caching_mr_tests.cpp
+++ b/cpp/tests/mr/caching_mr_tests.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_stream.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/caching_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
@@ -41,14 +42,182 @@ TEST(CachingMemoryResourceTest, ReusesSmallAllocation)
 TEST(CachingMemoryResourceTest, ReleasesCachedBlocksOnFailure)
 {
   cuda_mr cuda;
-  limiting_mr limiter{cuda, 22UL << 20};
+  limiting_mr limiter{cuda, 41UL << 20};
   caching_mr mr{limiter};
 
-  auto* small = mr.allocate_sync(4096);
-  mr.deallocate_sync(small, 4096);
+  auto* first = mr.allocate_sync(2UL << 20);
+  mr.deallocate_sync(first, 2UL << 20);
 
-  EXPECT_EQ(mr.cached_small_bytes(), 2UL << 20);
-  EXPECT_NO_THROW((void)mr.allocate_sync(20UL << 20));
+  EXPECT_EQ(mr.cached_large_bytes(), 20UL << 20);
+  void* large{};
+  EXPECT_NO_THROW(large = mr.allocate_sync(22UL << 20));
+  EXPECT_EQ(limiter.get_allocated_bytes(), 22UL << 20);
+  mr.deallocate_sync(large, 22UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, DoesNotReleaseLiveSmallSegment)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 2UL << 20};
+  caching_mr mr{limiter};
+
+  auto* ptr = mr.allocate_sync(4096);
+  EXPECT_EQ(mr.release_small_blocks(), 0);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 2UL << 20);
+  mr.deallocate_sync(ptr, 4096);
+  EXPECT_EQ(mr.release_small_blocks(), 2UL << 20);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 0);
+}
+
+TEST(CachingMemoryResourceTest, DoesNotReleasePartiallyFreeSmallSegment)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 2UL << 20};
+  caching_mr mr{limiter};
+
+  auto* ptr1 = mr.allocate_sync(4096);
+  auto* ptr2 = mr.allocate_sync(4096);
+  mr.deallocate_sync(ptr1, 4096);
+
+  EXPECT_EQ(mr.release_small_blocks(), 0);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 2UL << 20);
+
+  mr.deallocate_sync(ptr2, 4096);
+  EXPECT_EQ(mr.release_small_blocks(), 2UL << 20);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 0);
+}
+
+TEST(CachingMemoryResourceTest, ReleaseMergesCrossStreamFreeBlocks)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 2UL << 20};
+  caching_mr mr{limiter};
+  rmm::cuda_stream stream{};
+
+  auto* ptr1 = mr.allocate_sync(4096);
+  auto* ptr2 = mr.allocate_sync(4096);
+  mr.deallocate_sync(ptr1, 4096);
+  mr.deallocate(rmm::cuda_stream_view{stream}, ptr2, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  stream.synchronize();
+
+  EXPECT_EQ(mr.release_small_blocks(), 2UL << 20);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 0);
+}
+
+TEST(CachingMemoryResourceTest, MediumAllocationUsesLargeSegment)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 20UL << 20};
+  caching_mr mr{limiter};
+
+  auto* ptr = mr.allocate_sync(2UL << 20);
+  EXPECT_EQ(mr.cached_large_bytes(), 20UL << 20);
+  mr.deallocate_sync(ptr, 2UL << 20);
+  EXPECT_EQ(mr.release_large_blocks(), 20UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, LargeRemainderTooSmallConsumesWholeBlock)
+{
+  caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+
+  auto* large = mr.allocate_sync(4UL << 20);
+  mr.deallocate_sync(large, 4UL << 20);
+
+  auto* small = mr.allocate_sync(19UL << 20);
+  EXPECT_EQ(large, small);
+  EXPECT_EQ(mr.release_large_blocks(), 0);
+  mr.deallocate_sync(small, 19UL << 20);
+  EXPECT_EQ(mr.release_large_blocks(), 20UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, MaxSplitSizePreventsSplittingLargeBlock)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 40UL << 20};
+  caching_mr mr{limiter, 4UL << 20};
+
+  auto* large = mr.allocate_sync(6UL << 20);
+  mr.deallocate_sync(large, 6UL << 20);
+
+  auto* small = mr.allocate_sync(2UL << 20);
+  EXPECT_NE(large, small);
+  mr.deallocate_sync(small, 2UL << 20);
+  EXPECT_EQ(mr.release_large_blocks(), 40UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, ReusesOtherStreamAllocation)
+{
+  caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+  rmm::cuda_stream stream{};
+
+  auto* ptr1 = mr.allocate(rmm::cuda_stream_view{stream}, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(rmm::cuda_stream_view{stream}, ptr1, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr2 = mr.allocate_sync(4096);
+
+  EXPECT_EQ(ptr1, ptr2);
+  mr.deallocate_sync(ptr2, 4096);
+}
+
+TEST(CachingMemoryResourceTest, ReusesDeletedStreamAllocation)
+{
+  caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+
+  void* ptr1{};
+  {
+    rmm::cuda_stream stream{};
+    ptr1 = mr.allocate(rmm::cuda_stream_view{stream}, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    mr.deallocate(rmm::cuda_stream_view{stream}, ptr1, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    stream.synchronize();
+  }
+
+  auto* ptr2 = mr.allocate_sync(4096);
+  EXPECT_EQ(ptr1, ptr2);
+  mr.deallocate_sync(ptr2, 4096);
+}
+
+TEST(CachingMemoryResourceTest, DestructorReleasesCachedBlocks)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 2UL << 20};
+
+  {
+    caching_mr mr{limiter};
+    auto* ptr = mr.allocate_sync(4096);
+    mr.deallocate_sync(ptr, 4096);
+    EXPECT_EQ(limiter.get_allocated_bytes(), 2UL << 20);
+  }
+
+  EXPECT_EQ(limiter.get_allocated_bytes(), 0);
+}
+
+TEST(CachingMemoryResourceTest, SmallRemainderTooSmallConsumesWholeBlock)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 2UL << 20};
+  caching_mr mr{limiter};
+
+  auto* first  = mr.allocate_sync(1UL << 20);
+  auto* second = mr.allocate_sync((1UL << 20) - 256);
+
+  EXPECT_THROW((void)mr.allocate_sync(256), rmm::out_of_memory);
+
+  mr.deallocate_sync(second, (1UL << 20) - 256);
+  mr.deallocate_sync(first, 1UL << 20);
+  EXPECT_EQ(mr.release_small_blocks(), 2UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, SplitsReusableLargeBlock)
+{
+  caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+
+  auto* large = mr.allocate_sync(4UL << 20);
+  mr.deallocate_sync(large, 4UL << 20);
+
+  auto* smaller = mr.allocate_sync(2UL << 20);
+  EXPECT_EQ(large, smaller);
+  EXPECT_EQ(mr.release_large_blocks(), 0);
+  mr.deallocate_sync(smaller, 2UL << 20);
+  EXPECT_EQ(mr.release_large_blocks(), 20UL << 20);
 }
 
 TEST(CachingMemoryResourceTest, ReleaseDropsCachedBytes)

--- a/cpp/tests/mr/caching_mr_tests.cpp
+++ b/cpp/tests/mr/caching_mr_tests.cpp
@@ -19,6 +19,7 @@ using caching_mr  = rmm::mr::caching_memory_resource;
 using cuda_mr     = rmm::mr::cuda_memory_resource;
 using limiting_mr = rmm::mr::limiting_resource_adaptor;
 using oom_policy  = rmm::mr::caching_memory_resource_oom_fallback_policy;
+using pool_policy = rmm::mr::caching_memory_resource_pool_policy;
 
 TEST(CachingMemoryResourceTest, UpstreamSizingPolicy)
 {
@@ -90,6 +91,68 @@ TEST(CachingMemoryResourceTest, OversizedThenAllFallbackPreservesOtherPool)
   EXPECT_EQ(mr.cached_small_bytes(), 2UL << 20);
   EXPECT_EQ(limiter.get_allocated_bytes(), 22UL << 20);
   mr.deallocate_sync(ptr, 3UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, SeparatePoolPolicyDoesNotReuseLargeBlockForSmallRequest)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 22UL << 20};
+  caching_mr mr{limiter};
+
+  auto* large = mr.allocate_sync(2UL << 20);
+  mr.deallocate_sync(large, 2UL << 20);
+
+  auto* small = mr.allocate_sync(4096);
+  EXPECT_NE(large, small);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 22UL << 20);
+  mr.deallocate_sync(small, 4096);
+}
+
+TEST(CachingMemoryResourceTest, UnifiedPoolPolicyReusesLargeBlockForSmallRequest)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 20UL << 20};
+  caching_mr mr{
+    limiter, std::nullopt, oom_policy::release_oversized_then_all, pool_policy::unified};
+
+  auto* large = mr.allocate_sync(2UL << 20);
+  mr.deallocate_sync(large, 2UL << 20);
+
+  auto* small = mr.allocate_sync(4096);
+  EXPECT_EQ(large, small);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 20UL << 20);
+  mr.deallocate_sync(small, 4096);
+}
+
+TEST(CachingMemoryResourceTest, SeparatePoolPolicyDoesNotReuseSmallBlockForLargeRequest)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 22UL << 20};
+  caching_mr mr{limiter};
+
+  auto* small = mr.allocate_sync(1UL << 20);
+  mr.deallocate_sync(small, 1UL << 20);
+
+  auto* large = mr.allocate_sync(2UL << 20);
+  EXPECT_NE(small, large);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 22UL << 20);
+  mr.deallocate_sync(large, 2UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, UnifiedPoolPolicyReusesSmallBlockForLargeRequest)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 2UL << 20};
+  caching_mr mr{
+    limiter, std::nullopt, oom_policy::release_oversized_then_all, pool_policy::unified};
+
+  auto* small = mr.allocate_sync(1UL << 20);
+  mr.deallocate_sync(small, 1UL << 20);
+
+  auto* large = mr.allocate_sync(2UL << 20);
+  EXPECT_EQ(small, large);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 2UL << 20);
+  mr.deallocate_sync(large, 2UL << 20);
 }
 
 TEST(CachingMemoryResourceTest, DoesNotReleaseLiveSmallSegment)

--- a/cpp/tests/mr/caching_mr_tests.cpp
+++ b/cpp/tests/mr/caching_mr_tests.cpp
@@ -18,6 +18,7 @@ namespace {
 using caching_mr  = rmm::mr::caching_memory_resource;
 using cuda_mr     = rmm::mr::cuda_memory_resource;
 using limiting_mr = rmm::mr::limiting_resource_adaptor;
+using oom_policy  = rmm::mr::caching_memory_resource_oom_fallback_policy;
 
 TEST(CachingMemoryResourceTest, UpstreamSizingPolicy)
 {
@@ -53,6 +54,42 @@ TEST(CachingMemoryResourceTest, ReleasesCachedBlocksOnFailure)
   EXPECT_NO_THROW(large = mr.allocate_sync(22UL << 20));
   EXPECT_EQ(limiter.get_allocated_bytes(), 22UL << 20);
   mr.deallocate_sync(large, 22UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, ReleaseAllFallbackReleasesBothPools)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 22UL << 20};
+  caching_mr mr{limiter, 4UL << 20, oom_policy::release_all};
+
+  auto* small = mr.allocate_sync(4096);
+  auto* large = mr.allocate_sync(2UL << 20);
+  mr.deallocate_sync(small, 4096);
+  mr.deallocate_sync(large, 2UL << 20);
+
+  void* ptr{};
+  EXPECT_NO_THROW(ptr = mr.allocate_sync(3UL << 20));
+  EXPECT_EQ(mr.cached_small_bytes(), 0);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 20UL << 20);
+  mr.deallocate_sync(ptr, 3UL << 20);
+}
+
+TEST(CachingMemoryResourceTest, OversizedThenAllFallbackPreservesOtherPool)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 22UL << 20};
+  caching_mr mr{limiter, 4UL << 20, oom_policy::release_oversized_then_all};
+
+  auto* small = mr.allocate_sync(4096);
+  auto* large = mr.allocate_sync(2UL << 20);
+  mr.deallocate_sync(small, 4096);
+  mr.deallocate_sync(large, 2UL << 20);
+
+  void* ptr{};
+  EXPECT_NO_THROW(ptr = mr.allocate_sync(3UL << 20));
+  EXPECT_EQ(mr.cached_small_bytes(), 2UL << 20);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 22UL << 20);
+  mr.deallocate_sync(ptr, 3UL << 20);
 }
 
 TEST(CachingMemoryResourceTest, DoesNotReleaseLiveSmallSegment)

--- a/cpp/tests/mr/caching_mr_tests.cpp
+++ b/cpp/tests/mr/caching_mr_tests.cpp
@@ -15,11 +15,12 @@
 namespace rmm::test {
 namespace {
 
-using caching_mr  = rmm::mr::caching_memory_resource;
-using cuda_mr     = rmm::mr::cuda_memory_resource;
-using limiting_mr = rmm::mr::limiting_resource_adaptor;
-using oom_policy  = rmm::mr::caching_memory_resource_oom_fallback_policy;
-using pool_policy = rmm::mr::caching_memory_resource_pool_policy;
+using caching_mr    = rmm::mr::caching_memory_resource;
+using cuda_mr       = rmm::mr::cuda_memory_resource;
+using limiting_mr   = rmm::mr::limiting_resource_adaptor;
+using oom_policy    = rmm::mr::caching_memory_resource_oom_fallback_policy;
+using pool_policy   = rmm::mr::caching_memory_resource_pool_policy;
+using stream_policy = rmm::mr::caching_memory_resource_stream_reuse_policy;
 
 TEST(CachingMemoryResourceTest, UpstreamSizingPolicy)
 {
@@ -247,7 +248,11 @@ TEST(CachingMemoryResourceTest, MaxSplitSizePreventsSplittingLargeBlock)
 
 TEST(CachingMemoryResourceTest, ReusesOtherStreamAllocation)
 {
-  caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+  caching_mr mr{rmm::mr::get_current_device_resource_ref(),
+                std::nullopt,
+                oom_policy::release_oversized_then_all,
+                pool_policy::separate,
+                stream_policy::cross_stream};
   rmm::cuda_stream stream{};
 
   auto* ptr1 = mr.allocate(rmm::cuda_stream_view{stream}, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
@@ -258,9 +263,43 @@ TEST(CachingMemoryResourceTest, ReusesOtherStreamAllocation)
   mr.deallocate_sync(ptr2, 4096);
 }
 
-TEST(CachingMemoryResourceTest, ReusesDeletedStreamAllocation)
+TEST(CachingMemoryResourceTest, SameStreamPolicyDoesNotReuseOtherStreamAllocation)
+{
+  cuda_mr cuda;
+  limiting_mr limiter{cuda, 4UL << 20};
+  caching_mr mr{limiter};
+  rmm::cuda_stream stream{};
+
+  auto* ptr1 = mr.allocate(rmm::cuda_stream_view{stream}, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(rmm::cuda_stream_view{stream}, ptr1, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  stream.synchronize();
+
+  auto* ptr2 = mr.allocate_sync(4096);
+  EXPECT_NE(ptr1, ptr2);
+  EXPECT_EQ(limiter.get_allocated_bytes(), 4UL << 20);
+  mr.deallocate_sync(ptr2, 4096);
+}
+
+TEST(CachingMemoryResourceTest, SameStreamPolicyReusesSameStreamAllocation)
 {
   caching_mr mr{rmm::mr::get_current_device_resource_ref()};
+  rmm::cuda_stream stream{};
+
+  auto* ptr1 = mr.allocate(rmm::cuda_stream_view{stream}, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  mr.deallocate(rmm::cuda_stream_view{stream}, ptr1, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto* ptr2 = mr.allocate(rmm::cuda_stream_view{stream}, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  EXPECT_EQ(ptr1, ptr2);
+  mr.deallocate(rmm::cuda_stream_view{stream}, ptr2, 4096, rmm::CUDA_ALLOCATION_ALIGNMENT);
+}
+
+TEST(CachingMemoryResourceTest, ReusesDeletedStreamAllocation)
+{
+  caching_mr mr{rmm::mr::get_current_device_resource_ref(),
+                std::nullopt,
+                oom_policy::release_oversized_then_all,
+                pool_policy::separate,
+                stream_policy::cross_stream};
 
   void* ptr1{};
   {


### PR DESCRIPTION
## Description
This is a draft, not ready for review.

I am experimenting with a memory allocator inspired by PyTorch's caching allocator. I plan to compare its performance over a range of workloads, fragmentation behavior, and OOM resilience against the existing RMM pool and arena memory resources.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
