### PR TITLE
wheels: test against PyTorch 2.14

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,6 @@ jobs:
       - wheel-build-python
       - wheel-tests
       - wheel-tests-integration-optional
-      - wheel-tests-integration-optional-nightly
       - devcontainer
       - telemetry-setup
     permissions:
@@ -442,21 +441,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
-      script: ci/test_wheel_integrations.sh
-  wheel-tests-integration-optional-nightly:
-    needs: [wheel-build-python, changed-files]
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      packages: read
-      pull-requests: read
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.10
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
-    with:
-      build_type: pull-request
-      matrix_type: nightly
       script: ci/test_wheel_integrations.sh
   devcontainer:
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,6 +27,7 @@ jobs:
       - wheel-build-python
       - wheel-tests
       - wheel-tests-integration-optional
+      - wheel-tests-integration-optional-nightly
       - devcontainer
       - telemetry-setup
     permissions:
@@ -441,6 +442,21 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
     with:
       build_type: pull-request
+      script: ci/test_wheel_integrations.sh
+  wheel-tests-integration-optional-nightly:
+    needs: [wheel-build-python, changed-files]
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@release/26.10
+    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_wheels
+    with:
+      build_type: pull-request
+      matrix_type: nightly
       script: ci/test_wheel_integrations.sh
   devcontainer:
     permissions:

--- a/ci/test_wheel_integrations.sh
+++ b/ci/test_wheel_integrations.sh
@@ -40,7 +40,7 @@ CUDA_MINOR=$(echo "${RAPIDS_CUDA_VERSION}" | cut -d'.' -f2)
 # See notes in 'dependencies.yaml' for details on supported versions.
 if \
     { [ "${CUDA_MAJOR}" -eq 12 ] && [ "${CUDA_MINOR}" -eq 9 ]; } \
-    || { [ "${CUDA_MAJOR}" -eq 13 ]; }; \
+    || { [ "${CUDA_MAJOR}" -eq 13 ] && [ "${CUDA_MINOR}" -lt 3 ]; }; \
 then
 
     # ensure a CUDA variant of 'torch' is used
@@ -61,7 +61,7 @@ then
         EXITCODE="${EXITCODE_PYTORCH}"
     fi
 else
-    rapids-logger "Skipping PyTorch tests (requires CUDA 12.9 or 13.0, found ${RAPIDS_CUDA_VERSION})"
+    rapids-logger "Skipping PyTorch tests (requires CUDA 12.9 or <13.3, found ${RAPIDS_CUDA_VERSION})"
 fi
 
 echo "::endgroup::"

--- a/ci/test_wheel_integrations.sh
+++ b/ci/test_wheel_integrations.sh
@@ -40,7 +40,7 @@ CUDA_MINOR=$(echo "${RAPIDS_CUDA_VERSION}" | cut -d'.' -f2)
 # See notes in 'dependencies.yaml' for details on supported versions.
 if \
     { [ "${CUDA_MAJOR}" -eq 12 ] && [ "${CUDA_MINOR}" -eq 9 ]; } \
-    || { [ "${CUDA_MAJOR}" -eq 13 ] && [ "${CUDA_MINOR}" -eq 0 ]; }; \
+    || { [ "${CUDA_MAJOR}" -eq 13 ]; }; \
 then
 
     # ensure a CUDA variant of 'torch' is used

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -532,7 +532,7 @@ dependencies:
               require_gpu: "true"
             packages:
               - *torch_cu129_index
-              - torch==2.13.0+cu129
+              - torch==2.14.0+cu129
           - matrix:
               cuda: "13.0"
               dependencies: "oldest"
@@ -545,7 +545,7 @@ dependencies:
               require_gpu: "true"
             packages:
               - *torch_cu130_index
-              - torch==2.13.0+cu130
+              - torch==2.14.0+cu130
           - matrix:
               cuda: "13.1"
               require_gpu: "true"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -532,20 +532,32 @@ dependencies:
               require_gpu: "true"
             packages:
               - *torch_cu129_index
-              - torch==2.10.0+cu129
+              - torch==2.13.0+cu129
           - matrix:
               cuda: "13.0"
               dependencies: "oldest"
               require_gpu: "true"
             packages:
-              - &torch_index_cu13 --extra-index-url=https://download.pytorch.org/whl/cu130
+              - &torch_cu130_index --extra-index-url=https://download.pytorch.org/whl/cu130
               - torch==2.9.0+cu130
           - matrix:
               cuda: "13.0"
               require_gpu: "true"
             packages:
-              - *torch_index_cu13
-              - torch==2.10.0+cu130
+              - *torch_cu130_index
+              - torch==2.13.0+cu130
+          - matrix:
+              cuda: "13.1"
+              require_gpu: "true"
+            packages:
+              - *torch_cu130_index
+              - torch==2.13.0+cu130
+          - matrix:
+              cuda: "13.*"
+              require_gpu: "true"
+            packages:
+              - --extra-index-url=https://download.pytorch.org/whl/cu132
+              - torch==2.14.0+cu132
           - matrix:
               require_gpu: "false"
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -532,7 +532,7 @@ dependencies:
               require_gpu: "true"
             packages:
               - *torch_cu129_index
-              - torch==2.14.0+cu129
+              - torch==2.13.0+cu129
           - matrix:
               cuda: "13.0"
               dependencies: "oldest"


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/327

There are official PyTorch 2.14 wheels now. Let's test against them.

## Notes for Reviewers

### How I tested this

Triggered a CI run with both the PR and nightly matrices, to be sure we cover all combinations.

Saw `torch` 2.14.0 getting installed in some places, and all jobs succeeding:

```text
Successfully installed 
...
cuda-toolkit-13.0.3.0
...
nvidia-nccl-cu13-2.30.7
nvidia-nvjitlink-13.4.52
...
torch-2.14.0+cu130
triton-3.8.0
```

([build link](https://github.com/rapidsai/rmm/actions/runs/34425641478/job/102712602015?pr=2541#step:13:358))

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rmm/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.