### PR TITLE
Add stream_ref-compatible cuda_stream_view methods

### DIFF
--- a/cpp/include/rmm/cuda_stream_view.hpp
+++ b/cpp/include/rmm/cuda_stream_view.hpp
@@ -62,6 +62,13 @@ class cuda_stream_view {
   [[nodiscard]] cudaStream_t value() const noexcept;
 
   /**
+   * @brief Get the wrapped stream.
+   *
+   * @return cudaStream_t The underlying stream referenced by this cuda_stream_view
+   */
+  [[nodiscard]] cudaStream_t get() const noexcept;
+
+  /**
    * @brief Implicit conversion to cudaStream_t.
    *
    * @return cudaStream_t The underlying stream referenced by this cuda_stream_view
@@ -93,6 +100,15 @@ class cuda_stream_view {
    * @throw rmm::cuda_error if stream synchronization fails
    */
   void synchronize() const;
+
+  /**
+   * @brief Synchronize the viewed CUDA stream.
+   *
+   * Calls `cudaStreamSynchronize()`.
+   *
+   * @throw rmm::cuda_error if stream synchronization fails
+   */
+  void sync() const;
 
   /**
    * @brief Synchronize the viewed CUDA stream. Does not throw if there is an error.

--- a/cpp/src/cuda_stream_view.cpp
+++ b/cpp/src/cuda_stream_view.cpp
@@ -21,6 +21,8 @@ cuda_stream_view::cuda_stream_view(cuda::stream_ref stream) noexcept : stream_{s
 
 cudaStream_t cuda_stream_view::value() const noexcept { return stream_; }
 
+cudaStream_t cuda_stream_view::get() const noexcept { return value(); }
+
 cuda_stream_view::operator cudaStream_t() const noexcept { return value(); }
 
 cuda_stream_view::operator cuda::stream_ref() const noexcept { return value(); }
@@ -53,6 +55,8 @@ bool is_default_stream(cuda::stream_ref stream) noexcept
 }  // namespace detail
 
 void cuda_stream_view::synchronize() const { RMM_CUDA_TRY(cudaStreamSynchronize(stream_)); }
+
+void cuda_stream_view::sync() const { synchronize(); }
 
 void cuda_stream_view::synchronize_no_throw() const noexcept
 {

--- a/cpp/tests/cuda_stream_tests.cpp
+++ b/cpp/tests/cuda_stream_tests.cpp
@@ -39,6 +39,14 @@ TEST_F(CudaStreamTest, Equality)
   EXPECT_NE(static_cast<cudaStream_t>(stream_a), rmm::cuda_stream_default.value());
 }
 
+TEST_F(CudaStreamTest, StreamViewCompatibilityAliases)
+{
+  rmm::cuda_stream stream;
+  auto const view = stream.view();
+  EXPECT_EQ(view.get(), view.value());
+  EXPECT_NO_THROW(view.sync());
+}
+
 TEST_F(CudaStreamTest, ImplicitConversionToStreamRef)
 {
   rmm::cuda_stream stream;

--- a/python/rmm/rmm/librmm/cuda_stream_view.pxd
+++ b/python/rmm/rmm/librmm/cuda_stream_view.pxd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from cuda.bindings.cyruntime cimport cudaStream_t
@@ -10,9 +10,11 @@ cdef extern from "rmm/cuda_stream_view.hpp" namespace "rmm" nogil:
         cuda_stream_view()
         cuda_stream_view(cudaStream_t)
         cudaStream_t value()
+        cudaStream_t get()
         bool is_default()
         bool is_per_thread_default()
         void synchronize() except +
+        void sync() except +
 
     cdef bool operator==(cuda_stream_view const, cuda_stream_view const)
 


### PR DESCRIPTION
## Description

Add `get()` and `sync()` aliases to `rmm::cuda_stream_view` so its accessor and synchronization API matches `cuda::stream_ref` while preserving `value()` and `synchronize()`. Expose the aliases to Cython and cover them in the stream tests.

This makes it easier to migrate downstream libraries to the new APIs of `cuda::stream_ref` without source-breaking changes. We will eventually deprecate `rmm::cuda_stream_view` in favor of `cuda::stream_ref` so these are somewhat temporary expansions of the API.

Related to rapidsai/build-planning#318.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.