### PR TITLE
Fix 26.08 references

### DIFF
--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-mambaforge"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/rmm/devcontainer:26.08-cuda12.9-conda"
+      "ghcr.io/rapidsai/rmm/devcontainer:26.10-cuda12.9-conda"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-cuda12.9"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/rmm/devcontainer:26.08-cuda12.9-pip"
+      "ghcr.io/rapidsai/rmm/devcontainer:26.10-cuda12.9-pip"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda13.3-conda/devcontainer.json
+++ b/.devcontainer/cuda13.3-conda/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-mambaforge"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/rmm/devcontainer:26.08-cuda13.3-conda"
+      "ghcr.io/rapidsai/rmm/devcontainer:26.10-cuda13.3-conda"
     ]
   },
   "runArgs": [

--- a/.devcontainer/cuda13.3-pip/devcontainer.json
+++ b/.devcontainer/cuda13.3-pip/devcontainer.json
@@ -8,7 +8,7 @@
       "BASE": "rapidsai/devcontainers:26.10-cpp-cuda13.3"
     },
     "cacheFrom": [
-      "ghcr.io/rapidsai/rmm/devcontainer:26.08-cuda13.3-pip"
+      "ghcr.io/rapidsai/rmm/devcontainer:26.10-cuda13.3-pip"
     ]
   },
   "runArgs": [

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -247,7 +247,7 @@ jobs:
       build_type: pull-request
       node_type: cpu16
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.08-latest"
+      container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/test_cmake.sh"
   conda-cpp-build:
     needs: [build-details, checks]

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 ########################
 # RMM Version Updater #
@@ -101,6 +101,7 @@ done
 # .devcontainer files
 find .devcontainer/ -type f -name devcontainer.json -print0 | while IFS= read -r -d '' filename; do
     sed_runner "s@rapidsai/devcontainers:[0-9.]*@rapidsai/devcontainers:${NEXT_SHORT_TAG}@g" "${filename}"
+    sed_runner "s@ghcr.io/rapidsai/rmm/devcontainer:[0-9.]*@ghcr.io/rapidsai/rmm/devcontainer:${NEXT_SHORT_TAG}@g" "${filename}"
     sed_runner "s@rapidsai/devcontainers/features/rapids-build-utils:[0-9.]*@rapidsai/devcontainers/features/rapids-build-utils:${NEXT_SHORT_TAG_PEP440}@" "${filename}"
     sed_runner "s@rapids-\${localWorkspaceFolderBasename}-[0-9.]*@rapids-\${localWorkspaceFolderBasename}-${NEXT_SHORT_TAG}@g" "${filename}"
 done


### PR DESCRIPTION
## Description
Update devcontainer cache image tags missed by the 26.10 version bump.

Teach the version update script to update these tags in future releases.

xref: rapidsai/build-planning#316

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
