### PR TITLE
Fix callback resource alignment forwarding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
     rev: v0.19.0
     hooks:
       - id: cython-lint
+        # Accommodates the canonical 104-char SPDX copyright header enforced by verify-copyright.
         args: ["--max-line-length=104"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
     rev: v0.19.0
     hooks:
       - id: cython-lint
+        args: ["--max-line-length=104"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v20.1.8
     hooks:

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -24,32 +24,35 @@ namespace mr {
  * @brief Callback function type used by callback memory resource for allocation.
  *
  * The signature of the callback function is:
- *   `void* allocate_callback_t(std::size_t bytes, cuda_stream_view stream, void* arg);`
+ *   `void* allocate_callback_t(cuda_stream_view stream, std::size_t bytes, std::size_t alignment,
+ *                             void* arg);`
  *
  * * Returns a pointer to an allocation of at least `bytes` usable immediately on
- *   `stream`. The stream-ordered behavior requirements are identical to
- *   `allocate`.
+ *   `stream` with the requested `alignment`. The stream-ordered behavior requirements are
+ *   identical to `allocate`.
  *
  * * The `arg` is provided to the constructor of the `callback_memory_resource`
  *   and will be forwarded along to every invocation of the callback function.
  */
-using allocate_callback_t = std::function<void*(std::size_t, cuda_stream_view, void*)>;
+using allocate_callback_t = std::function<void*(cuda_stream_view, std::size_t, std::size_t, void*)>;
 
 /**
  * @brief Callback function type used by callback_memory_resource for deallocation.
  *
  * The signature of the callback function is:
- *   `void deallocate_callback_t(void* ptr, std::size_t bytes, cuda_stream_view stream, void* arg);`
+ *   `void deallocate_callback_t(cuda_stream_view stream, void* ptr, std::size_t bytes,
+ *                              std::size_t alignment, void* arg);`
  *
  * * Deallocates memory pointed to by `ptr`. `bytes` specifies the size of the allocation
  *   in bytes, and must equal the value of `bytes` that was passed to the allocate callback
- *   function. The stream-ordered behavior requirements are identical to
- *   `deallocate`.
+ *   function. `alignment` must equal the value of `alignment` that was passed to the allocate
+ *   callback function. The stream-ordered behavior requirements are identical to `deallocate`.
  *
  * * The `arg` is provided to the constructor of the `callback_memory_resource`
  *   and will be forwarded along to every invocation of the callback function.
  */
-using deallocate_callback_t = std::function<void(void*, std::size_t, cuda_stream_view, void*)>;
+using deallocate_callback_t =
+  std::function<void(cuda_stream_view, void*, std::size_t, std::size_t, void*)>;
 
 namespace detail {
 class callback_memory_resource_impl;

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -24,7 +24,7 @@ namespace mr {
  * @brief Callback function type used by callback memory resource for allocation.
  *
  * The signature of the callback function is:
- *   `void* allocate_callback_t(cuda_stream_view stream, std::size_t bytes, std::size_t alignment,
+ *   `void* allocate_callback_t(cuda::stream_ref stream, std::size_t bytes, std::size_t alignment,
  *                             void* arg);`
  *
  * * The callback receives only valid power-of-two alignment values. An invalid alignment raises
@@ -37,13 +37,13 @@ namespace mr {
  * * The `arg` is provided to the constructor of the `callback_memory_resource`
  *   and will be forwarded along to every invocation of the callback function.
  */
-using allocate_callback_t = std::function<void*(cuda_stream_view, std::size_t, std::size_t, void*)>;
+using allocate_callback_t = std::function<void*(cuda::stream_ref, std::size_t, std::size_t, void*)>;
 
 /**
  * @brief Callback function type used by callback_memory_resource for deallocation.
  *
  * The signature of the callback function is:
- *   `void deallocate_callback_t(cuda_stream_view stream, void* ptr, std::size_t bytes,
+ *   `void deallocate_callback_t(cuda::stream_ref stream, void* ptr, std::size_t bytes,
  *                              std::size_t alignment, void* arg);`
  *
  * * Deallocates memory pointed to by `ptr`. `bytes` specifies the size of the allocation
@@ -58,7 +58,7 @@ using allocate_callback_t = std::function<void*(cuda_stream_view, std::size_t, s
  *   and will be forwarded along to every invocation of the callback function.
  */
 using deallocate_callback_t =
-  std::function<void(cuda_stream_view, void*, std::size_t, std::size_t, void*)>;
+  std::function<void(cuda::stream_ref, void*, std::size_t, std::size_t, void*)>;
 
 namespace detail {
 class callback_memory_resource_impl;

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -27,6 +27,9 @@ namespace mr {
  *   `void* allocate_callback_t(cuda_stream_view stream, std::size_t bytes, std::size_t alignment,
  *                             void* arg);`
  *
+ * * The callback receives only valid power-of-two alignment values. An invalid alignment raises
+ *   `rmm::logic_error` before callback invocation.
+ *
  * * Returns a pointer to an allocation of at least `bytes` usable immediately on
  *   `stream` with the requested `alignment`. The stream-ordered behavior requirements are
  *   identical to `allocate`.

--- a/cpp/include/rmm/mr/callback_memory_resource.hpp
+++ b/cpp/include/rmm/mr/callback_memory_resource.hpp
@@ -48,6 +48,9 @@ using allocate_callback_t = std::function<void*(cuda_stream_view, std::size_t, s
  *   function. `alignment` must equal the value of `alignment` that was passed to the allocate
  *   callback function. The stream-ordered behavior requirements are identical to `deallocate`.
  *
+ * * The callback must not throw. An exception escaping the callback causes termination because
+ *   deallocation is `noexcept`.
+ *
  * * The `arg` is provided to the constructor of the `callback_memory_resource`
  *   and will be forwarded along to every invocation of the callback function.
  */
@@ -85,7 +88,7 @@ class RMM_EXPORT callback_memory_resource
    * `allocate_callback` for allocation and `deallocate_callback` for deallocation.
    *
    * @param allocate_callback The callback function used for allocation
-   * @param deallocate_callback The callback function used for deallocation
+   * @param deallocate_callback The callback function used for deallocation. It must not throw.
    * @param allocate_callback_arg Additional context passed to `allocate_callback`.
    * It is the caller's responsibility to maintain the lifetime of the pointed-to data
    * for the duration of the lifetime of the `callback_memory_resource`.

--- a/cpp/include/rmm/mr/detail/callback_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/callback_memory_resource_impl.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -28,8 +28,9 @@ namespace detail {
 class callback_memory_resource_impl {
  public:
   callback_memory_resource_impl(
-    std::function<void*(std::size_t, cuda_stream_view, void*)> allocate_callback,
-    std::function<void(void*, std::size_t, cuda_stream_view, void*)> deallocate_callback,
+    std::function<void*(cuda_stream_view, std::size_t, std::size_t, void*)> allocate_callback,
+    std::function<void(cuda_stream_view, void*, std::size_t, std::size_t, void*)>
+      deallocate_callback,
     void* allocate_callback_arg,
     void* deallocate_callback_arg) noexcept;
 
@@ -71,8 +72,9 @@ class callback_memory_resource_impl {
   }
 
  private:
-  std::function<void*(std::size_t, cuda_stream_view, void*)> allocate_callback_;
-  std::function<void(void*, std::size_t, cuda_stream_view, void*)> deallocate_callback_;
+  std::function<void*(cuda_stream_view, std::size_t, std::size_t, void*)> allocate_callback_;
+  std::function<void(cuda_stream_view, void*, std::size_t, std::size_t, void*)>
+    deallocate_callback_;
   void* allocate_callback_arg_;
   void* deallocate_callback_arg_;
 };

--- a/cpp/include/rmm/mr/detail/callback_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/callback_memory_resource_impl.hpp
@@ -4,11 +4,11 @@
  */
 #pragma once
 
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
 #include <cstddef>
 #include <functional>
@@ -28,8 +28,8 @@ namespace detail {
 class callback_memory_resource_impl {
  public:
   callback_memory_resource_impl(
-    std::function<void*(cuda_stream_view, std::size_t, std::size_t, void*)> allocate_callback,
-    std::function<void(cuda_stream_view, void*, std::size_t, std::size_t, void*)>
+    std::function<void*(cuda::stream_ref, std::size_t, std::size_t, void*)> allocate_callback,
+    std::function<void(cuda::stream_ref, void*, std::size_t, std::size_t, void*)>
       deallocate_callback,
     void* allocate_callback_arg,
     void* deallocate_callback_arg) noexcept;
@@ -73,8 +73,8 @@ class callback_memory_resource_impl {
   }
 
  private:
-  std::function<void*(cuda_stream_view, std::size_t, std::size_t, void*)> allocate_callback_;
-  std::function<void(cuda_stream_view, void*, std::size_t, std::size_t, void*)>
+  std::function<void*(cuda::stream_ref, std::size_t, std::size_t, void*)> allocate_callback_;
+  std::function<void(cuda::stream_ref, void*, std::size_t, std::size_t, void*)>
     deallocate_callback_;
   void* allocate_callback_arg_;
   void* deallocate_callback_arg_;

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -1,8 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/aligned.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/callback_memory_resource_impl.hpp>
 
@@ -16,8 +17,8 @@ namespace mr {
 namespace detail {
 
 callback_memory_resource_impl::callback_memory_resource_impl(
-  std::function<void*(std::size_t, cuda_stream_view, void*)> allocate_callback,
-  std::function<void(void*, std::size_t, cuda_stream_view, void*)> deallocate_callback,
+  std::function<void*(cuda_stream_view, std::size_t, std::size_t, void*)> allocate_callback,
+  std::function<void(cuda_stream_view, void*, std::size_t, std::size_t, void*)> deallocate_callback,
   void* allocate_callback_arg,
   void* deallocate_callback_arg) noexcept
   : allocate_callback_(std::move(allocate_callback)),
@@ -29,17 +30,20 @@ callback_memory_resource_impl::callback_memory_resource_impl(
 
 void* callback_memory_resource_impl::allocate(cuda::stream_ref stream,
                                               std::size_t bytes,
-                                              std::size_t /*alignment*/)
+                                              std::size_t alignment)
 {
-  return allocate_callback_(bytes, cuda_stream_view{stream.get()}, allocate_callback_arg_);
+  RMM_EXPECTS(rmm::is_supported_alignment(alignment), "Allocation alignment is not a power of 2.");
+  return allocate_callback_(
+    cuda_stream_view{stream.get()}, bytes, alignment, allocate_callback_arg_);
 }
 
 void callback_memory_resource_impl::deallocate(cuda::stream_ref stream,
                                                void* ptr,
                                                std::size_t bytes,
-                                               std::size_t /*alignment*/) noexcept
+                                               std::size_t alignment) noexcept
 {
-  deallocate_callback_(ptr, bytes, cuda_stream_view{stream.get()}, deallocate_callback_arg_);
+  deallocate_callback_(
+    cuda_stream_view{stream.get()}, ptr, bytes, alignment, deallocate_callback_arg_);
 }
 
 void* callback_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -17,8 +17,8 @@ namespace mr {
 namespace detail {
 
 callback_memory_resource_impl::callback_memory_resource_impl(
-  std::function<void*(cuda_stream_view, std::size_t, std::size_t, void*)> allocate_callback,
-  std::function<void(cuda_stream_view, void*, std::size_t, std::size_t, void*)> deallocate_callback,
+  std::function<void*(cuda::stream_ref, std::size_t, std::size_t, void*)> allocate_callback,
+  std::function<void(cuda::stream_ref, void*, std::size_t, std::size_t, void*)> deallocate_callback,
   void* allocate_callback_arg,
   void* deallocate_callback_arg) noexcept
   : allocate_callback_(std::move(allocate_callback)),
@@ -33,8 +33,7 @@ void* callback_memory_resource_impl::allocate(cuda::stream_ref stream,
                                               std::size_t alignment)
 {
   RMM_EXPECTS(rmm::is_supported_alignment(alignment), "Allocation alignment is not a power of 2.");
-  return allocate_callback_(
-    cuda_stream_view{stream.get()}, bytes, alignment, allocate_callback_arg_);
+  return allocate_callback_(stream, bytes, alignment, allocate_callback_arg_);
 }
 
 void callback_memory_resource_impl::deallocate(cuda::stream_ref stream,
@@ -42,8 +41,7 @@ void callback_memory_resource_impl::deallocate(cuda::stream_ref stream,
                                                std::size_t bytes,
                                                std::size_t alignment) noexcept
 {
-  deallocate_callback_(
-    cuda_stream_view{stream.get()}, ptr, bytes, alignment, deallocate_callback_arg_);
+  deallocate_callback_(stream, ptr, bytes, alignment, deallocate_callback_arg_);
 }
 
 void* callback_memory_resource_impl::allocate_sync(std::size_t bytes, std::size_t alignment)

--- a/cpp/tests/mr/callback_mr_tests.cpp
+++ b/cpp/tests/mr/callback_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -7,7 +7,9 @@
 #include "../mock_resource.hpp"
 
 #include <rmm/aligned.hpp>
+#include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/error.hpp>
 #include <rmm/mr/callback_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
@@ -26,43 +28,115 @@ using ::testing::_;
 
 TEST(CallbackTest, TestCallbacksAreInvoked)
 {
-  auto base_mr      = mock_resource();
-  auto base_wrapper = mock_resource_wrapper{&base_mr};
-  auto base_ref     = device_async_resource_ref{base_wrapper};
-  EXPECT_CALL(base_mr, allocate(_, 10_MiB, _)).Times(1);
-  EXPECT_CALL(base_mr, deallocate(_, _, 10_MiB, _)).Times(1);
+  auto const size      = std::size_t{10_MiB};
+  auto const alignment = std::size_t{128};
+  auto base_mr         = mock_resource();
+  auto base_wrapper    = mock_resource_wrapper{&base_mr};
+  auto base_ref        = device_async_resource_ref{base_wrapper};
+  EXPECT_CALL(base_mr, allocate(_, size, alignment)).Times(1);
+  EXPECT_CALL(base_mr, deallocate(_, _, size, alignment)).Times(1);
 
-  auto allocate_callback = [](std::size_t size, cuda_stream_view stream, void* arg) {
-    auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
-    return base_mr.allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  };
-  auto deallocate_callback = [](void* ptr, std::size_t size, cuda_stream_view stream, void* arg) {
-    auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
-    base_mr.deallocate(stream, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  };
+  auto allocate_callback =
+    [](cuda_stream_view stream, std::size_t size, std::size_t alignment, void* arg) {
+      auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
+      return base_mr.allocate(stream, size, alignment);
+    };
+  auto deallocate_callback =
+    [](cuda_stream_view stream, void* ptr, std::size_t size, std::size_t alignment, void* arg) {
+      auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
+      base_mr.deallocate(stream, ptr, size, alignment);
+    };
   auto mr =
     rmm::mr::callback_memory_resource(allocate_callback, deallocate_callback, &base_ref, &base_ref);
-  auto const size = std::size_t{10_MiB};
-  auto* ptr       = mr.allocate_sync(size);
-  mr.deallocate_sync(ptr, size);
+  auto* ptr = mr.allocate_sync(size, alignment);
+  mr.deallocate_sync(ptr, size, alignment);
+}
+
+TEST(CallbackTest, ForwardsAllocationMetadata)
+{
+  auto base_mr         = rmm::mr::get_current_device_resource_ref();
+  auto stream          = rmm::cuda_stream{};
+  auto const size      = std::size_t{1024};
+  auto const alignment = std::size_t{128};
+
+  cuda_stream_view allocation_stream{};
+  cuda_stream_view deallocation_stream{};
+  void* allocation_ptr{};
+  void* deallocation_ptr{};
+  std::size_t allocation_size{};
+  std::size_t deallocation_size{};
+  std::size_t allocation_alignment{};
+  std::size_t deallocation_alignment{};
+
+  auto allocate_callback = [&](cuda_stream_view callback_stream,
+                               std::size_t callback_size,
+                               std::size_t callback_alignment,
+                               void*) {
+    allocation_stream    = callback_stream;
+    allocation_size      = callback_size;
+    allocation_alignment = callback_alignment;
+    allocation_ptr       = base_mr.allocate(callback_stream, callback_size, callback_alignment);
+    return allocation_ptr;
+  };
+  auto deallocate_callback = [&](cuda_stream_view callback_stream,
+                                 void* ptr,
+                                 std::size_t callback_size,
+                                 std::size_t callback_alignment,
+                                 void*) {
+    deallocation_stream    = callback_stream;
+    deallocation_ptr       = ptr;
+    deallocation_size      = callback_size;
+    deallocation_alignment = callback_alignment;
+    base_mr.deallocate(callback_stream, ptr, callback_size, callback_alignment);
+  };
+  auto mr = rmm::mr::callback_memory_resource(allocate_callback, deallocate_callback);
+
+  auto* ptr = mr.allocate(stream, size, alignment);
+  mr.deallocate(stream, ptr, size, alignment);
+
+  EXPECT_EQ(allocation_stream, stream);
+  EXPECT_EQ(allocation_ptr, ptr);
+  EXPECT_EQ(allocation_size, size);
+  EXPECT_EQ(allocation_alignment, alignment);
+  EXPECT_EQ(deallocation_stream, allocation_stream);
+  EXPECT_EQ(deallocation_ptr, allocation_ptr);
+  EXPECT_EQ(deallocation_size, allocation_size);
+  EXPECT_EQ(deallocation_alignment, allocation_alignment);
+}
+
+TEST(CallbackTest, RejectsInvalidAllocationAlignmentBeforeCallback)
+{
+  std::size_t callback_invocations{};
+  auto allocate_callback = [&callback_invocations](
+                             cuda_stream_view, std::size_t, std::size_t, void*) {
+    ++callback_invocations;
+    return nullptr;
+  };
+  auto deallocate_callback = [](cuda_stream_view, void*, std::size_t, std::size_t, void*) {};
+  auto mr = rmm::mr::callback_memory_resource(allocate_callback, deallocate_callback);
+
+  EXPECT_THROW((void)mr.allocate_sync(1024, 3), rmm::logic_error);
+  EXPECT_EQ(callback_invocations, 0);
 }
 
 TEST(CallbackTest, LoggingTest)
 {
   testing::internal::CaptureStdout();
 
-  auto base_mr           = rmm::mr::get_current_device_resource_ref();
-  auto allocate_callback = [](std::size_t size, cuda_stream_view stream, void* arg) {
-    std::cout << "Allocating " << size << " bytes" << std::endl;
-    auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
-    return base_mr.allocate(stream, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  };
+  auto base_mr = rmm::mr::get_current_device_resource_ref();
+  auto allocate_callback =
+    [](cuda_stream_view stream, std::size_t size, std::size_t alignment, void* arg) {
+      std::cout << "Allocating " << size << " bytes" << std::endl;
+      auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
+      return base_mr.allocate(stream, size, alignment);
+    };
 
-  auto deallocate_callback = [](void* ptr, std::size_t size, cuda_stream_view stream, void* arg) {
-    std::cout << "Deallocating " << size << " bytes" << std::endl;
-    auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
-    base_mr.deallocate(stream, ptr, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  };
+  auto deallocate_callback =
+    [](cuda_stream_view stream, void* ptr, std::size_t size, std::size_t alignment, void* arg) {
+      std::cout << "Deallocating " << size << " bytes" << std::endl;
+      auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
+      base_mr.deallocate(stream, ptr, size, alignment);
+    };
   auto mr =
     rmm::mr::callback_memory_resource(allocate_callback, deallocate_callback, &base_mr, &base_mr);
   auto const size = std::size_t{10_MiB};

--- a/cpp/tests/mr/callback_mr_tests.cpp
+++ b/cpp/tests/mr/callback_mr_tests.cpp
@@ -8,11 +8,12 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/cuda_stream_view.hpp>
 #include <rmm/error.hpp>
 #include <rmm/mr/callback_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
+
+#include <cuda/stream_ref>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -38,12 +39,12 @@ TEST(CallbackTest, TestCallbacksAreInvoked)
   EXPECT_CALL(base_mr, deallocate(_, _, size, alignment)).Times(1);
 
   auto allocate_callback =
-    [](cuda_stream_view stream, std::size_t size, std::size_t alignment, void* arg) {
+    [](cuda::stream_ref stream, std::size_t size, std::size_t alignment, void* arg) {
       auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
       return base_mr.allocate(stream, size, alignment);
     };
   auto deallocate_callback =
-    [](cuda_stream_view stream, void* ptr, std::size_t size, std::size_t alignment, void* arg) {
+    [](cuda::stream_ref stream, void* ptr, std::size_t size, std::size_t alignment, void* arg) {
       auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
       base_mr.deallocate(stream, ptr, size, alignment);
     };
@@ -60,8 +61,8 @@ TEST(CallbackTest, ForwardsAllocationMetadata)
   auto const size      = std::size_t{1024};
   auto const alignment = std::size_t{128};
 
-  cuda_stream_view allocation_stream{};
-  cuda_stream_view deallocation_stream{};
+  cuda::stream_ref allocation_stream{cudaStream_t{nullptr}};
+  cuda::stream_ref deallocation_stream{cudaStream_t{nullptr}};
   void* allocation_ptr{};
   void* deallocation_ptr{};
   std::size_t allocation_size{};
@@ -69,7 +70,7 @@ TEST(CallbackTest, ForwardsAllocationMetadata)
   std::size_t allocation_alignment{};
   std::size_t deallocation_alignment{};
 
-  auto allocate_callback = [&](cuda_stream_view callback_stream,
+  auto allocate_callback = [&](cuda::stream_ref callback_stream,
                                std::size_t callback_size,
                                std::size_t callback_alignment,
                                void*) {
@@ -79,7 +80,7 @@ TEST(CallbackTest, ForwardsAllocationMetadata)
     allocation_ptr       = base_mr.allocate(callback_stream, callback_size, callback_alignment);
     return allocation_ptr;
   };
-  auto deallocate_callback = [&](cuda_stream_view callback_stream,
+  auto deallocate_callback = [&](cuda::stream_ref callback_stream,
                                  void* ptr,
                                  std::size_t callback_size,
                                  std::size_t callback_alignment,
@@ -113,12 +114,12 @@ TEST(CallbackTest, ForwardsLargeAllocationAlignments)
   std::size_t allocation_alignment{};
   std::size_t deallocation_alignment{};
   auto allocate_callback = [&](
-                             cuda_stream_view, std::size_t, std::size_t callback_alignment, void*) {
+                             cuda::stream_ref, std::size_t, std::size_t callback_alignment, void*) {
     allocation_alignment = callback_alignment;
     return static_cast<void*>(&allocation);
   };
   auto deallocate_callback =
-    [&](cuda_stream_view, void*, std::size_t, std::size_t callback_alignment, void*) {
+    [&](cuda::stream_ref, void*, std::size_t, std::size_t callback_alignment, void*) {
       deallocation_alignment = callback_alignment;
     };
   auto mr = rmm::mr::callback_memory_resource(allocate_callback, deallocate_callback);
@@ -136,11 +137,11 @@ TEST(CallbackTest, RejectsInvalidAllocationAlignmentBeforeCallback)
 {
   std::size_t callback_invocations{};
   auto allocate_callback = [&callback_invocations](
-                             cuda_stream_view, std::size_t, std::size_t, void*) {
+                             cuda::stream_ref, std::size_t, std::size_t, void*) {
     ++callback_invocations;
     return nullptr;
   };
-  auto deallocate_callback = [](cuda_stream_view, void*, std::size_t, std::size_t, void*) {};
+  auto deallocate_callback = [](cuda::stream_ref, void*, std::size_t, std::size_t, void*) {};
   auto mr = rmm::mr::callback_memory_resource(allocate_callback, deallocate_callback);
 
   try {
@@ -158,14 +159,14 @@ TEST(CallbackTest, LoggingTest)
 
   auto base_mr = rmm::mr::get_current_device_resource_ref();
   auto allocate_callback =
-    [](cuda_stream_view stream, std::size_t size, std::size_t alignment, void* arg) {
+    [](cuda::stream_ref stream, std::size_t size, std::size_t alignment, void* arg) {
       std::cout << "Allocating " << size << " bytes" << std::endl;
       auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
       return base_mr.allocate(stream, size, alignment);
     };
 
   auto deallocate_callback =
-    [](cuda_stream_view stream, void* ptr, std::size_t size, std::size_t alignment, void* arg) {
+    [](cuda::stream_ref stream, void* ptr, std::size_t size, std::size_t alignment, void* arg) {
       std::cout << "Deallocating " << size << " bytes" << std::endl;
       auto base_mr = *static_cast<rmm::device_async_resource_ref*>(arg);
       base_mr.deallocate(stream, ptr, size, alignment);

--- a/cpp/tests/mr/callback_mr_tests.cpp
+++ b/cpp/tests/mr/callback_mr_tests.cpp
@@ -115,7 +115,12 @@ TEST(CallbackTest, RejectsInvalidAllocationAlignmentBeforeCallback)
   auto deallocate_callback = [](cuda_stream_view, void*, std::size_t, std::size_t, void*) {};
   auto mr = rmm::mr::callback_memory_resource(allocate_callback, deallocate_callback);
 
-  EXPECT_THROW((void)mr.allocate_sync(1024, 3), rmm::logic_error);
+  try {
+    (void)mr.allocate_sync(1024, 3);
+    FAIL() << "Expected invalid alignment to throw";
+  } catch (rmm::logic_error const& e) {
+    EXPECT_THAT(e.what(), testing::HasSubstr("not a power of 2"));
+  }
   EXPECT_EQ(callback_invocations, 0);
 }
 

--- a/cpp/tests/mr/callback_mr_tests.cpp
+++ b/cpp/tests/mr/callback_mr_tests.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstddef>
 #include <iostream>
 #include <string>
@@ -102,6 +103,33 @@ TEST(CallbackTest, ForwardsAllocationMetadata)
   EXPECT_EQ(deallocation_ptr, allocation_ptr);
   EXPECT_EQ(deallocation_size, allocation_size);
   EXPECT_EQ(deallocation_alignment, allocation_alignment);
+}
+
+TEST(CallbackTest, ForwardsLargeAllocationAlignments)
+{
+  auto const alignments = std::array<std::size_t, 2>{512, 4096};
+  alignas(4096) std::byte allocation{};
+
+  std::size_t allocation_alignment{};
+  std::size_t deallocation_alignment{};
+  auto allocate_callback = [&](
+                             cuda_stream_view, std::size_t, std::size_t callback_alignment, void*) {
+    allocation_alignment = callback_alignment;
+    return static_cast<void*>(&allocation);
+  };
+  auto deallocate_callback =
+    [&](cuda_stream_view, void*, std::size_t, std::size_t callback_alignment, void*) {
+      deallocation_alignment = callback_alignment;
+    };
+  auto mr = rmm::mr::callback_memory_resource(allocate_callback, deallocate_callback);
+
+  for (auto const alignment : alignments) {
+    auto* ptr = mr.allocate_sync(1, alignment);
+    mr.deallocate_sync(ptr, 1, alignment);
+
+    EXPECT_EQ(allocation_alignment, alignment);
+    EXPECT_EQ(deallocation_alignment, alignment);
+  }
 }
 
 TEST(CallbackTest, RejectsInvalidAllocationAlignmentBeforeCallback)

--- a/cpp/tests/mr/cccl_adaptor_tests.cpp
+++ b/cpp/tests/mr/cccl_adaptor_tests.cpp
@@ -22,6 +22,8 @@
 #include <rmm/mr/tracking_resource_adaptor.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/stream_ref>
+
 #include <gtest/gtest.h>
 
 #include <type_traits>
@@ -182,17 +184,13 @@ TEST(CallbackMRAdaptorTest, EqualityAndSharedOwnership)
   cuda_mr cuda{};
   rmm::device_async_resource_ref upstream{cuda};
 
-  auto alloc_cb =
-    [](rmm::cuda_stream_view stream, std::size_t bytes, std::size_t alignment, void* arg) {
-      return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(stream, bytes, alignment);
-    };
-  auto dealloc_cb = [](rmm::cuda_stream_view stream,
-                       void* ptr,
-                       std::size_t bytes,
-                       std::size_t alignment,
-                       void* arg) {
-    static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(stream, ptr, bytes, alignment);
+  auto alloc_cb = [](cuda::stream_ref stream, std::size_t bytes, std::size_t alignment, void* arg) {
+    return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(stream, bytes, alignment);
   };
+  auto dealloc_cb =
+    [](cuda::stream_ref stream, void* ptr, std::size_t bytes, std::size_t alignment, void* arg) {
+      static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(stream, ptr, bytes, alignment);
+    };
 
   callback_memory_resource mr{alloc_cb, dealloc_cb, &upstream, &upstream};
   auto copy = mr;

--- a/cpp/tests/mr/cccl_adaptor_tests.cpp
+++ b/cpp/tests/mr/cccl_adaptor_tests.cpp
@@ -182,13 +182,16 @@ TEST(CallbackMRAdaptorTest, EqualityAndSharedOwnership)
   cuda_mr cuda{};
   rmm::device_async_resource_ref upstream{cuda};
 
-  auto alloc_cb = [](std::size_t bytes, rmm::cuda_stream_view stream, void* arg) {
-    return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(
-      stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
-  };
-  auto dealloc_cb = [](void* ptr, std::size_t bytes, rmm::cuda_stream_view stream, void* arg) {
-    static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(
-      stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  auto alloc_cb =
+    [](rmm::cuda_stream_view stream, std::size_t bytes, std::size_t alignment, void* arg) {
+      return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(stream, bytes, alignment);
+    };
+  auto dealloc_cb = [](rmm::cuda_stream_view stream,
+                       void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment,
+                       void* arg) {
+    static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(stream, ptr, bytes, alignment);
   };
 
   callback_memory_resource mr{alloc_cb, dealloc_cb, &upstream, &upstream};

--- a/cpp/tests/mr/mr_ref_callback_tests.cpp
+++ b/cpp/tests/mr/mr_ref_callback_tests.cpp
@@ -11,6 +11,8 @@
 #include <rmm/mr/callback_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 
+#include <cuda/stream_ref>
+
 namespace rmm::test {
 
 struct CallbackMRFixture : public ::testing::Test {
@@ -18,14 +20,10 @@ struct CallbackMRFixture : public ::testing::Test {
   rmm::device_async_resource_ref upstream{cuda};
 
   rmm::mr::callback_memory_resource mr{
-    [](rmm::cuda_stream_view stream, std::size_t bytes, std::size_t alignment, void* arg) {
+    [](cuda::stream_ref stream, std::size_t bytes, std::size_t alignment, void* arg) {
       return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(stream, bytes, alignment);
     },
-    [](rmm::cuda_stream_view stream,
-       void* ptr,
-       std::size_t bytes,
-       std::size_t alignment,
-       void* arg) {
+    [](cuda::stream_ref stream, void* ptr, std::size_t bytes, std::size_t alignment, void* arg) {
       static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(stream, ptr, bytes, alignment);
     },
     &upstream,

--- a/cpp/tests/mr/mr_ref_callback_tests.cpp
+++ b/cpp/tests/mr/mr_ref_callback_tests.cpp
@@ -18,13 +18,15 @@ struct CallbackMRFixture : public ::testing::Test {
   rmm::device_async_resource_ref upstream{cuda};
 
   rmm::mr::callback_memory_resource mr{
-    [](std::size_t bytes, rmm::cuda_stream_view stream, void* arg) {
-      return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(
-        stream, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    [](rmm::cuda_stream_view stream, std::size_t bytes, std::size_t alignment, void* arg) {
+      return static_cast<rmm::device_async_resource_ref*>(arg)->allocate(stream, bytes, alignment);
     },
-    [](void* ptr, std::size_t bytes, rmm::cuda_stream_view stream, void* arg) {
-      static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(
-        stream, ptr, bytes, rmm::CUDA_ALLOCATION_ALIGNMENT);
+    [](rmm::cuda_stream_view stream,
+       void* ptr,
+       std::size_t bytes,
+       std::size_t alignment,
+       void* arg) {
+      static_cast<rmm::device_async_resource_ref*>(arg)->deallocate(stream, ptr, bytes, alignment);
     },
     &upstream,
     &upstream};

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -5,7 +5,7 @@
 # See https://github.com/cython/cython/issues/5589
 from builtins import BaseException
 
-from cuda.bindings.cyruntime cimport cudaMemPool_t
+from cuda.bindings.cyruntime cimport cudaMemPool_t, cudaStream_t
 from libc.stddef cimport size_t
 from libc.stdint cimport int8_t, int32_t, int64_t
 from libcpp cimport bool
@@ -266,18 +266,53 @@ cdef extern from "rmm/mr/fixed_size_memory_resource.hpp" \
 
 cdef extern from "rmm/mr/callback_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    ctypedef void* (*allocate_callback_t)(cuda_stream_view, size_t, size_t, void*)
-    ctypedef void (*deallocate_callback_t)(
-        cuda_stream_view, void*, size_t, size_t, void*
-    )
-
     cdef cppclass callback_memory_resource:
-        callback_memory_resource(
-            allocate_callback_t allocate_callback,
-            deallocate_callback_t deallocate_callback,
-            void* allocate_callback_arg,
-            void* deallocate_callback_arg
-        ) except +
+        pass
+
+cdef extern from * nogil:
+    """
+    #include <rmm/mr/callback_memory_resource.hpp>
+
+    using cython_allocate_callback_t = void* (*)(cudaStream_t, std::size_t, std::size_t, void*);
+    using cython_deallocate_callback_t =
+      void (*)(cudaStream_t, void*, std::size_t, std::size_t, void*);
+
+    inline rmm::mr::callback_memory_resource* make_callback_memory_resource(
+      cython_allocate_callback_t allocate_callback,
+      cython_deallocate_callback_t deallocate_callback,
+      void* allocate_callback_arg,
+      void* deallocate_callback_arg)
+    {
+      return new rmm::mr::callback_memory_resource{
+        [allocate_callback](cuda::stream_ref stream,
+                            std::size_t bytes,
+                            std::size_t alignment,
+                            void* arg) {
+          return allocate_callback(stream.get(), bytes, alignment, arg);
+        },
+        [deallocate_callback](cuda::stream_ref stream,
+                              void* ptr,
+                              std::size_t bytes,
+                              std::size_t alignment,
+                              void* arg) noexcept {
+          deallocate_callback(stream.get(), ptr, bytes, alignment, arg);
+        },
+        allocate_callback_arg,
+        deallocate_callback_arg};
+    }
+    """
+    ctypedef void* (*cython_allocate_callback_t)(
+        cudaStream_t, size_t, size_t, void*
+    )
+    ctypedef void (*cython_deallocate_callback_t)(
+        cudaStream_t, void*, size_t, size_t, void*
+    )
+    callback_memory_resource* make_callback_memory_resource(
+        cython_allocate_callback_t allocate_callback,
+        cython_deallocate_callback_t deallocate_callback,
+        void* allocate_callback_arg,
+        void* deallocate_callback_arg
+    ) except +
 
 cdef extern from "rmm/mr/binning_memory_resource.hpp" \
         namespace "rmm::mr" nogil:

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # This import is needed for Cython typing in translate_python_except_to_cpp
@@ -266,8 +266,10 @@ cdef extern from "rmm/mr/fixed_size_memory_resource.hpp" \
 
 cdef extern from "rmm/mr/callback_memory_resource.hpp" \
         namespace "rmm::mr" nogil:
-    ctypedef void* (*allocate_callback_t)(size_t, cuda_stream_view, void*)
-    ctypedef void (*deallocate_callback_t)(void*, size_t, cuda_stream_view, void*)
+    ctypedef void* (*allocate_callback_t)(cuda_stream_view, size_t, size_t, void*)
+    ctypedef void (*deallocate_callback_t)(
+        cuda_stream_view, void*, size_t, size_t, void*
+    )
 
     cdef cppclass callback_memory_resource:
         callback_memory_resource(

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyi
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyi
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable
@@ -95,8 +95,8 @@ class BinningMemoryResource(UpstreamResourceAdaptor):
 class CallbackMemoryResource(DeviceMemoryResource):
     def __init__(
         self,
-        allocate_func: Callable[[int, Stream], int],
-        deallocate_func: Callable[[int, int, Stream], None],
+        allocate_func: Callable[[Stream, int, int], int],
+        deallocate_func: Callable[[Stream, int, int, int], None],
     ) -> None: ...
 
 class LimitingResourceAdaptor(UpstreamResourceAdaptor):

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -9,7 +9,6 @@ from builtins import BaseException
 from collections import defaultdict
 
 cimport cython
-from cpython.exc cimport PyErr_WriteUnraisable
 from cuda.bindings cimport cyruntime
 from cython.operator cimport dereference as deref
 from libc.stddef cimport size_t
@@ -602,15 +601,12 @@ cdef void _deallocate_callback_wrapper(
     size_t alignment,
     void* ctx
 ) noexcept with gil:
-    try:
-        (<object>(ctx))(
-            Stream._from_cudaStream_t(stream.value()),
-            <uintptr_t>(ptr),
-            nbytes,
-            alignment
-        )
-    except BaseException:
-        PyErr_WriteUnraisable(<object>(ctx))
+    (<object>(ctx))(
+        Stream._from_cudaStream_t(stream.value()),
+        <uintptr_t>(ptr),
+        nbytes,
+        alignment
+    )
 
 
 cdef class CallbackMemoryResource(DeviceMemoryResource):

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -626,12 +626,15 @@ cdef class CallbackMemoryResource(DeviceMemoryResource):
         which to perform the allocation, an integer representing the number
         of bytes to allocate, and an integer representing the requested
         alignment. It must return an integer representing the pointer to the
-        allocated memory.
+        allocated memory. The returned pointer must satisfy the requested
+        alignment.
     deallocate_func: callable
         The deallocation function must accept four arguments: a Stream on
         which to perform the deallocation, an integer representing the pointer
         to the memory to free, an integer representing the number of bytes to
-        free, and an integer representing the allocation alignment.
+        free, and an integer representing the allocation alignment. It must not
+        raise an exception because deallocation is ``noexcept`` and an escaping
+        exception terminates the process.
 
     Examples
     --------
@@ -639,6 +642,8 @@ cdef class CallbackMemoryResource(DeviceMemoryResource):
     >>> base_mr = rmm.mr.CudaMemoryResource()
     >>> def allocate_func(stream, size, alignment):
     ...     print(f"Allocating {size} bytes")
+    ...     if alignment > 256:
+    ...         raise MemoryError("CudaMemoryResource supports up to 256-byte alignment")
     ...     return base_mr.allocate(size, stream)
     ...
     >>> def deallocate_func(stream, ptr, size, alignment):

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -9,6 +9,7 @@ from builtins import BaseException
 from collections import defaultdict
 
 cimport cython
+from cpython.exc cimport PyErr_WriteUnraisable
 from cuda.bindings cimport cyruntime
 from cython.operator cimport dereference as deref
 from libc.stddef cimport size_t
@@ -600,13 +601,16 @@ cdef void _deallocate_callback_wrapper(
     size_t nbytes,
     size_t alignment,
     void* ctx
-) except * with gil:
-    (<object>(ctx))(
-        Stream._from_cudaStream_t(stream.value()),
-        <uintptr_t>(ptr),
-        nbytes,
-        alignment
-    )
+) noexcept with gil:
+    try:
+        (<object>(ctx))(
+            Stream._from_cudaStream_t(stream.value()),
+            <uintptr_t>(ptr),
+            nbytes,
+            alignment
+        )
+    except BaseException:
+        PyErr_WriteUnraisable(<object>(ctx))
 
 
 cdef class CallbackMemoryResource(DeviceMemoryResource):
@@ -658,6 +662,9 @@ cdef class CallbackMemoryResource(DeviceMemoryResource):
     Allocating 256 bytes
     >>> del dbuf
     Deallocating 256 bytes
+
+    The base resource's 256-byte default alignment satisfies every request
+    accepted by this example.
     """
     def __init__(
         self,

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -625,16 +625,17 @@ cdef class CallbackMemoryResource(DeviceMemoryResource):
         The allocation function must accept three arguments: a Stream on
         which to perform the allocation, an integer representing the number
         of bytes to allocate, and an integer representing the requested
-        alignment. It must return an integer representing the pointer to the
-        allocated memory. The returned pointer must satisfy the requested
-        alignment.
+        alignment. The alignment is always a valid power of two because an
+        invalid request raises before callback invocation. The function must
+        return an integer representing the pointer to the allocated memory.
+        The returned pointer must satisfy the requested alignment.
     deallocate_func: callable
         The deallocation function must accept four arguments: a Stream on
         which to perform the deallocation, an integer representing the pointer
         to the memory to free, an integer representing the number of bytes to
         free, and an integer representing the allocation alignment. It must not
-        raise an exception because deallocation is ``noexcept`` and an escaping
-        exception terminates the process.
+        raise an exception because this callback boundary cannot propagate
+        Python exceptions.
 
     Examples
     --------

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -10,6 +10,7 @@ from collections import defaultdict
 
 cimport cython
 from cuda.bindings cimport cyruntime
+from cuda.bindings.cyruntime cimport cudaStream_t
 from cython.operator cimport dereference as deref
 from libc.stddef cimport size_t
 from libc.stdint cimport int8_t, int32_t, uintptr_t
@@ -27,7 +28,6 @@ from rmm.pylibrmm.utils cimport as_stream
 
 from rmm.pylibrmm.stream import DEFAULT_STREAM
 
-from rmm.librmm.cuda_stream_view cimport cuda_stream_view
 from rmm.librmm.per_device_resource cimport (
     cuda_device_id,
     set_per_device_resource as cpp_set_per_device_resource,
@@ -38,17 +38,16 @@ from rmm.statistics import Statistics
 
 from rmm.librmm.memory_resource cimport (
     CppExcept,
-    allocate_callback_t,
     allocation_handle_type,
     any_resource,
     arena_memory_resource,
     available_device_memory as c_available_device_memory,
     binning_memory_resource,
-    callback_memory_resource,
     cuda_async_memory_resource,
     cuda_async_view_memory_resource,
     cuda_memory_resource,
-    deallocate_callback_t,
+    cython_allocate_callback_t,
+    cython_deallocate_callback_t,
     device_accessible,
     device_async_resource_ref,
     failure_callback_resource_adaptor_oom,
@@ -56,6 +55,7 @@ from rmm.librmm.memory_resource cimport (
     fixed_size_memory_resource,
     limiting_resource_adaptor,
     logging_resource_adaptor,
+    make_callback_memory_resource,
     make_device_async_resource_ref,
     managed_memory_resource,
     percent_of_free_device_memory as c_percent_of_free_device_memory,
@@ -574,7 +574,7 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
 
 
 cdef void* _allocate_callback_wrapper(
-    cuda_stream_view stream,
+    cudaStream_t stream,
     size_t nbytes,
     size_t alignment,
     void* ctx
@@ -586,7 +586,7 @@ cdef void* _allocate_callback_wrapper(
     with gil:
         try:
             return <void*>(<uintptr_t>((<object>(ctx))(
-                Stream._from_cudaStream_t(stream.value()),
+                Stream._from_cudaStream_t(stream),
                 nbytes,
                 alignment
             )))
@@ -595,14 +595,14 @@ cdef void* _allocate_callback_wrapper(
     throw_cpp_except(err)
 
 cdef void _deallocate_callback_wrapper(
-    cuda_stream_view stream,
+    cudaStream_t stream,
     void* ptr,
     size_t nbytes,
     size_t alignment,
     void* ctx
 ) noexcept with gil:
     (<object>(ctx))(
-        Stream._from_cudaStream_t(stream.value()),
+        Stream._from_cudaStream_t(stream),
         <uintptr_t>(ptr),
         nbytes,
         alignment
@@ -669,9 +669,9 @@ cdef class CallbackMemoryResource(DeviceMemoryResource):
     ):
         self._allocate_func = allocate_func
         self._deallocate_func = deallocate_func
-        self.c_obj.reset(new callback_memory_resource(
-            <allocate_callback_t>(_allocate_callback_wrapper),
-            <deallocate_callback_t>(_deallocate_callback_wrapper),
+        self.c_obj.reset(make_callback_memory_resource(
+            <cython_allocate_callback_t>(_allocate_callback_wrapper),
+            <cython_deallocate_callback_t>(_deallocate_callback_wrapper),
             <void*>(allocate_func),
             <void*>(deallocate_func)
         ))

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -574,8 +574,9 @@ cdef class BinningMemoryResource(UpstreamResourceAdaptor):
 
 
 cdef void* _allocate_callback_wrapper(
-    size_t nbytes,
     cuda_stream_view stream,
+    size_t nbytes,
+    size_t alignment,
     void* ctx
     # Note that this function is specifically designed to rethrow Python
     # exceptions as C++ exceptions when called as a callback from C++, so it is
@@ -585,20 +586,27 @@ cdef void* _allocate_callback_wrapper(
     with gil:
         try:
             return <void*>(<uintptr_t>((<object>(ctx))(
+                Stream._from_cudaStream_t(stream.value()),
                 nbytes,
-                Stream._from_cudaStream_t(stream.value())
+                alignment
             )))
         except BaseException as e:
             err = translate_python_except_to_cpp(e)
     throw_cpp_except(err)
 
 cdef void _deallocate_callback_wrapper(
+    cuda_stream_view stream,
     void* ptr,
     size_t nbytes,
-    cuda_stream_view stream,
+    size_t alignment,
     void* ctx
 ) except * with gil:
-    (<object>(ctx))(<uintptr_t>(ptr), nbytes, Stream._from_cudaStream_t(stream.value()))
+    (<object>(ctx))(
+        Stream._from_cudaStream_t(stream.value()),
+        <uintptr_t>(ptr),
+        nbytes,
+        alignment
+    )
 
 
 cdef class CallbackMemoryResource(DeviceMemoryResource):
@@ -614,25 +622,26 @@ cdef class CallbackMemoryResource(DeviceMemoryResource):
     Parameters
     ----------
     allocate_func: callable
-        The allocation function must accept two arguments. An integer
-        representing the number of bytes to allocate and a Stream on
-        which to perform the allocation, and return an integer
-        representing the pointer to the allocated memory.
+        The allocation function must accept three arguments: a Stream on
+        which to perform the allocation, an integer representing the number
+        of bytes to allocate, and an integer representing the requested
+        alignment. It must return an integer representing the pointer to the
+        allocated memory.
     deallocate_func: callable
-        The deallocation function must accept three arguments. an integer
-        representing the pointer to the memory to free, a second
-        integer representing the number of bytes to free, and a Stream
-        on which to perform the deallocation.
+        The deallocation function must accept four arguments: a Stream on
+        which to perform the deallocation, an integer representing the pointer
+        to the memory to free, an integer representing the number of bytes to
+        free, and an integer representing the allocation alignment.
 
     Examples
     --------
     >>> import rmm
     >>> base_mr = rmm.mr.CudaMemoryResource()
-    >>> def allocate_func(size, stream):
+    >>> def allocate_func(stream, size, alignment):
     ...     print(f"Allocating {size} bytes")
     ...     return base_mr.allocate(size, stream)
     ...
-    >>> def deallocate_func(ptr, size, stream):
+    >>> def deallocate_func(stream, ptr, size, alignment):
     ...     print(f"Deallocating {size} bytes")
     ...     return base_mr.deallocate(ptr, size, stream)
     ...

--- a/python/rmm/rmm/tests/test_callback_memory_resource.py
+++ b/python/rmm/rmm/tests/test_callback_memory_resource.py
@@ -5,6 +5,7 @@
 
 import functools
 import gc
+import sys
 
 import pytest
 
@@ -66,6 +67,47 @@ def test_callback_mr_error(err_raise, err_catch):
 
     with pytest.raises(err_catch, match="My alloc error"):
         rmm.DeviceBuffer(size=256)
+
+
+def test_callback_mr_python_api_uses_default_alignment():
+    """Python allocation APIs do not expose alignment, so C++ covers values above 256."""
+    alignments = []
+    base_mr = rmm.mr.CudaMemoryResource()
+
+    def allocate_func(stream, size, alignment):
+        alignments.append(alignment)
+        return base_mr.allocate(size, stream)
+
+    def deallocate_func(stream, ptr, size, alignment):
+        alignments.append(alignment)
+        return base_mr.deallocate(ptr, size, stream)
+
+    cb_mr = rmm.mr.CallbackMemoryResource(allocate_func, deallocate_func)
+    buf = rmm.DeviceBuffer(size=1, mr=cb_mr)
+    del buf
+
+    assert alignments == [256, 256]
+
+
+def test_callback_mr_reports_deallocation_errors(monkeypatch):
+    base_mr = rmm.mr.CudaMemoryResource()
+    unraisable = []
+
+    def allocate_func(stream, size, alignment):
+        return base_mr.allocate(size, stream)
+
+    def deallocate_func(stream, ptr, size, alignment):
+        base_mr.deallocate(ptr, size, stream)
+        raise RuntimeError("My dealloc error")
+
+    monkeypatch.setattr(sys, "unraisablehook", unraisable.append)
+    cb_mr = rmm.mr.CallbackMemoryResource(allocate_func, deallocate_func)
+    buf = rmm.DeviceBuffer(size=1, mr=cb_mr)
+    del buf
+
+    assert len(unraisable) == 1
+    assert isinstance(unraisable[0].exc_value, RuntimeError)
+    assert str(unraisable[0].exc_value) == "My dealloc error"
 
 
 def test_device_buffer_with_mr():

--- a/python/rmm/rmm/tests/test_callback_memory_resource.py
+++ b/python/rmm/rmm/tests/test_callback_memory_resource.py
@@ -12,6 +12,7 @@ import rmm
 
 
 def test_custom_mr(capsys):
+    allocation_size = 257
     base_mr = rmm.mr.CudaMemoryResource()
     allocations = []
     deallocations = []
@@ -31,14 +32,14 @@ def test_custom_mr(capsys):
         rmm.mr.CallbackMemoryResource(allocate_func, deallocate_func)
     )
 
-    rmm.DeviceBuffer(size=256)
+    rmm.DeviceBuffer(size=allocation_size)
 
     captured = capsys.readouterr()
-    assert captured.out == "Allocating 256 bytes\nDeallocating 256 bytes\n"
+    assert captured.out == "Allocating 257 bytes\nDeallocating 257 bytes\n"
     assert len(allocations) == 1
+    assert allocations[0][2] == allocation_size
+    assert allocations[0][3] == 256
     assert deallocations == allocations
-    assert allocations[0][3] > 0
-    assert allocations[0][3] & (allocations[0][3] - 1) == 0
 
 
 @pytest.mark.parametrize(

--- a/python/rmm/rmm/tests/test_callback_memory_resource.py
+++ b/python/rmm/rmm/tests/test_callback_memory_resource.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for CallbackMemoryResource."""
@@ -13,13 +13,18 @@ import rmm
 
 def test_custom_mr(capsys):
     base_mr = rmm.mr.CudaMemoryResource()
+    allocations = []
+    deallocations = []
 
-    def allocate_func(size, stream):
+    def allocate_func(stream, size, alignment):
         print(f"Allocating {size} bytes")
-        return base_mr.allocate(size, stream)
+        ptr = base_mr.allocate(size, stream)
+        allocations.append((stream, ptr, size, alignment))
+        return ptr
 
-    def deallocate_func(ptr, size, stream):
+    def deallocate_func(stream, ptr, size, alignment):
         print(f"Deallocating {size} bytes")
+        deallocations.append((stream, ptr, size, alignment))
         return base_mr.deallocate(ptr, size, stream)
 
     rmm.mr.set_current_device_resource(
@@ -30,6 +35,10 @@ def test_custom_mr(capsys):
 
     captured = capsys.readouterr()
     assert captured.out == "Allocating 256 bytes\nDeallocating 256 bytes\n"
+    assert len(allocations) == 1
+    assert deallocations == allocations
+    assert allocations[0][3] > 0
+    assert allocations[0][3] & (allocations[0][3] - 1) == 0
 
 
 @pytest.mark.parametrize(
@@ -44,10 +53,10 @@ def test_custom_mr(capsys):
 def test_callback_mr_error(err_raise, err_catch):
     base_mr = rmm.mr.CudaMemoryResource()
 
-    def allocate_func(size, stream):
+    def allocate_func(stream, size, alignment):
         raise err_raise("My alloc error")
 
-    def deallocate_func(ptr, size, stream):
+    def deallocate_func(stream, ptr, size, alignment):
         return base_mr.deallocate(ptr, size)
 
     rmm.mr.set_current_device_resource(
@@ -63,11 +72,11 @@ def test_device_buffer_with_mr():
     base = rmm.mr.CudaMemoryResource()
     rmm.mr.set_current_device_resource(base)
 
-    def alloc_cb(size, stream, *, base):
+    def alloc_cb(stream, size, alignment, *, base):
         allocations.append(size)
         return base.allocate(size, stream)
 
-    def dealloc_cb(ptr, size, stream, *, base):
+    def dealloc_cb(stream, ptr, size, alignment, *, base):
         return base.deallocate(ptr, size, stream)
 
     cb_mr = rmm.mr.CallbackMemoryResource(

--- a/python/rmm/rmm/tests/test_failure_callback_resource_adaptor.py
+++ b/python/rmm/rmm/tests/test_failure_callback_resource_adaptor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for FailureCallbackResourceAdaptor."""
@@ -18,10 +18,10 @@ def test_failure_callback_resource_adaptor():
             retried[0] = True
             return True
 
-    def allocate_func(size, stream):
+    def allocate_func(stream, size, alignment):
         raise MemoryError("Intentional allocation failure")
 
-    def deallocate_func(ptr, size, stream):
+    def deallocate_func(stream, ptr, size, alignment):
         pass
 
     failing_mr = rmm.mr.CallbackMemoryResource(allocate_func, deallocate_func)
@@ -37,10 +37,10 @@ def test_failure_callback_resource_adaptor_error():
     def callback(nbytes: int) -> bool:
         raise RuntimeError("MyError")
 
-    def allocate_func(size, stream):
+    def allocate_func(stream, size, alignment):
         raise MemoryError("Intentional allocation failure")
 
-    def deallocate_func(ptr, size, stream):
+    def deallocate_func(stream, ptr, size, alignment):
         pass
 
     failing_mr = rmm.mr.CallbackMemoryResource(allocate_func, deallocate_func)

--- a/python/rmm/rmm/tests/test_failure_callback_resource_adaptor.py
+++ b/python/rmm/rmm/tests/test_failure_callback_resource_adaptor.py
@@ -9,16 +9,17 @@ import rmm
 
 
 def test_failure_callback_resource_adaptor():
-    retried = [False]
+    allocation_calls = 0
+    callback_calls = 0
 
     def callback(nbytes: int) -> bool:
-        if retried[0]:
-            return False
-        else:
-            retried[0] = True
-            return True
+        nonlocal callback_calls
+        callback_calls += 1
+        return callback_calls == 1
 
     def allocate_func(stream, size, alignment):
+        nonlocal allocation_calls
+        allocation_calls += 1
         raise MemoryError("Intentional allocation failure")
 
     def deallocate_func(stream, ptr, size, alignment):
@@ -30,7 +31,8 @@ def test_failure_callback_resource_adaptor():
 
     with pytest.raises(MemoryError):
         rmm.DeviceBuffer(size=256)
-    assert retried[0]
+    assert allocation_calls == 2
+    assert callback_calls == 2
 
 
 def test_failure_callback_resource_adaptor_error():


### PR DESCRIPTION
## Summary

- Match callback memory resource argument order with CCCL.
- Forward and validate allocation alignment before calling user callbacks.
- Update Cython, Python docs, type hints, tests, and the Cython line-length hook for the required SPDX header.

## Testing

- Focused C++ callback and CCCL tests: 7 passed.
- Focused Python callback tests: 8 passed.
- `pre-commit run --all-files`

Breaking change: `allocate_callback_t` and `deallocate_callback_t` reorder parameters (stream first) and add an `alignment` parameter, so existing C++ and Python callbacks must update their signatures; the break is loud (old callbacks fail to compile / raise TypeError) rather than silent. Needs the `breaking` label.

Closes #2397

