### PR TITLE
Fix missing event record in stream_ordered_memory_resource::merge_lists

### DIFF
--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -478,6 +478,13 @@ class stream_ordered_memory_resource : public crtp<PoolResource> {
 
     // Merge the two free lists
     blocks.insert(std::move(other_blocks));
+
+    // The merged-in blocks are now keyed by `stream_event.event`, but that event's last
+    // recorded position (if it was ever recorded) precedes the wait just enqueued above.
+    // Re-record the event so that later consumers of these blocks that synchronize on it
+    // (a cross-stream steal or merge, or `release()`) transitively wait on `other_event`,
+    // and therefore on any work still in flight on the donor stream.
+    RMM_CUDA_TRY(cudaEventRecord(stream_event.event, stream_event.stream));
   }
 
   /**

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -1,20 +1,31 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "../byte_literals.hpp"
+
+#include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/mr/limiting_resource_adaptor.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <memory>
+#include <thread>
 #include <vector>
 
 namespace rmm::test {
@@ -161,6 +172,103 @@ TEST(PoolTest, MultidevicePool)
       RMM_CUDA_TRY(cudaSetDevice(0));
     }
   }
+}
+
+// Host function used to stall a stream until the test releases it.
+void CUDART_CB spin_until_released(void* flag)
+{
+  auto* released = static_cast<std::atomic<bool>*>(flag);
+  while (!released->load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{1});
+  }
+}
+
+// Invariant under test: a freed block may be handed to another stream only after that stream
+// has been made dependent on all work that was in flight on the block when it was freed. This
+// must hold transitively when the pool moves whole free lists between streams: if stream A's
+// free list is merged into stream B's, and stream C later takes a block from B's list, C must
+// still be ordered after A's outstanding work on that block, even though C only synchronizes
+// with B's bookkeeping event.
+//
+// The test builds the shortest chain that exercises this, using three streams:
+//   stream A frees block X while a write of `pattern_a` to X is still pending on A (A is
+//   stalled by a host function, so the write cannot complete until the test releases it);
+//   stream B requests an allocation that the pool can only attempt by merging A's free list
+//   (containing X) into B's; the request itself fails, leaving X in B's list;
+//   stream C then allocates X out of B's list and writes `pattern_c` to it.
+// C's write must be stream-ordered after A's, so X must read back as `pattern_c` once both
+// streams have drained, regardless of timing. A probe event additionally checks that C's
+// write cannot complete while A is still stalled.
+TEST(PoolTest, CrossStreamStealAfterMergeWaitsForDonorStream)
+{
+  constexpr std::size_t block_size{1_MiB};
+  constexpr std::size_t pool_size{8_MiB};
+  constexpr int pattern_a{0xAA};
+  constexpr int pattern_c{0xBB};
+
+  pool_mr mr{rmm::mr::get_current_device_resource_ref(), pool_size, pool_size};
+  rmm::device_async_resource_ref ref{mr};
+
+  rmm::cuda_stream stream_a;
+  rmm::cuda_stream stream_b;
+  rmm::cuda_stream stream_c;
+
+  // X is carved from the front of the pool. The separator, allocated right behind it and held
+  // for the whole test, prevents X from coalescing with the rest of the pool's free memory.
+  void* ptr_x     = ref.allocate(stream_a.view(), block_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  void* separator = ref.allocate(stream_b.view(), block_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  // Stall stream A, enqueue a write to X behind the stall, then free X on A. The pool records
+  // A's event behind the pending write, so any consumer that waits on A's event cannot touch X
+  // before the write completes.
+  std::atomic<bool> release{false};
+  RMM_CUDA_TRY(cudaLaunchHostFunc(stream_a.value(), spin_until_released, &release));
+  RMM_CUDA_TRY(cudaMemsetAsync(ptr_x, pattern_a, block_size, stream_a.value()));
+  ref.deallocate(stream_a.view(), ptr_x, block_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  // 6.5 MiB exceeds every individual free block (X: 1 MiB, rest of the pool: 6 MiB) and, since
+  // the separator prevents coalescing, the merged list too; the pool is at its maximum size, so
+  // this throws -- but only after merging A's free list (with X in it) into B's.
+  constexpr auto unsatisfiable = 6_MiB + block_size / 2;
+  EXPECT_THROW((void)ref.allocate(stream_b.view(), unsatisfiable, rmm::CUDA_ALLOCATION_ALIGNMENT),
+               rmm::out_of_memory);
+
+  // Steal X from B's free list on a third stream and overwrite it. This waits only on B's
+  // event, which must have been recorded behind the wait on A's event during the merge above.
+  void* ptr_c = ref.allocate(stream_c.view(), block_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  EXPECT_EQ(ptr_c, ptr_x);  // best fit: the stolen block is exactly X
+  RMM_CUDA_TRY(cudaMemsetAsync(ptr_c, pattern_c, block_size, stream_c.value()));
+
+  // Probe whether C's write can complete while A is still stalled. With the dependency chain
+  // intact it cannot -- C's stream is ordered behind A's pending work -- so the probe must
+  // still be pending when the deadline expires; the deadline only bounds the poll and does not
+  // affect correctness. If the chain is broken, the write completes almost immediately and the
+  // poll observes it. (An unbounded poll would hang here on a correct implementation.)
+  cudaEvent_t probe{};
+  RMM_CUDA_TRY(cudaEventCreateWithFlags(&probe, cudaEventDisableTiming));
+  RMM_CUDA_TRY(cudaEventRecord(probe, stream_c.value()));
+  auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds{2};
+  auto probe_status   = cudaEventQuery(probe);
+  while (probe_status == cudaErrorNotReady && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{1});
+    probe_status = cudaEventQuery(probe);
+  }
+  EXPECT_EQ(probe_status, cudaErrorNotReady);
+
+  // Release stream A and drain both streams; only now may C's write complete.
+  release.store(true, std::memory_order_release);
+  stream_a.synchronize();
+  stream_c.synchronize();
+  RMM_CUDA_TRY(cudaEventDestroy(probe));
+
+  // Stream C's write is ordered after stream A's, so it must win.
+  std::vector<unsigned char> host(block_size);
+  RMM_CUDA_TRY(cudaMemcpy(host.data(), ptr_c, block_size, cudaMemcpyDefault));
+  EXPECT_TRUE(
+    std::all_of(host.cbegin(), host.cend(), [](unsigned char byte) { return byte == pattern_c; }));
+
+  ref.deallocate(stream_c.view(), ptr_c, block_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  ref.deallocate(stream_b.view(), separator, block_size, rmm::CUDA_ALLOCATION_ALIGNMENT);
 }
 
 class PoolMemoryResourceTest : public ::testing::Test {

--- a/cpp/tests/mr/pool_mr_tests.cpp
+++ b/cpp/tests/mr/pool_mr_tests.cpp
@@ -222,6 +222,15 @@ TEST(PoolTest, CrossStreamStealAfterMergeWaitsForDonorStream)
   // A's event behind the pending write, so any consumer that waits on A's event cannot touch X
   // before the write completes.
   std::atomic<bool> release{false};
+
+  // Unblock the callback during unwinding so resource teardown cannot wait on it indefinitely.
+  struct release_on_exit {
+    std::atomic<bool>& flag;
+
+    ~release_on_exit() { flag.store(true, std::memory_order_release); }
+  };
+
+  release_on_exit unblock{release};
   RMM_CUDA_TRY(cudaLaunchHostFunc(stream_a.value(), spin_until_released, &release));
   RMM_CUDA_TRY(cudaMemsetAsync(ptr_x, pattern_a, block_size, stream_a.value()));
   ref.deallocate(stream_a.view(), ptr_x, block_size, rmm::CUDA_ALLOCATION_ALIGNMENT);


### PR DESCRIPTION
## Description

Closes #2489 

`stream_ordered_memory_resource` guards cross-stream reuse of freed blocks with
a per-free-list CUDA event: `deallocate` records the list's event on the
deallocating stream, and a consumer on another stream does
`cudaStreamWaitEvent` on that event before reusing a block from the list.

`merge_lists()` breaks that chain. When an allocation can only be satisfied by
merging other streams' free lists (the `merge_first` pass of
`get_block_from_other_stream`), the merged-in blocks move into the allocating
stream's list, keyed by that stream's event -- but only a
`cudaStreamWaitEvent` is enqueued; the allocating stream's event is not
re-recorded. Its last recorded position (if it was ever recorded -- for a
stream that has not deallocated yet, the event has never been recorded and a
wait on it is a no-op) predates the barrier just enqueued, so the dependency on
the donor stream's still-in-flight work is silently dropped for every merged
block. Anything that later synchronizes only with the owning list's event sees
stale state:

* a cross-stream steal (non-merge path of `get_block_from_other_stream`) can
  hand the block to a third stream while the donor stream is still using it,
  causing concurrent reuse of the same memory (data corruption, and with
  in-flight kernels reading the block, hangs or illegal memory access);
* a subsequent merge propagates the same broken chain;
* `release()` (destructor) only does `cudaEventSynchronize` on each list's
  event, so it can return the pool to the upstream resource while a donor
  stream still has work in flight on a merged block.

The window closes as soon as the allocating stream performs any `deallocate`
(which re-records the event past the barrier) -- which is presumably why this
has been hard to hit and diagnose.

We hit this in production benchmarking of cuVS (8 host threads, one CUDA
stream each, sharing one `pool_memory_resource`): a CUB `DeviceRadixSort`
running on the donor stream had its temporary storage stolen by a third
stream and overwritten, which manifested as either a full-GPU hang in the
onesweep lookback (tile states zeroed by the thief's `thrust::fill`) or an
illegal memory access (offsets overwritten with garbage), a few minutes into
each run. With this one-line fix the same workload survived 40 consecutive
runs of the previously-fatal scenario with no failure (mean time to failure
was ~7-18 runs before).

The fix records the allocating stream's event immediately after the wait
enqueued by `merge_lists`, restoring transitivity of the wait chain. The added
`cudaEventRecord` is on the merge path only, which is already the slow path
(per-stream free list and the steal pass have both failed).

The new test builds the minimal broken chain deterministically with three
streams (donor A stalled by a host function with a pending write to block X,
stream B whose failed allocation merges A's list, stream C stealing X from B's
list) and checks which of two `cudaMemsetAsync` writes to X wins. It fails
without the fix (A's stalled write lands last and clobbers C's) and passes
with it (C's write is stream-ordered after A's). Verified on A100 / CUDA 12.9
(this gtest: fails with the fix reverted, passes with it; full POOL_MR_TEST
suite passes) and on Blackwell B300 / CUDA 13.1 (standalone equivalent against
the rmm 26.08 headers: 5/5 fail unfixed, 5/5 pass fixed).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.