### PR TITLE
put a <2 ceiling on cuda-core dependency

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cuda-bindings>=12.9.2,<13.0
-- cuda-core>=0.5.1
+- cuda-core>=0.5.1,<2
 - cuda-nvcc
 - cuda-version=12.9
 - cxx-compiler

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cuda-bindings>=12.9.2,<13.0
-- cuda-core>=0.5.1
+- cuda-core>=0.5.1,<2
 - cuda-nvcc
 - cuda-version=12.9
 - cxx-compiler

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cuda-bindings>=13.0.1,<14.0
-- cuda-core>=0.5.1
+- cuda-core>=0.5.1,<2
 - cuda-nvcc
 - cuda-version=13.3
 - cxx-compiler

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -11,7 +11,7 @@ dependencies:
 - clang==20.1.8
 - cmake>=4.0
 - cuda-bindings>=13.0.1,<14.0
-- cuda-core>=0.5.1
+- cuda-core>=0.5.1,<2
 - cuda-nvcc
 - cuda-version=13.3
 - cxx-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator
@@ -404,7 +404,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - cuda-core>=0.5.1
+          - cuda-core>=0.5.1,<2
           - packaging
           - pytest
           - pytest-cov

--- a/python/rmm/pyproject.toml
+++ b/python/rmm/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
@@ -36,7 +36,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "cuda-core>=0.5.1",
+    "cuda-core>=0.5.1,<2",
     "numba-cuda>=0.22.1",
     "numba>=0.60.0,<0.65.0",
     "packaging",


### PR DESCRIPTION
## Description

Follow-up to #2460

Puts a ceiling of `<2` on the project's `cuda-core` dependency.

Starting with the 1.x series, `cuda-core` is following strict semantic versioning, and some folks working on the project recommended doing this defensively: https://github.com/rapidsai/build-planning/issues/285#issuecomment-5027243158

There isn't yet a 2.x release, this is just defensive to protect CI and users if there eventually is one.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
