### PR TITLE
Set managed pool release threshold to maximum

### DIFF
--- a/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
@@ -50,10 +50,10 @@ class RMM_EXPORT cuda_async_managed_memory_resource final
    * @brief Constructs a cuda_async_managed_memory_resource with the default managed memory pool for
    * the current device.
    *
-   * The default managed memory pool is the pool that is created when the device is created. If its
-   * release threshold is zero, it is set to `std::numeric_limits<std::uint64_t>::max()`. An
-   * existing nonzero release threshold is preserved. This change is visible to all users of the
-   * device's default managed pool and retains unused backing memory across synchronizations.
+   * The default managed memory pool is the pool that is created when the device is created. Its
+   * release threshold is set to `std::numeric_limits<std::uint64_t>::max()`. This change is visible
+   * to all users of the device's default managed pool and retains unused backing memory across
+   * synchronizations.
    *
    * @throws rmm::logic_error if the CUDA version does not support `cudaMallocFromPoolAsync` with
    * managed memory pool

--- a/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
@@ -51,8 +51,8 @@ class RMM_EXPORT cuda_async_managed_memory_resource final
    * the current device.
    *
    * The default managed memory pool is the pool that is created when the device is created. Its
-   * release threshold is set to `std::numeric_limits<std::uint64_t>::max()`. This change is visible
-   * to all users of the device's default managed pool and retains unused backing memory across
+   * release threshold is set to the maximum value of `std::uint64_t`. This change is visible to all
+   * users of the device's default managed pool and retains unused backing memory across
    * synchronizations.
    *
    * @throws rmm::logic_error if the CUDA version does not support `cudaMallocFromPoolAsync` with

--- a/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_managed_memory_resource.hpp
@@ -50,8 +50,10 @@ class RMM_EXPORT cuda_async_managed_memory_resource final
    * @brief Constructs a cuda_async_managed_memory_resource with the default managed memory pool for
    * the current device.
    *
-   * The default managed memory pool is the pool that is created when the device is created.
-   * Pool properties such as the release threshold are not modified.
+   * The default managed memory pool is the pool that is created when the device is created. If its
+   * release threshold is zero, it is set to `std::numeric_limits<std::uint64_t>::max()`. An
+   * existing nonzero release threshold is preserved. This change is visible to all users of the
+   * device's default managed pool and retains unused backing memory across synchronizations.
    *
    * @throws rmm::logic_error if the CUDA version does not support `cudaMallocFromPoolAsync` with
    * managed memory pool

--- a/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
@@ -13,6 +13,8 @@
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 
 RMM_NAMESPACE_BEGIN
 namespace mr {
@@ -30,6 +32,14 @@ cuda_async_managed_memory_resource_impl::cuda_async_managed_memory_resource_impl
                            .id   = rmm::get_current_cuda_device().value()};
   RMM_CUDA_TRY(
     cudaMemGetDefaultMemPool(&managed_pool_handle, &location, cudaMemAllocationTypeManaged));
+  std::uint64_t release_threshold{};
+  RMM_CUDA_TRY(cudaMemPoolGetAttribute(
+    managed_pool_handle, cudaMemPoolAttrReleaseThreshold, &release_threshold));
+  if (release_threshold == 0) {
+    release_threshold = std::numeric_limits<std::uint64_t>::max();
+    RMM_CUDA_TRY(cudaMemPoolSetAttribute(
+      managed_pool_handle, cudaMemPoolAttrReleaseThreshold, &release_threshold));
+  }
   pool_ = cuda_async_view_memory_resource{managed_pool_handle};
 #endif
 }

--- a/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
@@ -32,14 +32,9 @@ cuda_async_managed_memory_resource_impl::cuda_async_managed_memory_resource_impl
                            .id   = rmm::get_current_cuda_device().value()};
   RMM_CUDA_TRY(
     cudaMemGetDefaultMemPool(&managed_pool_handle, &location, cudaMemAllocationTypeManaged));
-  std::uint64_t release_threshold{};
-  RMM_CUDA_TRY(cudaMemPoolGetAttribute(
+  std::uint64_t release_threshold = std::numeric_limits<std::uint64_t>::max();
+  RMM_CUDA_TRY(cudaMemPoolSetAttribute(
     managed_pool_handle, cudaMemPoolAttrReleaseThreshold, &release_threshold));
-  if (release_threshold == 0) {
-    release_threshold = std::numeric_limits<std::uint64_t>::max();
-    RMM_CUDA_TRY(cudaMemPoolSetAttribute(
-      managed_pool_handle, cudaMemPoolAttrReleaseThreshold, &release_threshold));
-  }
   pool_ = cuda_async_view_memory_resource{managed_pool_handle};
 #endif
 }

--- a/cpp/tests/mr/cuda_async_managed_mr_tests.cpp
+++ b/cpp/tests/mr/cuda_async_managed_mr_tests.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <rmm/cuda_device.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/cuda_async_managed_memory_resource.hpp>
@@ -29,51 +28,16 @@ class AsyncManagedMRTest : public ::testing::Test {
                    << "requires CUDA 13.0 or higher and concurrent managed "
                    << "access support.";
     }
-
-#if defined(CUDA_VERSION) && CUDA_VERSION >= RMM_MIN_ASYNC_MANAGED_ALLOC_CUDA_VERSION
-    cudaMemLocation location{.type = cudaMemLocationTypeDevice,
-                             .id   = rmm::get_current_cuda_device().value()};
-    RMM_CUDA_TRY(cudaMemGetDefaultMemPool(&managed_pool_, &location, cudaMemAllocationTypeManaged));
-    RMM_CUDA_TRY(cudaMemPoolGetAttribute(
-      managed_pool_, cudaMemPoolAttrReleaseThreshold, &original_release_threshold_));
-#endif
   }
-
-  void TearDown() override
-  {
-    if (managed_pool_ != nullptr) {
-      EXPECT_EQ(cudaSuccess,
-                cudaMemPoolSetAttribute(
-                  managed_pool_, cudaMemPoolAttrReleaseThreshold, &original_release_threshold_));
-    }
-  }
-
-  cudaMemPool_t managed_pool_{};
-  std::uint64_t original_release_threshold_{};
 };
 
 TEST_F(AsyncManagedMRTest, DefaultReleaseThresholdIsUint64Max)
 {
-  std::uint64_t threshold{};
-  RMM_CUDA_TRY(cudaMemPoolSetAttribute(managed_pool_, cudaMemPoolAttrReleaseThreshold, &threshold));
-
   cuda_async_managed_mr mr{};
+  std::uint64_t threshold{};
   RMM_CUDA_TRY(
     cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
   EXPECT_EQ(threshold, std::numeric_limits<std::uint64_t>::max());
-}
-
-TEST_F(AsyncManagedMRTest, NonzeroReleaseThresholdIsPreserved)
-{
-  constexpr std::uint64_t expected_threshold{1024};
-  std::uint64_t threshold{expected_threshold};
-  RMM_CUDA_TRY(cudaMemPoolSetAttribute(managed_pool_, cudaMemPoolAttrReleaseThreshold, &threshold));
-
-  cuda_async_managed_mr mr{};
-  threshold = 0;
-  RMM_CUDA_TRY(
-    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
-  EXPECT_EQ(threshold, expected_threshold);
 }
 
 TEST_F(AsyncManagedMRTest, BasicAllocateDeallocate)

--- a/cpp/tests/mr/cuda_async_managed_mr_tests.cpp
+++ b/cpp/tests/mr/cuda_async_managed_mr_tests.cpp
@@ -1,8 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <rmm/cuda_device.hpp>
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/cuda_async_managed_memory_resource.hpp>
@@ -10,6 +11,9 @@
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
 
 namespace rmm::test {
 namespace {
@@ -25,8 +29,52 @@ class AsyncManagedMRTest : public ::testing::Test {
                    << "requires CUDA 13.0 or higher and concurrent managed "
                    << "access support.";
     }
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= RMM_MIN_ASYNC_MANAGED_ALLOC_CUDA_VERSION
+    cudaMemLocation location{.type = cudaMemLocationTypeDevice,
+                             .id   = rmm::get_current_cuda_device().value()};
+    RMM_CUDA_TRY(cudaMemGetDefaultMemPool(&managed_pool_, &location, cudaMemAllocationTypeManaged));
+    RMM_CUDA_TRY(cudaMemPoolGetAttribute(
+      managed_pool_, cudaMemPoolAttrReleaseThreshold, &original_release_threshold_));
+#endif
   }
+
+  void TearDown() override
+  {
+    if (managed_pool_ != nullptr) {
+      EXPECT_EQ(cudaSuccess,
+                cudaMemPoolSetAttribute(
+                  managed_pool_, cudaMemPoolAttrReleaseThreshold, &original_release_threshold_));
+    }
+  }
+
+  cudaMemPool_t managed_pool_{};
+  std::uint64_t original_release_threshold_{};
 };
+
+TEST_F(AsyncManagedMRTest, DefaultReleaseThresholdIsUint64Max)
+{
+  std::uint64_t threshold{};
+  RMM_CUDA_TRY(cudaMemPoolSetAttribute(managed_pool_, cudaMemPoolAttrReleaseThreshold, &threshold));
+
+  cuda_async_managed_mr mr{};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
+  EXPECT_EQ(threshold, std::numeric_limits<std::uint64_t>::max());
+}
+
+TEST_F(AsyncManagedMRTest, NonzeroReleaseThresholdIsPreserved)
+{
+  constexpr std::uint64_t expected_threshold{1024};
+  std::uint64_t threshold{expected_threshold};
+  RMM_CUDA_TRY(cudaMemPoolSetAttribute(managed_pool_, cudaMemPoolAttrReleaseThreshold, &threshold));
+
+  cuda_async_managed_mr mr{};
+  threshold = 0;
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &threshold));
+  EXPECT_EQ(threshold, expected_threshold);
+}
 
 TEST_F(AsyncManagedMRTest, BasicAllocateDeallocate)
 {


### PR DESCRIPTION
## Description

Set CUDA's default managed-pool release threshold to `UINT64_MAX` when `cuda_async_managed_memory_resource` is constructed. This matches the default policy of `cuda_async_memory_resource` and retains managed-pool backing across synchronization points, avoiding the repeated allocation, mapping, and prefetch stalls measured in the linked issue.

Document the device-global memory-retention effect and add regression coverage for the maximum threshold.

Closes #2510.