### PR TITLE
pre-commit: update 'cython-lint' to 0.21.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         files: python/.*
         types: [cython]
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.19.0
+    rev: v0.21.1
     hooks:
       - id: cython-lint
   - repo: https://github.com/pre-commit/mirrors-clang-format


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/317

Updates `cython-lint` to 0.21.1, which contains a fix for compatibility with Cython 3.3.0+ (see linked issue for details).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
