### PR TITLE
X-ORG-2491: Enable docs version picker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Configuration file for the Sphinx documentation builder.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,12 @@ html_theme_options = {
     ],
     "show_toc_level": 1,
     "navbar_align": "right",
+    "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/rmm/versions.json",
+        "version_match": version,
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Contributes to #2491 

Let's enable the docs version picker.

N.B. I will backport this to 26.08 _after_ the release to ensure it goes live for those docs.
