### PR TITLE
Delete r-value reference ctor for device_scalar

### DIFF
--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -288,7 +288,7 @@ static_assert(!std::is_constructible_v<device_scalar<int>,
                                        int const,
                                        cuda_stream_view,
                                        cuda::mr::any_resource<cuda::mr::device_accessible>>);
-static_assert([]<typename Scalar> {
+static_assert([]<typename Scalar>(Scalar*) {
   return requires(Scalar& scalar, int value, cuda_stream_view stream) {
     scalar.set_value_async(value, stream);
   } && requires(Scalar& scalar, int const value, cuda_stream_view stream) {
@@ -298,7 +298,7 @@ static_assert([]<typename Scalar> {
   } && !requires(Scalar& scalar, int const value, cuda_stream_view stream) {
     scalar.set_value_async(std::move(value), stream);
   };
-}.template operator()<device_scalar<int>>());
+}(static_cast<device_scalar<int>*>(nullptr)));
 
 /** @} */  // end of group
 RMM_NAMESPACE_END

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -121,8 +121,10 @@ class device_scalar {
   // memory holding the literal can be freed before the async memcpy / memset executes.
   device_scalar(value_type&&,
                 cuda_stream_view stream,
-                cuda::mr::any_resource<cuda::mr::device_accessible> mr =
-                  mr::get_current_device_resource_ref()) = delete;
+                cuda::mr::any_resource<cuda::mr::device_accessible> mr) = delete;
+  device_scalar(value_type const&&,
+                cuda_stream_view stream,
+                cuda::mr::any_resource<cuda::mr::device_accessible> mr) = delete;
   /**
    * @brief Construct a new `device_scalar` by deep copying the contents of
    * another `device_scalar`, using the specified stream and memory
@@ -204,7 +206,8 @@ class device_scalar {
 
   // Disallow passing literals to set_value to avoid race conditions where the memory holding the
   // literal can be freed before the async memcpy / memset executes.
-  void set_value_async(value_type&&, cuda_stream_view) = delete;
+  void set_value_async(value_type&&, cuda_stream_view)       = delete;
+  void set_value_async(value_type const&&, cuda_stream_view) = delete;
 
   /**
    * @brief Sets the value of the `device_scalar` to zero on the specified stream.

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -119,10 +119,6 @@ class device_scalar {
 
   // Disallow passing literals to the constructor to avoid race conditions where the
   // memory holding the literal can be freed before the async memcpy / memset executes.
-  device_scalar(value_type&&,
-                cuda_stream_view stream,
-                cuda::mr::any_resource<cuda::mr::device_accessible> mr =
-                  mr::get_current_device_resource_ref()) = delete;
   device_scalar(value_type const&&,
                 cuda_stream_view stream,
                 cuda::mr::any_resource<cuda::mr::device_accessible> mr =
@@ -208,7 +204,6 @@ class device_scalar {
 
   // Disallow passing literals to set_value to avoid race conditions where the memory holding the
   // literal can be freed before the async memcpy / memset executes.
-  void set_value_async(value_type&&, cuda_stream_view)       = delete;
   void set_value_async(value_type const&&, cuda_stream_view) = delete;
 
   /**
@@ -277,6 +272,33 @@ class device_scalar {
  private:
   rmm::device_uvector<T> _storage;
 };
+
+static_assert(std::is_constructible_v<device_scalar<int>, int const&, cuda_stream_view>);
+static_assert(std::is_constructible_v<device_scalar<int>,
+                                      int const&,
+                                      cuda_stream_view,
+                                      cuda::mr::any_resource<cuda::mr::device_accessible>>);
+static_assert(!std::is_constructible_v<device_scalar<int>, int, cuda_stream_view>);
+static_assert(!std::is_constructible_v<device_scalar<int>, int const, cuda_stream_view>);
+static_assert(!std::is_constructible_v<device_scalar<int>,
+                                       int,
+                                       cuda_stream_view,
+                                       cuda::mr::any_resource<cuda::mr::device_accessible>>);
+static_assert(!std::is_constructible_v<device_scalar<int>,
+                                       int const,
+                                       cuda_stream_view,
+                                       cuda::mr::any_resource<cuda::mr::device_accessible>>);
+static_assert([]<typename Scalar> {
+  return requires(Scalar& scalar, int value, cuda_stream_view stream) {
+    scalar.set_value_async(value, stream);
+  } && requires(Scalar& scalar, int const value, cuda_stream_view stream) {
+    scalar.set_value_async(value, stream);
+  } && !requires(Scalar& scalar, int value, cuda_stream_view stream) {
+    scalar.set_value_async(std::move(value), stream);
+  } && !requires(Scalar& scalar, int const value, cuda_stream_view stream) {
+    scalar.set_value_async(std::move(value), stream);
+  };
+}.template operator()<device_scalar<int>>());
 
 /** @} */  // end of group
 RMM_NAMESPACE_END

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -121,10 +121,12 @@ class device_scalar {
   // memory holding the literal can be freed before the async memcpy / memset executes.
   device_scalar(value_type&&,
                 cuda_stream_view stream,
-                cuda::mr::any_resource<cuda::mr::device_accessible> mr) = delete;
+                cuda::mr::any_resource<cuda::mr::device_accessible> mr =
+                  mr::get_current_device_resource_ref()) = delete;
   device_scalar(value_type const&&,
                 cuda_stream_view stream,
-                cuda::mr::any_resource<cuda::mr::device_accessible> mr) = delete;
+                cuda::mr::any_resource<cuda::mr::device_accessible> mr =
+                  mr::get_current_device_resource_ref()) = delete;
   /**
    * @brief Construct a new `device_scalar` by deep copying the contents of
    * another `device_scalar`, using the specified stream and memory

--- a/cpp/include/rmm/device_scalar.hpp
+++ b/cpp/include/rmm/device_scalar.hpp
@@ -117,6 +117,12 @@ class device_scalar {
     set_value_async(initial_value, stream);
   }
 
+  // Disallow passing literals to the constructor to avoid race conditions where the
+  // memory holding the literal can be freed before the async memcpy / memset executes.
+  device_scalar(value_type&&,
+                cuda_stream_view stream,
+                cuda::mr::any_resource<cuda::mr::device_accessible> mr =
+                  mr::get_current_device_resource_ref()) = delete;
   /**
    * @brief Construct a new `device_scalar` by deep copying the contents of
    * another `device_scalar`, using the specified stream and memory


### PR DESCRIPTION
## Description
In #725 we deleted the r-value overload for set_value_async since it is unsafe: the immediate value can go out of scope before the stream-ordered copy completes. The device_scalar ctor has the same problem, but wasn't caught by that change because if we write

    device_scalar foo(1, stream);

By the time the ctor body calls set_value_async the immediate is no longer an r-value reference. To fix this, explicitly delete the r-value overload for the ctor.

- Closes #2526

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
