### PR TITLE
CI: Migrate custom jobs to RTX PRO 6000

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -291,7 +291,7 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_cpp
     with:
       build_type: pull-request
-      node_type: "gpu-l4-latest-1"
+      node_type: "gpu-rtxpro6000-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/test_cpp_debug.sh"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
-      node_type: "gpu-l4-latest-1"
+      node_type: "gpu-rtxpro6000-latest-1"
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.10-latest"
       script: "ci/test_cpp_debug.sh"


### PR DESCRIPTION
Migrates custom amd64 CI jobs from L4 to RTX PRO 6000 runners. This change helps rebalance CI capacity and uses the fastest hardware available for these jobs.

Documentation builds and ARM64 jobs remain on L4.

xref: https://github.com/rapidsai/build-planning/issues/322
