### PR TITLE
Fix parse_bytes overflow handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.codespell]
@@ -10,6 +10,9 @@ ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
 ignore-words-list = "thirdparty,couldn"
 builtin = "clear"
 quiet-level = 3
+
+[tool.cython-lint]
+max-line-length = 120
 
 [tool.ruff]
 line-length = 79

--- a/python/rmm/rmm/pylibrmm/helper.pyx
+++ b/python/rmm/rmm/pylibrmm/helper.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Helper functions for rmm"""
@@ -46,7 +46,7 @@ cdef object parse_bytes(object s):
     """
     cdef str suffix
     cdef double n
-    cdef int multiplier
+    cdef long long multiplier
 
     if isinstance(s, int):
         return s
@@ -64,4 +64,9 @@ cdef object parse_bytes(object s):
 
     multiplier = BYTE_SIZES[suffix.lower()]
 
-    return int(n*multiplier)
+    try:
+        return int(n*multiplier)
+    except OverflowError:
+        raise ValueError(
+            f"Could not parse {s} as a byte specification"
+        ) from None

--- a/python/rmm/rmm/tests/test_initialization.py
+++ b/python/rmm/rmm/tests/test_initialization.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for RMM initialization and reinitialization."""
@@ -22,10 +22,13 @@ def test_reinitialize_initial_pool_size_gt_max() -> None:
     assert "Initial pool size exceeds the maximum pool size" in str(e.value)
 
 
-def test_reinitialize_with_valid_str_arg_pool_size() -> None:
+@pytest.mark.parametrize("initial_pool_size", ["2kib", "0pib"])
+def test_reinitialize_with_valid_str_arg_pool_size(
+    initial_pool_size: str,
+) -> None:
     rmm.reinitialize(
         pool_allocator=True,
-        initial_pool_size="2kib",
+        initial_pool_size=initial_pool_size,
         maximum_pool_size="8kib",
     )
 
@@ -38,6 +41,11 @@ def test_reinitialize_with_invalid_str_arg_pool_size() -> None:
             maximum_pool_size="8k",
         )
     assert "Could not parse" in str(e.value)
+
+
+def test_reinitialize_with_overflowing_str_arg_pool_size() -> None:
+    with pytest.raises(ValueError, match="Could not parse"):
+        rmm.reinitialize(pool_allocator=True, initial_pool_size="1" * 400)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Closes #2514.

Return the documented `ValueError` when a parsed byte count overflows, and widen the suffix multiplier so documented TB/PB units parse successfully. Add regression coverage for both cases and configure Cython linting with a 120-character line limit.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.