### PR TITLE
Replace `<cuda/stream_ref>` includes with `<cuda/stream>`

### DIFF
--- a/cpp/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/cpp/benchmarks/utilities/simulated_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/benchmarks/utilities/simulated_memory_resource.hpp
+++ b/cpp/benchmarks/utilities/simulated_memory_resource.hpp
@@ -9,7 +9,7 @@
 #include <rmm/detail/format.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/cuda_stream.hpp
+++ b/cpp/include/rmm/cuda_stream.hpp
@@ -8,7 +8,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/detail/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <functional>

--- a/cpp/include/rmm/cuda_stream_view.hpp
+++ b/cpp/include/rmm/cuda_stream_view.hpp
@@ -7,7 +7,7 @@
 
 #include <rmm/detail/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_view_memory_resource.hpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/cuda_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_memory_resource.hpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 

--- a/cpp/include/rmm/mr/detail/cuda_async_managed_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/cuda_async_managed_memory_resource_impl.hpp
@@ -9,7 +9,7 @@
 #include <rmm/mr/cuda_async_view_memory_resource.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/detail/cuda_async_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/cuda_async_memory_resource_impl.hpp
@@ -9,7 +9,7 @@
 #include <rmm/mr/cuda_async_view_memory_resource.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
+++ b/cpp/include/rmm/mr/detail/failure_callback_resource_adaptor_impl.hpp
@@ -12,7 +12,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/detail/sam_headroom_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/sam_headroom_memory_resource_impl.hpp
@@ -9,7 +9,7 @@
 #include <rmm/mr/system_memory_resource.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
+++ b/cpp/include/rmm/mr/detail/stream_ordered_memory_resource.hpp
@@ -12,7 +12,7 @@
 #include <rmm/logger.hpp>
 #include <rmm/process_is_exiting.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <algorithm>

--- a/cpp/include/rmm/mr/managed_memory_resource.hpp
+++ b/cpp/include/rmm/mr/managed_memory_resource.hpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 

--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/include/rmm/mr/system_memory_resource.hpp
+++ b/cpp/include/rmm/mr/system_memory_resource.hpp
@@ -9,7 +9,7 @@
 #include <rmm/detail/export.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/src/cuda_stream_view.cpp
+++ b/cpp/src/cuda_stream_view.cpp
@@ -7,7 +7,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/detail/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <ostream>

--- a/cpp/src/mr/cuda_async_view_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_view_memory_resource.cpp
@@ -7,7 +7,7 @@
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/cuda_async_view_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/src/mr/cuda_memory_resource.cpp
+++ b/cpp/src/mr/cuda_memory_resource.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/aligned_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <algorithm>

--- a/cpp/src/mr/detail/arena_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/arena_memory_resource_impl.cpp
@@ -9,7 +9,7 @@
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/arena_memory_resource_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/callback_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/callback_memory_resource_impl.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/callback_memory_resource_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <utility>

--- a/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/limiting_resource_adaptor_impl.cpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/limiting_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/logging_resource_adaptor_impl.cpp
@@ -9,7 +9,7 @@
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/detail/logging_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/prefetch_resource_adaptor_impl.cpp
@@ -8,7 +8,7 @@
 #include <rmm/mr/detail/prefetch_resource_adaptor_impl.hpp>
 #include <rmm/prefetch.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/sam_headroom_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/sam_headroom_memory_resource_impl.cpp
@@ -9,7 +9,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/sam_headroom_memory_resource_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <algorithm>

--- a/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/statistics_resource_adaptor_impl.cpp
@@ -7,7 +7,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/statistics_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <stdexcept>

--- a/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/thread_safe_resource_adaptor_impl.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/detail/thread_safe_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 RMM_NAMESPACE_BEGIN

--- a/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
+++ b/cpp/src/mr/detail/tracking_resource_adaptor_impl.cpp
@@ -8,7 +8,7 @@
 #include <rmm/logger.hpp>
 #include <rmm/mr/detail/tracking_resource_adaptor_impl.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <sstream>

--- a/cpp/src/mr/managed_memory_resource.cpp
+++ b/cpp/src/mr/managed_memory_resource.cpp
@@ -6,7 +6,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/src/mr/pinned_host_memory_resource.cpp
+++ b/cpp/src/mr/pinned_host_memory_resource.cpp
@@ -7,7 +7,7 @@
 #include <rmm/detail/error.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/src/mr/system_memory_resource.cpp
+++ b/cpp/src/mr/system_memory_resource.cpp
@@ -8,7 +8,7 @@
 #include <rmm/detail/format.hpp>
 #include <rmm/mr/system_memory_resource.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -7,7 +7,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest-death-test.h>

--- a/cpp/tests/device_check_resource_adaptor.hpp
+++ b/cpp/tests/device_check_resource_adaptor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/tests/device_check_resource_adaptor.hpp
+++ b/cpp/tests/device_check_resource_adaptor.hpp
@@ -12,7 +12,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>

--- a/cpp/tests/mock_resource.hpp
+++ b/cpp/tests/mock_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/tests/mock_resource.hpp
+++ b/cpp/tests/mock_resource.hpp
@@ -8,7 +8,7 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <gmock/gmock.h>
 

--- a/cpp/tests/mr/arena_mr_tests.cpp
+++ b/cpp/tests/mr/arena_mr_tests.cpp
@@ -13,7 +13,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/cpp/tests/mr/failure_callback_mr_tests.cpp
+++ b/cpp/tests/mr/failure_callback_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/cpp/tests/mr/failure_callback_mr_tests.cpp
+++ b/cpp/tests/mr/failure_callback_mr_tests.cpp
@@ -13,7 +13,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

CCCL deprecated the `<cuda/stream_ref>` header; `cuda::stream_ref` is now provided by `<cuda/stream>`. This PR switches every `#include <cuda/stream_ref>` to `#include <cuda/stream>` so RMM builds against newer CCCL.

The `cuda::stream_ref` type is unchanged. This was observed in rapids-cmake CI: https://github.com/rapidsai/rapids-cmake/actions/runs/31745925779/job/94600794610?pr=1073

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nvidia.slack.com/archives/C0B3FFMK6PK/p1786722557219489?thread_ts=1786722557.219489&cid=C0B3FFMK6PK)

<div><a href="https://cursor.com/agents/bc-66770a18-9703-5f5f-8820-cb971c1f43dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66770a18-9703-5f5f-8820-cb971c1f43dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

