### PR TITLE
Limit arena size in C++ tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,7 +56,6 @@ jobs:
   build-details:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   check-nightly-ci:
-    if: false
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -235,7 +234,6 @@ jobs:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize conda-python-tests-integration-optional wheel-tests-integration-optional"
   cmake-tests:
-    if: false
     needs: checks
     permissions:
       actions: read
@@ -279,8 +277,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
-      matrix_type: nightly
-      matrix_filter: map(select(.GPU == "gb300"))
       script: ci/test_cpp.sh
   conda-cpp-debug-tests:
     needs: [checks, changed-files]
@@ -292,7 +288,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: false
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
@@ -300,7 +296,6 @@ jobs:
       container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/test_cpp_debug.sh"
   conda-python-build:
-    if: false
     needs: [build-details, conda-cpp-build]
     permissions:
       actions: read
@@ -383,7 +378,6 @@ jobs:
       dry-run: true
       version-map: '{"26.04": "legacy", "26.06": "stable"}'
   wheel-build-cpp:
-    if: false
     needs: [build-details, checks]
     permissions:
       actions: read
@@ -449,7 +443,6 @@ jobs:
       build_type: pull-request
       script: ci/test_wheel_integrations.sh
   devcontainer:
-    if: false
     permissions:
       actions: read
       contents: read
@@ -478,7 +471,7 @@ jobs:
     permissions:
       actions: write
     needs: pr-builder
-    if: false
+    if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() && github.run_attempt == '1' }}
     continue-on-error: true
     steps:
       - name: Telemetry summarize

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,6 +56,7 @@ jobs:
   build-details:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   check-nightly-ci:
+    if: false
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -234,6 +235,7 @@ jobs:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize conda-python-tests-integration-optional wheel-tests-integration-optional"
   cmake-tests:
+    if: false
     needs: checks
     permissions:
       actions: read
@@ -277,6 +279,8 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
+      matrix_type: nightly
+      matrix_filter: map(select(.GPU == "gb300"))
       script: ci/test_cpp.sh
   conda-cpp-debug-tests:
     needs: [checks, changed-files]
@@ -288,7 +292,7 @@ jobs:
       pull-requests: read
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
+    if: false
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"
@@ -296,6 +300,7 @@ jobs:
       container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/test_cpp_debug.sh"
   conda-python-build:
+    if: false
     needs: [build-details, conda-cpp-build]
     permissions:
       actions: read
@@ -378,6 +383,7 @@ jobs:
       dry-run: true
       version-map: '{"26.04": "legacy", "26.06": "stable"}'
   wheel-build-cpp:
+    if: false
     needs: [build-details, checks]
     permissions:
       actions: read
@@ -443,6 +449,7 @@ jobs:
       build_type: pull-request
       script: ci/test_wheel_integrations.sh
   devcontainer:
+    if: false
     permissions:
       actions: read
       contents: read
@@ -471,7 +478,7 @@ jobs:
     permissions:
       actions: write
     needs: pr-builder
-    if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() && github.run_attempt == '1' }}
+    if: false
     continue-on-error: true
     steps:
       - name: Telemetry summarize

--- a/ci/gpu_info.sh
+++ b/ci/gpu_info.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+rapids-logger "Check GPU status"
+nvidia-smi
+
+rapids-logger "Check memory configuration"
+nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
+grep Coherent /proc/driver/nvidia/params || echo "Coherent GPU memory mode not reported"
+grep -o 'init_on_alloc=[^ ]*' /proc/cmdline || echo "init_on_alloc: kernel default"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -33,13 +33,7 @@ set -u
 
 rapids-print-env
 
-rapids-logger "Check GPU status"
-nvidia-smi
-
-rapids-logger "Check memory configuration"
-nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
-grep Coherent /proc/driver/nvidia/params || echo "Coherent GPU memory mode not reported"
-grep -o 'init_on_alloc=[^ ]*' /proc/cmdline || echo "init_on_alloc: kernel default"
+./ci/gpu_info.sh
 
 # Run librmm gtests from librmm-tests package
 rapids-logger "Run gtests"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -32,12 +32,14 @@ conda activate test
 set -u
 
 rapids-print-env
-grep -o 'init_on_alloc=[^ ]*' /proc/cmdline || echo "init_on_alloc not set in /proc/cmdline"
 
 rapids-logger "Check GPU status"
 nvidia-smi
+
+rapids-logger "Check memory configuration"
 nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
 grep Coherent /proc/driver/nvidia/params || echo "Coherent GPU memory mode not reported"
+grep -o 'init_on_alloc=[^ ]*' /proc/cmdline || echo "init_on_alloc: kernel default"
 
 # Run librmm gtests from librmm-tests package
 rapids-logger "Run gtests"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -32,11 +32,12 @@ conda activate test
 set -u
 
 rapids-print-env
+grep -o 'init_on_alloc=[^ ]*' /proc/cmdline || echo "init_on_alloc not set in /proc/cmdline"
 
 rapids-logger "Check GPU status"
 nvidia-smi
 nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
-grep -o 'init_on_alloc=[^ ]*' /proc/cmdline || echo "init_on_alloc not set in /proc/cmdline"
+grep Coherent /proc/driver/nvidia/params || echo "Coherent GPU memory mode not reported"
 
 # Run librmm gtests from librmm-tests package
 rapids-logger "Run gtests"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -36,6 +36,7 @@ rapids-print-env
 rapids-logger "Check GPU status"
 nvidia-smi
 nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
+grep -o 'init_on_alloc=[^ ]*' /proc/cmdline || echo "init_on_alloc not set in /proc/cmdline"
 
 # Run librmm gtests from librmm-tests package
 rapids-logger "Run gtests"

--- a/ci/test_cpp_debug.sh
+++ b/ci/test_cpp_debug.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -33,9 +33,7 @@ set -u
 
 rapids-print-env
 
-rapids-logger "Check GPU status"
-nvidia-smi
-nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
+./ci/gpu_info.sh
 
 rapids-logger "Building librmm in Debug mode"
 cmake -S cpp -B cpp/build \

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -39,9 +39,7 @@ RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 
-rapids-logger "Check GPU status"
-nvidia-smi
-nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
+./ci/gpu_info.sh
 
 rapids-logger "pytest rmm"
 

--- a/ci/test_python_integrations.sh
+++ b/ci/test_python_integrations.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -22,9 +22,7 @@ RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}
 RAPIDS_COVERAGE_DIR=${RAPIDS_COVERAGE_DIR:-"${PWD}/coverage-results"}
 mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 
-rapids-logger "Check GPU status"
-nvidia-smi
-nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
+./ci/gpu_info.sh
 
 EXITCODE=0
 

--- a/ci/test_wheel_integrations.sh
+++ b/ci/test_wheel_integrations.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -eou pipefail
@@ -28,9 +28,7 @@ PIP_INSTALL_SHARED_ARGS=(
 
 EXITCODE=0
 
-rapids-logger "Check GPU status"
-nvidia-smi
-nvidia-smi -q | grep "Addressing Mode" || echo "Addressing Mode not reported"
+./ci/gpu_info.sh
 
 echo "::group::PyTorch Tests"
 

--- a/cpp/tests/mr/mr_ref_arena_tests.cpp
+++ b/cpp/tests/mr/mr_ref_arena_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -35,7 +35,7 @@ INSTANTIATE_TEST_SUITE_P(ArenaMultiThreadResourceTests,
 
 struct ArenaMRFixture : public ::testing::Test {
   rmm::mr::cuda_memory_resource upstream{};
-  rmm::mr::arena_memory_resource mr{upstream};
+  rmm::mr::arena_memory_resource mr{upstream, 8_GiB};
   rmm::device_async_resource_ref ref{mr};
   rmm::cuda_stream stream{};
 };

--- a/cpp/tests/mr/mr_ref_test.hpp
+++ b/cpp/tests/mr/mr_ref_test.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -400,7 +400,7 @@ inline auto make_system()
 
 inline auto make_arena()
 {
-  return std::make_shared<rmm::mr::arena_memory_resource>(rmm::mr::cuda_memory_resource{});
+  return std::make_shared<rmm::mr::arena_memory_resource>(rmm::mr::cuda_memory_resource{}, 8_GiB);
 }
 
 inline auto make_fixed_size()


### PR DESCRIPTION
## Description

Use an explicit 8 GiB arena in the C++ arena MR reference tests instead of the default half of available device memory. This prevents 116 fixture constructions from each reserving roughly 125 GiB on GB300 while preserving the capacity available on the original 16 GiB test target.

Measured on DGX Spark (128GB integrated memory), total test time for the arena MR reference tests decreased from 64.41 seconds to 11.88 seconds (81.6% reduction).

Additionally, on GB300, setting `init_on_alloc=0` reduced the C++ test-suite runtime from 399.09 seconds with the kernel default to 42.92 seconds, a 9.30× speedup and an 89.2% reduction. Both times were measured with the arena size limits from this PR -- we need both the arena size limits and `init_on_alloc=0` to achieve a reasonable test runtime.

Closes #2505. Follows the Python test precedent in #2273.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
