### PR TITLE
Add host initializer for pinned allocations

### DIFF
--- a/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
+++ b/cpp/include/rmm/mr/pinned_host_memory_resource.hpp
@@ -12,6 +12,7 @@
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
+#include <functional>
 
 RMM_NAMESPACE_BEGIN
 namespace mr {
@@ -23,15 +24,43 @@ namespace mr {
  */
 
 /**
+ * @brief Callback invoked to initialize host memory before it is registered with CUDA.
+ *
+ * The callback receives the allocation pointer and size in bytes. It must return only after all
+ * initialization is complete and must not deallocate or register the allocation. If the callback
+ * throws, the host allocation is released and the exception is propagated.
+ *
+ * If the same callback is used by multiple threads, it is the caller's responsibility to ensure
+ * that concurrent invocations are safe.
+ */
+using host_memory_initializer_t = std::function<void(void*, std::size_t)>;
+
+/**
  * @brief Memory resource class for allocating pinned host memory.
  *
- * This class uses CUDA's `cudaHostAlloc` to allocate pinned host memory. It satisfies the
- * `cuda::mr::resource` and `cuda::mr::synchronous_resource` concepts, and
+ * By default, this class uses CUDA's `cudaHostAlloc` to allocate pinned host memory. An optional
+ * host memory initializer can instead be provided to initialize an ordinary host allocation before
+ * it is pinned with `cudaHostRegister`. This lets callers control policies such as parallel page
+ * touching and NUMA placement without the resource owning process-level policy.
+ *
+ * This class satisfies the `cuda::mr::resource` and `cuda::mr::synchronous_resource` concepts, and
  * the `cuda::mr::host_accessible` and `cuda::mr::device_accessible` properties.
  */
 class RMM_EXPORT pinned_host_memory_resource final {
  public:
-  pinned_host_memory_resource()  = default;
+  pinned_host_memory_resource() = default;
+
+  /**
+   * @brief Constructs a pinned host memory resource using \p initializer.
+   *
+   * For each non-empty allocation, the resource allocates 256-byte-aligned host memory, invokes
+   * `initializer` with the allocation pointer and requested size, and then registers the allocation
+   * with `cudaHostRegister`. An empty initializer retains the default `cudaHostAlloc` behavior.
+   *
+   * @param initializer Callback invoked after host allocation and before CUDA registration
+   */
+  explicit pinned_host_memory_resource(host_memory_initializer_t initializer);
+
   ~pinned_host_memory_resource() = default;
   pinned_host_memory_resource(pinned_host_memory_resource const&) =
     default;  ///< @default_copy_constructor
@@ -122,9 +151,10 @@ class RMM_EXPORT pinned_host_memory_resource final {
   /**
    * @brief Compare this resource to another.
    *
-   * All instances of pinned_host_memory_resource are equivalent.
+   * Resources are equivalent when both use `cudaHostAlloc`, or both use an initializer followed by
+   * `cudaHostRegister`. The initializer itself does not participate in deallocation.
    *
-   * @return true Always
+   * @return true if allocations from either resource can be deallocated by the other
    */
   [[nodiscard]] bool operator==(pinned_host_memory_resource const&) const noexcept;
 
@@ -132,6 +162,9 @@ class RMM_EXPORT pinned_host_memory_resource final {
    * @copydoc operator==
    */
   [[nodiscard]] bool operator!=(pinned_host_memory_resource const&) const noexcept;
+
+ private:
+  host_memory_initializer_t initializer_{};
 };
 
 // static property checks

--- a/cpp/src/mr/pinned_host_memory_resource.cpp
+++ b/cpp/src/mr/pinned_host_memory_resource.cpp
@@ -5,15 +5,25 @@
 
 #include <rmm/detail/aligned.hpp>
 #include <rmm/detail/error.hpp>
+#include <rmm/detail/format.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 
 #include <cuda/stream>
 #include <cuda_runtime_api.h>
 
+#include <cassert>
 #include <cstddef>
+#include <new>
+#include <string>
+#include <utility>
 
 RMM_NAMESPACE_BEGIN
 namespace mr {
+
+pinned_host_memory_resource::pinned_host_memory_resource(host_memory_initializer_t initializer)
+  : initializer_{std::move(initializer)}
+{
+}
 
 void* pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
                                             std::size_t bytes,
@@ -26,6 +36,26 @@ void* pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_ref st
               rmm::bad_alloc);
 
   std::size_t constexpr alloc_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
+  if (initializer_) {
+    void* ptr{nullptr};
+    try {
+      ptr = ::operator new(bytes, std::align_val_t{alloc_alignment});
+    } catch (std::bad_alloc const& e) {
+      auto const msg = std::string{"Failed to allocate "} + rmm::detail::format_bytes(bytes) +
+                       std::string{" of host memory: "} + e.what();
+      RMM_FAIL(msg.c_str(), rmm::out_of_memory);
+    }
+
+    try {
+      initializer_(ptr, bytes);
+      RMM_CUDA_TRY_ALLOC(cudaHostRegister(ptr, bytes, cudaHostRegisterDefault), bytes);
+    } catch (...) {
+      ::operator delete(ptr, std::align_val_t{alloc_alignment});
+      throw;
+    }
+    return ptr;
+  }
+
   return rmm::detail::aligned_host_allocate(bytes, alloc_alignment, [](std::size_t size) {
     void* ptr{nullptr};
     RMM_CUDA_TRY_ALLOC(cudaHostAlloc(&ptr, size, cudaHostAllocDefault), size);
@@ -39,6 +69,16 @@ void pinned_host_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref s
                                              [[maybe_unused]] std::size_t alignment) noexcept
 {
   std::size_t constexpr alloc_alignment = rmm::CUDA_ALLOCATION_ALIGNMENT;
+  if (initializer_) {
+    if (ptr != nullptr) {
+      auto const status = cudaHostUnregister(ptr);
+      // Do not free memory that CUDA may still consider registered.
+      assert(status == cudaSuccess || status == cudaErrorCudartUnloading);
+      if (status == cudaSuccess) { ::operator delete(ptr, std::align_val_t{alloc_alignment}); }
+    }
+    return;
+  }
+
   rmm::detail::aligned_host_deallocate(ptr, bytes, alloc_alignment, [](void* ptr) {
     RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaFreeHost(ptr));
   });
@@ -58,14 +98,16 @@ void pinned_host_memory_resource::deallocate_sync(void* ptr,
   deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
 }
 
-bool pinned_host_memory_resource::operator==(pinned_host_memory_resource const&) const noexcept
+bool pinned_host_memory_resource::operator==(
+  pinned_host_memory_resource const& other) const noexcept
 {
-  return true;
+  return static_cast<bool>(initializer_) == static_cast<bool>(other.initializer_);
 }
 
-bool pinned_host_memory_resource::operator!=(pinned_host_memory_resource const&) const noexcept
+bool pinned_host_memory_resource::operator!=(
+  pinned_host_memory_resource const& other) const noexcept
 {
-  return false;
+  return !(*this == other);
 }
 
 }  // namespace mr

--- a/cpp/tests/mr/host_mr_ref_tests.cpp
+++ b/cpp/tests/mr/host_mr_ref_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -14,9 +14,14 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
+#include <cstring>
 #include <deque>
+#include <exception>
 #include <random>
+#include <stdexcept>
+#include <thread>
 
 namespace rmm::test {
 namespace {
@@ -239,5 +244,104 @@ TEST(PinnedHostResource, isPinned)
   EXPECT_NO_THROW(ptr = ref.allocate_sync(100, rmm::CUDA_ALLOCATION_ALIGNMENT));
   EXPECT_TRUE(is_pinned_memory(ptr));
   EXPECT_NO_THROW(ref.deallocate_sync(ptr, 100, rmm::CUDA_ALLOCATION_ALIGNMENT));
+}
+
+TEST(PinnedHostResource, InitializerRunsBeforeRegistration)
+{
+  constexpr std::size_t bytes{size_mb + 256};
+  std::size_t callback_count{};
+  rmm::mr::pinned_host_memory_resource mr{[&](void* ptr, std::size_t callback_bytes) {
+    ++callback_count;
+    EXPECT_NE(nullptr, ptr);
+    EXPECT_EQ(bytes, callback_bytes);
+    std::memset(ptr, 0x5a, callback_bytes);
+  }};
+
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = mr.allocate_sync(bytes));
+  EXPECT_EQ(1, callback_count);
+  EXPECT_TRUE(is_aligned(ptr, rmm::CUDA_ALLOCATION_ALIGNMENT));
+  EXPECT_TRUE(is_pinned_memory(ptr));
+  auto const* data = static_cast<unsigned char const*>(ptr);
+  EXPECT_EQ(0x5a, data[0]);
+  EXPECT_EQ(0x5a, data[bytes - 1]);
+  EXPECT_NO_THROW(mr.deallocate_sync(ptr, bytes));
+}
+
+TEST(PinnedHostResource, InitializerExceptionRollsBackAllocation)
+{
+  std::size_t callback_count{};
+  rmm::mr::pinned_host_memory_resource mr{[&](void* ptr, std::size_t bytes) {
+    if (callback_count++ == 0) { throw std::runtime_error{"injected initializer failure"}; }
+    std::memset(ptr, 0, bytes);
+  }};
+
+  EXPECT_THROW((void)mr.allocate_sync(size_kb), std::runtime_error);
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = mr.allocate_sync(size_kb));
+  EXPECT_EQ(2, callback_count);
+  EXPECT_TRUE(is_pinned_memory(ptr));
+  EXPECT_NO_THROW(mr.deallocate_sync(ptr, size_kb));
+}
+
+TEST(PinnedHostResource, InitializerSkipsUnallocatedMemory)
+{
+  bool callback_called{false};
+  rmm::mr::pinned_host_memory_resource mr{[&](void*, std::size_t) { callback_called = true; }};
+
+  EXPECT_EQ(nullptr, mr.allocate_sync(0));
+  EXPECT_FALSE(callback_called);
+  void* ptr{nullptr};
+  EXPECT_THROW(ptr = mr.allocate_sync(size_pb), std::bad_alloc);
+  EXPECT_EQ(nullptr, ptr);
+  EXPECT_FALSE(callback_called);
+}
+
+TEST(PinnedHostResource, InitializerSupportsConcurrentAllocations)
+{
+  std::atomic<std::size_t> callback_count{};
+  rmm::mr::pinned_host_memory_resource mr{[&](void* ptr, std::size_t bytes) {
+    callback_count.fetch_add(1, std::memory_order_relaxed);
+    std::memset(ptr, 0, bytes);
+  }};
+
+  constexpr std::size_t thread_count{8};
+  std::vector<std::exception_ptr> errors(thread_count);
+  std::vector<std::thread> threads;
+  threads.reserve(thread_count);
+  for (std::size_t index = 0; index < thread_count; ++index) {
+    threads.emplace_back([&, index] {
+      try {
+        auto* ptr = mr.allocate_sync(size_mb);
+        mr.deallocate_sync(ptr, size_mb);
+      } catch (...) {
+        errors[index] = std::current_exception();
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_EQ(thread_count, callback_count.load(std::memory_order_relaxed));
+  EXPECT_TRUE(std::all_of(
+    errors.cbegin(), errors.cend(), [](auto const& error) { return error == nullptr; }));
+}
+
+TEST(PinnedHostResource, EqualityReflectsAllocationStrategy)
+{
+  rmm::mr::pinned_host_memory_resource default_mr;
+  rmm::mr::host_memory_initializer_t empty_initializer;
+  rmm::mr::pinned_host_memory_resource empty_mr{empty_initializer};
+  rmm::mr::pinned_host_memory_resource registered_a{[](void*, std::size_t) {}};
+  rmm::mr::pinned_host_memory_resource registered_b{[](void*, std::size_t) {}};
+
+  EXPECT_EQ(default_mr, empty_mr);
+  EXPECT_NE(default_mr, registered_a);
+  EXPECT_EQ(registered_a, registered_b);
+
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = registered_a.allocate_sync(size_kb));
+  EXPECT_NO_THROW(registered_b.deallocate_sync(ptr, size_kb));
 }
 }  // namespace rmm::test

--- a/cpp/tests/mr/pinned_host_pool_mr_tests.cpp
+++ b/cpp/tests/mr/pinned_host_pool_mr_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -8,6 +8,9 @@
 #include <rmm/mr/pool_memory_resource.hpp>
 
 #include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstring>
 
 namespace rmm::test {
 namespace {
@@ -71,6 +74,25 @@ TEST(PinnedPoolTest, ThrowOutOfMemory)
   (void)mr.allocate_sync(1024);
 
   EXPECT_THROW((void)mr.allocate_sync(1024), rmm::out_of_memory);
+}
+
+TEST(PinnedPoolTest, InitializerCallback)
+{
+  constexpr std::size_t pool_size{16 * 1024 * 1024 + 256};
+  std::size_t callback_count{};
+  pool_mr mr{rmm::mr::pinned_host_memory_resource{[&](void* ptr, std::size_t bytes) {
+               ++callback_count;
+               EXPECT_EQ(pool_size, bytes);
+               std::memset(ptr, 0, bytes);
+             }},
+             pool_size,
+             pool_size};
+
+  EXPECT_EQ(1, callback_count);
+  void* ptr{nullptr};
+  EXPECT_NO_THROW(ptr = mr.allocate_sync(pool_size));
+  EXPECT_NE(nullptr, ptr);
+  EXPECT_NO_THROW(mr.deallocate_sync(ptr, pool_size));
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Closes #2496.

This adds an opt-in host-memory initializer to `pinned_host_memory_resource`. When an initializer is provided, RMM allocates aligned host memory, invokes the caller callback, and registers the initialized allocation with CUDA. Default construction continues to use `cudaHostAlloc` unchanged.

The callback gives applications a narrow hook for policies such as parallel first-touch and NUMA placement without making RMM own threads, affinity, or process-level state.

The registered path preserves the existing 256-byte alignment contract, rolls back ordinary host memory when initialization or registration fails, and unregisters memory before freeing it.

## Benchmark

Environment: RTX 3090, CUDA 13.0.48, GCC 14.4; 1 warm-up and 10 measured repetitions; 64 MiB H2D/D2H copies.

| Pool size | Threads | `cudaHostAlloc` P50 | Initializer P50 | Speedup |
|---|---:|---:|---:|---:|
| 1 GiB | 16 | 434.724 ms | 131.915 ms | 3.30x |
| 4 GiB | 16 | 1681.025 ms | 444.932 ms | 3.78x |
| 8 GiB | 16 | 3409.640 ms | 839.290 ms | 4.06x |

Across these cases, H2D/D2H P50/P95/P99 changes remained within 0.51%, and peak RSS was unchanged within measurement granularity. An 8-thread mixed-size stress test measured -1.59% throughput and +4.06% P95 allocation latency for the callback-backed pool, with identical peak RSS.

## Tests

- `HOST_MR_REF_TEST` (16/16)
- `HOST_MR_REF_PTDS_TEST` (16/16)
- `PINNED_HOST_POOL_MR_TEST` (6/6)
- `PINNED_HOST_POOL_MR_PTDS_TEST` (6/6)
- Full C++ build
- `pre-commit run --all-files`
- Additional benchmark/smoke coverage for callback failure rollback, zero/OOM behavior, concurrent allocation, non-default streams, CUDA graph capture/replay, non-page-aligned sizes, and NUMA-local/cross-socket first-touch

## Design question

Would you prefer this opt-in initializer directly on `pinned_host_memory_resource`, or a separate registered-host resource/adaptor to avoid changing the size/layout of the existing resource?
