### PR TITLE
Add experimental async pinned memory resource

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -93,6 +93,7 @@ add_library(
   src/mr/callback_memory_resource.cpp
   src/mr/cuda_async_managed_memory_resource.cpp
   src/mr/cuda_async_memory_resource.cpp
+  src/mr/cuda_async_pinned_memory_resource.cpp
   src/mr/cuda_async_view_memory_resource.cpp
   src/mr/cuda_memory_resource.cpp
   src/mr/detail/aligned_resource_adaptor_impl.cpp
@@ -101,6 +102,7 @@ add_library(
   src/mr/detail/callback_memory_resource_impl.cpp
   src/mr/detail/cuda_async_managed_memory_resource_impl.cpp
   src/mr/detail/cuda_async_memory_resource_impl.cpp
+  src/mr/detail/cuda_async_pinned_memory_resource_impl.cpp
   src/mr/detail/fixed_size_memory_resource_impl.cpp
   src/mr/detail/limiting_resource_adaptor_impl.cpp
   src/mr/detail/logging_resource_adaptor_impl.cpp

--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -29,6 +29,11 @@ namespace detail {
 #define RMM_MIN_ASYNC_MANAGED_ALLOC_CUDA_VERSION 13000
 
 /**
+ * @brief Minimum CUDA version supported by cuda_async_pinned_memory_resource
+ */
+#define RMM_MIN_ASYNC_PINNED_ALLOC_CUDA_VERSION 12090
+
+/**
  * @brief Determine at runtime if the CUDA driver supports the stream-ordered
  * memory allocator functions.
  *
@@ -152,6 +157,36 @@ struct runtime_async_managed_alloc {
              cuda_runtime_version >= RMM_MIN_ASYNC_MANAGED_ALLOC_CUDA_VERSION;
     }()};
     return supports_async_managed_pool;
+  }
+};
+
+/**
+ * @brief Determine whether the CUDA driver/runtime supports stream-ordered pinned host memory.
+ */
+struct runtime_async_pinned_alloc {
+  static bool is_supported()
+  {
+    static auto supports_async_pinned_pool{[] {
+      if (not runtime_async_alloc::is_supported()) { return false; }
+
+#if CUDART_VERSION >= 13000
+      int driver_version{};
+      auto const driver_result = cudaDriverGetVersion(&driver_version);
+      int runtime_version{};
+      auto const runtime_result = cudaRuntimeGetVersion(&runtime_version);
+      return driver_result == cudaSuccess and runtime_result == cudaSuccess and
+             driver_version >= 13000 and runtime_version >= 13000;
+#elif CUDART_VERSION >= RMM_MIN_ASYNC_PINNED_ALLOC_CUDA_VERSION
+      int host_numa_pool_supported{};
+      auto const result = cudaDeviceGetAttribute(&host_numa_pool_supported,
+                                                 cudaDevAttrHostNumaMemoryPoolsSupported,
+                                                 rmm::get_current_cuda_device().value());
+      return result == cudaSuccess and host_numa_pool_supported == 1;
+#else
+      return false;
+#endif
+    }()};
+    return supports_async_pinned_pool;
   }
 };
 

--- a/cpp/include/rmm/detail/runtime_capabilities.hpp
+++ b/cpp/include/rmm/detail/runtime_capabilities.hpp
@@ -170,12 +170,11 @@ struct runtime_async_pinned_alloc {
       if (not runtime_async_alloc::is_supported()) { return false; }
 
 #if CUDART_VERSION >= 13000
-      int driver_version{};
-      auto const driver_result = cudaDriverGetVersion(&driver_version);
-      int runtime_version{};
-      auto const runtime_result = cudaRuntimeGetVersion(&runtime_version);
-      return driver_result == cudaSuccess and runtime_result == cudaSuccess and
-             driver_version >= 13000 and runtime_version >= 13000;
+      int host_pool_supported{};
+      auto const result = cudaDeviceGetAttribute(&host_pool_supported,
+                                                 cudaDevAttrHostMemoryPoolsSupported,
+                                                 rmm::get_current_cuda_device().value());
+      return result == cudaSuccess and host_pool_supported == 1;
 #elif CUDART_VERSION >= RMM_MIN_ASYNC_PINNED_ALLOC_CUDA_VERSION
       int host_numa_pool_supported{};
       auto const result = cudaDeviceGetAttribute(&host_numa_pool_supported,

--- a/cpp/include/rmm/mr/cuda_async_pinned_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_pinned_memory_resource.hpp
@@ -10,7 +10,7 @@
 #include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 /**
  * @addtogroup memory_resources
@@ -25,10 +25,10 @@ namespace mr {
  * supplied stream and must not be accessed from the host until the allocation reaches the head of
  * that stream. Deallocations are ordered after preceding work on the supplied stream.
  *
- * With CUDA 12.x, all instances use a process-wide pinned memory pool on NUMA node 0. With CUDA
- * 13.0 and later, all instances use CUDA's default pinned host memory pool. In both cases,
- * allocations are accessible from all visible CUDA devices and pool properties such as the release
- * threshold are not modified.
+ * All instances use CCCL's process-wide default pinned memory pool. With CUDA 12.x, this pool is on
+ * NUMA node 0. With CUDA 13.0 and later, this is CUDA's default pinned host memory pool.
+ * Allocations are accessible from all visible CUDA devices. CCCL configures the pool to retain
+ * unused memory by setting its release threshold to the maximum value.
  */
 class RMM_EXPORT cuda_async_pinned_memory_resource final
   : public cuda::mr::shared_resource<detail::cuda_async_pinned_memory_resource_impl> {
@@ -55,7 +55,7 @@ class RMM_EXPORT cuda_async_pinned_memory_resource final
    * @brief Constructs a resource that uses the process-wide pinned host memory pool.
    *
    * @throws rmm::logic_error if stream-ordered pinned host allocation is unsupported
-   * @throws rmm::cuda_error if the pinned host memory pool cannot be initialized
+   * @throws cuda::cuda_error if the pinned host memory pool cannot be initialized
    */
   cuda_async_pinned_memory_resource();
 
@@ -90,4 +90,4 @@ static_assert(
 
 /** @} */  // end of group
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/include/rmm/mr/cuda_async_pinned_memory_resource.hpp
+++ b/cpp/include/rmm/mr/cuda_async_pinned_memory_resource.hpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <rmm/detail/export.hpp>
+#include <rmm/mr/detail/cuda_async_pinned_memory_resource_impl.hpp>
+
+#include <cuda/memory_resource>
+#include <cuda_runtime_api.h>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+/**
+ * @addtogroup memory_resources
+ * @{
+ * @file
+ */
+
+/**
+ * @brief Stream-ordered memory resource for allocating pinned host memory.
+ *
+ * This resource uses `cudaMallocFromPoolAsync` and `cudaFreeAsync`. Allocations are ordered on the
+ * supplied stream and must not be accessed from the host until the allocation reaches the head of
+ * that stream. Deallocations are ordered after preceding work on the supplied stream.
+ *
+ * With CUDA 12.x, all instances use a process-wide pinned memory pool on NUMA node 0. With CUDA
+ * 13.0 and later, all instances use CUDA's default pinned host memory pool. In both cases,
+ * allocations are accessible from all visible CUDA devices and pool properties such as the release
+ * threshold are not modified.
+ */
+class RMM_EXPORT cuda_async_pinned_memory_resource final
+  : public cuda::mr::shared_resource<detail::cuda_async_pinned_memory_resource_impl> {
+  using shared_base = cuda::mr::shared_resource<detail::cuda_async_pinned_memory_resource_impl>;
+
+ public:
+  /**
+   * @brief Enables the `cuda::mr::device_accessible` property
+   */
+  RMM_CONSTEXPR_FRIEND void get_property(cuda_async_pinned_memory_resource const&,
+                                         cuda::mr::device_accessible) noexcept
+  {
+  }
+
+  /**
+   * @brief Enables the `cuda::mr::host_accessible` property
+   */
+  RMM_CONSTEXPR_FRIEND void get_property(cuda_async_pinned_memory_resource const&,
+                                         cuda::mr::host_accessible) noexcept
+  {
+  }
+
+  /**
+   * @brief Constructs a resource that uses the process-wide pinned host memory pool.
+   *
+   * @throws rmm::logic_error if stream-ordered pinned host allocation is unsupported
+   * @throws rmm::cuda_error if the pinned host memory pool cannot be initialized
+   */
+  cuda_async_pinned_memory_resource();
+
+  /**
+   * @brief Returns the underlying native CUDA memory pool handle.
+   *
+   * @return Handle to the underlying CUDA memory pool
+   */
+  [[nodiscard]] cudaMemPool_t pool_handle() const noexcept;
+
+  ~cuda_async_pinned_memory_resource() = default;
+  cuda_async_pinned_memory_resource(cuda_async_pinned_memory_resource const&) =
+    default;  ///< @default_copy_constructor
+  cuda_async_pinned_memory_resource(cuda_async_pinned_memory_resource&&) =
+    default;  ///< @default_move_constructor
+  cuda_async_pinned_memory_resource& operator=(cuda_async_pinned_memory_resource const&) =
+    default;  ///< @default_copy_assignment{cuda_async_pinned_memory_resource}
+  cuda_async_pinned_memory_resource& operator=(cuda_async_pinned_memory_resource&&) =
+    default;  ///< @default_move_assignment{cuda_async_pinned_memory_resource}
+};
+
+static_assert(cuda::mr::synchronous_resource<cuda_async_pinned_memory_resource>);
+static_assert(cuda::mr::resource<cuda_async_pinned_memory_resource>);
+static_assert(cuda::mr::synchronous_resource_with<cuda_async_pinned_memory_resource,
+                                                  cuda::mr::device_accessible>);
+static_assert(cuda::mr::synchronous_resource_with<cuda_async_pinned_memory_resource,
+                                                  cuda::mr::host_accessible>);
+static_assert(
+  cuda::mr::resource_with<cuda_async_pinned_memory_resource, cuda::mr::device_accessible>);
+static_assert(
+  cuda::mr::resource_with<cuda_async_pinned_memory_resource, cuda::mr::host_accessible>);
+
+/** @} */  // end of group
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/include/rmm/mr/detail/cuda_async_pinned_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/cuda_async_pinned_memory_resource_impl.hpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <rmm/aligned.hpp>
+#include <rmm/mr/cuda_async_view_memory_resource.hpp>
+
+#include <cuda/memory_resource>
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <memory>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+namespace detail {
+
+/**
+ * @brief Implementation class for cuda_async_pinned_memory_resource.
+ *
+ * Delegates allocation and deallocation to a view of the process-wide pinned host memory pool. The
+ * implementation is held by `cuda_async_pinned_memory_resource` through `cuda::mr::shared_resource`
+ * for reference-counted ownership.
+ */
+class cuda_async_pinned_memory_resource_impl {
+ public:
+  struct construction_tag {};
+
+  cuda_async_pinned_memory_resource_impl();
+  explicit cuda_async_pinned_memory_resource_impl(construction_tag);
+
+  ~cuda_async_pinned_memory_resource_impl() = default;
+
+  cuda_async_pinned_memory_resource_impl(cuda_async_pinned_memory_resource_impl const&) = delete;
+  cuda_async_pinned_memory_resource_impl(cuda_async_pinned_memory_resource_impl&&)      = delete;
+  cuda_async_pinned_memory_resource_impl& operator=(cuda_async_pinned_memory_resource_impl const&) =
+    delete;
+  cuda_async_pinned_memory_resource_impl& operator=(cuda_async_pinned_memory_resource_impl&&) =
+    delete;
+
+  [[nodiscard]] bool operator==(cuda_async_pinned_memory_resource_impl const& other) const noexcept
+  {
+    if (this == std::addressof(other)) { return true; }
+    return pool_handle() == other.pool_handle();
+  }
+
+  [[nodiscard]] bool operator!=(cuda_async_pinned_memory_resource_impl const& other) const noexcept
+  {
+    return !(*this == other);
+  }
+
+  /**
+   * @brief Returns the underlying native CUDA memory pool handle.
+   *
+   * @return Handle to the underlying CUDA memory pool
+   */
+  [[nodiscard]] cudaMemPool_t pool_handle() const noexcept;
+
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
+
+  RMM_CONSTEXPR_FRIEND void get_property(cuda_async_pinned_memory_resource_impl const&,
+                                         cuda::mr::device_accessible) noexcept
+  {
+  }
+
+  RMM_CONSTEXPR_FRIEND void get_property(cuda_async_pinned_memory_resource_impl const&,
+                                         cuda::mr::host_accessible) noexcept
+  {
+  }
+
+ private:
+  cuda_async_view_memory_resource pool_{};
+};
+
+}  // namespace detail
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/include/rmm/mr/detail/cuda_async_pinned_memory_resource_impl.hpp
+++ b/cpp/include/rmm/mr/detail/cuda_async_pinned_memory_resource_impl.hpp
@@ -14,7 +14,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
 
@@ -59,16 +59,17 @@ class cuda_async_pinned_memory_resource_impl {
    */
   [[nodiscard]] cudaMemPool_t pool_handle() const noexcept;
 
-  void* allocate(cuda::stream_ref stream,
-                 std::size_t bytes,
-                 std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+  [[nodiscard]] void* allocate(cuda::stream_ref stream,
+                               std::size_t bytes,
+                               std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   void deallocate(cuda::stream_ref stream,
                   void* ptr,
                   std::size_t bytes,
                   std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept;
 
-  void* allocate_sync(std::size_t bytes, std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
+  [[nodiscard]] void* allocate_sync(std::size_t bytes,
+                                    std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT);
 
   void deallocate_sync(void* ptr,
                        std::size_t bytes,
@@ -90,4 +91,4 @@ class cuda_async_pinned_memory_resource_impl {
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/cuda_async_pinned_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_pinned_memory_resource.cpp
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/mr/cuda_async_pinned_memory_resource.hpp>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+
+cuda_async_pinned_memory_resource::cuda_async_pinned_memory_resource()
+  : shared_base(cuda::mr::make_shared_resource<detail::cuda_async_pinned_memory_resource_impl>(
+      detail::cuda_async_pinned_memory_resource_impl::construction_tag{}))
+{
+}
+
+cudaMemPool_t cuda_async_pinned_memory_resource::pool_handle() const noexcept
+{
+  return get().pool_handle();
+}
+
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/src/mr/cuda_async_pinned_memory_resource.cpp
+++ b/cpp/src/mr/cuda_async_pinned_memory_resource.cpp
@@ -5,7 +5,7 @@
 
 #include <rmm/mr/cuda_async_pinned_memory_resource.hpp>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 
 cuda_async_pinned_memory_resource::cuda_async_pinned_memory_resource()
@@ -20,4 +20,4 @@ cudaMemPool_t cuda_async_pinned_memory_resource::pool_handle() const noexcept
 }
 
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/cuda_async_pinned_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_pinned_memory_resource_impl.cpp
@@ -7,72 +7,20 @@
 #include <rmm/detail/runtime_capabilities.hpp>
 #include <rmm/mr/detail/cuda_async_pinned_memory_resource_impl.hpp>
 
+#include <cuda/memory_pool>
 #include <cuda_runtime_api.h>
 
 #include <cstddef>
 
-namespace RMM_NAMESPACE {
+RMM_NAMESPACE_BEGIN
 namespace mr {
 namespace detail {
-namespace {
-
-void enable_access_from_all_devices(cudaMemPool_t pool_handle)
-{
-  int device_count{};
-  RMM_CUDA_TRY(cudaGetDeviceCount(&device_count));
-  for (int device = 0; device < device_count; ++device) {
-    cudaMemAccessDesc access{};
-    access.location.type = cudaMemLocationTypeDevice;
-    access.location.id   = device;
-    access.flags         = cudaMemAccessFlagsProtReadWrite;
-    RMM_CUDA_TRY(cudaMemPoolSetAccess(pool_handle, &access, 1));
-  }
-}
-
-cudaMemPool_t create_process_wide_pinned_pool()
-{
-  cudaMemPool_t pool_handle{};
-
-#if CUDART_VERSION >= 13000
-  cudaMemLocation location{.type = cudaMemLocationTypeHost, .id = 0};
-  RMM_CUDA_TRY(cudaMemGetDefaultMemPool(&pool_handle, &location, cudaMemAllocationTypePinned));
-#else
-  cudaMemPoolProps properties{};
-  properties.allocType     = cudaMemAllocationTypePinned;
-  properties.handleTypes   = cudaMemHandleTypeNone;
-  properties.location.type = cudaMemLocationTypeHostNuma;
-  properties.location.id   = 0;
-  RMM_CUDA_TRY(cudaMemPoolCreate(&pool_handle, &properties));
-#endif
-
-  try {
-    enable_access_from_all_devices(pool_handle);
-  } catch (...) {
-#if CUDART_VERSION < 13000
-    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaMemPoolDestroy(pool_handle));
-#endif
-    throw;
-  }
-
-  // CUDA 12.x does not provide a default pinned host pool. Keep the custom pool alive for the
-  // process lifetime so every resource instance remains equivalent and can deallocate allocations
-  // made by any other instance. CUDA owns the default pool returned on CUDA 13 and later.
-  return pool_handle;
-}
-
-cudaMemPool_t get_process_wide_pinned_pool()
-{
-  static cudaMemPool_t const pool_handle = create_process_wide_pinned_pool();
-  return pool_handle;
-}
-
-}  // namespace
 
 cuda_async_pinned_memory_resource_impl::cuda_async_pinned_memory_resource_impl()
 {
   RMM_EXPECTS(rmm::detail::runtime_async_pinned_alloc::is_supported(),
               "cuda_async_pinned_memory_resource is unsupported by this CUDA driver/runtime");
-  pool_ = cuda_async_view_memory_resource{get_process_wide_pinned_pool()};
+  pool_ = cuda_async_view_memory_resource{cuda::pinned_default_memory_pool().get()};
 }
 
 cuda_async_pinned_memory_resource_impl::cuda_async_pinned_memory_resource_impl(construction_tag)
@@ -115,4 +63,4 @@ void cuda_async_pinned_memory_resource_impl::deallocate_sync(void* ptr,
 
 }  // namespace detail
 }  // namespace mr
-}  // namespace RMM_NAMESPACE
+RMM_NAMESPACE_END

--- a/cpp/src/mr/detail/cuda_async_pinned_memory_resource_impl.cpp
+++ b/cpp/src/mr/detail/cuda_async_pinned_memory_resource_impl.cpp
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rmm/detail/error.hpp>
+#include <rmm/detail/runtime_capabilities.hpp>
+#include <rmm/mr/detail/cuda_async_pinned_memory_resource_impl.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+namespace RMM_NAMESPACE {
+namespace mr {
+namespace detail {
+namespace {
+
+void enable_access_from_all_devices(cudaMemPool_t pool_handle)
+{
+  int device_count{};
+  RMM_CUDA_TRY(cudaGetDeviceCount(&device_count));
+  for (int device = 0; device < device_count; ++device) {
+    cudaMemAccessDesc access{};
+    access.location.type = cudaMemLocationTypeDevice;
+    access.location.id   = device;
+    access.flags         = cudaMemAccessFlagsProtReadWrite;
+    RMM_CUDA_TRY(cudaMemPoolSetAccess(pool_handle, &access, 1));
+  }
+}
+
+cudaMemPool_t create_process_wide_pinned_pool()
+{
+  cudaMemPool_t pool_handle{};
+
+#if CUDART_VERSION >= 13000
+  cudaMemLocation location{.type = cudaMemLocationTypeHost, .id = 0};
+  RMM_CUDA_TRY(cudaMemGetDefaultMemPool(&pool_handle, &location, cudaMemAllocationTypePinned));
+#else
+  cudaMemPoolProps properties{};
+  properties.allocType     = cudaMemAllocationTypePinned;
+  properties.handleTypes   = cudaMemHandleTypeNone;
+  properties.location.type = cudaMemLocationTypeHostNuma;
+  properties.location.id   = 0;
+  RMM_CUDA_TRY(cudaMemPoolCreate(&pool_handle, &properties));
+#endif
+
+  try {
+    enable_access_from_all_devices(pool_handle);
+  } catch (...) {
+#if CUDART_VERSION < 13000
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaMemPoolDestroy(pool_handle));
+#endif
+    throw;
+  }
+
+  // CUDA 12.x does not provide a default pinned host pool. Keep the custom pool alive for the
+  // process lifetime so every resource instance remains equivalent and can deallocate allocations
+  // made by any other instance. CUDA owns the default pool returned on CUDA 13 and later.
+  return pool_handle;
+}
+
+cudaMemPool_t get_process_wide_pinned_pool()
+{
+  static cudaMemPool_t const pool_handle = create_process_wide_pinned_pool();
+  return pool_handle;
+}
+
+}  // namespace
+
+cuda_async_pinned_memory_resource_impl::cuda_async_pinned_memory_resource_impl()
+{
+  RMM_EXPECTS(rmm::detail::runtime_async_pinned_alloc::is_supported(),
+              "cuda_async_pinned_memory_resource is unsupported by this CUDA driver/runtime");
+  pool_ = cuda_async_view_memory_resource{get_process_wide_pinned_pool()};
+}
+
+cuda_async_pinned_memory_resource_impl::cuda_async_pinned_memory_resource_impl(construction_tag)
+  : cuda_async_pinned_memory_resource_impl()
+{
+}
+
+cudaMemPool_t cuda_async_pinned_memory_resource_impl::pool_handle() const noexcept
+{
+  return pool_.pool_handle();
+}
+
+void* cuda_async_pinned_memory_resource_impl::allocate(cuda::stream_ref stream,
+                                                       std::size_t bytes,
+                                                       std::size_t alignment)
+{
+  return pool_.allocate(stream, bytes, alignment);
+}
+
+void cuda_async_pinned_memory_resource_impl::deallocate(cuda::stream_ref stream,
+                                                        void* ptr,
+                                                        std::size_t bytes,
+                                                        std::size_t /*alignment*/) noexcept
+{
+  pool_.deallocate(stream, ptr, bytes);
+}
+
+void* cuda_async_pinned_memory_resource_impl::allocate_sync(std::size_t bytes,
+                                                            std::size_t alignment)
+{
+  return pool_.allocate_sync(bytes, alignment);
+}
+
+void cuda_async_pinned_memory_resource_impl::deallocate_sync(void* ptr,
+                                                             std::size_t bytes,
+                                                             std::size_t alignment) noexcept
+{
+  pool_.deallocate_sync(ptr, bytes, alignment);
+}
+
+}  // namespace detail
+}  // namespace mr
+}  // namespace RMM_NAMESPACE

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -165,6 +165,9 @@ ConfigureTest(CUDA_ASYNC_MR_SHARED_CUDART_TEST mr/cuda_async_mr_tests.cpp CUDART
 
 # cuda_async managed mr tests (available with CUDA 13+ runtime/driver)
 ConfigureTest(CUDA_ASYNC_MANAGED_MR_TEST mr/cuda_async_managed_mr_tests.cpp)
+
+# cuda_async pinned mr tests (available with CUDA 12.9+ runtime/driver)
+ConfigureTest(CUDA_ASYNC_PINNED_MR_TEST mr/cuda_async_pinned_mr_tests.cpp)
 
 # thrust allocator tests
 ConfigureTest(THRUST_ALLOCATOR_TEST mr/thrust_allocator_tests.cu)

--- a/cpp/tests/mr/cuda_async_pinned_mr_tests.cpp
+++ b/cpp/tests/mr/cuda_async_pinned_mr_tests.cpp
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <future>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <vector>
@@ -174,13 +175,13 @@ TEST_F(AsyncPinnedMRTest, CopyKeepsResourceAlive)
   copy->deallocate_sync(ptr, size);
 }
 
-TEST_F(AsyncPinnedMRTest, PoolHasDefaultReleaseThreshold)
+TEST_F(AsyncPinnedMRTest, PoolRetainsUnusedMemory)
 {
   cuda_async_pinned_mr mr{};
-  std::uint64_t release_threshold{1};
+  std::uint64_t release_threshold{};
   RMM_CUDA_TRY(
     cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &release_threshold));
-  EXPECT_EQ(release_threshold, std::uint64_t{0});
+  EXPECT_EQ(release_threshold, std::numeric_limits<std::size_t>::max());
 }
 
 TEST_F(AsyncPinnedMRTest, AllocationsUseExposedPool)

--- a/cpp/tests/mr/cuda_async_pinned_mr_tests.cpp
+++ b/cpp/tests/mr/cuda_async_pinned_mr_tests.cpp
@@ -1,0 +1,316 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "../byte_literals.hpp"
+
+#include <rmm/aligned.hpp>
+#include <rmm/cuda_stream.hpp>
+#include <rmm/detail/error.hpp>
+#include <rmm/detail/runtime_capabilities.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/error.hpp>
+#include <rmm/mr/cuda_async_pinned_memory_resource.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace rmm::test {
+namespace {
+
+using cuda_async_pinned_mr = rmm::mr::cuda_async_pinned_memory_resource;
+
+static_assert(cuda::mr::synchronous_resource_with<cuda_async_pinned_mr, cuda::mr::host_accessible>);
+static_assert(
+  cuda::mr::synchronous_resource_with<cuda_async_pinned_mr, cuda::mr::device_accessible>);
+static_assert(cuda::mr::resource_with<cuda_async_pinned_mr, cuda::mr::host_accessible>);
+static_assert(cuda::mr::resource_with<cuda_async_pinned_mr, cuda::mr::device_accessible>);
+
+class AsyncPinnedMRTest : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    if (!rmm::detail::runtime_async_pinned_alloc::is_supported()) {
+      GTEST_SKIP() << "Skipping tests because stream-ordered pinned host allocation is "
+                      "unsupported by this CUDA driver/runtime.";
+    }
+  }
+};
+
+struct host_callback_gate {
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool started{};
+  bool released{};
+};
+
+void release(host_callback_gate& gate) noexcept
+{
+  {
+    std::lock_guard lock{gate.mutex};
+    gate.released = true;
+  }
+  gate.condition.notify_all();
+}
+
+struct callback_guard {
+  host_callback_gate& gate;
+  cudaStream_t stream;
+
+  ~callback_guard()
+  {
+    release(gate);
+    RMM_ASSERT_CUDA_SUCCESS_SAFE_SHUTDOWN(cudaStreamSynchronize(stream));
+  }
+};
+
+TEST_F(AsyncPinnedMRTest, BasicAllocateDeallocate)
+{
+  constexpr std::size_t size{1_KiB};
+  cuda_async_pinned_mr mr{};
+
+  auto* ptr = mr.allocate_sync(size);
+  ASSERT_NE(ptr, nullptr);
+  mr.deallocate_sync(ptr, size);
+
+  EXPECT_EQ(mr.allocate_sync(0), nullptr);
+  EXPECT_NO_THROW(mr.deallocate_sync(nullptr, 0));
+
+  rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};
+  EXPECT_EQ(mr.allocate(stream, 0, rmm::CUDA_ALLOCATION_ALIGNMENT), nullptr);
+  EXPECT_NO_THROW(mr.deallocate(stream, nullptr, 0, rmm::CUDA_ALLOCATION_ALIGNMENT));
+}
+
+TEST_F(AsyncPinnedMRTest, AllocatedPointerIsPinnedAndHostAccessible)
+{
+  constexpr std::size_t size{4_KiB};
+  constexpr std::uint8_t expected_value{0x2a};
+  cuda_async_pinned_mr mr{};
+
+  auto* ptr = static_cast<std::uint8_t*>(mr.allocate_sync(size));
+  ASSERT_NE(ptr, nullptr);
+
+  cudaPointerAttributes attributes{};
+  RMM_CUDA_TRY(cudaPointerGetAttributes(&attributes, ptr));
+  EXPECT_EQ(attributes.type, cudaMemoryTypeHost);
+  EXPECT_EQ(attributes.hostPointer, ptr);
+  EXPECT_NE(attributes.devicePointer, nullptr);
+
+  std::fill_n(ptr, size, expected_value);
+  EXPECT_TRUE(
+    std::all_of(ptr, ptr + size, [](std::uint8_t value) { return value == expected_value; }));
+
+  mr.deallocate_sync(ptr, size);
+}
+
+TEST_F(AsyncPinnedMRTest, SupportedAlignments)
+{
+  cuda_async_pinned_mr mr{};
+
+  for (std::size_t alignment = 1; alignment <= rmm::CUDA_ALLOCATION_ALIGNMENT; alignment *= 2) {
+    constexpr std::size_t size{513};
+    auto* ptr = mr.allocate_sync(size, alignment);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_TRUE(rmm::is_pointer_aligned(ptr, alignment)) << "alignment: " << alignment;
+    mr.deallocate_sync(ptr, size, alignment);
+  }
+}
+
+TEST_F(AsyncPinnedMRTest, RejectsUnsupportedAlignment)
+{
+  cuda_async_pinned_mr mr{};
+  rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};
+
+  for (auto alignment : std::array<std::size_t, 3>{0, 192, 512}) {
+    EXPECT_THROW((void)mr.allocate_sync(100, alignment), rmm::bad_alloc)
+      << "alignment: " << alignment;
+    EXPECT_THROW((void)mr.allocate(stream, 100, alignment), rmm::bad_alloc)
+      << "alignment: " << alignment;
+  }
+}
+
+TEST_F(AsyncPinnedMRTest, AllInstancesSharePoolAndCompareEqual)
+{
+  cuda_async_pinned_mr first{};
+  cuda_async_pinned_mr second{};
+  auto copy = first;
+
+  ASSERT_NE(first.pool_handle(), nullptr);
+  EXPECT_EQ(first.pool_handle(), second.pool_handle());
+  EXPECT_EQ(first.pool_handle(), copy.pool_handle());
+  EXPECT_EQ(first, second);
+  EXPECT_EQ(first, copy);
+
+  constexpr std::size_t size{1_KiB};
+  auto* ptr = first.allocate_sync(size);
+  EXPECT_NO_THROW(second.deallocate_sync(ptr, size));
+}
+
+TEST_F(AsyncPinnedMRTest, CopyKeepsResourceAlive)
+{
+  std::optional<cuda_async_pinned_mr> copy;
+  {
+    cuda_async_pinned_mr original{};
+    copy.emplace(original);
+    EXPECT_EQ(original, *copy);
+  }
+
+  constexpr std::size_t size{1_KiB};
+  auto* ptr = copy->allocate_sync(size);
+  ASSERT_NE(ptr, nullptr);
+  copy->deallocate_sync(ptr, size);
+}
+
+TEST_F(AsyncPinnedMRTest, PoolHasDefaultReleaseThreshold)
+{
+  cuda_async_pinned_mr mr{};
+  std::uint64_t release_threshold{1};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrReleaseThreshold, &release_threshold));
+  EXPECT_EQ(release_threshold, std::uint64_t{0});
+}
+
+TEST_F(AsyncPinnedMRTest, AllocationsUseExposedPool)
+{
+  constexpr std::size_t size{1_MiB};
+  cuda_async_pinned_mr mr{};
+
+  std::uint64_t used_before{};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrUsedMemCurrent, &used_before));
+
+  auto* ptr = mr.allocate_sync(size);
+  ASSERT_NE(ptr, nullptr);
+
+  std::uint64_t used_during{};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrUsedMemCurrent, &used_during));
+  EXPECT_GE(used_during, used_before + size);
+
+  mr.deallocate_sync(ptr, size);
+
+  std::uint64_t used_after{};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrUsedMemCurrent, &used_after));
+  EXPECT_EQ(used_after, used_before);
+}
+
+TEST_F(AsyncPinnedMRTest, PoolIsAccessibleFromAllVisibleDevices)
+{
+  cuda_async_pinned_mr mr{};
+  int device_count{};
+  RMM_CUDA_TRY(cudaGetDeviceCount(&device_count));
+
+  for (int device = 0; device < device_count; ++device) {
+    cudaMemLocation location{.type = cudaMemLocationTypeDevice, .id = device};
+    cudaMemAccessFlags flags{cudaMemAccessFlagsProtNone};
+    RMM_CUDA_TRY(cudaMemPoolGetAccess(&flags, mr.pool_handle(), &location));
+    EXPECT_EQ(flags, cudaMemAccessFlagsProtReadWrite) << "device: " << device;
+  }
+}
+
+#if CUDART_VERSION >= 13000
+TEST_F(AsyncPinnedMRTest, UsesCudaDefaultPinnedHostPool)
+{
+  cuda_async_pinned_mr mr{};
+  cudaMemLocation location{.type = cudaMemLocationTypeHost, .id = 0};
+  cudaMemPool_t default_pool{};
+  RMM_CUDA_TRY(cudaMemGetDefaultMemPool(&default_pool, &location, cudaMemAllocationTypePinned));
+  EXPECT_EQ(mr.pool_handle(), default_pool);
+
+  cudaMemAllocationType allocation_type{cudaMemAllocationTypeInvalid};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrAllocationType, &allocation_type));
+  EXPECT_EQ(allocation_type, cudaMemAllocationTypePinned);
+
+  cudaMemLocationType location_type{cudaMemLocationTypeNone};
+  RMM_CUDA_TRY(
+    cudaMemPoolGetAttribute(mr.pool_handle(), cudaMemPoolAttrLocationType, &location_type));
+  EXPECT_EQ(location_type, cudaMemLocationTypeHost);
+}
+#endif
+
+TEST_F(AsyncPinnedMRTest, DeallocationIsStreamOrdered)
+{
+  constexpr std::size_t size{1_MiB};
+  constexpr std::uint8_t expected_value{0x2a};
+  constexpr auto callback_timeout     = std::chrono::seconds{10};
+  constexpr auto deallocation_timeout = std::chrono::seconds{5};
+
+  cuda_async_pinned_mr mr{};
+  rmm::cuda_stream stream{rmm::cuda_stream::flags::non_blocking};
+  rmm::device_buffer device{size, stream};
+
+  auto* pinned = static_cast<std::uint8_t*>(mr.allocate_sync(size));
+  ASSERT_NE(pinned, nullptr);
+  std::fill_n(pinned, size, expected_value);
+
+  host_callback_gate gate;
+  std::future<void> deallocation;
+  callback_guard guard{gate, stream.value()};
+
+  RMM_CUDA_TRY(cudaLaunchHostFunc(
+    stream.value(),
+    [](void* data) {
+      auto& gate = *static_cast<host_callback_gate*>(data);
+      std::unique_lock lock{gate.mutex};
+      gate.started = true;
+      gate.condition.notify_all();
+      gate.condition.wait(lock, [&gate] { return gate.released; });
+    },
+    &gate));
+
+  bool callback_started{};
+  {
+    std::unique_lock lock{gate.mutex};
+    callback_started =
+      gate.condition.wait_for(lock, callback_timeout, [&gate] { return gate.started; });
+  }
+  if (!callback_started) {
+    release(gate);
+    stream.synchronize();
+    mr.deallocate_sync(pinned, size);
+    FAIL() << "CUDA host callback did not start before timeout";
+  }
+
+  RMM_CUDA_TRY(
+    cudaMemcpyAsync(device.data(), pinned, size, cudaMemcpyHostToDevice, stream.value()));
+
+  int device_id{};
+  RMM_CUDA_TRY(cudaGetDevice(&device_id));
+  deallocation                   = std::async(std::launch::async, [&, device_id] {
+    RMM_CUDA_TRY(cudaSetDevice(device_id));
+    mr.deallocate(stream, pinned, size, rmm::CUDA_ALLOCATION_ALIGNMENT);
+  });
+  auto const deallocation_status = deallocation.wait_for(deallocation_timeout);
+
+  // Always release the callback before waiting on the asynchronous task. With cudaFreeHost, the
+  // task remains blocked until the preceding copy completes; cudaFreeAsync returns immediately
+  // after ordering the free behind the copy.
+  release(gate);
+  deallocation.get();
+  stream.synchronize();
+
+  std::vector<std::uint8_t> result(size);
+  RMM_CUDA_TRY(cudaMemcpy(result.data(), device.data(), size, cudaMemcpyDeviceToHost));
+
+  EXPECT_EQ(deallocation_status, std::future_status::ready);
+  EXPECT_TRUE(std::all_of(
+    result.begin(), result.end(), [](std::uint8_t value) { return value == expected_value; }));
+}
+
+}  // namespace
+}  // namespace rmm::test

--- a/cpp/tests/mr/host_mr_ref_tests.cpp
+++ b/cpp/tests/mr/host_mr_ref_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.codespell]
@@ -10,6 +10,10 @@ ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
 ignore-words-list = "thirdparty,couldn"
 builtin = "clear"
 quiet-level = 3
+
+[tool.cython-lint]
+# Line-too-long is ignored because canonical copyright headers exceed 88 characters.
+ignore = ["E501"]
 
 [tool.ruff]
 line-length = 79

--- a/python/rmm/rmm/librmm/memory_resource.pxd
+++ b/python/rmm/rmm/librmm/memory_resource.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # This import is needed for Cython typing in translate_python_except_to_cpp
@@ -114,6 +114,8 @@ cdef extern from *:
     optional[device_async_resource_ref] make_device_async_resource_ref(
         cuda_async_managed_memory_resource&) except +
     optional[device_async_resource_ref] make_device_async_resource_ref(
+        cuda_async_pinned_memory_resource&) except +
+    optional[device_async_resource_ref] make_device_async_resource_ref(
         pool_memory_resource&) except +
     optional[device_async_resource_ref] make_device_async_resource_ref(
         arena_memory_resource&) except +
@@ -224,6 +226,13 @@ cdef extern from "rmm/mr/cuda_async_managed_memory_resource.hpp" \
 
     cdef cppclass cuda_async_managed_memory_resource:
         cuda_async_managed_memory_resource() except +
+        cudaMemPool_t pool_handle() const
+
+cdef extern from "rmm/mr/cuda_async_pinned_memory_resource.hpp" \
+        namespace "rmm::mr" nogil:
+
+    cdef cppclass cuda_async_pinned_memory_resource:
+        cuda_async_pinned_memory_resource() except +
         cudaMemPool_t pool_handle() const
 
 cdef extern from "rmm/mr/cuda_async_memory_resource.hpp" \

--- a/python/rmm/rmm/mr/experimental.py
+++ b/python/rmm/rmm/mr/experimental.py
@@ -1,12 +1,14 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Experimental memory resource features that may change or be removed in future releases."""
 
 from rmm.pylibrmm.memory_resource.experimental import (
     CudaAsyncManagedMemoryResource,
+    CudaAsyncPinnedMemoryResource,
 )
 
 __all__ = [
     "CudaAsyncManagedMemoryResource",
+    "CudaAsyncPinnedMemoryResource",
 ]

--- a/python/rmm/rmm/pylibrmm/device_buffer.pyx
+++ b/python/rmm/rmm/pylibrmm/device_buffer.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import numpy as np
 
@@ -506,7 +506,7 @@ cpdef void copy_ptr_to_host(uintptr_t db,
 
     with nogil:
         _copy_async(<const void*>(db), <void*>(&hb[0]), len(hb),
-                    cudaMemcpyKind.cudaMemcpyDeviceToHost, stream.view())
+                    cudaMemcpyKind.cudaMemcpyDefault, stream.view())
 
     if stream.c_is_default():
         stream.c_synchronize()
@@ -550,7 +550,7 @@ cpdef void copy_host_to_ptr(const unsigned char[::1] hb,
 
     with nogil:
         _copy_async(<const void*>(&hb[0]), <void*>(db), len(hb),
-                    cudaMemcpyKind.cudaMemcpyHostToDevice, stream.view())
+                    cudaMemcpyKind.cudaMemcpyDefault, stream.view())
 
     if stream.c_is_default():
         stream.c_synchronize()
@@ -584,4 +584,4 @@ cpdef void copy_device_to_ptr(uintptr_t d_src,
 
     with nogil:
         _copy_async(<const void*>(d_src), <void*>(d_dst), count,
-                    cudaMemcpyKind.cudaMemcpyDeviceToDevice, stream.view())
+                    cudaMemcpyKind.cudaMemcpyDefault, stream.view())

--- a/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/_memory_resource.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/python/rmm/rmm/pylibrmm/memory_resource/experimental.pxd
+++ b/python/rmm/rmm/pylibrmm/memory_resource/experimental.pxd
@@ -1,12 +1,18 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from libcpp.memory cimport unique_ptr
 
-from rmm.librmm.memory_resource cimport cuda_async_managed_memory_resource
+from rmm.librmm.memory_resource cimport (
+    cuda_async_managed_memory_resource,
+    cuda_async_pinned_memory_resource,
+)
 # import from the private _memory_resource to avoid a circular import
 from rmm.pylibrmm.memory_resource._memory_resource cimport DeviceMemoryResource
 
 
 cdef class CudaAsyncManagedMemoryResource(DeviceMemoryResource):
     cdef unique_ptr[cuda_async_managed_memory_resource] c_obj
+
+cdef class CudaAsyncPinnedMemoryResource(DeviceMemoryResource):
+    cdef unique_ptr[cuda_async_pinned_memory_resource] c_obj

--- a/python/rmm/rmm/pylibrmm/memory_resource/experimental.pyi
+++ b/python/rmm/rmm/pylibrmm/memory_resource/experimental.pyi
@@ -1,8 +1,12 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from rmm.pylibrmm.memory_resource._memory_resource import DeviceMemoryResource
 
 class CudaAsyncManagedMemoryResource(DeviceMemoryResource):
+    def __init__(self) -> None: ...
+    def pool_handle(self) -> int: ...
+
+class CudaAsyncPinnedMemoryResource(DeviceMemoryResource):
     def __init__(self) -> None: ...
     def pool_handle(self) -> int: ...

--- a/python/rmm/rmm/pylibrmm/memory_resource/experimental.pyx
+++ b/python/rmm/rmm/pylibrmm/memory_resource/experimental.pyx
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Experimental memory resource features."""
@@ -8,6 +8,7 @@ from libc.stdint cimport uintptr_t
 
 from rmm.librmm.memory_resource cimport (
     cuda_async_managed_memory_resource,
+    cuda_async_pinned_memory_resource,
     make_device_async_resource_ref,
 )
 # import from the private _memory_resource to avoid a circular import
@@ -27,6 +28,33 @@ cdef class CudaAsyncManagedMemoryResource(DeviceMemoryResource):
     """
     def __cinit__(self):
         self.c_obj.reset(new cuda_async_managed_memory_resource())
+        self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
+
+    def pool_handle(self):
+        """
+        Returns the underlying CUDA memory pool handle.
+
+        Returns
+        -------
+        int
+            Handle to the underlying CUDA memory pool
+        """
+        return <uintptr_t>(deref(self.c_obj).pool_handle())
+
+
+cdef class CudaAsyncPinnedMemoryResource(DeviceMemoryResource):
+    """
+    Stream-ordered memory resource for allocating pinned host memory.
+
+    Allocations and deallocations are ordered on the supplied CUDA stream.
+    An allocation must not be accessed from the host until it reaches the
+    head of that stream, and the deallocation stream must follow all uses of
+    the allocation.
+
+    The memory is accessible from both the host and CUDA devices.
+    """
+    def __cinit__(self):
+        self.c_obj.reset(new cuda_async_pinned_memory_resource())
         self.c_ref = make_device_async_resource_ref(deref(self.c_obj))
 
     def pool_handle(self):

--- a/python/rmm/rmm/tests/test_cuda_async_pinned_memory_resource.py
+++ b/python/rmm/rmm/tests/test_cuda_async_pinned_memory_resource.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for CudaAsyncPinnedMemoryResource."""
+
+import ctypes
+
+import numpy as np
+from numba import cuda
+
+import rmm
+from rmm.pylibrmm.stream import CudaStreamFlags, Stream
+
+
+@cuda.jit
+def _increment(values):
+    i = cuda.grid(1)
+    if i < values.size:
+        values[i] += 1
+
+
+def test_cuda_async_pinned_memory_resource_pool_handle():
+    mr = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+    other = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+
+    pool_handle = mr.pool_handle()
+    assert isinstance(pool_handle, int)
+    assert pool_handle != 0
+    assert other.pool_handle() == pool_handle
+
+
+def test_cuda_async_pinned_memory_resource_non_default_stream():
+    mr = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+    stream = Stream(flags=CudaStreamFlags.NON_BLOCKING)
+
+    ptr = mr.allocate(1024, stream=stream)
+    assert ptr != 0
+    mr.deallocate(ptr, 1024, stream=stream)
+    stream.synchronize()
+
+
+def test_cuda_async_pinned_memory_resource_host_and_device_access():
+    mr = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+    stream = Stream(flags=CudaStreamFlags.NON_BLOCKING)
+    size = 128
+    buffer = rmm.DeviceBuffer(size=size, stream=stream, mr=mr)
+
+    expected = np.arange(size, dtype="u1")
+    buffer.copy_from_host(expected, stream=stream)
+    stream.synchronize()
+
+    host_view = np.ctypeslib.as_array(
+        (ctypes.c_uint8 * size).from_address(buffer.ptr)
+    )
+    np.testing.assert_array_equal(host_view, expected)
+
+    # Numba's EMM copy paths require true device allocations. Construct a
+    # device view of this existing allocation to test kernel access without
+    # asking Numba to allocate from the pinned memory resource.
+    device_view = cuda.as_cuda_array(buffer)
+    numba_stream = cuda.external_stream(stream.__cuda_stream__()[1])
+    _increment[1, 128, numba_stream](device_view)
+    stream.synchronize()
+
+    expected += 1
+    np.testing.assert_array_equal(host_view, expected)
+
+
+def test_cuda_async_pinned_memory_resource_device_buffer_copies():
+    pinned_mr = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+    device_mr = rmm.mr.CudaMemoryResource()
+    stream = Stream(flags=CudaStreamFlags.NON_BLOCKING)
+    size = 251
+
+    pinned_source = rmm.DeviceBuffer(size=size, stream=stream, mr=pinned_mr)
+    device_buffer = rmm.DeviceBuffer(size=size, stream=stream, mr=device_mr)
+    pinned_destination = rmm.DeviceBuffer(
+        size=size, stream=stream, mr=pinned_mr
+    )
+    pinned_copy = rmm.DeviceBuffer(size=size, stream=stream, mr=pinned_mr)
+
+    expected = np.arange(size, dtype="u1")
+    pinned_source.copy_from_host(expected, stream=stream)
+    device_buffer.copy_from_device(pinned_source, stream=stream)
+    pinned_destination.copy_from_device(device_buffer, stream=stream)
+    pinned_copy.copy_from_device(pinned_destination, stream=stream)
+    result = pinned_copy.copy_to_host(stream=stream)
+    stream.synchronize()
+
+    np.testing.assert_array_equal(result, expected)

--- a/python/rmm/rmm/tests/test_cuda_async_pinned_memory_resource.py
+++ b/python/rmm/rmm/tests/test_cuda_async_pinned_memory_resource.py
@@ -6,6 +6,7 @@
 import ctypes
 
 import numpy as np
+import pytest
 from numba import cuda
 
 import rmm
@@ -19,8 +20,20 @@ def _increment(values):
         values[i] += 1
 
 
-def test_cuda_async_pinned_memory_resource_pool_handle():
-    mr = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+@pytest.fixture(scope="module")
+def mr():
+    try:
+        return rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+    except RuntimeError as error:
+        if str(error).endswith(
+            "cuda_async_pinned_memory_resource is unsupported "
+            "by this CUDA driver/runtime"
+        ):
+            pytest.skip(str(error))
+        raise
+
+
+def test_cuda_async_pinned_memory_resource_pool_handle(mr):
     other = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
 
     pool_handle = mr.pool_handle()
@@ -29,8 +42,7 @@ def test_cuda_async_pinned_memory_resource_pool_handle():
     assert other.pool_handle() == pool_handle
 
 
-def test_cuda_async_pinned_memory_resource_non_default_stream():
-    mr = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+def test_cuda_async_pinned_memory_resource_non_default_stream(mr):
     stream = Stream(flags=CudaStreamFlags.NON_BLOCKING)
 
     ptr = mr.allocate(1024, stream=stream)
@@ -39,8 +51,7 @@ def test_cuda_async_pinned_memory_resource_non_default_stream():
     stream.synchronize()
 
 
-def test_cuda_async_pinned_memory_resource_host_and_device_access():
-    mr = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+def test_cuda_async_pinned_memory_resource_host_and_device_access(mr):
     stream = Stream(flags=CudaStreamFlags.NON_BLOCKING)
     size = 128
     buffer = rmm.DeviceBuffer(size=size, stream=stream, mr=mr)
@@ -59,15 +70,15 @@ def test_cuda_async_pinned_memory_resource_host_and_device_access():
     # asking Numba to allocate from the pinned memory resource.
     device_view = cuda.as_cuda_array(buffer)
     numba_stream = cuda.external_stream(stream.__cuda_stream__()[1])
-    _increment[1, 128, numba_stream](device_view)
+    _increment[128, 128, numba_stream](device_view)
     stream.synchronize()
 
     expected += 1
     np.testing.assert_array_equal(host_view, expected)
 
 
-def test_cuda_async_pinned_memory_resource_device_buffer_copies():
-    pinned_mr = rmm.mr.experimental.CudaAsyncPinnedMemoryResource()
+def test_cuda_async_pinned_memory_resource_device_buffer_copies(mr):
+    pinned_mr = mr
     device_mr = rmm.mr.CudaMemoryResource()
     stream = Stream(flags=CudaStreamFlags.NON_BLOCKING)
     size = 251

--- a/python/rmm/rmm/tests/test_pinned_host_memory_resource.py
+++ b/python/rmm/rmm/tests/test_pinned_host_memory_resource.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for PinnedHostMemoryResource."""


### PR DESCRIPTION
## Description

Adds an experimental `cuda_async_pinned_memory_resource` backed by CCCL's process-wide default pinned memory pool. The resource provides stream-ordered allocation and deallocation, exposes host- and device-accessible properties, and supports CUDA 12.9+ capability detection.

Adds Python bindings and updates `DeviceBuffer` copy helpers to infer copy direction so pinned allocations work as sources and destinations.

Supersedes #2164. Contributes to #2054 and provides a stream-ordered pinned allocation path for #2053.

The CUDA 12.9 path still needs CI validation.

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.