### PR TITLE
Replace <cuda/stream_ref> includes with <cuda/stream>

### DIFF
--- a/cpp/include/rmm/detail/cuda_stream.hpp
+++ b/cpp/include/rmm/detail/cuda_stream.hpp
@@ -7,7 +7,7 @@
 
 #include <rmm/detail/export.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 RMM_NAMESPACE_BEGIN
 namespace detail {


### PR DESCRIPTION
While #2513 fixed all issues in rmm, we had another inflight PR (#2511) that used the old include.

Found by downstream failures in rapids-cmake ( https://github.com/rapidsai/rapids-cmake/pull/1079 )