### PR TITLE
Clarify asynchronous Python buffer copy APIs

### DIFF
--- a/docs/python/mr.md
+++ b/docs/python/mr.md
@@ -7,3 +7,13 @@
    :undoc-members:
    :show-inheritance:
 ```
+
+## Experimental Memory Resources
+
+```{eval-rst}
+.. automodule:: rmm.mr.experimental
+   :members:
+   :inherited-members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/python/pylibrmm.md
+++ b/docs/python/pylibrmm.md
@@ -11,11 +11,17 @@ This module contains the low-level Cython bindings for RMM. Some components from
 - Logging utilities (available through `rmm`)
 - CUDA stream wrappers (documented below)
 
-## Device Buffer Functions
+## CUDA Stream
+
+The stream classes are available only through `rmm.pylibrmm` and provide low-level CUDA stream management.
+
+### rmm.pylibrmm.stream
 
 ```{eval-rst}
-.. automodule:: rmm.pylibrmm.device_buffer
-   :members: copy_device_to_ptr, copy_host_to_ptr, copy_ptr_to_host, to_device
+.. automodule:: rmm.pylibrmm.stream
+   :members:
+   :undoc-members:
+   :show-inheritance:
 ```
 
 ## CUDA Stream Pool
@@ -27,15 +33,9 @@ This module contains the low-level Cython bindings for RMM. Some components from
    :show-inheritance:
 ```
 
-## CUDA Stream Classes
-
-The stream classes are available only through `rmm.pylibrmm` and provide low-level CUDA stream management.
-
-### rmm.pylibrmm.stream
+## Device Buffer Functions
 
 ```{eval-rst}
-.. automodule:: rmm.pylibrmm.stream
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. automodule:: rmm.pylibrmm.device_buffer
+   :members: copy_device_to_ptr, copy_host_to_ptr, copy_ptr_to_host, to_device
 ```

--- a/docs/python/pylibrmm.md
+++ b/docs/python/pylibrmm.md
@@ -11,6 +11,22 @@ This module contains the low-level Cython bindings for RMM. Some components from
 - Logging utilities (available through `rmm`)
 - CUDA stream wrappers (documented below)
 
+## Device Buffer Functions
+
+```{eval-rst}
+.. automodule:: rmm.pylibrmm.device_buffer
+   :members: copy_device_to_ptr, copy_host_to_ptr, copy_ptr_to_host, to_device
+```
+
+## CUDA Stream Pool
+
+```{eval-rst}
+.. automodule:: rmm.pylibrmm.cuda_stream_pool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
 ## CUDA Stream Classes
 
 The stream classes are available only through `rmm.pylibrmm` and provide low-level CUDA stream management.

--- a/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyx
+++ b/python/rmm/rmm/pylibrmm/cuda_stream_pool.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 cimport cython
@@ -20,6 +20,14 @@ cdef class CudaStreamPool:
 
     Provides thread-safe access to a collection of CUDA stream objects.
     Successive calls may return views of identical streams.
+
+    Parameters
+    ----------
+    pool_size : int, optional
+        Number of streams in the pool. Defaults to 16.
+    flags : CudaStreamFlags, optional
+        Flags used to create each stream. Defaults to
+        ``CudaStreamFlags.SYNC_DEFAULT``.
     """
 
     def __cinit__(self, size_t pool_size = 16,

--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import numpy as np
 
@@ -41,43 +41,44 @@ from rmm.pylibrmm.memory_resource cimport (
 # See https://github.com/rapidsai/rmm/pull/931 for details.
 @cython.no_gc_clear
 cdef class DeviceBuffer:
+    """Construct a ``DeviceBuffer`` with optional size and data pointer
+
+    Parameters
+    ----------
+    ptr : int
+        pointer to some data on host or device to copy over
+    size : int
+        size of the buffer to allocate
+        (and possibly size of data to copy)
+    stream : optional
+        CUDA stream to use for construction and/or copying,
+        defaults to the CUDA default stream. A reference to the
+        stream is stored internally to ensure it doesn't go out of
+        scope while the DeviceBuffer is in use. Destroying the
+        underlying stream while the DeviceBuffer is in use will
+        result in undefined behavior.
+    mr : optional
+       DeviceMemoryResource for the allocation, if not provided
+       defaults to the current device resource.
+
+    Notes
+    -----
+    If the pointer passed is non-null and ``stream`` is the default stream,
+    the stream is synchronized after the copy. If a non-default ``stream``
+    is provided, the copy is asynchronous. The caller must keep the source
+    data valid and unmodified until the stream is synchronized.
+
+    Examples
+    --------
+    >>> import rmm
+    >>> db = rmm.DeviceBuffer(size=5)
+    """
 
     def __cinit__(self, *,
                   uintptr_t ptr=0,
                   size_t size=0,
                   Stream stream=DEFAULT_STREAM,
                   DeviceMemoryResource mr=None):
-        """Construct a ``DeviceBuffer`` with optional size and data pointer
-
-        Parameters
-        ----------
-        ptr : int
-            pointer to some data on host or device to copy over
-        size : int
-            size of the buffer to allocate
-            (and possibly size of data to copy)
-        stream : optional
-            CUDA stream to use for construction and/or copying,
-            defaults to the CUDA default stream. A reference to the
-            stream is stored internally to ensure it doesn't go out of
-            scope while the DeviceBuffer is in use. Destroying the
-            underlying stream while the DeviceBuffer is in use will
-            result in undefined behavior.
-        mr : optional
-           DeviceMemoryResource for the allocation, if not provided
-           defaults to the current device resource.
-
-        Note
-        ----
-        If the pointer passed is non-null and ``stream`` is the default stream,
-        it is synchronized after the copy. However if a non-default ``stream``
-        is provided, this function is fully asynchronous.
-
-        Examples
-        --------
-        >>> import rmm
-        >>> db = rmm.DeviceBuffer(size=5)
-        """
         cdef const void* c_ptr
         stream = as_stream(stream)
         # Save a reference to the MR and stream used for allocation
@@ -228,7 +229,13 @@ cdef class DeviceBuffer:
     @staticmethod
     def to_device(const unsigned char[::1] b,
                   Stream stream=DEFAULT_STREAM):
-        """Calls ``to_device`` function on arguments provided."""
+        """Return a new ``DeviceBuffer`` containing a copy of ``b``.
+
+        If ``stream`` is the default stream, it is synchronized after the copy.
+        If a non-default ``stream`` is provided, the copy is asynchronous. The
+        caller must keep ``b`` alive and unmodified until the stream is
+        synchronized.
+        """
         stream = as_stream(stream)
         return to_device(b, stream)
 
@@ -281,6 +288,13 @@ cdef class DeviceBuffer:
             :class:`bytes`-like buffer to copy from
         stream : optional
             CUDA stream to use for copying, defaults to the default stream
+
+        Notes
+        -----
+        If ``stream`` is the default stream, it is synchronized after the copy.
+        If a non-default ``stream`` is provided, the copy is asynchronous. The
+        caller must keep ``ary`` alive and unmodified until the stream is
+        synchronized.
 
         Examples
         --------
@@ -420,6 +434,13 @@ cpdef DeviceBuffer to_device(const unsigned char[::1] b,
     -------
     ``DeviceBuffer`` with copy of data from host
 
+    Notes
+    -----
+    If ``stream`` is the default stream, it is synchronized after the copy.
+    If a non-default ``stream`` is provided, the copy is asynchronous. The
+    caller must keep ``b`` alive and unmodified until the stream is
+    synchronized.
+
     Examples
     --------
     >>> import rmm
@@ -481,8 +502,8 @@ cpdef void copy_ptr_to_host(uintptr_t db,
     hb : ``bytes``-like buffer to write into
     stream : CUDA stream to use for copying, default the default stream
 
-    Note
-    ----
+    Notes
+    -----
     If ``stream`` is the default stream, it is synchronized after the copy.
     However if a non-default ``stream`` is provided, this function is fully
     asynchronous.
@@ -524,11 +545,12 @@ cpdef void copy_host_to_ptr(const unsigned char[::1] hb,
     db : pointer to data on device to write into
     stream : CUDA stream to use for copying, default the default stream
 
-    Note
-    ----
+    Notes
+    -----
     If ``stream`` is the default stream, it is synchronized after the copy.
-    However if a non-default ``stream`` is provided, this function is fully
-    asynchronous.
+    If a non-default ``stream`` is provided, the copy is asynchronous. The
+    caller must keep ``hb`` alive and unmodified until the stream is
+    synchronized.
 
     Examples
     --------

--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -427,12 +427,15 @@ cpdef DeviceBuffer to_device(const unsigned char[::1] b,
 
     Parameters
     ----------
-    b : ``bytes``-like data on host to copy to device
-    stream : CUDA stream to use for copying, default the default stream
+    b : buffer
+        Host data to copy to device.
+    stream : Stream, optional
+        CUDA stream to use for copying. Defaults to the default stream.
 
     Returns
     -------
-    ``DeviceBuffer`` with copy of data from host
+    DeviceBuffer
+        Device buffer containing a copy of the host data.
 
     Notes
     -----
@@ -498,9 +501,12 @@ cpdef void copy_ptr_to_host(uintptr_t db,
 
     Parameters
     ----------
-    db : pointer to data on device to copy
-    hb : ``bytes``-like buffer to write into
-    stream : CUDA stream to use for copying, default the default stream
+    db : int
+        Pointer to device data to copy.
+    hb : writable buffer
+        Host buffer to write into.
+    stream : Stream, optional
+        CUDA stream to use for copying. Defaults to the default stream.
 
     Notes
     -----
@@ -541,9 +547,12 @@ cpdef void copy_host_to_ptr(const unsigned char[::1] hb,
 
     Parameters
     ----------
-    hb : ``bytes``-like host buffer to copy
-    db : pointer to data on device to write into
-    stream : CUDA stream to use for copying, default the default stream
+    hb : buffer
+        Host data to copy.
+    db : int
+        Pointer to device memory to write into.
+    stream : Stream, optional
+        CUDA stream to use for copying. Defaults to the default stream.
 
     Notes
     -----
@@ -587,10 +596,14 @@ cpdef void copy_device_to_ptr(uintptr_t d_src,
 
     Parameters
     ----------
-    d_src : pointer to data on device to copy from
-    d_dst : pointer to data on device to write into
-    count : the size in bytes to copy
-    stream : CUDA stream to use for copying, default the default stream
+    d_src : int
+        Pointer to device data to copy.
+    d_dst : int
+        Pointer to device memory to write into.
+    count : int
+        Number of bytes to copy.
+    stream : Stream, optional
+        CUDA stream to use for copying. Defaults to the default stream.
 
     Examples
     --------


### PR DESCRIPTION
## Summary

- clarify that host-to-device copies on non-default streams are asynchronous and require callers to preserve source buffers
- publish `DeviceBuffer` constructor and low-level device-buffer function documentation through Sphinx
- expose other missing public Cython APIs discovered during the documentation audit

Closes #2521