### PR TITLE
Enable public docs features in CI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,7 @@ todo_include_todos = False
 html_theme = "nvidia_sphinx_theme"
 
 html_theme_options = {
+    "public_docs_features": os.environ.get("CI") == "true",
     "external_links": [],
     "icon_links": [
         {


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/319

Enable the NVIDIA Sphinx theme’s `public_docs_features` option when `CI=true`, while leaving local documentation builds unchanged.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
