### PR TITLE
X-ORG-2491: Publish API docs to docs.nvidia.com

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
     with:
       docs-projects: rmm,librmm
       dry-run: false
-      version-map: '{"26.08": "legacy", "26.10": "stable"}'
+      version-map: '{"26.06": "legacy", "26.08": "stable"}'
   wheel-build-cpp:
     needs: [telemetry-setup]
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,6 +118,27 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.10-latest"
       script: ci/build_docs.sh
+  publish-api-docs:
+    if: github.ref_type == 'branch'
+    needs: [docs-build]
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      akamai-access-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_ACCESS_TOKEN }}
+      akamai-client-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_TOKEN }}
+      akamai-client-secret: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_SECRET }}
+      akamai-host: ${{ secrets.NVIDIA_DOCS_AKAMAI_HOST }}
+      target-aws-access-key-id: ${{ secrets.NVIDIA_DOCS_AWS_ACCESS_KEY_ID }}
+      target-aws-region: ${{ secrets.NVIDIA_DOCS_AWS_REGION }}
+      target-aws-secret-access-key: ${{ secrets.NVIDIA_DOCS_AWS_SECRET_ACCESS_KEY }}
+      target-s3-bucket: ${{ secrets.NVIDIA_DOCS_S3_BUCKET }}
+    uses: rapidsai/shared-workflows/.github/workflows/publish-api-docs.yaml@josephine/x-org-596-finesse-publish-api-docs
+    with:
+      akamai-emails-to-notify: joberholtzer@nvidia.com
+      docs-projects: rmm,librmm
+      dry-run: false
+      version-map: '{"26.08": "legacy", "26.10": "stable"}'
   wheel-build-cpp:
     needs: [telemetry-setup]
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,14 +128,14 @@ jobs:
       akamai-access-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_ACCESS_TOKEN }}
       akamai-client-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_TOKEN }}
       akamai-client-secret: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_SECRET }}
+      akamai-emails-to-notify: ${{ secrets.NVIDIA_DOCS_AKAMAI_EMAILS_TO_NOTIFY }}
       akamai-host: ${{ secrets.NVIDIA_DOCS_AKAMAI_HOST }}
       target-aws-access-key-id: ${{ secrets.NVIDIA_DOCS_AWS_ACCESS_KEY_ID }}
       target-aws-region: ${{ secrets.NVIDIA_DOCS_AWS_REGION }}
       target-aws-secret-access-key: ${{ secrets.NVIDIA_DOCS_AWS_SECRET_ACCESS_KEY }}
       target-s3-bucket: ${{ secrets.NVIDIA_DOCS_S3_BUCKET }}
-    uses: rapidsai/shared-workflows/.github/workflows/publish-api-docs.yaml@josephine/x-org-596-finesse-publish-api-docs
+    uses: rapidsai/shared-workflows/.github/workflows/publish-api-docs.yaml@main
     with:
-      akamai-emails-to-notify: joberholtzer@nvidia.com
       docs-projects: rmm,librmm
       dry-run: false
       version-map: '{"26.08": "legacy", "26.10": "stable"}'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
     with:
       docs-projects: rmm,librmm
       dry-run: false
-      version-map: '{"26.06": "legacy", "26.08": "stable"}'
+      version-map: '{"26.04": "legacy", "26.06": "stable"}'
   wheel-build-cpp:
     needs: [telemetry-setup]
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -351,7 +351,7 @@ jobs:
     with:
       docs-projects: rmm,librmm
       dry-run: true
-      version-map: '{"26.08": "legacy", "26.10": "stable"}'
+      version-map: '{"26.06": "legacy", "26.08": "stable"}'
   wheel-build-cpp:
     needs: checks
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,7 @@ jobs:
       - conda-python-tests
       - conda-python-tests-integration-optional
       - docs-build
+      - publish-api-docs
       - wheel-build-cpp
       - wheel-build-python
       - wheel-tests
@@ -330,6 +331,27 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/build_docs.sh"
+  publish-api-docs:
+    if: github.ref_type == 'branch'
+    needs: [docs-build]
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      akamai-access-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_ACCESS_TOKEN }}
+      akamai-client-token: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_TOKEN }}
+      akamai-client-secret: ${{ secrets.NVIDIA_DOCS_AKAMAI_CLIENT_SECRET }}
+      akamai-emails-to-notify: ${{ secrets.NVIDIA_DOCS_AKAMAI_EMAILS_TO_NOTIFY }}
+      akamai-host: ${{ secrets.NVIDIA_DOCS_AKAMAI_HOST }}
+      target-aws-access-key-id: ${{ secrets.NVIDIA_DOCS_AWS_ACCESS_KEY_ID }}
+      target-aws-region: ${{ secrets.NVIDIA_DOCS_AWS_REGION }}
+      target-aws-secret-access-key: ${{ secrets.NVIDIA_DOCS_AWS_SECRET_ACCESS_KEY }}
+      target-s3-bucket: ${{ secrets.NVIDIA_DOCS_S3_BUCKET }}
+    uses: rapidsai/shared-workflows/.github/workflows/publish-api-docs.yaml@josephine/x-org-596-finesse-publish-api-docs
+    with:
+      docs-projects: rmm,librmm
+      dry-run: true
+      version-map: '{"26.08": "legacy", "26.10": "stable"}'
   wheel-build-cpp:
     needs: checks
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -347,7 +347,7 @@ jobs:
       target-aws-region: ${{ secrets.NVIDIA_DOCS_AWS_REGION }}
       target-aws-secret-access-key: ${{ secrets.NVIDIA_DOCS_AWS_SECRET_ACCESS_KEY }}
       target-s3-bucket: ${{ secrets.NVIDIA_DOCS_S3_BUCKET }}
-    uses: rapidsai/shared-workflows/.github/workflows/publish-api-docs.yaml@josephine/x-org-596-finesse-publish-api-docs
+    uses: rapidsai/shared-workflows/.github/workflows/publish-api-docs.yaml@main
     with:
       docs-projects: rmm,librmm
       dry-run: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -351,7 +351,7 @@ jobs:
     with:
       docs-projects: rmm,librmm
       dry-run: true
-      version-map: '{"26.06": "legacy", "26.08": "stable"}'
+      version-map: '{"26.04": "legacy", "26.06": "stable"}'
   wheel-build-cpp:
     needs: checks
     permissions:


### PR DESCRIPTION
## Description

Contributes to #2491 

As part of publishing API docs to docs.nvidia.com, we need to integrate a [new shared workflow](https://github.com/rapidsai/shared-workflows/blob/main/.github/workflows/publish-api-docs.yaml) into the build workflow.

This integration will take the docs publish by the docs-build job and push them to the docs.nvidia.com S3 bucket. It does not automatically make those docs go live - that needs to be handled out-of-band by the docs team themselves.

N.B. This _does not replace_ publishing docs to docs.rapidsai.org. This is _in addition to_.

XREF: https://github.com/rapidsai/shared-workflows/issues/596

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
